### PR TITLE
Add file-based agent profile system for composable LLM identity

### DIFF
--- a/design/agent-identity.md
+++ b/design/agent-identity.md
@@ -1,0 +1,167 @@
+# Agent Identity & Profile System
+
+## Overview
+
+The agent identity system provides a file-based, composable way to define an agent's personality, goals, and behavioral constraints. It separates **messaging identity** (`AgentIdentity` — name + instance ID for routing) from **LLM identity** (`AgentProfile` — personality, directives, and style for system prompts).
+
+## Design Decisions
+
+### Why Separate Identity from Profile?
+
+`AgentIdentity` is a messaging-layer concern: it identifies an agent on the bus for routing and correlation. `AgentProfile` is an LLM-layer concern: it defines how the agent behaves when generating responses. These serve different purposes and change at different rates:
+
+- Identity is stable per deployment (set once at startup).
+- Profile documents can be swapped between deployments without changing routing.
+- Not all agents need an LLM profile (e.g., a pure routing agent).
+
+### Why Markdown Files?
+
+Markdown was chosen over JSON/YAML configuration because:
+
+1. **Human-readable**: Non-developers (prompt engineers, content designers) can author and review personality documents without learning a schema.
+2. **Composable**: The `##` heading convention naturally segments documents into named sections that can be individually referenced or overridden.
+3. **Convention alignment**: Modern agent frameworks (SOUL.md, CrewAI, Character Cards) use markdown for agent definitions. This makes RockBot compatible with existing community patterns.
+4. **Version control friendly**: Markdown diffs are easy to review in pull requests.
+
+### Why Three Document Types?
+
+The soul/directives/style split follows the separation of concerns principle:
+
+| Document | Changes when... | Authored by... |
+|----------|----------------|----------------|
+| **soul.md** | Agent personality is redesigned | Prompt engineer |
+| **directives.md** | Deployment requirements change | Operations / developer |
+| **style.md** | Voice/tone needs tuning | Content designer |
+
+This means you can swap directives for a new deployment environment without touching the agent's core personality, or add style polish without risking behavioral changes.
+
+### Why a Hosted Service for Loading?
+
+`AgentProfileLoader` implements `IHostedService` to load profile documents during `StartAsync`, consistent with the existing `AgentDiscoveryService` pattern. This ensures:
+
+- Profile is available before any message handlers run.
+- Missing required files fail fast at startup (not on first message).
+- The loaded `AgentProfile` is registered as a singleton for injection.
+
+## Document Structure
+
+### soul.md (Required)
+
+Defines who the agent IS — stable personality traits.
+
+```markdown
+# Agent Name
+
+Optional preamble text.
+
+## Identity
+
+Core identity description.
+
+## Personality
+
+Behavioral traits and communication style.
+
+## Worldview
+
+How the agent perceives and approaches problems.
+
+## Boundaries
+
+What the agent will and won't do.
+
+## Vocabulary
+
+Preferred terminology and language patterns.
+```
+
+### directives.md (Required)
+
+Defines HOW the agent operates — deployment-specific instructions.
+
+```markdown
+## Goal
+
+What the agent is trying to accomplish.
+
+## Instructions
+
+Step-by-step operational guidelines.
+
+## Response Format
+
+Expected output structure.
+
+## Constraints
+
+Hard limits on behavior.
+```
+
+### style.md (Optional)
+
+Voice and tone polish for user-facing agents.
+
+```markdown
+## Tone
+
+Overall communication tone.
+
+## Examples
+
+Sample interactions demonstrating desired style.
+
+## Patterns
+
+Recurring phrases or formatting patterns.
+```
+
+## Parsing Rules
+
+- `#` headings flow into the preamble (not section boundaries).
+- `##` headings delimit sections.
+- Content before the first `##` is the preamble.
+- No `##` headings → entire content becomes preamble (permissive).
+- Empty documents produce no preamble and no sections.
+
+## System Prompt Composition
+
+`DefaultSystemPromptBuilder` composes the prompt as:
+
+```
+You are {agent-name}.
+
+{soul.md raw content}
+
+{directives.md raw content}
+
+{style.md raw content, if present}
+```
+
+Custom builders can implement `ISystemPromptBuilder` for more sophisticated composition (e.g., selecting specific sections, adding runtime context).
+
+## Registration
+
+```csharp
+builder.Services.AddRockBotHost(agent =>
+{
+    agent.WithIdentity("my-agent");
+    agent.WithProfile();                          // convention: loads from ./agent/
+    // or:
+    agent.WithProfile(opts =>                     // custom paths
+    {
+        opts.BasePath = "./my-config/";
+        opts.SoulPath = "custom-soul.md";
+    });
+});
+```
+
+## Error Handling
+
+| Scenario | Behavior |
+|----------|----------|
+| Missing `soul.md` | `FileNotFoundException` at startup (fatal) |
+| Missing `directives.md` | `FileNotFoundException` at startup (fatal) |
+| Missing `style.md` | `AgentProfile.Style` is null (not an error) |
+| Empty document | Valid — no preamble, no sections |
+| No `##` headings | Valid — entire content becomes preamble |
+| `StylePath` set to null | Style loading skipped entirely |

