### PR TITLE
feat: implement web search and browse tools (closes #8)

### DIFF
--- a/RockBot.slnx
+++ b/RockBot.slnx
@@ -24,6 +24,7 @@
     <Project Path="src/RockBot.Memory/RockBot.Memory.csproj" />
     <Project Path="src/RockBot.Skills/RockBot.Skills.csproj" />
     <Project Path="src/RockBot.Cli/RockBot.Cli.csproj" />
+    <Project Path="src/RockBot.Tools.Web/RockBot.Tools.Web.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/RockBot.Host.Tests/RockBot.Host.Tests.csproj" />
@@ -34,6 +35,7 @@
     <Project Path="tests/RockBot.Telemetry.Tests/RockBot.Telemetry.Tests.csproj" />
     <Project Path="tests/RockBot.UserProxy.Tests/RockBot.UserProxy.Tests.csproj" />
     <Project Path="tests/RockBot.Cli.Tests/RockBot.Cli.Tests.csproj" />
+    <Project Path="tests/RockBot.Tools.Web.Tests/RockBot.Tools.Web.Tests.csproj" />
   </Folder>
   <Project Path="src/RockBot.Messaging.Abstractions/RockBot.Messaging.Abstractions.csproj" />
   <Project Path="src/RockBot.Messaging.RabbitMQ/RockBot.Messaging.RabbitMQ.csproj" />

--- a/src/RockBot.Tools.Web/Brave/BraveSearchProvider.cs
+++ b/src/RockBot.Tools.Web/Brave/BraveSearchProvider.cs
@@ -1,0 +1,51 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace RockBot.Tools.Web.Brave;
+
+internal sealed class BraveSearchProvider(
+    IHttpClientFactory httpClientFactory,
+    WebToolOptions options,
+    ILogger<BraveSearchProvider> logger) : IWebSearchProvider
+{
+    private const string BaseUrl = "https://api.search.brave.com/res/v1/web/search";
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    public async Task<IReadOnlyList<WebSearchResult>> SearchAsync(string query, int maxResults, CancellationToken ct)
+    {
+        var apiKey = Environment.GetEnvironmentVariable(options.ApiKeyEnvVar);
+        if (string.IsNullOrEmpty(apiKey))
+        {
+            logger.LogWarning("Brave API key not found in environment variable '{EnvVar}'", options.ApiKeyEnvVar);
+            return [];
+        }
+
+        using var client = httpClientFactory.CreateClient("RockBot.Tools.Web.Brave");
+
+        var count = Math.Min(maxResults, 20);
+        var url = $"{BaseUrl}?q={Uri.EscapeDataString(query)}&count={count}";
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Add("Accept", "application/json");
+        request.Headers.Add("X-Subscription-Token", apiKey);
+
+        using var response = await client.SendAsync(request, ct);
+        response.EnsureSuccessStatusCode();
+
+        var json = await response.Content.ReadAsStringAsync(ct);
+        var braveResponse = JsonSerializer.Deserialize<BraveSearchResponse>(json, JsonOptions);
+
+        if (braveResponse?.Web?.Results is null)
+            return [];
+
+        return braveResponse.Web.Results
+            .Where(r => r.Title is not null && r.Url is not null)
+            .Select(r => new WebSearchResult
+            {
+                Title = r.Title!,
+                Url = r.Url!,
+                Snippet = r.Description ?? string.Empty
+            })
+            .ToList();
+    }
+}

--- a/src/RockBot.Tools.Web/Brave/BraveSearchResponse.cs
+++ b/src/RockBot.Tools.Web/Brave/BraveSearchResponse.cs
@@ -1,0 +1,27 @@
+using System.Text.Json.Serialization;
+
+namespace RockBot.Tools.Web.Brave;
+
+internal sealed class BraveSearchResponse
+{
+    [JsonPropertyName("web")]
+    public BraveWebResults? Web { get; set; }
+}
+
+internal sealed class BraveWebResults
+{
+    [JsonPropertyName("results")]
+    public List<BraveResult>? Results { get; set; }
+}
+
+internal sealed class BraveResult
+{
+    [JsonPropertyName("title")]
+    public string? Title { get; set; }
+
+    [JsonPropertyName("url")]
+    public string? Url { get; set; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+}

--- a/src/RockBot.Tools.Web/HttpWebBrowseProvider.cs
+++ b/src/RockBot.Tools.Web/HttpWebBrowseProvider.cs
@@ -1,0 +1,39 @@
+using AngleSharp;
+using AngleSharp.Dom;
+using Microsoft.Extensions.Logging;
+
+namespace RockBot.Tools.Web;
+
+internal sealed class HttpWebBrowseProvider(
+    IHttpClientFactory httpClientFactory,
+    ILogger<HttpWebBrowseProvider> logger) : IWebBrowseProvider
+{
+    public async Task<WebPageContent> FetchAsync(string url, CancellationToken ct)
+    {
+        using var client = httpClientFactory.CreateClient("RockBot.Tools.Web.Browse");
+        var html = await client.GetStringAsync(url, ct);
+
+        var config = Configuration.Default;
+        var context = BrowsingContext.New(config);
+        var document = await context.OpenAsync(req => req.Content(html), ct);
+
+        var title = document.Title ?? string.Empty;
+
+        foreach (var element in document.QuerySelectorAll("script, style").ToList())
+            element.Remove();
+
+        var cleanedHtml = document.Body?.InnerHtml ?? html;
+
+        var converter = new ReverseMarkdown.Converter();
+        var markdown = converter.Convert(cleanedHtml);
+
+        logger.LogDebug("Fetched and converted {Url} ({Length} chars of Markdown)", url, markdown.Length);
+
+        return new WebPageContent
+        {
+            Title = title,
+            Content = markdown,
+            SourceUrl = url
+        };
+    }
+}

--- a/src/RockBot.Tools.Web/IWebBrowseProvider.cs
+++ b/src/RockBot.Tools.Web/IWebBrowseProvider.cs
@@ -1,0 +1,12 @@
+namespace RockBot.Tools.Web;
+
+/// <summary>
+/// Provider-agnostic interface for fetching web page content.
+/// </summary>
+public interface IWebBrowseProvider
+{
+    /// <summary>
+    /// Fetch a web page and return its content as Markdown.
+    /// </summary>
+    Task<WebPageContent> FetchAsync(string url, CancellationToken ct);
+}

--- a/src/RockBot.Tools.Web/IWebSearchProvider.cs
+++ b/src/RockBot.Tools.Web/IWebSearchProvider.cs
@@ -1,0 +1,12 @@
+namespace RockBot.Tools.Web;
+
+/// <summary>
+/// Provider-agnostic interface for web search.
+/// </summary>
+public interface IWebSearchProvider
+{
+    /// <summary>
+    /// Search the web and return a list of results.
+    /// </summary>
+    Task<IReadOnlyList<WebSearchResult>> SearchAsync(string query, int maxResults, CancellationToken ct);
+}

--- a/src/RockBot.Tools.Web/RockBot.Tools.Web.csproj
+++ b/src/RockBot.Tools.Web/RockBot.Tools.Web.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>RockBot.Tools.Web</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="RockBot.Tools.Web.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AngleSharp" Version="1.4.*" />
+    <PackageReference Include="ReverseMarkdown" Version="4.*" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\RockBot.Tools.Abstractions\RockBot.Tools.Abstractions.csproj" />
+    <ProjectReference Include="..\RockBot.Host\RockBot.Host.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/RockBot.Tools.Web/WebBrowseToolExecutor.cs
+++ b/src/RockBot.Tools.Web/WebBrowseToolExecutor.cs
@@ -1,0 +1,62 @@
+using System.Text.Json;
+
+namespace RockBot.Tools.Web;
+
+internal sealed class WebBrowseToolExecutor(IWebBrowseProvider browseProvider) : IToolExecutor
+{
+    public async Task<ToolInvokeResponse> ExecuteAsync(ToolInvokeRequest request, CancellationToken ct)
+    {
+        string url;
+
+        try
+        {
+            var args = ParseArguments(request.Arguments);
+            if (!args.TryGetValue("url", out var urlElement))
+                return Error(request, "Missing required argument: url");
+
+            url = urlElement.GetString() ?? string.Empty;
+        }
+        catch (Exception ex)
+        {
+            return Error(request, $"Invalid arguments: {ex.Message}");
+        }
+
+        try
+        {
+            var page = await browseProvider.FetchAsync(url, ct);
+
+            var content = string.IsNullOrWhiteSpace(page.Title)
+                ? page.Content
+                : $"# {page.Title}\n\n{page.Content}";
+
+            return new ToolInvokeResponse
+            {
+                ToolCallId = request.ToolCallId,
+                ToolName = request.ToolName,
+                Content = content,
+                IsError = false
+            };
+        }
+        catch (Exception ex)
+        {
+            return Error(request, $"Failed to fetch page: {ex.Message}");
+        }
+    }
+
+    private static ToolInvokeResponse Error(ToolInvokeRequest request, string message) =>
+        new()
+        {
+            ToolCallId = request.ToolCallId,
+            ToolName = request.ToolName,
+            Content = message,
+            IsError = true
+        };
+
+    private static Dictionary<string, JsonElement> ParseArguments(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+            return [];
+
+        return JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json) ?? [];
+    }
+}

--- a/src/RockBot.Tools.Web/WebPageContent.cs
+++ b/src/RockBot.Tools.Web/WebPageContent.cs
@@ -1,0 +1,16 @@
+namespace RockBot.Tools.Web;
+
+/// <summary>
+/// Fetched web page content in Markdown format.
+/// </summary>
+public sealed record WebPageContent
+{
+    public required string Title { get; init; }
+
+    /// <summary>
+    /// Page body converted to Markdown.
+    /// </summary>
+    public required string Content { get; init; }
+
+    public required string SourceUrl { get; init; }
+}

--- a/src/RockBot.Tools.Web/WebSearchResult.cs
+++ b/src/RockBot.Tools.Web/WebSearchResult.cs
@@ -1,0 +1,11 @@
+namespace RockBot.Tools.Web;
+
+/// <summary>
+/// A single web search result.
+/// </summary>
+public sealed record WebSearchResult
+{
+    public required string Title { get; init; }
+    public required string Url { get; init; }
+    public required string Snippet { get; init; }
+}

--- a/src/RockBot.Tools.Web/WebSearchToolExecutor.cs
+++ b/src/RockBot.Tools.Web/WebSearchToolExecutor.cs
@@ -1,0 +1,87 @@
+using System.Text;
+using System.Text.Json;
+
+namespace RockBot.Tools.Web;
+
+internal sealed class WebSearchToolExecutor(
+    IWebSearchProvider searchProvider,
+    WebToolOptions options) : IToolExecutor
+{
+    public async Task<ToolInvokeResponse> ExecuteAsync(ToolInvokeRequest request, CancellationToken ct)
+    {
+        string query;
+        int count = options.MaxSearchResults;
+
+        try
+        {
+            var args = ParseArguments(request.Arguments);
+            if (!args.TryGetValue("query", out var queryElement))
+            {
+                return Error(request, "Missing required argument: query");
+            }
+
+            query = queryElement.GetString() ?? string.Empty;
+
+            if (args.TryGetValue("count", out var countElement) && countElement.ValueKind == JsonValueKind.Number)
+                count = Math.Min(countElement.GetInt32(), 20);
+        }
+        catch (Exception ex)
+        {
+            return Error(request, $"Invalid arguments: {ex.Message}");
+        }
+
+        try
+        {
+            var results = await searchProvider.SearchAsync(query, count, ct);
+
+            if (results.Count == 0)
+            {
+                return new ToolInvokeResponse
+                {
+                    ToolCallId = request.ToolCallId,
+                    ToolName = request.ToolName,
+                    Content = "No results found.",
+                    IsError = false
+                };
+            }
+
+            var sb = new StringBuilder();
+            for (int i = 0; i < results.Count; i++)
+            {
+                var r = results[i];
+                sb.AppendLine($"{i + 1}. [{r.Title}]({r.Url})");
+                if (!string.IsNullOrWhiteSpace(r.Snippet))
+                    sb.AppendLine($"   {r.Snippet}");
+            }
+
+            return new ToolInvokeResponse
+            {
+                ToolCallId = request.ToolCallId,
+                ToolName = request.ToolName,
+                Content = sb.ToString().TrimEnd(),
+                IsError = false
+            };
+        }
+        catch (Exception ex)
+        {
+            return Error(request, $"Search failed: {ex.Message}");
+        }
+    }
+
+    private static ToolInvokeResponse Error(ToolInvokeRequest request, string message) =>
+        new()
+        {
+            ToolCallId = request.ToolCallId,
+            ToolName = request.ToolName,
+            Content = message,
+            IsError = true
+        };
+
+    private static Dictionary<string, JsonElement> ParseArguments(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+            return [];
+
+        return JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json) ?? [];
+    }
+}

