### PR TITLE
docs: add README, LICENSE, and CODE_OF_CONDUCT

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,42 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and maintainers pledge to make participation in this project a respectful and harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy toward other community members
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery
+- Personal attacks or insults
+- Trolling or deliberately inflammatory comments
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, issues, and other contributions that do not align with this Code of Conduct, or to temporarily or permanently ban any contributor for behaviors they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces and when an individual is officially representing the project in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the maintainers via GitHub Issues. All complaints will be reviewed and investigated and will result in a response deemed necessary and appropriate to the circumstances. Maintainers are obligated to maintain confidentiality with regard to the reporter.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Marimer LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,170 @@
+# RockBot
+
+An event-driven autonomous agent framework for .NET 10.
+
+---
+
+## What is RockBot?
+
+RockBot is a framework for building **multi-agent AI systems** where agents communicate exclusively through a message bus. There is no shared memory, no direct method calls between agents, and no LLM-generated code running in-process with the host.
+
+Each agent is an isolated process that reacts to messages, invokes tools, calls LLMs, delegates work to other agents, and emits responses — all via a topic-based pub/sub message bus backed by RabbitMQ (or an in-process bus for local development).
+
+### Core components
+
+| Project | Purpose |
+|---|---|
+| `RockBot.Messaging.Abstractions` | Transport-agnostic contracts (`IMessagePublisher`, `IMessageSubscriber`, `MessageEnvelope`) |
+| `RockBot.Messaging.RabbitMQ` | RabbitMQ provider with topic exchanges and dead-letter queues |
+| `RockBot.Messaging.InProcess` | In-memory bus for local development and testing |
+| `RockBot.Host` | Agent host runtime — receives messages and dispatches through the handler pipeline |
+| `RockBot.Llm` | LLM integration via `Microsoft.Extensions.AI` |
+| `RockBot.Tools` / `RockBot.Tools.Mcp` | Tool invocation — REST and MCP (Model Context Protocol) |
+| `RockBot.Scripts.Container` | Ephemeral script execution in isolated Kubernetes containers |
+| `RockBot.A2A` | Agent-to-agent task delegation over the message bus |
+| `RockBot.Cli` | Unified host application — runs agents as hosted services |
+
+---
+
+## Why RockBot?
+
+Most AI agent frameworks run LLM-generated code in the same process as the host application. This creates serious security and coupling problems:
+
+- **LLM code can access the host directly** — file system, network, secrets, everything
+- **Swapping LLM providers or tool backends** requires invasive changes throughout the codebase
+- **One runaway agent** can crash or compromise the entire system
+- **Scaling individual components** is impractical when everything runs together
+
+RockBot is built around four foundational design goals:
+
+### Separation of concerns
+
+Every responsibility in the system has a clear owner with a well-defined boundary. Agents handle reasoning. The message bus handles routing. Tool bridges handle execution. LLM providers handle inference. None of these cross into each other's domain — they communicate only through typed messages. This makes each layer independently testable, replaceable, and understandable.
+
+### Isolation of execution
+
+LLM-generated code never runs in the same process as the host. Agents run in **separate processes** with no shared memory. Scripts execute in **ephemeral Kubernetes containers** that are discarded immediately after use. A compromised or runaway agent cannot access the host, read its secrets, or affect other agents. Failure is contained by design.
+
+### Principle of least privilege
+
+Each component knows only what it needs to do its job. Agents receive only the messages addressed to them. Tool bridges expose only the tools they are explicitly configured to serve. Scripts run in containers with no network access, no persistent storage, and no credentials. No component accumulates capabilities or context beyond its immediate task.
+
+### Cloud-native by design
+
+RockBot assumes it will run in a distributed, containerized environment. Agents are **stateless** — state lives in messages or external stores, never in process memory. Components **scale independently** — add more LLM workers without touching tool bridges, or scale script runners without restarting agents. The message bus provides **back-pressure, dead-letter queues, and durability** so the system degrades gracefully under load. Configuration flows in from the environment, secrets from Kubernetes Secrets, and observability out through OpenTelemetry.
+
+The result is a swarm of agents that coordinate through messages, where the failure or compromise of any single component cannot cascade system-wide.
+
+---
+
+## Deployment
+
+### Prerequisites
+
+- [.NET 10 SDK](https://dotnet.microsoft.com/download)
+- [RabbitMQ](https://www.rabbitmq.com/download.html) (or Docker: `docker run -d -p 5672:5672 rabbitmq:4`)
+- Kubernetes cluster (required only for ephemeral script execution)
+
+### Build
+
+```bash
+dotnet build RockBot.slnx
+```
+
+### Run tests
+
+Unit tests only (no external dependencies):
+
+```bash
+dotnet test RockBot.slnx
+```
+
+Unit tests + RabbitMQ integration tests:
+
+```bash
+ROCKBOT_RABBITMQ_HOST=localhost dotnet test RockBot.slnx
+```
+
+### Configuration
+
+RockBot uses the standard .NET configuration stack. Create an `appsettings.json` alongside `RockBot.Cli` or use environment variables:
+
+```json
+{
+  "RabbitMq": {
+    "Host": "localhost",
+    "Port": 5672,
+    "Username": "guest",
+    "Password": "guest"
+  }
+}
+```
+
+For local secrets (do not commit credentials):
+
+```bash
+dotnet user-secrets set "RabbitMq:Password" "your-password" --project src/RockBot.Cli
+```
+
+For production, inject secrets via Kubernetes Secrets as environment variables.
+
+### Run the agent host
+
+```bash
+dotnet run --project src/RockBot.Cli
+```
+
+### Agent profiles
+
+Each agent is configured through three markdown files in its working directory:
+
+| File | Purpose |
+|---|---|
+| `soul.md` | Core identity, values, and goals |
+| `directives.md` | Behavioral rules and constraints |
+| `style.md` | Tone, formatting, and communication style |
+
+These files are human-readable, version-controlled, and composed at runtime into the agent's system prompt.
+
+### MCP tool configuration
+
+Place an `mcp.json` file alongside `RockBot.Cli` to configure MCP server connections. The MCP bridge will discover and register available tools automatically.
+
+---
+
+## Contributing
+
+Contributions are welcome. Please open an issue before starting significant work so we can discuss the approach.
+
+### Getting started
+
+1. Fork the repository and create a branch from `main`
+2. Make your changes with tests covering new behavior
+3. Ensure all tests pass: `dotnet test RockBot.slnx`
+4. Open a pull request with a clear description of what changed and why
+
+### Guidelines
+
+- **Keep it simple.** Avoid over-engineering. Add only what the current task requires.
+- **Async-first.** All I/O must be `Task`-based — no blocking calls.
+- **Nullable reference types are enabled.** Respect null-safety throughout.
+- **Use Rocks for mocking**, not Moq.
+- **Integration tests** should return `Assert.Inconclusive` when RabbitMQ is unavailable, not fail.
+- **Console apps** use `Spectre.Console` for argument parsing and output.
+- **Configuration** goes through the standard .NET configuration stack — no custom mechanisms.
+
+### Code of conduct
+
+This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating, you agree to uphold it.
+
+---
+
+## Acknowledgements
+
+RockBot is inspired by [OpenClaw](https://openclaw.ai/) and [NanoBot](https://github.com/HKUDS/nanobot), both of which explored multi-agent coordination and tool-augmented LLM systems. RockBot builds on those ideas with a stronger emphasis on process isolation, least-privilege execution, and cloud-native deployment.
+
+---
+
+## License
+
+[MIT](LICENSE)


### PR DESCRIPTION
## Summary

- Adds `README.md` covering what RockBot is, why it exists (separation of concerns, isolation of execution, principle of least privilege, cloud-native design), deployment instructions, and contributing guidelines
- Adds `LICENSE` (MIT)
- Adds `CODE_OF_CONDUCT.md` (Contributor Covenant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)