--- a/src/RockBot.Host.Abstractions/AgentProfile.cs
+++ b/src/RockBot.Host.Abstractions/AgentProfile.cs
@@ -1,0 +1,40 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// The composed agent profile built from soul, directives, and optional style documents.
+/// </summary>
+/// <param name="Soul">Who the agent IS — stable personality document.</param>
+/// <param name="Directives">HOW the agent operates — deployment-specific instructions.</param>
+/// <param name="Style">Optional voice/tone document for user-facing agents.</param>
+public sealed record AgentProfile(
+    AgentProfileDocument Soul,
+    AgentProfileDocument Directives,
+    AgentProfileDocument? Style = null)
+{
+    /// <summary>
+    /// All loaded documents in composition order (soul, directives, then style if present).
+    /// </summary>
+    public IReadOnlyList<AgentProfileDocument> Documents { get; } =
+        Style is not null
+            ? [Soul, Directives, Style]
+            : [Soul, Directives];
+
+    /// <summary>
+    /// Finds a section by name across all documents (first match wins).
+    /// </summary>
+    /// <param name="name">Case-insensitive section heading to search for.</param>
+    /// <returns>The matching section, or null if not found.</returns>
+    public AgentProfileSection? FindSection(string name)
+    {
+        foreach (var doc in Documents)
+        {
+            foreach (var section in doc.Sections)
+            {
+                if (section.Name.Equals(name, StringComparison.OrdinalIgnoreCase))
+                    return section;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/RockBot.Host.Abstractions/AgentProfileDocument.cs
+++ b/src/RockBot.Host.Abstractions/AgentProfileDocument.cs
@@ -1,0 +1,17 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// A parsed agent profile document (soul, directives, or style).
+/// </summary>
+/// <param name="DocumentType">The kind of document (e.g. "soul", "directives", "style").</param>
+/// <param name="Preamble">
+/// Content before the first <c>##</c> heading, including any <c>#</c> title.
+/// Null when the document starts immediately with a <c>##</c> section.
+/// </param>
+/// <param name="Sections">Sections delimited by <c>##</c> headings.</param>
+/// <param name="RawContent">The original, unmodified markdown content.</param>
+public sealed record AgentProfileDocument(
+    string DocumentType,
+    string? Preamble,
+    IReadOnlyList<AgentProfileSection> Sections,
+    string RawContent);

--- a/src/RockBot.Host.Abstractions/AgentProfileOptions.cs
+++ b/src/RockBot.Host.Abstractions/AgentProfileOptions.cs
@@ -1,0 +1,32 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Options for locating agent profile documents on disk.
+/// Relative paths are resolved against <c>IHostEnvironment.ContentRootPath</c>.
+/// </summary>
+public sealed class AgentProfileOptions
+{
+    /// <summary>
+    /// Base directory for profile documents. Defaults to <c>"agent"</c>.
+    /// </summary>
+    public string BasePath { get; set; } = "agent";
+
+    /// <summary>
+    /// Path to the soul document. When relative, resolved under <see cref="BasePath"/>.
+    /// Defaults to <c>"soul.md"</c>.
+    /// </summary>
+    public string SoulPath { get; set; } = "soul.md";
+
+    /// <summary>
+    /// Path to the directives document. When relative, resolved under <see cref="BasePath"/>.
+    /// Defaults to <c>"directives.md"</c>.
+    /// </summary>
+    public string DirectivesPath { get; set; } = "directives.md";
+
+    /// <summary>
+    /// Path to the optional style document. When relative, resolved under <see cref="BasePath"/>.
+    /// Null means no style document is expected.
+    /// Defaults to <c>"style.md"</c>.
+    /// </summary>
+    public string? StylePath { get; set; } = "style.md";
+}

--- a/src/RockBot.Host.Abstractions/AgentProfileSection.cs
+++ b/src/RockBot.Host.Abstractions/AgentProfileSection.cs
@@ -1,0 +1,9 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// A single named section within an agent profile document,
+/// delimited by a <c>##</c> heading in the source markdown.
+/// </summary>
+/// <param name="Name">The section heading text (without the <c>##</c> prefix).</param>
+/// <param name="Content">The section body content.</param>
+public sealed record AgentProfileSection(string Name, string Content);

--- a/src/RockBot.Host.Abstractions/IAgentProfileProvider.cs
+++ b/src/RockBot.Host.Abstractions/IAgentProfileProvider.cs
@@ -1,0 +1,12 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Loads an <see cref="AgentProfile"/> from its backing store.
+/// </summary>
+public interface IAgentProfileProvider
+{
+    /// <summary>
+    /// Loads and parses the agent profile documents.
+    /// </summary>
+    Task<AgentProfile> LoadAsync(CancellationToken cancellationToken = default);
+}

--- a/src/RockBot.Host.Abstractions/ISystemPromptBuilder.cs
+++ b/src/RockBot.Host.Abstractions/ISystemPromptBuilder.cs
@@ -1,0 +1,12 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Composes an LLM system prompt from an <see cref="AgentProfile"/> and <see cref="AgentIdentity"/>.
+/// </summary>
+public interface ISystemPromptBuilder
+{
+    /// <summary>
+    /// Builds the system prompt string.
+    /// </summary>
+    string Build(AgentProfile profile, AgentIdentity identity);
+}

--- a/src/RockBot.Host/AgentProfileExtensions.cs
+++ b/src/RockBot.Host/AgentProfileExtensions.cs
@@ -1,0 +1,38 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace RockBot.Host;
+
+/// <summary>
+/// Extension methods for registering the agent profile system.
+/// </summary>
+public static class AgentProfileExtensions
+{
+    /// <summary>
+    /// Registers the agent profile system with default options (loads from <c>./agent/</c>).
+    /// </summary>
+    public static AgentHostBuilder WithProfile(this AgentHostBuilder builder)
+        => builder.WithProfile(_ => { });
+
+    /// <summary>
+    /// Registers the agent profile system with custom options.
+    /// </summary>
+    public static AgentHostBuilder WithProfile(
+        this AgentHostBuilder builder,
+        Action<AgentProfileOptions> configure)
+    {
+        builder.Services.Configure(configure);
+
+        var holder = new ProfileHolder();
+        builder.Services.AddSingleton(holder);
+        builder.Services.AddSingleton(sp => sp.GetRequiredService<ProfileHolder>().Profile);
+
+        builder.Services.AddSingleton<IAgentProfileProvider, FileAgentProfileProvider>();
+        builder.Services.AddSingleton<ISystemPromptBuilder, DefaultSystemPromptBuilder>();
+
+        builder.Services.AddSingleton<AgentProfileLoader>();
+        builder.Services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<AgentProfileLoader>());
+
+        return builder;
+    }
+}

--- a/src/RockBot.Host/AgentProfileLoader.cs
+++ b/src/RockBot.Host/AgentProfileLoader.cs
@@ -1,0 +1,41 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace RockBot.Host;
+
+/// <summary>
+/// Hosted service that loads the <see cref="AgentProfile"/> during startup
+/// and registers it as a singleton for injection into handlers.
+/// </summary>
+internal sealed class AgentProfileLoader(
+    IAgentProfileProvider provider,
+    ProfileHolder holder,
+    ILogger<AgentProfileLoader> logger) : IHostedService
+{
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Loading agent profile...");
+        var profile = await provider.LoadAsync(cancellationToken);
+        holder.Profile = profile;
+        logger.LogInformation("Agent profile loaded successfully");
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}
+
+/// <summary>
+/// Holds the loaded <see cref="AgentProfile"/> singleton.
+/// Registered as a singleton so the profile can be set during startup
+/// and resolved by handlers at any time.
+/// </summary>
+internal sealed class ProfileHolder
+{
+    private AgentProfile? _profile;
+
+    public AgentProfile Profile
+    {
+        get => _profile ?? throw new InvalidOperationException(
+            "Agent profile has not been loaded yet. Ensure AgentProfileLoader has started.");
+        set => _profile = value;
+    }
+}

--- a/src/RockBot.Host/DefaultSystemPromptBuilder.cs
+++ b/src/RockBot.Host/DefaultSystemPromptBuilder.cs
@@ -1,0 +1,31 @@
+using System.Text;
+
+namespace RockBot.Host;
+
+/// <summary>
+/// Builds a system prompt by prepending the agent's name and appending
+/// each profile document's raw content in order.
+/// </summary>
+public sealed class DefaultSystemPromptBuilder : ISystemPromptBuilder
+{
+    /// <inheritdoc />
+    public string Build(AgentProfile profile, AgentIdentity identity)
+    {
+        ArgumentNullException.ThrowIfNull(profile);
+        ArgumentNullException.ThrowIfNull(identity);
+
+        var sb = new StringBuilder();
+        sb.Append("You are ");
+        sb.Append(identity.Name);
+        sb.AppendLine(".");
+        sb.AppendLine();
+
+        foreach (var doc in profile.Documents)
+        {
+            sb.AppendLine(doc.RawContent.TrimEnd());
+            sb.AppendLine();
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+}

--- a/src/RockBot.Host/FileAgentProfileProvider.cs
+++ b/src/RockBot.Host/FileAgentProfileProvider.cs
@@ -1,0 +1,74 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace RockBot.Host;
+
+/// <summary>
+/// Loads agent profile documents from disk, resolving relative paths against
+/// <see cref="AppContext.BaseDirectory"/> (the output directory where content files
+/// are copied) combined with <see cref="AgentProfileOptions.BasePath"/>.
+/// </summary>
+internal sealed class FileAgentProfileProvider(
+    IOptions<AgentProfileOptions> options,
+    ILogger<FileAgentProfileProvider> logger) : IAgentProfileProvider
+{
+    public async Task<AgentProfile> LoadAsync(CancellationToken cancellationToken = default)
+    {
+        var opts = options.Value;
+
+        var soul = await LoadDocumentAsync("soul", opts.SoulPath, opts.BasePath, required: true, cancellationToken);
+        var directives = await LoadDocumentAsync("directives", opts.DirectivesPath, opts.BasePath, required: true, cancellationToken);
+
+        AgentProfileDocument? style = null;
+        if (opts.StylePath is not null)
+        {
+            style = await LoadDocumentAsync("style", opts.StylePath, opts.BasePath, required: false, cancellationToken);
+        }
+
+        var profile = new AgentProfile(soul!, directives!, style);
+        logger.LogInformation(
+            "Loaded agent profile: soul={SoulSections} sections, directives={DirectivesSections} sections, style={HasStyle}",
+            soul!.Sections.Count, directives!.Sections.Count, style is not null);
+
+        return profile;
+    }
+
+    private async Task<AgentProfileDocument?> LoadDocumentAsync(
+        string documentType, string path, string basePath, bool required, CancellationToken cancellationToken)
+    {
+        var resolvedPath = ResolvePath(path, basePath);
+
+        if (!File.Exists(resolvedPath))
+        {
+            if (required)
+            {
+                throw new FileNotFoundException(
+                    $"Required agent profile document '{documentType}' not found at: {resolvedPath}",
+                    resolvedPath);
+            }
+
+            logger.LogDebug("Optional profile document '{DocumentType}' not found at {Path}, skipping",
+                documentType, resolvedPath);
+            return null;
+        }
+
+        var content = await File.ReadAllTextAsync(resolvedPath, cancellationToken);
+        logger.LogDebug("Loaded profile document '{DocumentType}' from {Path} ({Length} chars)",
+            documentType, resolvedPath, content.Length);
+
+        return ProfileMarkdownParser.Parse(documentType, content);
+    }
+
+    private static string ResolvePath(string path, string basePath)
+    {
+        if (Path.IsPathRooted(path))
+            return path;
+
+        var baseDir = Path.IsPathRooted(basePath)
+            ? basePath
+            : Path.Combine(AppContext.BaseDirectory, basePath);
+
+        return Path.Combine(baseDir, path);
+    }
+}

--- a/src/RockBot.Host/ProfileMarkdownParser.cs
+++ b/src/RockBot.Host/ProfileMarkdownParser.cs
@@ -1,0 +1,76 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Splits a markdown document on <c>## </c> headings into an <see cref="AgentProfileDocument"/>.
+/// A <c>#</c> title flows into the preamble; only <c>##</c> headings delimit sections.
+/// </summary>
+internal static class ProfileMarkdownParser
+{
+    private const string SectionPrefix = "## ";
+
+    /// <summary>
+    /// Parses raw markdown content into an <see cref="AgentProfileDocument"/>.
+    /// </summary>
+    public static AgentProfileDocument Parse(string documentType, string content)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(documentType);
+        ArgumentNullException.ThrowIfNull(content);
+
+        if (content.Length == 0)
+        {
+            return new AgentProfileDocument(documentType, null, [], content);
+        }
+
+        var lines = content.Split('\n');
+        var sections = new List<AgentProfileSection>();
+        var preambleLines = new List<string>();
+        string? currentHeading = null;
+        var currentBody = new List<string>();
+        var inPreamble = true;
+
+        foreach (var line in lines)
+        {
+            if (line.StartsWith(SectionPrefix, StringComparison.Ordinal))
+            {
+                if (!inPreamble && currentHeading is not null)
+                {
+                    sections.Add(BuildSection(currentHeading, currentBody));
+                }
+
+                currentHeading = line[SectionPrefix.Length..].TrimEnd();
+                currentBody.Clear();
+                inPreamble = false;
+            }
+            else if (inPreamble)
+            {
+                preambleLines.Add(line);
+            }
+            else
+            {
+                currentBody.Add(line);
+            }
+        }
+
+        // Flush last section
+        if (!inPreamble && currentHeading is not null)
+        {
+            sections.Add(BuildSection(currentHeading, currentBody));
+        }
+
+        var preamble = preambleLines.Count > 0
+            ? string.Join('\n', preambleLines).Trim()
+            : null;
+
+        // Treat whitespace-only preamble as absent
+        if (string.IsNullOrWhiteSpace(preamble))
+            preamble = null;
+
+        return new AgentProfileDocument(documentType, preamble, sections, content);
+    }
+
+    private static AgentProfileSection BuildSection(string heading, List<string> bodyLines)
+    {
+        var body = string.Join('\n', bodyLines).Trim();
+        return new AgentProfileSection(heading, body);
+    }
+}

--- a/src/RockBot.SampleAgent/Program.cs
+++ b/src/RockBot.SampleAgent/Program.cs
@@ -43,6 +43,7 @@ else
 builder.Services.AddRockBotHost(agent =>
 {
     agent.WithIdentity("sample-agent");
+    agent.WithProfile();
     agent.HandleMessage<UserMessage, UserMessageHandler>();
     agent.SubscribeTo(UserProxyTopics.UserMessage);
 });

--- a/src/RockBot.SampleAgent/RockBot.SampleAgent.csproj
+++ b/src/RockBot.SampleAgent/RockBot.SampleAgent.csproj
@@ -16,6 +16,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Content Include="agent\**\*.md" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\RockBot.Host.Abstractions\RockBot.Host.Abstractions.csproj" />
     <ProjectReference Include="..\RockBot.Host\RockBot.Host.csproj" />
     <ProjectReference Include="..\RockBot.Messaging.Abstractions\RockBot.Messaging.Abstractions.csproj" />

--- a/src/RockBot.SampleAgent/UserMessageHandler.cs
+++ b/src/RockBot.SampleAgent/UserMessageHandler.cs
@@ -14,6 +14,8 @@ internal sealed class UserMessageHandler(
     IChatClient chatClient,
     IMessagePublisher publisher,
     AgentIdentity agent,
+    AgentProfile profile,
+    ISystemPromptBuilder promptBuilder,
     ILogger<UserMessageHandler> logger) : IMessageHandler<UserMessage>
 {
     public async Task HandleAsync(UserMessage message, MessageHandlerContext context)
@@ -26,9 +28,10 @@ internal sealed class UserMessageHandler(
 
         try
         {
+            var systemPrompt = promptBuilder.Build(profile, agent);
             var chatMessages = new List<ChatMessage>
             {
-                new(ChatRole.System, "You are a helpful assistant named " + agent.Name + "."),
+                new(ChatRole.System, systemPrompt),
                 new(ChatRole.User, message.Content)
             };
 

--- a/src/RockBot.SampleAgent/agent/directives.md
+++ b/src/RockBot.SampleAgent/agent/directives.md
@@ -1,0 +1,17 @@
+# Operating Directives
+
+## Goal
+
+Assist the user with their request in a helpful, accurate, and timely manner.
+
+## Instructions
+
+1. Read the user's message carefully before responding.
+2. Provide concise answers unless the user asks for detail.
+3. Use markdown formatting when it improves readability.
+4. If the request is ambiguous, ask a clarifying question.
+
+## Constraints
+
+- Keep responses under 500 words unless the user requests more detail.
+- Do not generate content that is harmful, misleading, or inappropriate.

--- a/src/RockBot.SampleAgent/agent/soul.md
+++ b/src/RockBot.SampleAgent/agent/soul.md
@@ -1,0 +1,17 @@
+# Sample Agent
+
+A demonstration agent for the RockBot framework.
+
+## Identity
+
+You are a general-purpose assistant built on the RockBot event-driven agent framework. You help users by answering questions, explaining concepts, and working through problems step by step.
+
+## Personality
+
+You are friendly, patient, and concise. You prefer clear, direct answers over verbose explanations. When you don't know something, you say so honestly rather than guessing.
+
+## Boundaries
+
+- You do not execute code or access external systems directly.
+- You do not make up facts or cite sources you haven't verified.
+- You stay on topic and redirect politely if asked about something outside your capabilities.

--- a/tests/RockBot.Host.Tests/AgentProfileExtensionsTests.cs
+++ b/tests/RockBot.Host.Tests/AgentProfileExtensionsTests.cs
@@ -1,0 +1,100 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using RockBot.Messaging;
+
+namespace RockBot.Host.Tests;
+
+[TestClass]
+public class AgentProfileExtensionsTests
+{
+    [TestMethod]
+    public void WithProfile_RegistersProfileProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddRockBotHost(agent =>
+        {
+            agent.WithIdentity("test-agent");
+            agent.WithProfile();
+        });
+
+        var provider = services.BuildServiceProvider();
+        var profileProvider = provider.GetService<IAgentProfileProvider>();
+
+        Assert.IsNotNull(profileProvider);
+    }
+
+    [TestMethod]
+    public void WithProfile_RegistersSystemPromptBuilder()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddRockBotHost(agent =>
+        {
+            agent.WithIdentity("test-agent");
+            agent.WithProfile();
+        });
+
+        var provider = services.BuildServiceProvider();
+        var promptBuilder = provider.GetService<ISystemPromptBuilder>();
+
+        Assert.IsNotNull(promptBuilder);
+        Assert.IsInstanceOfType<DefaultSystemPromptBuilder>(promptBuilder);
+    }
+
+    [TestMethod]
+    public void WithProfile_RegistersHostedService()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IMessageSubscriber>(new StubSubscriber());
+        services.AddRockBotHost(agent =>
+        {
+            agent.WithIdentity("test-agent");
+            agent.WithProfile();
+        });
+
+        var provider = services.BuildServiceProvider();
+        var hostedServices = provider.GetServices<IHostedService>();
+
+        Assert.IsTrue(
+            hostedServices.Any(s => s is AgentProfileLoader),
+            "Expected AgentProfileLoader to be registered as IHostedService");
+    }
+
+    [TestMethod]
+    public void WithProfile_CustomOptions_ConfiguresBasePath()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddRockBotHost(agent =>
+        {
+            agent.WithIdentity("test-agent");
+            agent.WithProfile(opts => opts.BasePath = "custom-path");
+        });
+
+        var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<Microsoft.Extensions.Options.IOptions<AgentProfileOptions>>();
+
+        Assert.AreEqual("custom-path", options.Value.BasePath);
+    }
+
+    private sealed class StubSubscriber : IMessageSubscriber
+    {
+        public Task<ISubscription> SubscribeAsync(string topic, string subscriptionName,
+            Func<MessageEnvelope, CancellationToken, Task<MessageResult>> handler,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<ISubscription>(new StubSubscription(topic, subscriptionName));
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private sealed class StubSubscription(string topic, string subscriptionName) : ISubscription
+    {
+        public string Topic => topic;
+        public string SubscriptionName => subscriptionName;
+        public bool IsActive => true;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/tests/RockBot.Host.Tests/DefaultSystemPromptBuilderTests.cs
+++ b/tests/RockBot.Host.Tests/DefaultSystemPromptBuilderTests.cs
@@ -1,0 +1,71 @@
+namespace RockBot.Host.Tests;
+
+[TestClass]
+public class DefaultSystemPromptBuilderTests
+{
+    [TestMethod]
+    public void Build_PrependsAgentName()
+    {
+        var soul = new AgentProfileDocument("soul", null, [], "Soul content.");
+        var directives = new AgentProfileDocument("directives", null, [], "Directive content.");
+        var profile = new AgentProfile(soul, directives);
+        var identity = new AgentIdentity("echo-agent");
+        var builder = new DefaultSystemPromptBuilder();
+
+        var prompt = builder.Build(profile, identity);
+
+        Assert.IsTrue(prompt.StartsWith("You are echo-agent."));
+    }
+
+    [TestMethod]
+    public void Build_IncludesAllDocuments()
+    {
+        var soul = new AgentProfileDocument("soul", null, [], "I am a helpful agent.");
+        var directives = new AgentProfileDocument("directives", null, [], "Follow these rules.");
+        var profile = new AgentProfile(soul, directives);
+        var identity = new AgentIdentity("test-agent");
+        var builder = new DefaultSystemPromptBuilder();
+
+        var prompt = builder.Build(profile, identity);
+
+        Assert.IsTrue(prompt.Contains("I am a helpful agent."));
+        Assert.IsTrue(prompt.Contains("Follow these rules."));
+    }
+
+    [TestMethod]
+    public void Build_IncludesStyleWhenPresent()
+    {
+        var soul = new AgentProfileDocument("soul", null, [], "Soul.");
+        var directives = new AgentProfileDocument("directives", null, [], "Directives.");
+        var style = new AgentProfileDocument("style", null, [], "Be witty.");
+        var profile = new AgentProfile(soul, directives, style);
+        var identity = new AgentIdentity("test-agent");
+        var builder = new DefaultSystemPromptBuilder();
+
+        var prompt = builder.Build(profile, identity);
+
+        Assert.IsTrue(prompt.Contains("Soul."));
+        Assert.IsTrue(prompt.Contains("Directives."));
+        Assert.IsTrue(prompt.Contains("Be witty."));
+    }
+
+    [TestMethod]
+    public void Build_DocumentsAppearInOrder()
+    {
+        var soul = new AgentProfileDocument("soul", null, [], "AAA-SOUL");
+        var directives = new AgentProfileDocument("directives", null, [], "BBB-DIRECTIVES");
+        var style = new AgentProfileDocument("style", null, [], "CCC-STYLE");
+        var profile = new AgentProfile(soul, directives, style);
+        var identity = new AgentIdentity("test-agent");
+        var builder = new DefaultSystemPromptBuilder();
+
+        var prompt = builder.Build(profile, identity);
+
+        var soulIdx = prompt.IndexOf("AAA-SOUL");
+        var directivesIdx = prompt.IndexOf("BBB-DIRECTIVES");
+        var styleIdx = prompt.IndexOf("CCC-STYLE");
+
+        Assert.IsTrue(soulIdx < directivesIdx, "Soul should appear before directives");
+        Assert.IsTrue(directivesIdx < styleIdx, "Directives should appear before style");
+    }
+}

--- a/tests/RockBot.Host.Tests/FileAgentProfileProviderTests.cs
+++ b/tests/RockBot.Host.Tests/FileAgentProfileProviderTests.cs
@@ -1,0 +1,153 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace RockBot.Host.Tests;
+
+[TestClass]
+public class FileAgentProfileProviderTests
+{
+    private string _tempDir = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "rockbot-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(_tempDir, "agent"));
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    [TestMethod]
+    public async Task LoadAsync_WithAllFiles_ReturnsCompleteProfile()
+    {
+        WriteFile("agent/soul.md", "# My Soul\n\n## Identity\n\nI am helpful.");
+        WriteFile("agent/directives.md", "## Goal\n\nBe useful.");
+        WriteFile("agent/style.md", "## Tone\n\nFriendly.");
+
+        var provider = CreateProvider();
+        var profile = await provider.LoadAsync();
+
+        Assert.IsNotNull(profile.Soul);
+        Assert.AreEqual("soul", profile.Soul.DocumentType);
+        Assert.AreEqual(1, profile.Soul.Sections.Count);
+        Assert.AreEqual("Identity", profile.Soul.Sections[0].Name);
+
+        Assert.IsNotNull(profile.Directives);
+        Assert.AreEqual("directives", profile.Directives.DocumentType);
+
+        Assert.IsNotNull(profile.Style);
+        Assert.AreEqual("style", profile.Style.DocumentType);
+    }
+
+    [TestMethod]
+    public async Task LoadAsync_MissingOptionalStyle_ReturnsProfileWithNullStyle()
+    {
+        WriteFile("agent/soul.md", "## Identity\n\nI am helpful.");
+        WriteFile("agent/directives.md", "## Goal\n\nBe useful.");
+
+        var provider = CreateProvider();
+        var profile = await provider.LoadAsync();
+
+        Assert.IsNotNull(profile.Soul);
+        Assert.IsNotNull(profile.Directives);
+        Assert.IsNull(profile.Style);
+        Assert.AreEqual(2, profile.Documents.Count);
+    }
+
+    [TestMethod]
+    public async Task LoadAsync_MissingSoul_ThrowsFileNotFoundException()
+    {
+        WriteFile("agent/directives.md", "## Goal\n\nBe useful.");
+
+        var provider = CreateProvider();
+
+        var ex = await Assert.ThrowsExactlyAsync<FileNotFoundException>(
+            () => provider.LoadAsync());
+        Assert.IsTrue(ex.Message.Contains("soul"));
+    }
+
+    [TestMethod]
+    public async Task LoadAsync_MissingDirectives_ThrowsFileNotFoundException()
+    {
+        WriteFile("agent/soul.md", "## Identity\n\nI am helpful.");
+
+        var provider = CreateProvider();
+
+        var ex = await Assert.ThrowsExactlyAsync<FileNotFoundException>(
+            () => provider.LoadAsync());
+        Assert.IsTrue(ex.Message.Contains("directives"));
+    }
+
+    [TestMethod]
+    public async Task LoadAsync_CustomBasePath_ResolvesCorrectly()
+    {
+        var customDir = Path.Combine(_tempDir, "custom");
+        Directory.CreateDirectory(customDir);
+        File.WriteAllText(Path.Combine(customDir, "soul.md"), "## Identity\n\nCustom soul.");
+        File.WriteAllText(Path.Combine(customDir, "directives.md"), "## Goal\n\nCustom directives.");
+
+        var provider = CreateProvider(opts => opts.BasePath = customDir);
+        var profile = await provider.LoadAsync();
+
+        Assert.IsTrue(profile.Soul.RawContent.Contains("Custom soul."));
+    }
+
+    [TestMethod]
+    public async Task LoadAsync_AbsolutePaths_UsedDirectly()
+    {
+        var absDir = Path.Combine(_tempDir, "absolute");
+        Directory.CreateDirectory(absDir);
+        File.WriteAllText(Path.Combine(absDir, "my-soul.md"), "## Identity\n\nAbsolute soul.");
+        File.WriteAllText(Path.Combine(absDir, "my-directives.md"), "## Goal\n\nAbsolute directives.");
+
+        var provider = CreateProvider(opts =>
+        {
+            opts.SoulPath = Path.Combine(absDir, "my-soul.md");
+            opts.DirectivesPath = Path.Combine(absDir, "my-directives.md");
+            opts.StylePath = null;
+        });
+
+        var profile = await provider.LoadAsync();
+
+        Assert.IsTrue(profile.Soul.RawContent.Contains("Absolute soul."));
+    }
+
+    [TestMethod]
+    public async Task LoadAsync_StylePathNull_SkipsStyleEntirely()
+    {
+        WriteFile("agent/soul.md", "## Identity\n\nSoul.");
+        WriteFile("agent/directives.md", "## Goal\n\nDirectives.");
+        WriteFile("agent/style.md", "## Tone\n\nStyle exists but should be skipped.");
+
+        var provider = CreateProvider(opts => opts.StylePath = null);
+        var profile = await provider.LoadAsync();
+
+        Assert.IsNull(profile.Style);
+    }
+
+    private void WriteFile(string relativePath, string content)
+    {
+        var fullPath = Path.Combine(_tempDir, relativePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
+        File.WriteAllText(fullPath, content);
+    }
+
+    private FileAgentProfileProvider CreateProvider(Action<AgentProfileOptions>? configure = null)
+    {
+        // Use absolute BasePath so tests don't depend on AppContext.BaseDirectory
+        var opts = new AgentProfileOptions
+        {
+            BasePath = Path.Combine(_tempDir, "agent")
+        };
+        configure?.Invoke(opts);
+
+        return new FileAgentProfileProvider(
+            Options.Create(opts),
+            NullLogger<FileAgentProfileProvider>.Instance);
+    }
+}

--- a/tests/RockBot.Host.Tests/ProfileMarkdownParserTests.cs
+++ b/tests/RockBot.Host.Tests/ProfileMarkdownParserTests.cs
@@ -1,0 +1,158 @@
+namespace RockBot.Host.Tests;
+
+[TestClass]
+public class ProfileMarkdownParserTests
+{
+    [TestMethod]
+    public void Parse_EmptyContent_ReturnsEmptyDocument()
+    {
+        var doc = ProfileMarkdownParser.Parse("soul", "");
+
+        Assert.AreEqual("soul", doc.DocumentType);
+        Assert.IsNull(doc.Preamble);
+        Assert.AreEqual(0, doc.Sections.Count);
+        Assert.AreEqual("", doc.RawContent);
+    }
+
+    [TestMethod]
+    public void Parse_NoHeadings_EntireContentBecomesPreamble()
+    {
+        var content = """
+            # My Agent Soul
+
+            This agent is friendly and helpful.
+            It likes to tell jokes.
+            """;
+
+        var doc = ProfileMarkdownParser.Parse("soul", content);
+
+        Assert.IsNotNull(doc.Preamble);
+        Assert.IsTrue(doc.Preamble.Contains("My Agent Soul"));
+        Assert.IsTrue(doc.Preamble.Contains("friendly and helpful"));
+        Assert.AreEqual(0, doc.Sections.Count);
+    }
+
+    [TestMethod]
+    public void Parse_SingleSection_ParsesCorrectly()
+    {
+        var content = """
+            ## Identity
+
+            I am a helpful coding assistant.
+            """;
+
+        var doc = ProfileMarkdownParser.Parse("soul", content);
+
+        Assert.IsNull(doc.Preamble);
+        Assert.AreEqual(1, doc.Sections.Count);
+        Assert.AreEqual("Identity", doc.Sections[0].Name);
+        Assert.AreEqual("I am a helpful coding assistant.", doc.Sections[0].Content);
+    }
+
+    [TestMethod]
+    public void Parse_MultipleSections_ParsesAll()
+    {
+        var content = """
+            ## Identity
+
+            I am a helpful assistant.
+
+            ## Personality
+
+            Friendly and approachable.
+
+            ## Boundaries
+
+            Never give medical advice.
+            """;
+
+        var doc = ProfileMarkdownParser.Parse("directives", content);
+
+        Assert.AreEqual("directives", doc.DocumentType);
+        Assert.AreEqual(3, doc.Sections.Count);
+
+        Assert.AreEqual("Identity", doc.Sections[0].Name);
+        Assert.IsTrue(doc.Sections[0].Content.Contains("helpful assistant"));
+
+        Assert.AreEqual("Personality", doc.Sections[1].Name);
+        Assert.IsTrue(doc.Sections[1].Content.Contains("Friendly"));
+
+        Assert.AreEqual("Boundaries", doc.Sections[2].Name);
+        Assert.IsTrue(doc.Sections[2].Content.Contains("medical advice"));
+    }
+
+    [TestMethod]
+    public void Parse_PreambleBeforeSections_BothCaptured()
+    {
+        var content = """
+            # Echo Agent Soul
+
+            This is the soul of the echo agent.
+
+            ## Identity
+
+            I am an echo agent.
+
+            ## Worldview
+
+            I believe in repeating things.
+            """;
+
+        var doc = ProfileMarkdownParser.Parse("soul", content);
+
+        Assert.IsNotNull(doc.Preamble);
+        Assert.IsTrue(doc.Preamble.Contains("Echo Agent Soul"));
+        Assert.IsTrue(doc.Preamble.Contains("soul of the echo agent"));
+
+        Assert.AreEqual(2, doc.Sections.Count);
+        Assert.AreEqual("Identity", doc.Sections[0].Name);
+        Assert.AreEqual("Worldview", doc.Sections[1].Name);
+    }
+
+    [TestMethod]
+    public void Parse_PreservesRawContent()
+    {
+        var content = "## Identity\n\nI am a test agent.\n";
+
+        var doc = ProfileMarkdownParser.Parse("soul", content);
+
+        Assert.AreEqual(content, doc.RawContent);
+    }
+
+    [TestMethod]
+    public void Parse_WhitespaceOnlyPreamble_TreatedAsNull()
+    {
+        var content = """
+
+            ## Identity
+
+            Test content.
+            """;
+
+        var doc = ProfileMarkdownParser.Parse("soul", content);
+
+        Assert.IsNull(doc.Preamble);
+    }
+
+    [TestMethod]
+    public void Parse_SectionWithMultipleLines_ContentPreserved()
+    {
+        var content = """
+            ## Instructions
+
+            1. Always be helpful.
+            2. Use simple language.
+            3. Be concise.
+
+            Additional notes:
+            - Keep responses short.
+            """;
+
+        var doc = ProfileMarkdownParser.Parse("directives", content);
+
+        Assert.AreEqual(1, doc.Sections.Count);
+        var section = doc.Sections[0];
+        Assert.IsTrue(section.Content.Contains("1. Always be helpful."));
+        Assert.IsTrue(section.Content.Contains("Keep responses short."));
+    }
+}


### PR DESCRIPTION
## Summary

- Introduces `AgentProfile` as the LLM-layer complement to `AgentIdentity` (messaging-layer), with composable markdown documents (`soul.md`, `directives.md`, optional `style.md`) parsed at startup into system prompts
- Adds abstraction types, `ProfileMarkdownParser`, `FileAgentProfileProvider`, `DefaultSystemPromptBuilder`, `AgentProfileLoader` hosted service, and `WithProfile()` builder extension
- Updates the sample agent to use profile-based system prompts instead of the hardcoded string

## Test plan

- [x] 23 new unit tests covering parser, prompt builder, file provider, and DI registration (67 total, all passing)
- [ ] Run `RockBot.SampleAgent` — confirm it loads profile docs and LLM system prompt includes soul/directives content
- [ ] Delete `soul.md` from output — verify startup fails with clear `FileNotFoundException`
- [ ] Delete `style.md` — verify startup succeeds (optional file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)