### PR TITLE
fix: Blazor .NET 10 static assets, Enter key, and connection indicator

### DIFF
--- a/deploy/helm/rockbot/values.yaml
+++ b/deploy/helm/rockbot/values.yaml
@@ -1,5 +1,5 @@
 # ── Image pull policy ────────────────────────────────────────────────────────
-imagePullPolicy: IfNotPresent
+imagePullPolicy: Always
 
 # ── Namespace ─────────────────────────────────────────────────────────────────
 namespace: rockbot

--- a/src/RockBot.UserProxy.Blazor/Components/App.razor
+++ b/src/RockBot.UserProxy.Blazor/Components/App.razor
@@ -4,12 +4,15 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <base href="/" />
+    <ResourcePreloader />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="css/app.css" />
+    <link rel="stylesheet" href="@Assets["css/app.css"]" />
+    <ImportMap />
     <HeadOutlet />
 </head>
 <body>
     <Routes @rendermode="InteractiveServer" />
-    <script src="_framework/blazor.web.js"></script>
+    <script src="@Assets["js/chat.js"]"></script>
+    <script src="@Assets["_framework/blazor.web.js"]"></script>
 </body>
 </html>

--- a/src/RockBot.UserProxy.Blazor/Dockerfile
+++ b/src/RockBot.UserProxy.Blazor/Dockerfile
@@ -1,12 +1,19 @@
-# Build stage
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
+USER $APP_UID
+WORKDIR /app
+EXPOSE 8080
+ENV ASPNETCORE_URLS=http://+:8080
+ENV ASPNETCORE_ENVIRONMENT=Production
+
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 
 # Clear Windows-specific NuGet fallback folders that break Linux builds
 RUN printf '<configuration><fallbackPackageFolders><clear /></fallbackPackageFolders></configuration>' \
     > /src/NuGet.config
 
-# Copy solution and project files
+# Copy solution and project files for layer-cached restore
 COPY RockBot.slnx .
 COPY src/RockBot.UserProxy.Blazor/RockBot.UserProxy.Blazor.csproj src/RockBot.UserProxy.Blazor/
 COPY src/RockBot.UserProxy/RockBot.UserProxy.csproj src/RockBot.UserProxy/
@@ -14,37 +21,18 @@ COPY src/RockBot.UserProxy.Abstractions/RockBot.UserProxy.Abstractions.csproj sr
 COPY src/RockBot.Messaging.RabbitMQ/RockBot.Messaging.RabbitMQ.csproj src/RockBot.Messaging.RabbitMQ/
 COPY src/RockBot.Messaging.Abstractions/RockBot.Messaging.Abstractions.csproj src/RockBot.Messaging.Abstractions/
 
-# Restore dependencies
 RUN dotnet restore src/RockBot.UserProxy.Blazor/RockBot.UserProxy.Blazor.csproj
 
-# Copy source code
 COPY src/ src/
 
-# Build and publish
 WORKDIR /src/src/RockBot.UserProxy.Blazor
-RUN dotnet publish -c Release -o /app/publish --no-restore
+RUN dotnet build RockBot.UserProxy.Blazor.csproj -c $BUILD_CONFIGURATION -o /app/build --no-restore
 
-# Runtime stage
-FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
+FROM build AS publish
+ARG BUILD_CONFIGURATION=Release
+RUN dotnet publish RockBot.UserProxy.Blazor.csproj -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
+
+FROM base AS final
 WORKDIR /app
-
-# Create non-root user
-RUN groupadd -r rockbot && useradd -r -g rockbot rockbot
-
-# Copy published files
-COPY --from=build /app/publish .
-
-# Set ownership
-RUN chown -R rockbot:rockbot /app
-
-# Switch to non-root user
-USER rockbot
-
-# Expose port
-EXPOSE 8080
-
-# Set environment variables
-ENV ASPNETCORE_URLS=http://+:8080
-ENV ASPNETCORE_ENVIRONMENT=Production
-
+COPY --from=publish /app/publish .
 ENTRYPOINT ["dotnet", "RockBot.UserProxy.Blazor.dll"]

--- a/src/RockBot.UserProxy.Blazor/Pages/Chat.razor
+++ b/src/RockBot.UserProxy.Blazor/Pages/Chat.razor
@@ -12,9 +12,13 @@
 <div class="chat-container d-flex flex-column vh-100">
     <div class="chat-header bg-primary text-white p-3 d-flex justify-content-between align-items-center">
         <h1 class="h4 mb-0">RockBot Chat</h1>
-        <button class="btn btn-sm btn-outline-light" @onclick="ToggleDarkMode" title="Toggle dark/light mode">
-            @(IsDarkMode ? "☀️" : "🌙")
-        </button>
+        <div class="d-flex align-items-center gap-2">
+            <span class="connection-dot @(ProxyService.IsConnected ? "connected" : "disconnected")"
+                  title="@(ProxyService.IsConnected ? "Connected to message bus" : "Disconnected from message bus")"></span>
+            <button class="btn btn-sm btn-outline-light" @onclick="ToggleDarkMode" title="Toggle dark/light mode">
+                @(IsDarkMode ? "☀️" : "🌙")
+            </button>
+        </div>
     </div>
 
     <div class="chat-messages flex-grow-1 overflow-auto p-3" @ref="messagesContainer">
