### PR TITLE
refactor: extract memory tools into RockBot.Memory class library

### DIFF
--- a/RockBot.slnx
+++ b/RockBot.slnx
@@ -21,6 +21,7 @@
     <Project Path="src/RockBot.UserProxy.Abstractions/RockBot.UserProxy.Abstractions.csproj" />
     <Project Path="src/RockBot.UserProxy/RockBot.UserProxy.csproj" />
     <Project Path="src/RockBot.UserProxy.Cli/RockBot.UserProxy.Cli.csproj" />
+    <Project Path="src/RockBot.Memory/RockBot.Memory.csproj" />
     <Project Path="src/RockBot.Cli/RockBot.Cli.csproj" />
   </Folder>
   <Folder Name="/tests/">

--- a/src/RockBot.Cli/Program.cs
+++ b/src/RockBot.Cli/Program.cs
@@ -11,6 +11,7 @@ using RockBot.Cli.McpBridge;
 using RockBot.Cli.ScriptBridge;
 using RockBot.Scripts.Container;
 using RockBot.Cli;
+using RockBot.Memory;
 using RockBot.Tools;
 using RockBot.Tools.Mcp;
 using RockBot.UserProxy;

--- a/src/RockBot.Cli/RockBot.Cli.csproj
+++ b/src/RockBot.Cli/RockBot.Cli.csproj
@@ -31,6 +31,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\RockBot.Host.Abstractions\RockBot.Host.Abstractions.csproj" />
+    <ProjectReference Include="..\RockBot.Memory\RockBot.Memory.csproj" />
     <ProjectReference Include="..\RockBot.Tools\RockBot.Tools.csproj" />
     <ProjectReference Include="..\RockBot.Tools.Mcp\RockBot.Tools.Mcp.csproj" />
     <ProjectReference Include="..\RockBot.Host\RockBot.Host.csproj" />

--- a/src/RockBot.Cli/UserMessageHandler.cs
+++ b/src/RockBot.Cli/UserMessageHandler.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
 using RockBot.Host;
+using RockBot.Memory;
 using RockBot.Messaging;
 using RockBot.Tools;
 using RockBot.UserProxy;

--- a/src/RockBot.Memory/InjectedMemoryTracker.cs
+++ b/src/RockBot.Memory/InjectedMemoryTracker.cs
@@ -1,6 +1,6 @@
 using System.Collections.Concurrent;
 
-namespace RockBot.Cli;
+namespace RockBot.Memory;
 
 /// <summary>
 /// Tracks which long-term memory entry IDs have already been injected into each session's
@@ -11,7 +11,7 @@ namespace RockBot.Cli;
 /// Registered as a singleton. State is in-process and resets on restart (intentional — the
 /// LLM's context window resets too, so re-injection on the next process start is correct).
 /// </summary>
-internal sealed class InjectedMemoryTracker
+public sealed class InjectedMemoryTracker
 {
     // sessionId -> set of already-injected memory IDs
     // ConcurrentDictionary<string, byte> is the standard concurrent hash-set pattern.

--- a/src/RockBot.Memory/MemoryTools.cs
+++ b/src/RockBot.Memory/MemoryTools.cs
@@ -6,14 +6,14 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using RockBot.Host;
 
-namespace RockBot.Cli;
+namespace RockBot.Memory;
 
 /// <summary>
 /// LLM-callable tools for managing long-term agent memory.
 /// Methods are discovered by <c>AIFunctionFactory.Create</c> and exposed to the LLM.
 /// Registered as a singleton so <see cref="AIFunction"/> instances are built once.
 /// </summary>
-internal sealed class MemoryTools
+public sealed class MemoryTools
 {
     private static readonly JsonSerializerOptions JsonOptions = new()
     {

--- a/src/RockBot.Memory/RockBot.Memory.csproj
+++ b/src/RockBot.Memory/RockBot.Memory.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>RockBot.Memory</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.AI" Version="10.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\RockBot.Host.Abstractions\RockBot.Host.Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/RockBot.Memory/WorkingMemoryTools.cs
+++ b/src/RockBot.Memory/WorkingMemoryTools.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
 using RockBot.Host;
 
-namespace RockBot.Cli;
+namespace RockBot.Memory;
 
 /// <summary>
 /// LLM-callable tools for session-scoped working memory — a scratch space for caching
@@ -13,7 +13,7 @@ namespace RockBot.Cli;
 ///
 /// Instantiated per-message with the session ID baked in so no ambient session state is needed.
 /// </summary>
-internal sealed class WorkingMemoryTools
+public sealed class WorkingMemoryTools
 {
     private readonly IWorkingMemory _workingMemory;
     private readonly string _sessionId;

--- a/tests/RockBot.Cli.Tests/InjectedMemoryTrackerTests.cs
+++ b/tests/RockBot.Cli.Tests/InjectedMemoryTrackerTests.cs
@@ -1,6 +1,6 @@
-using RockBot.Cli;
+using RockBot.Memory;
 
-namespace RockBot.Cli.Tests;
+namespace RockBot.Memory.Tests;
 
 [TestClass]
 public class InjectedMemoryTrackerTests

--- a/tests/RockBot.Cli.Tests/MemoryToolsTests.cs
+++ b/tests/RockBot.Cli.Tests/MemoryToolsTests.cs
@@ -1,9 +1,9 @@
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging.Abstractions;
 using RockBot.Host;
-using RockBot.Cli;
+using RockBot.Memory;
 
-namespace RockBot.Cli.Tests;
+namespace RockBot.Memory.Tests;
 
 [TestClass]
 public class MemoryToolsTests

--- a/tests/RockBot.Cli.Tests/RockBot.Cli.Tests.csproj
+++ b/tests/RockBot.Cli.Tests/RockBot.Cli.Tests.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\RockBot.Cli\RockBot.Cli.csproj" />
+    <ProjectReference Include="..\..\src\RockBot.Memory\RockBot.Memory.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

- Moves `MemoryTools`, `WorkingMemoryTools`, and `InjectedMemoryTracker` from `RockBot.Cli` into a new `RockBot.Memory` class library
- `RockBot.Cli` gains a project reference to `RockBot.Memory`; the agent executable is now a thin compositor rather than owning memory tool logic
- Test namespaces updated to reflect the new home; all 30 existing tests continue to pass

Closes #13

## Test plan

- [x] `dotnet build RockBot.slnx` — 0 errors
- [x] `dotnet test RockBot.slnx` — all unit tests pass (30/30 in `RockBot.Cli.Tests`, 411 total across all suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)