### PR TITLE
feat: add RockBot.Scripts.Bridge for ephemeral K8s script execution

### DIFF
--- a/RockBot.slnx
+++ b/RockBot.slnx
@@ -16,6 +16,7 @@
     <Project Path="src/RockBot.Tools.Rest/RockBot.Tools.Rest.csproj" />
     <Project Path="src/RockBot.Scripts.Abstractions/RockBot.Scripts.Abstractions.csproj" />
     <Project Path="src/RockBot.Scripts.Container/RockBot.Scripts.Container.csproj" />
+    <Project Path="src/RockBot.Scripts.Bridge/RockBot.Scripts.Bridge.csproj" />
     <Project Path="src/RockBot.A2A.Abstractions/RockBot.A2A.Abstractions.csproj" />
     <Project Path="src/RockBot.A2A/RockBot.A2A.csproj" />
     <Project Path="src/RockBot.Telemetry/RockBot.Telemetry.csproj" />

--- a/src/RockBot.Scripts.Abstractions/IScriptRunner.cs
+++ b/src/RockBot.Scripts.Abstractions/IScriptRunner.cs
@@ -1,0 +1,9 @@
+namespace RockBot.Scripts;
+
+/// <summary>
+/// Executes scripts in isolated containers and returns the result.
+/// </summary>
+public interface IScriptRunner
+{
+    Task<ScriptInvokeResponse> ExecuteAsync(ScriptInvokeRequest request, CancellationToken ct);
+}

--- a/src/RockBot.Scripts.Bridge/Program.cs
+++ b/src/RockBot.Scripts.Bridge/Program.cs
@@ -1,0 +1,23 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using RockBot.Messaging.RabbitMQ;
+using RockBot.Scripts.Bridge;
+using RockBot.Scripts.Container;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.Services.AddRockBotRabbitMq();
+
+builder.Services.AddContainerScriptRunner(opts =>
+{
+    builder.Configuration.GetSection("Scripts:Container").Bind(opts);
+});
+
+builder.Services.Configure<ScriptBridgeOptions>(
+    builder.Configuration.GetSection("ScriptBridge"));
+
+builder.Services.AddHostedService<ScriptBridgeService>();
+
+var app = builder.Build();
+await app.RunAsync();

--- a/src/RockBot.Scripts.Bridge/RockBot.Scripts.Bridge.csproj
+++ b/src/RockBot.Scripts.Bridge/RockBot.Scripts.Bridge.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>RockBot.Scripts.Bridge</RootNamespace>
+    <UserSecretsId>b3f8e2a1-4c7d-4e9f-a012-3b5c6d7e8f90</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\RockBot.Scripts.Container\RockBot.Scripts.Container.csproj" />
+    <ProjectReference Include="..\RockBot.Messaging.RabbitMQ\RockBot.Messaging.RabbitMQ.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/RockBot.Scripts.Bridge/ScriptBridgeOptions.cs
+++ b/src/RockBot.Scripts.Bridge/ScriptBridgeOptions.cs
@@ -1,0 +1,19 @@
+namespace RockBot.Scripts.Bridge;
+
+/// <summary>
+/// Configuration options for the script bridge service.
+/// </summary>
+public sealed class ScriptBridgeOptions
+{
+    /// <summary>
+    /// Agent name used as the source identifier in published messages
+    /// and as the subscription queue name suffix. Defaults to "script-bridge".
+    /// </summary>
+    public string AgentName { get; set; } = "script-bridge";
+
+    /// <summary>
+    /// Default topic for publishing script results when no ReplyTo is set.
+    /// Defaults to "script.result".
+    /// </summary>
+    public string DefaultResultTopic { get; set; } = "script.result";
+}