--- a/src/RockBot.Tools.Web/WebServiceCollectionExtensions.cs
+++ b/src/RockBot.Tools.Web/WebServiceCollectionExtensions.cs
@@ -1,0 +1,33 @@
+using Microsoft.Extensions.DependencyInjection;
+using RockBot.Host;
+using RockBot.Tools.Web.Brave;
+
+namespace RockBot.Tools.Web;
+
+/// <summary>
+/// DI registration extensions for web tools.
+/// </summary>
+public static class WebServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers web search and browse tools.
+    /// </summary>
+    public static AgentHostBuilder AddWebTools(
+        this AgentHostBuilder builder,
+        Action<WebToolOptions> configure)
+    {
+        var options = new WebToolOptions();
+        configure(options);
+        builder.Services.AddSingleton(options);
+
+        builder.Services.AddHttpClient("RockBot.Tools.Web.Brave");
+        builder.Services.AddHttpClient("RockBot.Tools.Web.Browse");
+
+        builder.Services.AddSingleton<IWebSearchProvider, BraveSearchProvider>();
+        builder.Services.AddSingleton<IWebBrowseProvider, HttpWebBrowseProvider>();
+
+        builder.Services.AddHostedService<WebToolRegistrar>();
+
+        return builder;
+    }
+}

