### PR TITLE
fix: GitHub API routing, link visibility, and persistence directives

### DIFF
--- a/src/RockBot.Cli/agent/directives.md
+++ b/src/RockBot.Cli/agent/directives.md
@@ -27,11 +27,87 @@ scripts, scheduling, or anything else — follow this priority order:
 Your own skills always take precedence — they reflect real lessons learned that
 static guides cannot know about. Use guides as seeds, not as permanent references.
 
+## What the Framework Does Automatically
+
+The following happen on every turn **without you needing to ask**. Understanding
+these prevents you from wasting tool calls on work already done for you.
+
+### Memory auto-surfacing
+
+Before you see the user's message, the framework runs a BM25 keyword search of
+your entire long-term memory against the user's text. The top matching entries
+are injected into your context automatically — only entries you haven't seen yet
+this session (delta injection). You do **not** need to call `search_memory` at
+the start of every turn; relevant memories are already there.
+
+Call `search_memory` explicitly only when you want to search with a specific
+query that differs from the user's raw message (e.g., after the user clarifies
+what they meant, or when you want to narrow to a category).
+
+### Skill index and per-turn recall
+
+At the start of each session, a summary index of all your skills is injected
+once so you know what you have. Then, on every turn, the same BM25 search runs
+against your skill library — newly relevant skills are injected as the
+conversation evolves. You do **not** need to call `list_skills` repeatedly.
+
+### Tool discovery at startup
+
+MCP tools are discovered automatically when the process starts. Any MCP server
+listed in the configuration is connected and its tools registered. Call
+`list_tool_guides` to see what subsystems are available and `get_tool_guide` for
+usage details — but the tools themselves are already loaded and callable.
+
 ### After using a tool guide
 
 If you complete a real task using a tool guide and no skill exists yet, save one.
 Combine the guide's instructions with anything you discovered: edge cases, better
 argument patterns, pitfalls to avoid.
+
+## Persistence When Facing Obstacles
+
+When a tool call returns an unexpected result, an error, or content that doesn't
+satisfy the user's request, **do not give up and report failure**. Treat the
+obstacle as a problem to solve.
+
+### Required escalation sequence
+
+Work through these alternatives before telling the user you cannot do something:
+
+1. **Diagnose the result** — understand *why* it failed. A 200 response with
+   garbled content is different from a network error. A permission message from
+   a JavaScript-rendered page is different from a real 403.
+
+2. **Try a different approach to the same goal.** Examples:
+   - `web_browse` returned noise → try `web_search` for the same content, or
+     search for the direct API endpoint (e.g. GitHub's REST API instead of the
+     HTML page)
+   - An API requires auth → search for an unauthenticated equivalent or a
+     cached/mirror version
+   - A URL is blocked → search for the same information from another source
+
+3. **Write and run a script** — if web tools can't get the data, use
+   `execute_python_script` to fetch it directly (e.g. `requests.get` with
+   custom headers, parsing JSON from a REST API, using `curl`-style calls).
+   Scripts can set headers, follow redirects, and handle formats that
+   `web_browse` cannot.
+
+4. **Search for how to do it** — use `web_search` to find the correct API,
+   endpoint, or technique, then apply what you learn immediately.
+
+5. **Report to the user only after exhausting the above** — and when you do,
+   explain specifically what you tried and why each approach failed. Never
+   report "I can't access that" after only one failed attempt.
+
+### What this looks like in practice
+
+- GitHub issue page returns JavaScript noise → immediately try the GitHub REST
+  API (`https://api.github.com/repos/{owner}/{repo}/issues/{number}`) or run a
+  Python script with `requests`.
+- A web page requires login → search for a cached version, an API equivalent,
+  or ask the user for credentials before giving up.
+- A script fails → read the error, fix it, and retry. Don't report the error
+  to the user until you've made at least one correction attempt.
 
 ## Safety
 