--- a/src/RockBot.Scripts.Bridge/ScriptBridgeService.cs
+++ b/src/RockBot.Scripts.Bridge/ScriptBridgeService.cs
@@ -1,0 +1,111 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using RockBot.Messaging;
+using RockBot.Scripts;
+
+namespace RockBot.Scripts.Bridge;
+
+/// <summary>
+/// Hosted service that listens for script invocation requests on the message bus,
+/// executes them in ephemeral K8s pods via <see cref="IScriptRunner"/>,
+/// and publishes results back to the ReplyTo topic.
+/// </summary>
+public sealed class ScriptBridgeService : IHostedService, IAsyncDisposable
+{
+    private readonly IMessagePublisher _publisher;
+    private readonly IMessageSubscriber _subscriber;
+    private readonly IScriptRunner _runner;
+    private readonly ScriptBridgeOptions _options;
+    private readonly ILogger<ScriptBridgeService> _logger;
+
+    private ISubscription? _subscription;
+
+    public ScriptBridgeService(
+        IMessagePublisher publisher,
+        IMessageSubscriber subscriber,
+        IScriptRunner runner,
+        IOptions<ScriptBridgeOptions> options,
+        ILogger<ScriptBridgeService> logger)
+    {
+        _publisher = publisher;
+        _subscriber = subscriber;
+        _runner = runner;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Script bridge starting (agent={AgentName})", _options.AgentName);
+
+        _subscription = await _subscriber.SubscribeAsync(
+            "script.invoke",
+            $"script-bridge.{_options.AgentName}",
+            HandleScriptInvokeAsync,
+            cancellationToken);
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Script bridge stopping");
+
+        if (_subscription is not null)
+            await _subscription.DisposeAsync();
+    }
+
+    private async Task<MessageResult> HandleScriptInvokeAsync(MessageEnvelope envelope, CancellationToken ct)
+    {
+        var request = envelope.GetPayload<ScriptInvokeRequest>();
+        if (request is null)
+        {
+            _logger.LogWarning("Received script.invoke with null payload — dead-lettering");
+            return MessageResult.DeadLetter;
+        }
+
+        var replyTo = envelope.ReplyTo ?? _options.DefaultResultTopic;
+        var correlationId = envelope.CorrelationId;
+
+        _logger.LogInformation("→ script {ToolCallId} timeout={Timeout}s", request.ToolCallId, request.TimeoutSeconds);
+
+        ScriptInvokeResponse response;
+
+        try
+        {
+            response = await _runner.ExecuteAsync(request, ct);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Script {ToolCallId} runner threw unexpectedly", request.ToolCallId);
+
+            response = new ScriptInvokeResponse
+            {
+                ToolCallId = request.ToolCallId,
+                Stderr = ex.Message,
+                ExitCode = -1,
+                ElapsedMs = 0
+            };
+        }
+
+        if (response.IsSuccess)
+            _logger.LogInformation("← script {ToolCallId} OK in {ElapsedMs}ms", request.ToolCallId, response.ElapsedMs);
+        else
+            _logger.LogWarning("← script {ToolCallId} exit={ExitCode} in {ElapsedMs}ms: {Stderr}",
+                request.ToolCallId, response.ExitCode, response.ElapsedMs, response.Stderr);
+
+        var outEnvelope = response.ToEnvelope(source: _options.AgentName, correlationId: correlationId);
+        await _publisher.PublishAsync(replyTo, outEnvelope, ct);
+
+        return MessageResult.Ack;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_subscription is not null)
+            await _subscription.DisposeAsync();
+    }
+}

--- a/src/RockBot.Scripts.Bridge/appsettings.json
+++ b/src/RockBot.Scripts.Bridge/appsettings.json
@@ -1,0 +1,27 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "RabbitMQ": {
+    "Host": "localhost",
+    "Port": 5672,
+    "Username": "guest",
+    "Password": "guest",
+    "Exchange": "rockbot"
+  },
+  "ScriptBridge": {
+    "AgentName": "script-bridge",
+    "DefaultResultTopic": "script.result"
+  },
+  "Scripts": {
+    "Container": {
+      "Namespace": "rockbot-scripts",
+      "Image": "python:3.12-slim",
+      "CpuLimit": "500m",
+      "MemoryLimit": "256Mi"
+    }
+  }
+}