--- a/src/RockBot.Tools.Web/WebToolOptions.cs
+++ b/src/RockBot.Tools.Web/WebToolOptions.cs
@@ -1,0 +1,22 @@
+namespace RockBot.Tools.Web;
+
+/// <summary>
+/// Configuration options for web tools.
+/// </summary>
+public sealed class WebToolOptions
+{
+    /// <summary>
+    /// The search provider to use. Defaults to "brave".
+    /// </summary>
+    public string SearchProvider { get; set; } = "brave";
+
+    /// <summary>
+    /// Environment variable name containing the search API key.
+    /// </summary>
+    public string ApiKeyEnvVar { get; set; } = "BRAVE_API_KEY";
+
+    /// <summary>
+    /// Maximum number of search results to return. Defaults to 10.
+    /// </summary>
+    public int MaxSearchResults { get; set; } = 10;
+}

--- a/src/RockBot.Tools.Web/WebToolRegistrar.cs
+++ b/src/RockBot.Tools.Web/WebToolRegistrar.cs
@@ -1,0 +1,69 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace RockBot.Tools.Web;
+
+internal sealed class WebToolRegistrar(
+    IToolRegistry registry,
+    IWebSearchProvider searchProvider,
+    IWebBrowseProvider browseProvider,
+    WebToolOptions options,
+    ILogger<WebToolRegistrar> logger) : IHostedService
+{
+    private const string SearchSchema = """
+        {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string",
+              "description": "The search query"
+            },
+            "count": {
+              "type": "integer",
+              "description": "Number of results to return (1-20, default 10)",
+              "minimum": 1,
+              "maximum": 20
+            }
+          },
+          "required": ["query"]
+        }
+        """;
+
+    private const string BrowseSchema = """
+        {
+          "type": "object",
+          "properties": {
+            "url": {
+              "type": "string",
+              "description": "The URL of the web page to fetch"
+            }
+          },
+          "required": ["url"]
+        }
+        """;
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        registry.Register(new ToolRegistration
+        {
+            Name = "web_search",
+            Description = "Search the web and return titles, URLs, and snippets",
+            ParametersSchema = SearchSchema,
+            Source = "web"
+        }, new WebSearchToolExecutor(searchProvider, options));
+        logger.LogInformation("Registered web tool: web_search");
+
+        registry.Register(new ToolRegistration
+        {
+            Name = "web_browse",
+            Description = "Fetch a web page and return its content as Markdown",
+            ParametersSchema = BrowseSchema,
+            Source = "web"
+        }, new WebBrowseToolExecutor(browseProvider));
+        logger.LogInformation("Registered web tool: web_browse");
+
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/tests/RockBot.Tools.Web.Tests/BraveSearchProviderTests.cs
+++ b/tests/RockBot.Tools.Web.Tests/BraveSearchProviderTests.cs
@@ -1,0 +1,137 @@
+using System.Net;
+using System.Text;
+using Microsoft.Extensions.Logging.Abstractions;
+using RockBot.Tools.Web.Brave;
+
+namespace RockBot.Tools.Web.Tests;
+
+[TestClass]
+public class BraveSearchProviderTests
+{
+    private const string ValidResponse = """
+        {
+          "web": {
+            "results": [
+              {
+                "title": "Example Result",
+                "url": "https://example.com",
+                "description": "This is a snippet"
+              },
+              {
+                "title": "Another Result",
+                "url": "https://another.com",
+                "description": "Another snippet"
+              }
+            ]
+          }
+        }
+        """;
+
+    [TestMethod]
+    public async Task SearchAsync_SendsCorrectUrlAndHeaders()
+    {
+        var handler = new CaptureHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(ValidResponse, Encoding.UTF8, "application/json")
+        });
+        var options = new WebToolOptions { ApiKeyEnvVar = "ROCKBOT_TEST_BRAVE_KEY_URL" };
+        Environment.SetEnvironmentVariable("ROCKBOT_TEST_BRAVE_KEY_URL", "test-api-key");
+        try
+        {
+            var provider = new BraveSearchProvider(new StubFactory(handler), options, NullLogger<BraveSearchProvider>.Instance);
+            await provider.SearchAsync("hello world", 5, CancellationToken.None);
+
+            Assert.IsNotNull(handler.CapturedRequest);
+            StringAssert.Contains(handler.CapturedRequest.RequestUri!.AbsoluteUri, "q=hello%20world");
+            StringAssert.Contains(handler.CapturedRequest.RequestUri.AbsoluteUri, "count=5");
+            Assert.IsTrue(handler.CapturedRequest.Headers.Contains("X-Subscription-Token"));
+            Assert.AreEqual("test-api-key",
+                handler.CapturedRequest.Headers.GetValues("X-Subscription-Token").First());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("ROCKBOT_TEST_BRAVE_KEY_URL", null);
+        }
+    }
+
+    [TestMethod]
+    public async Task SearchAsync_DeserializesResultsCorrectly()
+    {
+        var handler = new CaptureHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(ValidResponse, Encoding.UTF8, "application/json")
+        });
+        var options = new WebToolOptions { ApiKeyEnvVar = "ROCKBOT_TEST_BRAVE_KEY_DESER" };
+        Environment.SetEnvironmentVariable("ROCKBOT_TEST_BRAVE_KEY_DESER", "test-api-key");
+        try
+        {
+            var provider = new BraveSearchProvider(new StubFactory(handler), options, NullLogger<BraveSearchProvider>.Instance);
+            var results = await provider.SearchAsync("test", 10, CancellationToken.None);
+
+            Assert.AreEqual(2, results.Count);
+            Assert.AreEqual("Example Result", results[0].Title);
+            Assert.AreEqual("https://example.com", results[0].Url);
+            Assert.AreEqual("This is a snippet", results[0].Snippet);
+            Assert.AreEqual("Another Result", results[1].Title);
+            Assert.AreEqual("Another snippet", results[1].Snippet);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("ROCKBOT_TEST_BRAVE_KEY_DESER", null);
+        }
+    }
+
+    [TestMethod]
+    public async Task SearchAsync_ReturnsEmpty_WhenApiKeyMissing()
+    {
+        var handler = new CaptureHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json")
+        });
+        var options = new WebToolOptions { ApiKeyEnvVar = "ROCKBOT_TEST_BRAVE_KEY_NONEXISTENT_12345" };
+        var provider = new BraveSearchProvider(new StubFactory(handler), options, NullLogger<BraveSearchProvider>.Instance);
+
+        var results = await provider.SearchAsync("test", 10, CancellationToken.None);
+
+        Assert.AreEqual(0, results.Count);
+    }
+
+    [TestMethod]
+    public async Task SearchAsync_CapsCountAt20()
+    {
+        var handler = new CaptureHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("""{"web": {"results": []}}""", Encoding.UTF8, "application/json")
+        });
+        var options = new WebToolOptions { ApiKeyEnvVar = "ROCKBOT_TEST_BRAVE_KEY_CAP" };
+        Environment.SetEnvironmentVariable("ROCKBOT_TEST_BRAVE_KEY_CAP", "test-api-key");
+        try
+        {
+            var provider = new BraveSearchProvider(new StubFactory(handler), options, NullLogger<BraveSearchProvider>.Instance);
+            await provider.SearchAsync("test", 50, CancellationToken.None);
+
+            StringAssert.Contains(handler.CapturedRequest!.RequestUri!.AbsoluteUri, "count=20");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("ROCKBOT_TEST_BRAVE_KEY_CAP", null);
+        }
+    }
+
+    private sealed class CaptureHandler(HttpResponseMessage response) : HttpMessageHandler
+    {
+        public HttpRequestMessage? CapturedRequest { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            CapturedRequest = request;
+            return Task.FromResult(response);
+        }
+    }
+
+    private sealed class StubFactory(HttpMessageHandler handler) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new(handler);
+    }
+}