@@ -71,7 +75,7 @@
             <button 
                 type="submit" 
                 class="btn btn-primary"
-                disabled="@(string.IsNullOrWhiteSpace(currentMessage) || ChatState.IsProcessing)"
+                disabled="@(string.IsNullOrWhiteSpace(currentMessage) || ChatState.IsProcessing || !ProxyService.IsConnected)"
                 aria-label="Send message">
                 Send
             </button>
@@ -88,6 +92,7 @@
     private ElementReference messageInput;
     private bool IsDarkMode = false;
     private Action? _stateChangedHandler;
+    private Action? _connectionChangedHandler;
     private int _renderedMessageCount = 0;
     private static readonly MarkdownPipeline MarkdownPipeline = new MarkdownPipelineBuilder()
         .UseAdvancedExtensions()
@@ -97,12 +102,17 @@
     {
         _stateChangedHandler = () => InvokeAsync(StateHasChanged);
         ChatState.OnStateChanged += _stateChangedHandler;
+
+        _connectionChangedHandler = () => InvokeAsync(StateHasChanged);
+        ProxyService.OnConnectionChanged += _connectionChangedHandler;
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender)
         {
+            await JSRuntime.InvokeVoidAsync("chatHelpers.preventEnterNewline", messageInput);
+
             // Check for system dark mode preference
             IsDarkMode = await JSRuntime.InvokeAsync<bool>("eval",
                 "window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches");
@@ -208,5 +218,6 @@
     public void Dispose()
     {
         ChatState.OnStateChanged -= _stateChangedHandler;
+        ProxyService.OnConnectionChanged -= _connectionChangedHandler;
     }
 }

--- a/src/RockBot.UserProxy.Blazor/Program.cs
+++ b/src/RockBot.UserProxy.Blazor/Program.cs
@@ -28,7 +28,7 @@ if (!app.Environment.IsDevelopment())
 app.UseHttpsRedirection();
 app.UseAntiforgery();
 
-app.UseStaticFiles();
+app.MapStaticAssets();
 app.MapRazorComponents<App>()
     .AddInteractiveServerRenderMode();
 

--- a/src/RockBot.UserProxy.Blazor/wwwroot/css/app.css
+++ b/src/RockBot.UserProxy.Blazor/wwwroot/css/app.css
@@ -123,6 +123,25 @@ body {
     box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25);
 }
 
+/* Connection status indicator */
+.connection-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    display: inline-block;
+    flex-shrink: 0;
+}
+
+.connection-dot.connected {
+    background-color: #4ade80;
+    box-shadow: 0 0 4px #4ade80;
+}
+
+.connection-dot.disconnected {
+    background-color: #f87171;
+    box-shadow: 0 0 4px #f87171;
+}
+
 /* Dark mode support */
 body.dark-mode {
     background-color: var(--dark-bg);

--- a/src/RockBot.UserProxy.Blazor/wwwroot/js/chat.js
+++ b/src/RockBot.UserProxy.Blazor/wwwroot/js/chat.js
@@ -1,0 +1,9 @@
+window.chatHelpers = {
+    preventEnterNewline: function (element) {
+        element.addEventListener('keydown', function (e) {
+            if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault();
+            }
+        });
+    }
+};


### PR DESCRIPTION
## Summary

- **Fix `blazor.web.js` 404**: `--no-restore` on `dotnet publish` skips the MSBuild targets that copy `wwwroot/_framework/` files; removing it fixes the issue. Also switched to `MapStaticAssets()`, added `<ResourcePreloader />` and `<ImportMap />` to `App.razor`, and updated all local asset references to use `@Assets[...]` (including `_framework/blazor.web.js`) per .NET 10 requirements.
- **Fix Enter key**: Added a small JS helper (`wwwroot/js/chat.js`) that calls `preventDefault()` on keydown for Enter (without Shift), preventing the textarea from inserting a newline before Blazor's async server-side handler responds.
- **Connection status indicator**: `UserProxyService` now exposes `IsConnected` and `OnConnectionChanged`. The chat header shows a green/red dot next to the dark/light toggle, and the Send button is gated on connection state.
- **`imagePullPolicy: Always`**: Changed from `IfNotPresent` so `latest`-tagged images are always pulled on pod restart.

## Test plan

- [ ] Browse to the app — no `blazor.web.js` 404 in the browser console
- [ ] Dark/light mode toggle works
- [ ] Typing a message and pressing Enter submits it (no newline inserted)
- [ ] Connection dot shows green when RabbitMQ is reachable, red when not
- [ ] Send button is disabled when disconnected or message is empty
- [ ] `kubectl rollout restart` picks up a newly pushed image

🤖 Generated with [Claude Code](https://claude.com/claude-code)