--- a/src/RockBot.Scripts.Container/ContainerScriptRunner.cs
+++ b/src/RockBot.Scripts.Container/ContainerScriptRunner.cs
@@ -12,7 +12,7 @@ namespace RockBot.Scripts.Container;
 internal sealed class ContainerScriptRunner(
     IKubernetes kubernetes,
     ContainerScriptOptions options,
-    ILogger<ContainerScriptRunner> logger)
+    ILogger<ContainerScriptRunner> logger) : IScriptRunner
 {
     public async Task<ScriptInvokeResponse> ExecuteAsync(ScriptInvokeRequest request, CancellationToken ct)
     {

--- a/src/RockBot.Scripts.Container/ContainerScriptServiceCollectionExtensions.cs
+++ b/src/RockBot.Scripts.Container/ContainerScriptServiceCollectionExtensions.cs
@@ -12,6 +12,26 @@ namespace RockBot.Scripts.Container;
 public static class ContainerScriptServiceCollectionExtensions
 {
     /// <summary>
+    /// Registers <see cref="IScriptRunner"/> backed by ephemeral K8s pods.
+    /// Use this when hosting the script runner as a standalone service (e.g. RockBot.Scripts.Bridge).
+    /// </summary>
+    public static IServiceCollection AddContainerScriptRunner(
+        this IServiceCollection services,
+        Action<ContainerScriptOptions>? configure = null)
+    {
+        var options = new ContainerScriptOptions();
+        configure?.Invoke(options);
+        services.AddSingleton(options);
+
+        services.TryAddSingleton<IKubernetes>(_ =>
+            new Kubernetes(KubernetesClientConfiguration.BuildDefaultConfig()));
+
+        services.AddSingleton<IScriptRunner, ContainerScriptRunner>();
+
+        return services;
+    }
+
+    /// <summary>
     /// Registers the container script handler and subscribes to "script.invoke".
     /// Also registers a ScriptToolExecutor in the tool registry for LLM tool invocation.
     /// </summary>

--- a/tests/RockBot.Scripts.Tests/KubernetesIntegrationTests.cs
+++ b/tests/RockBot.Scripts.Tests/KubernetesIntegrationTests.cs
@@ -1,0 +1,155 @@
+using k8s;
+using Microsoft.Extensions.Logging.Abstractions;
+using RockBot.Scripts;
+using RockBot.Scripts.Container;
+
+namespace RockBot.Scripts.Tests;
+
+/// <summary>
+/// End-to-end integration tests that spin up real K8s pods.
+/// Gated by the ROCKBOT_K8S_CONTEXT environment variable.
+/// Set it to any value (e.g. "docker-desktop" or "k3s") to enable.
+///
+/// Run with:
+///   ROCKBOT_K8S_CONTEXT=docker-desktop dotnet test --filter "ClassName~KubernetesIntegrationTests"
+/// </summary>
+[TestClass]
+public class KubernetesIntegrationTests
+{
+    private static IKubernetes? _kubernetes;
+    private static ContainerScriptOptions _options = new()
+    {
+        Namespace = "rockbot-scripts",
+        Image = "python:3.12-slim",
+        CpuLimit = "500m",
+        MemoryLimit = "256Mi"
+    };
+
+    [ClassInitialize]
+    public static void ClassInitialize(TestContext _)
+    {
+        var context = Environment.GetEnvironmentVariable("ROCKBOT_K8S_CONTEXT");
+        if (string.IsNullOrEmpty(context))
+            return;
+
+        var config = KubernetesClientConfiguration.BuildDefaultConfig();
+        _kubernetes = new Kubernetes(config);
+    }
+
+    private IScriptRunner CreateRunner()
+    {
+        if (_kubernetes is null)
+            Assert.Inconclusive("ROCKBOT_K8S_CONTEXT not set — skipping K8s integration tests");
+
+        return new ContainerScriptRunner(_kubernetes, _options, NullLogger<ContainerScriptRunner>.Instance);
+    }
+
+    [TestMethod]
+    public async Task ExecuteAsync_SimpleScript_ReturnsStdout()
+    {
+        var runner = CreateRunner();
+
+        var request = new ScriptInvokeRequest
+        {
+            ToolCallId = "test-simple",
+            Script = "print('hello from k8s')"
+        };
+
+        var response = await runner.ExecuteAsync(request, CancellationToken.None);
+
+        Assert.AreEqual(0, response.ExitCode);
+        Assert.IsTrue(response.IsSuccess);
+        StringAssert.Contains(response.Output, "hello from k8s");
+        Assert.IsTrue(response.ElapsedMs > 0);
+    }
+
+    [TestMethod]
+    public async Task ExecuteAsync_ScriptWithJsonOutput_ReturnsJson()
+    {
+        var runner = CreateRunner();
+
+        var request = new ScriptInvokeRequest
+        {
+            ToolCallId = "test-json",
+            Script = "import json; print(json.dumps({'result': 42, 'ok': True}))"
+        };
+
+        var response = await runner.ExecuteAsync(request, CancellationToken.None);
+
+        Assert.AreEqual(0, response.ExitCode);
+        StringAssert.Contains(response.Output, "\"result\"");
+        StringAssert.Contains(response.Output, "42");
+    }
+
+    [TestMethod]
+    public async Task ExecuteAsync_ScriptWithNonZeroExit_ReturnsFailure()
+    {
+        var runner = CreateRunner();
+
+        var request = new ScriptInvokeRequest
+        {
+            ToolCallId = "test-error",
+            Script = "raise ValueError('intentional error')"
+        };
+
+        var response = await runner.ExecuteAsync(request, CancellationToken.None);
+
+        Assert.AreNotEqual(0, response.ExitCode);
+        Assert.IsFalse(response.IsSuccess);
+    }
+
+    [TestMethod]
+    public async Task ExecuteAsync_ScriptWithInputData_ReadsFromEnvVar()
+    {
+        var runner = CreateRunner();
+
+        var request = new ScriptInvokeRequest
+        {
+            ToolCallId = "test-input",
+            Script = "import os; print(os.environ['ROCKBOT_INPUT'])",
+            InputData = "hello-input"
+        };
+
+        var response = await runner.ExecuteAsync(request, CancellationToken.None);
+
+        Assert.AreEqual(0, response.ExitCode);
+        StringAssert.Contains(response.Output, "hello-input");
+    }
+
+    [TestMethod]
+    public async Task ExecuteAsync_ScriptWithPipPackage_InstallsAndRuns()
+    {
+        var runner = CreateRunner();
+
+        var request = new ScriptInvokeRequest
+        {
+            ToolCallId = "test-pip",
+            Script = "import requests; print(requests.__version__)",
+            PipPackages = ["requests"],
+            TimeoutSeconds = 120
+        };
+
+        var response = await runner.ExecuteAsync(request, CancellationToken.None);
+
+        Assert.AreEqual(0, response.ExitCode);
+        Assert.IsNotNull(response.Output);
+    }
+
+    [TestMethod]
+    public async Task ExecuteAsync_ScriptTimeout_ReturnsTimeoutError()
+    {
+        var runner = CreateRunner();
+
+        var request = new ScriptInvokeRequest
+        {
+            ToolCallId = "test-timeout",
+            Script = "import time; time.sleep(300)",
+            TimeoutSeconds = 5
+        };
+
+        var response = await runner.ExecuteAsync(request, CancellationToken.None);
+
+        Assert.AreNotEqual(0, response.ExitCode);
+        Assert.IsFalse(response.IsSuccess);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `IScriptRunner` interface to `RockBot.Scripts.Abstractions` so the bridge can depend on the contract without coupling to K8s internals
- `ContainerScriptRunner` implements `IScriptRunner`; new `AddContainerScriptRunner(IServiceCollection)` extension enables standalone hosting alongside the existing agent-embedded `AddContainerScriptHandler`
- New `RockBot.Scripts.Bridge` project: plain `IHostedService` (same pattern as MCP bridge) that subscribes to `script.invoke`, executes Python in ephemeral K8s pods, and publishes `ScriptInvokeResponse` to the `ReplyTo` topic
- K8s integration tests added to `RockBot.Scripts.Tests`, gated by `ROCKBOT_K8S_CONTEXT` env var

## Test plan

- [ ] `dotnet test RockBot.slnx` — all unit tests pass, K8s tests skipped when env var not set
- [ ] `ROCKBOT_K8S_CONTEXT=<context> dotnet test --filter "ClassName~KubernetesIntegrationTests"` — runs end-to-end against real cluster (requires `rockbot-scripts` namespace)
- [ ] `dotnet run --project src/RockBot.Scripts.Bridge` — service starts and subscribes to `script.invoke`

🤖 Generated with [Claude Code](https://claude.com/claude-code)