--- a/tests/RockBot.Tools.Web.Tests/HttpWebBrowseProviderTests.cs
+++ b/tests/RockBot.Tools.Web.Tests/HttpWebBrowseProviderTests.cs
@@ -1,0 +1,106 @@
+using System.Net;
+using System.Text;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace RockBot.Tools.Web.Tests;
+
+[TestClass]
+public class HttpWebBrowseProviderTests
+{
+    private const string SampleHtml = """
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <title>Test Page Title</title>
+            <style>body { color: red; }</style>
+        </head>
+        <body>
+            <script>alert('hello');</script>
+            <h1>Main Heading</h1>
+            <p>This is a paragraph with a <a href="https://example.com">link</a>.</p>
+        </body>
+        </html>
+        """;
+
+    [TestMethod]
+    public async Task FetchAsync_ExtractsTitleFromHtml()
+    {
+        var provider = MakeProvider(SampleHtml);
+
+        var result = await provider.FetchAsync("https://example.com", CancellationToken.None);
+
+        Assert.AreEqual("Test Page Title", result.Title);
+    }
+
+    [TestMethod]
+    public async Task FetchAsync_ConvertsHtmlToMarkdown()
+    {
+        var provider = MakeProvider(SampleHtml);
+
+        var result = await provider.FetchAsync("https://example.com", CancellationToken.None);
+
+        StringAssert.Contains(result.Content, "Main Heading");
+        StringAssert.Contains(result.Content, "paragraph");
+    }
+
+    [TestMethod]
+    public async Task FetchAsync_StripsScriptTags()
+    {
+        var provider = MakeProvider(SampleHtml);
+
+        var result = await provider.FetchAsync("https://example.com", CancellationToken.None);
+
+        Assert.IsFalse(result.Content.Contains("alert('hello')"), "Script content should be stripped");
+    }
+
+    [TestMethod]
+    public async Task FetchAsync_StripsStyleTags()
+    {
+        var provider = MakeProvider(SampleHtml);
+
+        var result = await provider.FetchAsync("https://example.com", CancellationToken.None);
+
+        Assert.IsFalse(result.Content.Contains("color: red"), "Style content should be stripped");
+    }
+
+    [TestMethod]
+    public async Task FetchAsync_SetsSourceUrl()
+    {
+        var provider = MakeProvider("<html><head><title>T</title></head><body>Content</body></html>");
+
+        var result = await provider.FetchAsync("https://example.com/page", CancellationToken.None);
+
+        Assert.AreEqual("https://example.com/page", result.SourceUrl);
+    }
+
+    [TestMethod]
+    public async Task FetchAsync_ConvertsLinksToMarkdown()
+    {
+        var provider = MakeProvider(SampleHtml);
+
+        var result = await provider.FetchAsync("https://example.com", CancellationToken.None);
+
+        StringAssert.Contains(result.Content, "[link](https://example.com)");
+    }
+
+    private static HttpWebBrowseProvider MakeProvider(string html)
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(html, Encoding.UTF8, "text/html")
+        };
+        return new HttpWebBrowseProvider(new StubFactory(new StubHandler(response)), NullLogger<HttpWebBrowseProvider>.Instance);
+    }
+
+    private sealed class StubHandler(HttpResponseMessage response) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(response);
+    }
+
+    private sealed class StubFactory(HttpMessageHandler handler) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new(handler);
+    }
+}

