### PR TITLE
fix: return full pod log on script failure for agent debugging

### DIFF
--- a/src/RockBot.Scripts.Container/ContainerScriptHandler.cs
+++ b/src/RockBot.Scripts.Container/ContainerScriptHandler.cs
@@ -51,14 +51,6 @@ internal sealed class ContainerScriptHandler(
                 exitCode = completedPod.Status?.ContainerStatuses?
                     .FirstOrDefault(c => c.Name == "script")?
                     .State?.Terminated?.ExitCode ?? -1;
-
-                // Try to get stderr from terminated reason if exit code is non-zero
-                if (exitCode != 0)
-                {
-                    stderr = completedPod.Status?.ContainerStatuses?
-                        .FirstOrDefault(c => c.Name == "script")?
-                        .State?.Terminated?.Reason;
-                }
             }
             else
             {

--- a/src/RockBot.Scripts.Container/ContainerScriptRunner.cs
+++ b/src/RockBot.Scripts.Container/ContainerScriptRunner.cs
@@ -50,19 +50,10 @@ internal sealed class ContainerScriptRunner(
                 .FirstOrDefault(c => c.Name == "script")?
                 .State?.Terminated?.ExitCode ?? -1;
 
-            string? stderr = null;
-            if (exitCode != 0)
-            {
-                stderr = completedPod.Status?.ContainerStatuses?
-                    .FirstOrDefault(c => c.Name == "script")?
-                    .State?.Terminated?.Reason;
-            }
-
             return new ScriptInvokeResponse
             {
                 ToolCallId = request.ToolCallId,
                 Output = stdout,
-                Stderr = stderr,
                 ExitCode = exitCode,
                 ElapsedMs = sw.ElapsedMilliseconds
             };


### PR DESCRIPTION
## Summary

- When a script exits non-zero, the previous code set `Stderr` to `Terminated.Reason` which just returns the string `"Error"` — useless for debugging
- The pod log already captures the complete output (stdout + stderr combined via `2>&1` shell redirects on both pip and python)
- `Output` now always contains the full pod log so agents can see Python tracebacks, pip install errors, and other diagnostic output regardless of exit code

## Test plan

- [ ] Run a script with a syntax error — agent should receive the full Python traceback in the response
- [ ] Run a script with an import for a missing package (no `pip_packages`) — agent should see `ModuleNotFoundError` with traceback
- [ ] Run a script that times out — `Stderr` still reports the timeout message correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)