### PR TITLE
refactor: extract skill tools into RockBot.Skills class library

### DIFF
--- a/RockBot.slnx
+++ b/RockBot.slnx
@@ -22,6 +22,7 @@
     <Project Path="src/RockBot.UserProxy/RockBot.UserProxy.csproj" />
     <Project Path="src/RockBot.UserProxy.Cli/RockBot.UserProxy.Cli.csproj" />
     <Project Path="src/RockBot.Memory/RockBot.Memory.csproj" />
+    <Project Path="src/RockBot.Skills/RockBot.Skills.csproj" />
     <Project Path="src/RockBot.Cli/RockBot.Cli.csproj" />
   </Folder>
   <Folder Name="/tests/">

--- a/src/RockBot.Cli/Program.cs
+++ b/src/RockBot.Cli/Program.cs
@@ -12,6 +12,7 @@ using RockBot.Cli.ScriptBridge;
 using RockBot.Scripts.Container;
 using RockBot.Cli;
 using RockBot.Memory;
+using RockBot.Skills;
 using RockBot.Tools;
 using RockBot.Tools.Mcp;
 using RockBot.UserProxy;

--- a/src/RockBot.Cli/RockBot.Cli.csproj
+++ b/src/RockBot.Cli/RockBot.Cli.csproj
@@ -32,6 +32,7 @@
   <ItemGroup>
     <ProjectReference Include="..\RockBot.Host.Abstractions\RockBot.Host.Abstractions.csproj" />
     <ProjectReference Include="..\RockBot.Memory\RockBot.Memory.csproj" />
+    <ProjectReference Include="..\RockBot.Skills\RockBot.Skills.csproj" />
     <ProjectReference Include="..\RockBot.Tools\RockBot.Tools.csproj" />
     <ProjectReference Include="..\RockBot.Tools.Mcp\RockBot.Tools.Mcp.csproj" />
     <ProjectReference Include="..\RockBot.Host\RockBot.Host.csproj" />

--- a/src/RockBot.Cli/UserMessageHandler.cs
+++ b/src/RockBot.Cli/UserMessageHandler.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging;
 using RockBot.Host;
 using RockBot.Memory;
 using RockBot.Messaging;
+using RockBot.Skills;
 using RockBot.Tools;
 using RockBot.UserProxy;
 

--- a/src/RockBot.Skills/RockBot.Skills.csproj
+++ b/src/RockBot.Skills/RockBot.Skills.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>RockBot.Skills</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.AI" Version="10.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.*" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\RockBot.Host.Abstractions\RockBot.Host.Abstractions.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/RockBot.Skills/SkillIndexTracker.cs
+++ b/src/RockBot.Skills/SkillIndexTracker.cs
@@ -1,13 +1,13 @@
 using System.Collections.Concurrent;
 
-namespace RockBot.Cli;
+namespace RockBot.Skills;
 
 /// <summary>
 /// Tracks which sessions have already received the skill index injection,
 /// so it is only injected once per session rather than on every turn.
 /// Registered as a singleton.
 /// </summary>
-internal sealed class SkillIndexTracker
+public sealed class SkillIndexTracker
 {
     private readonly ConcurrentDictionary<string, byte> _injectedSessions = new();
 

--- a/src/RockBot.Skills/SkillTools.cs
+++ b/src/RockBot.Skills/SkillTools.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
 using RockBot.Host;
 
-namespace RockBot.Cli;
+namespace RockBot.Skills;
 
 /// <summary>
 /// LLM-callable tools for managing agent skills — named markdown procedure documents
@@ -14,7 +14,7 @@ namespace RockBot.Cli;
 /// Background LLM calls generate summaries for newly saved skills, mirroring the memory
 /// enrichment pattern in <see cref="MemoryTools"/>.
 /// </summary>
-internal sealed class SkillTools
+public sealed class SkillTools
 {
     private const string SummarySystemPrompt =
         """
@@ -152,7 +152,7 @@ internal sealed class SkillTools
     }
 
     /// <summary>Formats the skill list as the index block shown to the LLM.</summary>
-    internal static string FormatIndex(IReadOnlyList<Skill> skills)
+    public static string FormatIndex(IReadOnlyList<Skill> skills)
     {
         if (skills.Count == 0)
             return "No skills saved yet.";

--- a/tests/RockBot.Cli.Tests/RockBot.Cli.Tests.csproj
+++ b/tests/RockBot.Cli.Tests/RockBot.Cli.Tests.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\RockBot.Cli\RockBot.Cli.csproj" />
     <ProjectReference Include="..\..\src\RockBot.Memory\RockBot.Memory.csproj" />
+    <ProjectReference Include="..\..\src\RockBot.Skills\RockBot.Skills.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/RockBot.Cli.Tests/SkillToolsTests.cs
+++ b/tests/RockBot.Cli.Tests/SkillToolsTests.cs
@@ -1,7 +1,7 @@
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging.Abstractions;
 using RockBot.Host;
-using RockBot.Cli;
+using RockBot.Skills;
 
 namespace RockBot.Cli.Tests;
 


### PR DESCRIPTION
## Summary

- Moves `SkillTools` and `SkillIndexTracker` out of `RockBot.Cli` into a new `RockBot.Skills` class library, mirroring the `RockBot.Memory` extraction pattern (closes #12)
- `FileSkillStore`, `ISkillStore`, `Skill`, `SkillOptions`, and `WithSkills()` remain in `RockBot.Host` / `RockBot.Host.Abstractions`
- Both types changed from `internal sealed` to `public sealed`; namespace changed from `RockBot.Cli` to `RockBot.Skills`

## Test plan

- [x] `dotnet build RockBot.slnx` — 0 errors
- [x] `SkillToolsTests` (13 tests) — all pass
- [x] Existing `FileSkillStoreTests` in `RockBot.Host.Tests` unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)