--- a/tests/RockBot.Tools.Web.Tests/RockBot.Tools.Web.Tests.csproj
+++ b/tests/RockBot.Tools.Web.Tests/RockBot.Tools.Web.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.*" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\RockBot.Tools.Web\RockBot.Tools.Web.csproj" />
+    <ProjectReference Include="..\..\src\RockBot.Tools.Abstractions\RockBot.Tools.Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/RockBot.Tools.Web.Tests/WebBrowseToolExecutorTests.cs
+++ b/tests/RockBot.Tools.Web.Tests/WebBrowseToolExecutorTests.cs
@@ -1,0 +1,110 @@
+namespace RockBot.Tools.Web.Tests;
+
+[TestClass]
+public class WebBrowseToolExecutorTests
+{
+    private static ToolInvokeRequest MakeRequest(string? arguments = null) => new()
+    {
+        ToolCallId = "call_1",
+        ToolName = "web_browse",
+        Arguments = arguments
+    };
+
+    [TestMethod]
+    public async Task ExecuteAsync_PassesUrlToProvider()
+    {
+        var provider = new CapturingBrowseProvider(new WebPageContent
+        {
+            Title = "Test Page",
+            Content = "Content here",
+            SourceUrl = "https://example.com"
+        });
+        var executor = new WebBrowseToolExecutor(provider);
+
+        await executor.ExecuteAsync(MakeRequest("""{"url": "https://example.com"}"""), CancellationToken.None);
+
+        Assert.AreEqual("https://example.com", provider.LastUrl);
+    }
+
+    [TestMethod]
+    public async Task ExecuteAsync_ReturnsContentWithTitle()
+    {
+        var provider = new CapturingBrowseProvider(new WebPageContent
+        {
+            Title = "Test Page",
+            Content = "Content here",
+            SourceUrl = "https://example.com"
+        });
+        var executor = new WebBrowseToolExecutor(provider);
+
+        var response = await executor.ExecuteAsync(MakeRequest("""{"url": "https://example.com"}"""), CancellationToken.None);
+
+        Assert.IsFalse(response.IsError);
+        Assert.IsNotNull(response.Content);
+        StringAssert.Contains(response.Content, "# Test Page");
+        StringAssert.Contains(response.Content, "Content here");
+    }
+
+    [TestMethod]
+    public async Task ExecuteAsync_ReturnsContentWithoutTitle_WhenTitleEmpty()
+    {
+        var provider = new CapturingBrowseProvider(new WebPageContent
+        {
+            Title = "",
+            Content = "Just the body content",
+            SourceUrl = "https://example.com"
+        });
+        var executor = new WebBrowseToolExecutor(provider);
+
+        var response = await executor.ExecuteAsync(MakeRequest("""{"url": "https://example.com"}"""), CancellationToken.None);
+
+        Assert.IsFalse(response.IsError);
+        Assert.AreEqual("Just the body content", response.Content);
+    }
+
+    [TestMethod]
+    public async Task ExecuteAsync_ReturnsError_WhenProviderThrows()
+    {
+        var executor = new WebBrowseToolExecutor(
+            new ThrowingBrowseProvider(new HttpRequestException("Connection refused")));
+
+        var response = await executor.ExecuteAsync(MakeRequest("""{"url": "https://example.com"}"""), CancellationToken.None);
+
+        Assert.IsTrue(response.IsError);
+        StringAssert.Contains(response.Content, "Failed to fetch page");
+    }
+
+    [TestMethod]
+    public async Task ExecuteAsync_ReturnsError_WhenUrlMissing()
+    {
+        var provider = new CapturingBrowseProvider(new WebPageContent
+        {
+            Title = "",
+            Content = "",
+            SourceUrl = ""
+        });
+        var executor = new WebBrowseToolExecutor(provider);
+
+        var response = await executor.ExecuteAsync(MakeRequest("""{"query": "wrong argument"}"""), CancellationToken.None);
+
+        Assert.IsTrue(response.IsError);
+        StringAssert.Contains(response.Content, "url");
+    }
+
+    private sealed class CapturingBrowseProvider(WebPageContent result) : IWebBrowseProvider
+    {
+        public string? LastUrl { get; private set; }
+
+        public Task<WebPageContent> FetchAsync(string url, CancellationToken ct)
+        {
+            LastUrl = url;
+            return Task.FromResult(result);
+        }
+    }
+
+    private sealed class ThrowingBrowseProvider(Exception exception) : IWebBrowseProvider
+    {
+        public Task<WebPageContent> FetchAsync(string url, CancellationToken ct)
+            => Task.FromException<WebPageContent>(exception);
+    }
+}