--- a/src/RockBot.Tools.Web/GitHubApiWebBrowseProvider.cs
+++ b/src/RockBot.Tools.Web/GitHubApiWebBrowseProvider.cs
@@ -1,0 +1,130 @@
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
+
+namespace RockBot.Tools.Web;
+
+/// <summary>
+/// Routes GitHub issue and pull-request URLs to the GitHub REST API so content
+/// is returned without requiring JavaScript or authentication on public repos.
+/// All other URLs fall through to the inner <see cref="IWebBrowseProvider"/>.
+/// </summary>
+internal sealed partial class GitHubApiWebBrowseProvider(
+    HttpWebBrowseProvider fallback,
+    IHttpClientFactory httpClientFactory,
+    ILogger<GitHubApiWebBrowseProvider> logger) : IWebBrowseProvider
+{
+    // github.com/{owner}/{repo}/issues/{number}
+    [GeneratedRegex(@"^https?://github\.com/(?<owner>[^/]+)/(?<repo>[^/]+)/issues/(?<number>\d+)", RegexOptions.IgnoreCase)]
+    private static partial Regex IssueUrlPattern();
+
+    // github.com/{owner}/{repo}/pull/{number}
+    [GeneratedRegex(@"^https?://github\.com/(?<owner>[^/]+)/(?<repo>[^/]+)/pull/(?<number>\d+)", RegexOptions.IgnoreCase)]
+    private static partial Regex PullUrlPattern();
+
+    public async Task<WebPageContent> FetchAsync(string url, CancellationToken ct)
+    {
+        var issueMatch = IssueUrlPattern().Match(url);
+        if (issueMatch.Success)
+        {
+            return await FetchIssueOrPrAsync(
+                issueMatch.Groups["owner"].Value,
+                issueMatch.Groups["repo"].Value,
+                int.Parse(issueMatch.Groups["number"].Value),
+                isPr: false,
+                url,
+                ct);
+        }
+
+        var prMatch = PullUrlPattern().Match(url);
+        if (prMatch.Success)
+        {
+            return await FetchIssueOrPrAsync(
+                prMatch.Groups["owner"].Value,
+                prMatch.Groups["repo"].Value,
+                int.Parse(prMatch.Groups["number"].Value),
+                isPr: true,
+                url,
+                ct);
+        }
+
+        return await fallback.FetchAsync(url, ct);
+    }
+
+    private async Task<WebPageContent> FetchIssueOrPrAsync(
+        string owner, string repo, int number, bool isPr, string originalUrl, CancellationToken ct)
+    {
+        var kind = isPr ? "pulls" : "issues";
+        var apiUrl = $"https://api.github.com/repos/{owner}/{repo}/{kind}/{number}";
+
+        logger.LogDebug("Routing GitHub URL to API: {ApiUrl}", apiUrl);
+
+        using var client = httpClientFactory.CreateClient("RockBot.Tools.Web.GitHub");
+        JsonElement item;
+        try
+        {
+            item = await client.GetFromJsonAsync<JsonElement>(apiUrl, ct);
+        }
+        catch (HttpRequestException ex)
+        {
+            logger.LogWarning("GitHub API request failed for {Url}: {Message}", apiUrl, ex.Message);
+            return await fallback.FetchAsync(originalUrl, ct);
+        }
+
+        var title = item.TryGetString("title") ?? "(no title)";
+        var state = item.TryGetString("state") ?? "unknown";
+        var body = item.TryGetString("body") ?? "(no description)";
+        var author = item.TryGetProperty("user")?.TryGetString("login") ?? "unknown";
+        var createdAt = item.TryGetString("created_at") ?? string.Empty;
+        var updatedAt = item.TryGetString("updated_at") ?? string.Empty;
+        var htmlUrl = item.TryGetString("html_url") ?? originalUrl;
+
+        var labels = item.TryGetProperty("labels") is JsonElement labelsEl
+            ? labelsEl.EnumerateArray()
+                .Select(l => l.TryGetString("name"))
+                .Where(n => n != null)
+                .ToList()
+            : [];
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"**Repository:** {owner}/{repo}");
+        sb.AppendLine($"**State:** {state}");
+        sb.AppendLine($"**Author:** {author}");
+        if (!string.IsNullOrEmpty(createdAt)) sb.AppendLine($"**Created:** {createdAt}");
+        if (!string.IsNullOrEmpty(updatedAt)) sb.AppendLine($"**Updated:** {updatedAt}");
+        if (labels.Count > 0) sb.AppendLine($"**Labels:** {string.Join(", ", labels)}");
+        sb.AppendLine($"**URL:** {htmlUrl}");
+        sb.AppendLine();
+        sb.AppendLine("---");
+        sb.AppendLine();
+        sb.AppendLine(body);
+
+        var kindLabel = isPr ? "PR" : "Issue";
+        return new WebPageContent
+        {
+            Title = $"{kindLabel} #{number}: {title} [{owner}/{repo}]",
+            Content = sb.ToString(),
+            SourceUrl = originalUrl
+        };
+    }
+}
+
+/// <summary>
+/// JsonElement extension helpers used only within this provider.
+/// </summary>
+file static class JsonElementExtensions
+{
+    internal static string? TryGetString(this JsonElement el, string propertyName)
+    {
+        return el.TryGetProperty(propertyName, out var prop) && prop.ValueKind == JsonValueKind.String
+            ? prop.GetString()
+            : null;
+    }
+
+    internal static JsonElement? TryGetProperty(this JsonElement el, string propertyName)
+    {
+        return el.TryGetProperty(propertyName, out var prop) ? prop : null;
+    }
+}

