### PR TITLE
feat: allow Shift+Enter and Ctrl+Enter to insert newlines in chat input

### DIFF
--- a/src/RockBot.UserProxy.Blazor/Pages/Chat.razor
+++ b/src/RockBot.UserProxy.Blazor/Pages/Chat.razor
@@ -180,7 +180,7 @@
 
     private async Task HandleKeyDown(KeyboardEventArgs e)
     {
-        if (e.Key == "Enter" && !e.ShiftKey)
+        if (e.Key == "Enter" && !e.ShiftKey && !e.CtrlKey)
             await SendMessage();
     }
 

--- a/src/RockBot.UserProxy.Blazor/wwwroot/js/chat.js
+++ b/src/RockBot.UserProxy.Blazor/wwwroot/js/chat.js
@@ -1,9 +1,12 @@
 window.chatHelpers = {
     preventEnterNewline: function (element) {
         element.addEventListener('keydown', function (e) {
-            if (e.key === 'Enter' && !e.shiftKey) {
+            if (e.key === 'Enter' && !e.shiftKey && !e.ctrlKey) {
+                // Plain Enter — prevent default so the form doesn't add a newline;
+                // Blazor's HandleKeyDown will call SendMessage.
                 e.preventDefault();
             }
+            // Shift+Enter and Ctrl+Enter: allow default so the browser inserts a newline.
         });
     }
 };


### PR DESCRIPTION
## Summary
- Plain `Enter` continues to send the message
- `Shift+Enter` now inserts a newline for multi-line composition
- `Ctrl+Enter` now inserts a newline for multi-line composition

## Test plan
- [ ] Type a message and press `Enter` — message sends
- [ ] Press `Shift+Enter` — newline inserted in textarea
- [ ] Press `Ctrl+Enter` — newline inserted in textarea

🤖 Generated with [Claude Code](https://claude.com/claude-code)