--- a/tests/RockBot.Tools.Web.Tests/WebSearchToolExecutorTests.cs
+++ b/tests/RockBot.Tools.Web.Tests/WebSearchToolExecutorTests.cs
@@ -1,0 +1,111 @@
+namespace RockBot.Tools.Web.Tests;
+
+[TestClass]
+public class WebSearchToolExecutorTests
+{
+    private static ToolInvokeRequest MakeRequest(string? arguments = null) => new()
+    {
+        ToolCallId = "call_1",
+        ToolName = "web_search",
+        Arguments = arguments
+    };
+
+    [TestMethod]
+    public async Task ExecuteAsync_FormatsResultsAsNumberedMarkdownList()
+    {
+        var provider = new StubSearchProvider([
+            new WebSearchResult { Title = "Result One", Url = "https://example.com/1", Snippet = "First result snippet" },
+            new WebSearchResult { Title = "Result Two", Url = "https://example.com/2", Snippet = "Second result snippet" }
+        ]);
+        var executor = new WebSearchToolExecutor(provider, new WebToolOptions());
+
+        var response = await executor.ExecuteAsync(MakeRequest("""{"query": "test query"}"""), CancellationToken.None);
+
+        Assert.IsFalse(response.IsError);
+        Assert.IsNotNull(response.Content);
+        StringAssert.Contains(response.Content, "1. [Result One](https://example.com/1)");
+        StringAssert.Contains(response.Content, "   First result snippet");
+        StringAssert.Contains(response.Content, "2. [Result Two](https://example.com/2)");
+        StringAssert.Contains(response.Content, "   Second result snippet");
+    }
+
+    [TestMethod]
+    public async Task ExecuteAsync_ReturnsNoResultsMessage_WhenEmpty()
+    {
+        var executor = new WebSearchToolExecutor(new StubSearchProvider([]), new WebToolOptions());
+
+        var response = await executor.ExecuteAsync(MakeRequest("""{"query": "obscure query"}"""), CancellationToken.None);
+
+        Assert.IsFalse(response.IsError);
+        Assert.AreEqual("No results found.", response.Content);
+    }
+
+    [TestMethod]
+    public async Task ExecuteAsync_ReturnsError_WhenProviderThrows()
+    {
+        var executor = new WebSearchToolExecutor(
+            new ThrowingSearchProvider(new HttpRequestException("Network error")),
+            new WebToolOptions());
+
+        var response = await executor.ExecuteAsync(MakeRequest("""{"query": "test"}"""), CancellationToken.None);
+
+        Assert.IsTrue(response.IsError);
+        StringAssert.Contains(response.Content, "Search failed");
+    }
+
+    [TestMethod]
+    public async Task ExecuteAsync_ReturnsError_WhenQueryMissing()
+    {
+        var executor = new WebSearchToolExecutor(new StubSearchProvider([]), new WebToolOptions());
+
+        var response = await executor.ExecuteAsync(MakeRequest("""{"count": 5}"""), CancellationToken.None);
+
+        Assert.IsTrue(response.IsError);
+        StringAssert.Contains(response.Content, "query");
+    }
+
+    [TestMethod]
+    public async Task ExecuteAsync_RespectsCountArgument()
+    {
+        var provider = new CountCapturingSearchProvider();
+        var executor = new WebSearchToolExecutor(provider, new WebToolOptions { MaxSearchResults = 10 });
+
+        await executor.ExecuteAsync(MakeRequest("""{"query": "test", "count": 5}"""), CancellationToken.None);
+
+        Assert.AreEqual(5, provider.LastCount);
+    }
+
+    [TestMethod]
+    public async Task ExecuteAsync_CapsCountAt20()
+    {
+        var provider = new CountCapturingSearchProvider();
+        var executor = new WebSearchToolExecutor(provider, new WebToolOptions());
+
+        await executor.ExecuteAsync(MakeRequest("""{"query": "test", "count": 99}"""), CancellationToken.None);
+
+        Assert.AreEqual(20, provider.LastCount);
+    }
+
+    private sealed class StubSearchProvider(IReadOnlyList<WebSearchResult> results) : IWebSearchProvider
+    {
+        public Task<IReadOnlyList<WebSearchResult>> SearchAsync(string query, int maxResults, CancellationToken ct)
+            => Task.FromResult(results);
+    }
+
+    private sealed class ThrowingSearchProvider(Exception exception) : IWebSearchProvider
+    {
+        public Task<IReadOnlyList<WebSearchResult>> SearchAsync(string query, int maxResults, CancellationToken ct)
+            => Task.FromException<IReadOnlyList<WebSearchResult>>(exception);
+    }
+
+    private sealed class CountCapturingSearchProvider : IWebSearchProvider
+    {
+        public int LastCount { get; private set; }
+
+        public Task<IReadOnlyList<WebSearchResult>> SearchAsync(string query, int maxResults, CancellationToken ct)
+        {
+            LastCount = maxResults;
+            return Task.FromResult<IReadOnlyList<WebSearchResult>>([]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `RockBot.Tools.Web` library with `web_search` and `web_browse` as `IToolExecutor` implementations, registered via `builder.AddWebTools(...)` — consistent with the `AddRestTools`/`AddMcpTools` pattern
- Provider-agnostic `IWebSearchProvider` / `IWebBrowseProvider` interfaces with Brave Search as the first search implementation and `HttpWebBrowseProvider` for page fetching
- Browse output is Markdown (via AngleSharp + ReverseMarkdown) for LLM token efficiency; `<script>` and `<style>` tags are stripped before conversion
- Brave API key read from a configurable environment variable (`BRAVE_API_KEY` by default)

## Test plan

- [x] 21 MSTest unit tests — all pass (`dotnet test RockBot.slnx --filter "ClassName~RockBot.Tools.Web"`)
- [x] Full solution builds clean (`dotnet build RockBot.slnx`)
- [ ] Manual smoke test: set `BRAVE_API_KEY` and call `SearchAsync` to verify live results parse correctly
- [ ] Manual smoke test: call `FetchAsync("https://example.com")` and verify Markdown output is LLM-readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)