--- a/src/RockBot.Tools.Web/WebServiceCollectionExtensions.cs
+++ b/src/RockBot.Tools.Web/WebServiceCollectionExtensions.cs
@@ -23,9 +23,18 @@ public static class WebServiceCollectionExtensions
 
         builder.Services.AddHttpClient("RockBot.Tools.Web.Brave");
         builder.Services.AddHttpClient("RockBot.Tools.Web.Browse");
+        builder.Services.AddHttpClient("RockBot.Tools.Web.GitHub", client =>
+        {
+            // GitHub API requires a User-Agent header
+            client.DefaultRequestHeaders.UserAgent.ParseAdd("RockBot/1.0");
+            client.DefaultRequestHeaders.Accept.ParseAdd("application/vnd.github.v3+json");
+        });
 
         builder.Services.AddSingleton<IWebSearchProvider, BraveSearchProvider>();
-        builder.Services.AddSingleton<IWebBrowseProvider, HttpWebBrowseProvider>();
+        // HttpWebBrowseProvider registered as concrete type so GitHubApiWebBrowseProvider
+        // can inject it directly as a fallback for non-GitHub URLs.
+        builder.Services.AddSingleton<HttpWebBrowseProvider>();
+        builder.Services.AddSingleton<IWebBrowseProvider, GitHubApiWebBrowseProvider>();
 
         builder.Services.AddSingleton<IToolSkillProvider, WebToolSkillProvider>();
 

--- a/src/RockBot.UserProxy.Blazor/wwwroot/css/app.css
+++ b/src/RockBot.UserProxy.Blazor/wwwroot/css/app.css
@@ -72,6 +72,26 @@ body {
     margin-bottom: 0;
 }
 
+/* Links inside user bubbles (blue bg) must be white to stay visible */
+.user-message .message-bubble .message-content a {
+    color: rgba(255, 255, 255, 0.9);
+    text-decoration: underline;
+}
+
+.user-message .message-bubble .message-content a:hover {
+    color: white;
+}
+
+/* Links inside error bubbles (red bg) — same issue */
+.message-bubble.bg-danger .message-content a {
+    color: rgba(255, 255, 255, 0.9);
+    text-decoration: underline;
+}
+
+.message-bubble.bg-danger .message-content a:hover {
+    color: white;
+}
+
 .message-content code {
     background-color: rgba(0, 0, 0, 0.05);
     padding: 2px 4px;


### PR DESCRIPTION
## Summary

- **GitHub web browse fix**: Routes `github.com` issue/PR URLs to the GitHub REST API instead of scraping HTML (which requires JavaScript to render). Non-GitHub URLs fall through to the existing provider unchanged.
- **Invisible link fix**: Browser-default blue links were invisible on blue (user) and red (error) message bubbles. Added explicit white link color rules for both.
- **Persistence directive**: Instructs the agent to treat tool failures as problems to solve — escalating through alternative approaches (different tool, web search, Python script) before reporting failure.
- **Framework awareness directive**: Explains to the agent what the framework already does automatically (memory surfacing, skill recall, tool discovery) to prevent redundant tool calls.

## Test plan

- [ ] Send a GitHub issue URL (e.g. `https://github.com/MarimerLLC/rockbot/issues/55`) in chat — agent should read the issue content without error
- [ ] Type a message containing a URL in the user input and verify the link is visible (white, underlined) on the blue bubble in both light and dark mode
- [ ] Verify agent attempts alternative approaches when a tool returns unexpected results instead of immediately reporting failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)