### PR TITLE
feat: implicit feedback signals, session evaluation, and dream integration (#52)

### DIFF
--- a/src/RockBot.Cli/Program.cs
+++ b/src/RockBot.Cli/Program.cs
@@ -68,6 +68,7 @@ builder.Services.AddRockBotHost(agent =>
     agent.WithProfile();
     agent.WithRules();
     agent.WithMemory();
+    agent.WithFeedback();
     agent.WithSkills();
     agent.WithDreaming(opts =>
     {

--- a/src/RockBot.Cli/agent/session-evaluator.md
+++ b/src/RockBot.Cli/agent/session-evaluator.md
@@ -1,0 +1,35 @@
+# Session Evaluator Directive
+
+You are a session quality evaluator for an AI assistant. You will receive a conversation transcript and must evaluate the quality of the agent's responses.
+
+## Your task
+
+Review all conversation turns and assess:
+
+1. **Overall quality** — Did the agent answer accurately and helpfully?
+2. **Tool usage** — Which tools worked well? Which failed, were misused, or were called but should not have been?
+3. **Corrections** — How many times did the user correct the agent (e.g. "that's wrong", "actually...", "no, I meant...")?
+4. **Summary** — Write one sentence describing the session quality.
+
+## Output format
+
+Return ONLY a valid JSON object. No markdown, no explanation, no code fences — just the raw JSON.
+
+```
+{
+  "summary": "one-sentence evaluation of session quality",
+  "toolsWorkedWell": ["tool-a", "tool-b"],
+  "toolsFailedOrMissed": ["tool-c"],
+  "correctionsMade": 0,
+  "overallQuality": "good|fair|poor"
+}
+```
+
+- `summary`: one sentence, 15 words or fewer, describing the overall session quality
+- `toolsWorkedWell`: names of tools that returned useful results and were used appropriately
+- `toolsFailedOrMissed`: names of tools that threw errors, returned wrong data, or should have been used but weren't
+- `correctionsMade`: count of user corrections detected in the conversation
+- `overallQuality`: one of `good`, `fair`, or `poor`
+  - `good` — agent was accurate, helpful, and used tools correctly
+  - `fair` — some errors or corrections, but overall useful
+  - `poor` — multiple failures, repeated corrections, or unhelpful responses

--- a/src/RockBot.Host.Abstractions/FeedbackEntry.cs
+++ b/src/RockBot.Host.Abstractions/FeedbackEntry.cs
@@ -1,0 +1,12 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// A single recorded quality signal from an agent session.
+/// </summary>
+public sealed record FeedbackEntry(
+    string Id,
+    string SessionId,
+    FeedbackSignalType SignalType,
+    string Summary,
+    string? Detail,
+    DateTimeOffset Timestamp);

--- a/src/RockBot.Host.Abstractions/FeedbackOptions.cs
+++ b/src/RockBot.Host.Abstractions/FeedbackOptions.cs
@@ -1,0 +1,28 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Options for the feedback capture and session evaluation system.
+/// </summary>
+public sealed class FeedbackOptions
+{
+    /// <summary>
+    /// Base directory for per-session feedback JSONL files.
+    /// Relative paths are resolved under <see cref="AgentProfileOptions.BasePath"/>.
+    /// </summary>
+    public string BasePath { get; set; } = "feedback";
+
+    /// <summary>
+    /// How long a session must be idle (no new turns) before it is considered ended
+    /// and eligible for session-summary evaluation.
+    /// </summary>
+    public TimeSpan SessionIdleThreshold { get; set; } = TimeSpan.FromMinutes(30);
+
+    /// <summary>
+    /// Path to the session evaluator LLM directive file.
+    /// Relative paths are resolved under <see cref="AgentProfileOptions.BasePath"/>.
+    /// </summary>
+    public string EvaluatorDirectivePath { get; set; } = "session-evaluator.md";
+
+    /// <summary>How often the session summary service polls for sessions to evaluate.</summary>
+    public TimeSpan PollInterval { get; set; } = TimeSpan.FromMinutes(5);
+}

--- a/src/RockBot.Host.Abstractions/FeedbackSignalType.cs
+++ b/src/RockBot.Host.Abstractions/FeedbackSignalType.cs
@@ -1,0 +1,16 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Classifies the quality signal carried by a <see cref="FeedbackEntry"/>.
+/// </summary>
+public enum FeedbackSignalType
+{
+    /// <summary>A user message was detected as correcting the agent.</summary>
+    Correction,
+
+    /// <summary>A tool call threw or returned an error result.</summary>
+    ToolFailure,
+
+    /// <summary>An LLM-produced evaluation of a completed session.</summary>
+    SessionSummary
+}

--- a/src/RockBot.Host.Abstractions/IConversationMemory.cs
+++ b/src/RockBot.Host.Abstractions/IConversationMemory.cs
@@ -20,4 +20,9 @@ public interface IConversationMemory
     /// Clears all turns for the specified session.
     /// </summary>
     Task ClearAsync(string sessionId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the IDs of all sessions currently held in memory.
+    /// </summary>
+    Task<IReadOnlyList<string>> ListSessionsAsync(CancellationToken cancellationToken = default);
 }

--- a/src/RockBot.Host.Abstractions/IFeedbackStore.cs
+++ b/src/RockBot.Host.Abstractions/IFeedbackStore.cs
@@ -1,0 +1,21 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Persistent store for agent feedback signals.
+/// Entries are written by signal capture (correction detection, tool failures, session summaries)
+/// and queried by the dreaming system to inform memory consolidation.
+/// </summary>
+public interface IFeedbackStore
+{
+    /// <summary>Appends a feedback entry to the store.</summary>
+    Task AppendAsync(FeedbackEntry entry, CancellationToken cancellationToken = default);
+
+    /// <summary>Returns all feedback entries for the specified session.</summary>
+    Task<IReadOnlyList<FeedbackEntry>> GetBySessionAsync(string sessionId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns feedback entries recorded on or after <paramref name="since"/>,
+    /// ordered by timestamp ascending, capped at <paramref name="maxResults"/>.
+    /// </summary>
+    Task<IReadOnlyList<FeedbackEntry>> QueryRecentAsync(DateTimeOffset since, int maxResults, CancellationToken cancellationToken = default);
+}

--- a/src/RockBot.Host/AgentMemoryExtensions.cs
+++ b/src/RockBot.Host/AgentMemoryExtensions.cs
@@ -112,4 +112,25 @@ public static class AgentMemoryExtensions
 
         return builder;
     }
+
+    /// <summary>
+    /// Registers the feedback capture system: <see cref="IFeedbackStore"/> (file-backed) and
+    /// the <see cref="SessionSummaryService"/> background evaluator.
+    /// Requires <see cref="IConversationMemory"/> and an LLM client to be registered.
+    /// </summary>
+    public static AgentHostBuilder WithFeedback(
+        this AgentHostBuilder builder,
+        Action<FeedbackOptions>? configure = null)
+    {
+        if (configure is not null)
+            builder.Services.Configure(configure);
+        else
+            builder.Services.Configure<FeedbackOptions>(_ => { });
+
+        builder.Services.AddSingleton<IFeedbackStore, FileFeedbackStore>();
+        builder.Services.AddSingleton<SessionSummaryService>();
+        builder.Services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<SessionSummaryService>());
+
+        return builder;
+    }
 }

--- a/src/RockBot.Host/FileConversationMemory.cs
+++ b/src/RockBot.Host/FileConversationMemory.cs
@@ -111,6 +111,20 @@ internal sealed class FileConversationMemory : IConversationMemory, IHostedServi
         DeleteSessionFile(sessionId);
     }
 
+    public Task<IReadOnlyList<string>> ListSessionsAsync(CancellationToken cancellationToken = default)
+    {
+        if (!Directory.Exists(_basePath))
+            return Task.FromResult<IReadOnlyList<string>>(Array.Empty<string>());
+
+        var sessionIds = Directory.EnumerateFiles(_basePath, "*.json")
+            .Select(Path.GetFileNameWithoutExtension)
+            .Where(id => id is not null)
+            .Cast<string>()
+            .ToList();
+
+        return Task.FromResult<IReadOnlyList<string>>(sessionIds);
+    }
+
     // ── Internals ─────────────────────────────────────────────────────────────
 
     private async Task PersistSessionAsync(string sessionId, CancellationToken ct)

--- a/src/RockBot.Host/FileFeedbackStore.cs
+++ b/src/RockBot.Host/FileFeedbackStore.cs
@@ -1,0 +1,128 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace RockBot.Host;
+
+/// <summary>
+/// File-based feedback store. Each session's entries are appended to a separate JSONL file:
+/// <c>{basePath}/{sessionId}.jsonl</c>. One JSON object per line.
+/// </summary>
+internal sealed class FileFeedbackStore : IFeedbackStore
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true
+    };
+
+    private readonly string _basePath;
+    private readonly ILogger<FileFeedbackStore> _logger;
+
+    /// <summary>Per-session semaphores prevent concurrent writes racing on the same file.</summary>
+    private readonly ConcurrentDictionary<string, SemaphoreSlim> _writeLocks = new();
+
+    public FileFeedbackStore(
+        IOptions<FeedbackOptions> options,
+        IOptions<AgentProfileOptions> profileOptions,
+        ILogger<FileFeedbackStore> logger)
+    {
+        _basePath = ResolvePath(options.Value.BasePath, profileOptions.Value.BasePath);
+        _logger = logger;
+
+        Directory.CreateDirectory(_basePath);
+        _logger.LogInformation("Feedback store path: {Path}", _basePath);
+    }
+
+    public async Task AppendAsync(FeedbackEntry entry, CancellationToken cancellationToken = default)
+    {
+        var sem = _writeLocks.GetOrAdd(entry.SessionId, _ => new SemaphoreSlim(1, 1));
+        await sem.WaitAsync(cancellationToken);
+        try
+        {
+            var path = Path.Combine(_basePath, $"{entry.SessionId}.jsonl");
+            var line = JsonSerializer.Serialize(entry, JsonOptions);
+            await File.AppendAllTextAsync(path, line + Environment.NewLine, cancellationToken);
+
+            _logger.LogDebug("Feedback appended [{SignalType}] for session {SessionId}", entry.SignalType, entry.SessionId);
+        }
+        finally
+        {
+            sem.Release();
+        }
+    }
+
+    public async Task<IReadOnlyList<FeedbackEntry>> GetBySessionAsync(string sessionId, CancellationToken cancellationToken = default)
+    {
+        var path = Path.Combine(_basePath, $"{sessionId}.jsonl");
+        if (!File.Exists(path))
+            return Array.Empty<FeedbackEntry>();
+
+        return await ReadEntriesAsync(path, cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<FeedbackEntry>> QueryRecentAsync(
+        DateTimeOffset since,
+        int maxResults,
+        CancellationToken cancellationToken = default)
+    {
+        if (!Directory.Exists(_basePath))
+            return Array.Empty<FeedbackEntry>();
+
+        var results = new List<FeedbackEntry>();
+
+        foreach (var file in Directory.EnumerateFiles(_basePath, "*.jsonl"))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var entries = await ReadEntriesAsync(file, cancellationToken);
+            results.AddRange(entries.Where(e => e.Timestamp >= since));
+        }
+
+        return results
+            .OrderBy(e => e.Timestamp)
+            .Take(maxResults)
+            .ToList();
+    }
+
+    private async Task<IReadOnlyList<FeedbackEntry>> ReadEntriesAsync(string path, CancellationToken cancellationToken)
+    {
+        var entries = new List<FeedbackEntry>();
+        try
+        {
+            var lines = await File.ReadAllLinesAsync(path, cancellationToken);
+            foreach (var line in lines)
+            {
+                if (string.IsNullOrWhiteSpace(line)) continue;
+                try
+                {
+                    var entry = JsonSerializer.Deserialize<FeedbackEntry>(line, JsonOptions);
+                    if (entry is not null)
+                        entries.Add(entry);
+                }
+                catch (JsonException ex)
+                {
+                    _logger.LogWarning(ex, "Failed to deserialize feedback entry from {Path}", path);
+                }
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "Failed to read feedback file {Path}", path);
+        }
+        return entries;
+    }
+
+    private static string ResolvePath(string path, string basePath)
+    {
+        if (Path.IsPathRooted(path))
+            return path;
+
+        var baseDir = Path.IsPathRooted(basePath)
+            ? basePath
+            : Path.Combine(AppContext.BaseDirectory, basePath);
+
+        return Path.Combine(baseDir, path);
+    }
+}

--- a/src/RockBot.Host/InMemoryConversationMemory.cs
+++ b/src/RockBot.Host/InMemoryConversationMemory.cs
@@ -66,6 +66,9 @@ internal sealed class InMemoryConversationMemory : IConversationMemory, IDisposa
         return Task.CompletedTask;
     }
 
+    public Task<IReadOnlyList<string>> ListSessionsAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<string>>([.. _sessions.Keys]);
+
     private void CleanupIdleSessions(object? state)
     {
         var cutoff = DateTimeOffset.UtcNow - _options.SessionIdleTimeout;

--- a/src/RockBot.Host/SessionSummaryService.cs
+++ b/src/RockBot.Host/SessionSummaryService.cs
@@ -1,0 +1,234 @@
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace RockBot.Host;
+
+/// <summary>
+/// Hosted service that periodically evaluates completed sessions and writes
+/// <see cref="FeedbackEntry"/> records with <see cref="FeedbackSignalType.SessionSummary"/>
+/// to the <see cref="IFeedbackStore"/>.
+///
+/// A session is eligible for evaluation once it has been idle for longer than
+/// <see cref="FeedbackOptions.SessionIdleThreshold"/>. Each session is evaluated at most
+/// once per process lifetime (tracked in a <see cref="HashSet{T}"/>).
+/// </summary>
+internal sealed class SessionSummaryService : IHostedService, IDisposable
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true
+    };
+
+    private readonly IConversationMemory _conversationMemory;
+    private readonly IFeedbackStore _feedbackStore;
+    private readonly ILlmClient _llmClient;
+    private readonly FeedbackOptions _options;
+    private readonly AgentProfileOptions _profileOptions;
+    private readonly ILogger<SessionSummaryService> _logger;
+
+    /// <summary>Sessions already evaluated in this process run (prevents redundant re-evaluation).</summary>
+    private readonly HashSet<string> _evaluated = [];
+
+    private Timer? _timer;
+    private string? _evaluatorDirective;
+
+    public SessionSummaryService(
+        IConversationMemory conversationMemory,
+        IFeedbackStore feedbackStore,
+        ILlmClient llmClient,
+        IOptions<FeedbackOptions> options,
+        IOptions<AgentProfileOptions> profileOptions,
+        ILogger<SessionSummaryService> logger)
+    {
+        _conversationMemory = conversationMemory;
+        _feedbackStore = feedbackStore;
+        _llmClient = llmClient;
+        _options = options.Value;
+        _profileOptions = profileOptions.Value;
+        _logger = logger;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        var directivePath = ResolvePath(_options.EvaluatorDirectivePath, _profileOptions.BasePath);
+        _evaluatorDirective = File.Exists(directivePath)
+            ? File.ReadAllText(directivePath)
+            : BuiltInDirective;
+
+        if (!File.Exists(directivePath))
+            _logger.LogWarning("SessionSummaryService: evaluator directive not found at {Path}; using built-in fallback", directivePath);
+        else
+            _logger.LogInformation("SessionSummaryService: loaded evaluator directive from {Path}", directivePath);
+
+        _timer = new Timer(
+            state => { _ = EvaluateSessionsAsync(); },
+            null,
+            _options.PollInterval,
+            _options.PollInterval);
+
+        _logger.LogInformation("SessionSummaryService: scheduled — polling every {Interval}", _options.PollInterval);
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _timer?.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+        return Task.CompletedTask;
+    }
+
+    public void Dispose() => _timer?.Dispose();
+
+    private async Task EvaluateSessionsAsync()
+    {
+        try
+        {
+            var sessionIds = await _conversationMemory.ListSessionsAsync();
+            if (sessionIds.Count == 0) return;
+
+            var idleThreshold = DateTimeOffset.UtcNow - _options.SessionIdleThreshold;
+
+            foreach (var sessionId in sessionIds)
+            {
+                if (_evaluated.Contains(sessionId))
+                    continue;
+
+                var turns = await _conversationMemory.GetTurnsAsync(sessionId);
+                if (turns.Count == 0)
+                    continue;
+
+                var lastTurnAt = turns.Max(t => t.Timestamp);
+                if (lastTurnAt > idleThreshold)
+                {
+                    // Session is still active — skip it this poll cycle
+                    continue;
+                }
+
+                _logger.LogInformation(
+                    "SessionSummaryService: evaluating idle session {SessionId} (last turn: {LastTurn:u})",
+                    sessionId, lastTurnAt);
+
+                await EvaluateSessionAsync(sessionId, turns);
+                _evaluated.Add(sessionId);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "SessionSummaryService: evaluation cycle failed");
+        }
+    }
+
+    private async Task EvaluateSessionAsync(string sessionId, IReadOnlyList<ConversationTurn> turns)
+    {
+        // Back off if LLM is busy
+        while (!_llmClient.IsIdle)
+        {
+            _logger.LogDebug("SessionSummaryService: LLM busy, delaying evaluation for session {SessionId}", sessionId);
+            await Task.Delay(TimeSpan.FromSeconds(5));
+        }
+
+        var userMessage = new StringBuilder();
+        userMessage.AppendLine($"Evaluate the following conversation session ({turns.Count} turns):");
+        userMessage.AppendLine();
+
+        foreach (var turn in turns)
+            userMessage.AppendLine($"[{turn.Role.ToUpperInvariant()}]: {turn.Content}");
+
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.System, _evaluatorDirective!),
+            new(ChatRole.User, userMessage.ToString())
+        };
+
+        try
+        {
+            var response = await _llmClient.GetResponseAsync(messages, new ChatOptions());
+            var raw = response.Text?.Trim() ?? string.Empty;
+            var json = ExtractJsonObject(raw);
+
+            if (string.IsNullOrEmpty(json))
+            {
+                _logger.LogWarning("SessionSummaryService: LLM returned no parseable JSON for session {SessionId}", sessionId);
+                return;
+            }
+
+            var result = JsonSerializer.Deserialize<SessionEvalDto>(json, JsonOptions);
+            if (result is null)
+            {
+                _logger.LogWarning("SessionSummaryService: failed to deserialize evaluation for session {SessionId}", sessionId);
+                return;
+            }
+
+            var summary = result.Summary ?? "Session evaluated (no summary returned).";
+            var entry = new FeedbackEntry(
+                Id: Guid.NewGuid().ToString("N")[..12],
+                SessionId: sessionId,
+                SignalType: FeedbackSignalType.SessionSummary,
+                Summary: summary,
+                Detail: json,
+                Timestamp: DateTimeOffset.UtcNow);
+
+            await _feedbackStore.AppendAsync(entry);
+
+            _logger.LogInformation(
+                "SessionSummaryService: evaluated session {SessionId} — quality={Quality}",
+                sessionId, result.OverallQuality ?? "unknown");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "SessionSummaryService: failed to evaluate session {SessionId}", sessionId);
+        }
+    }
+
+    private static string ExtractJsonObject(string text)
+    {
+        // Strip <think>...</think> blocks (DeepSeek reasoning preamble)
+        var thinkStart = text.IndexOf("<think>", StringComparison.OrdinalIgnoreCase);
+        var thinkEnd = text.IndexOf("</think>", StringComparison.OrdinalIgnoreCase);
+        if (thinkStart >= 0 && thinkEnd > thinkStart)
+            text = text[(thinkEnd + "</think>".Length)..].TrimStart();
+
+        var objStart = text.IndexOf('{');
+        var objEnd = text.LastIndexOf('}');
+        if (objStart >= 0 && objEnd > objStart)
+            return text[objStart..(objEnd + 1)];
+
+        return string.Empty;
+    }
+
+    private static string ResolvePath(string path, string basePath)
+    {
+        if (Path.IsPathRooted(path))
+            return path;
+
+        var baseDir = Path.IsPathRooted(basePath)
+            ? basePath
+            : Path.Combine(AppContext.BaseDirectory, basePath);
+
+        return Path.Combine(baseDir, path);
+    }
+
+    private const string BuiltInDirective = """
+        You are a session quality evaluator. Review the conversation turns provided and evaluate the agent's performance.
+        Return ONLY a valid JSON object — no markdown, no explanation, no code fences.
+
+        {
+          "summary": "one-sentence evaluation of session quality",
+          "toolsWorkedWell": ["tool-a"],
+          "toolsFailedOrMissed": ["tool-b"],
+          "correctionsMade": 0,
+          "overallQuality": "good|fair|poor"
+        }
+        """;
+
+    private sealed record SessionEvalDto(
+        string? Summary,
+        List<string>? ToolsWorkedWell,
+        List<string>? ToolsFailedOrMissed,
+        int? CorrectionsMade,
+        string? OverallQuality);
+}

--- a/tests/RockBot.Host.Tests/FileFeedbackStoreTests.cs
+++ b/tests/RockBot.Host.Tests/FileFeedbackStoreTests.cs
@@ -1,0 +1,205 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace RockBot.Host.Tests;
+
+[TestClass]
+public class FileFeedbackStoreTests
+{
+    private string _tempDir = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "rockbot-feedback-test-" + Guid.NewGuid().ToString("N"));
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    // ── Append / read round-trip ──────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task AppendAsync_And_GetBySessionAsync_RoundTrips()
+    {
+        var store = CreateStore();
+        var entry = MakeEntry("session-1", FeedbackSignalType.Correction, "user corrected agent");
+
+        await store.AppendAsync(entry);
+        var results = await store.GetBySessionAsync("session-1");
+
+        Assert.AreEqual(1, results.Count);
+        Assert.AreEqual(entry.Id, results[0].Id);
+        Assert.AreEqual("session-1", results[0].SessionId);
+        Assert.AreEqual(FeedbackSignalType.Correction, results[0].SignalType);
+        Assert.AreEqual("user corrected agent", results[0].Summary);
+    }
+
+    [TestMethod]
+    public async Task AppendAsync_MultipleEntries_AllPersisted()
+    {
+        var store = CreateStore();
+        var e1 = MakeEntry("session-1", FeedbackSignalType.Correction, "correction 1");
+        var e2 = MakeEntry("session-1", FeedbackSignalType.ToolFailure, "tool error");
+        var e3 = MakeEntry("session-1", FeedbackSignalType.SessionSummary, "session evaluated");
+
+        await store.AppendAsync(e1);
+        await store.AppendAsync(e2);
+        await store.AppendAsync(e3);
+
+        var results = await store.GetBySessionAsync("session-1");
+        Assert.AreEqual(3, results.Count);
+    }
+
+    // ── GetBySessionAsync isolation ───────────────────────────────────────────
+
+    [TestMethod]
+    public async Task GetBySessionAsync_ReturnsOnlyThatSession()
+    {
+        var store = CreateStore();
+        await store.AppendAsync(MakeEntry("session-A", FeedbackSignalType.Correction, "for A"));
+        await store.AppendAsync(MakeEntry("session-B", FeedbackSignalType.ToolFailure, "for B"));
+
+        var resultsA = await store.GetBySessionAsync("session-A");
+        var resultsB = await store.GetBySessionAsync("session-B");
+
+        Assert.AreEqual(1, resultsA.Count);
+        Assert.AreEqual("session-A", resultsA[0].SessionId);
+        Assert.AreEqual(1, resultsB.Count);
+        Assert.AreEqual("session-B", resultsB[0].SessionId);
+    }
+
+    [TestMethod]
+    public async Task GetBySessionAsync_UnknownSession_ReturnsEmpty()
+    {
+        var store = CreateStore();
+        var results = await store.GetBySessionAsync("nonexistent");
+        Assert.AreEqual(0, results.Count);
+    }
+
+    // ── Multiple sessions in separate files ───────────────────────────────────
+
+    [TestMethod]
+    public async Task MultipleSessionsAreStoredInSeparateFiles()
+    {
+        var store = CreateStore();
+        await store.AppendAsync(MakeEntry("sess-1", FeedbackSignalType.Correction, "a"));
+        await store.AppendAsync(MakeEntry("sess-2", FeedbackSignalType.ToolFailure, "b"));
+
+        var feedbackDir = Path.Combine(_tempDir, "feedback");
+        var files = Directory.GetFiles(feedbackDir, "*.jsonl");
+        Assert.AreEqual(2, files.Length);
+        Assert.IsTrue(files.Any(f => Path.GetFileNameWithoutExtension(f) == "sess-1"));
+        Assert.IsTrue(files.Any(f => Path.GetFileNameWithoutExtension(f) == "sess-2"));
+    }
+
+    // ── QueryRecentAsync ──────────────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task QueryRecentAsync_FiltersEntriesBeforeSince()
+    {
+        var store = CreateStore();
+        var now = DateTimeOffset.UtcNow;
+
+        var old = MakeEntry("session-1", FeedbackSignalType.Correction, "old", timestamp: now.AddHours(-2));
+        var recent = MakeEntry("session-1", FeedbackSignalType.ToolFailure, "recent", timestamp: now.AddMinutes(-5));
+
+        await store.AppendAsync(old);
+        await store.AppendAsync(recent);
+
+        var results = await store.QueryRecentAsync(since: now.AddHours(-1), maxResults: 100);
+
+        Assert.AreEqual(1, results.Count);
+        Assert.AreEqual("recent", results[0].Summary);
+    }
+
+    [TestMethod]
+    public async Task QueryRecentAsync_RespectsMaxResults()
+    {
+        var store = CreateStore();
+        var now = DateTimeOffset.UtcNow;
+
+        for (var i = 0; i < 5; i++)
+            await store.AppendAsync(MakeEntry("session-1", FeedbackSignalType.Correction, $"entry-{i}", timestamp: now.AddMinutes(-i)));
+
+        var results = await store.QueryRecentAsync(since: now.AddHours(-1), maxResults: 3);
+
+        Assert.AreEqual(3, results.Count);
+    }
+
+    [TestMethod]
+    public async Task QueryRecentAsync_ScansAllSessions()
+    {
+        var store = CreateStore();
+        var now = DateTimeOffset.UtcNow;
+
+        await store.AppendAsync(MakeEntry("session-A", FeedbackSignalType.Correction, "from A", timestamp: now.AddMinutes(-10)));
+        await store.AppendAsync(MakeEntry("session-B", FeedbackSignalType.ToolFailure, "from B", timestamp: now.AddMinutes(-5)));
+
+        var results = await store.QueryRecentAsync(since: now.AddHours(-1), maxResults: 100);
+
+        Assert.AreEqual(2, results.Count);
+        Assert.IsTrue(results.Any(r => r.Summary == "from A"));
+        Assert.IsTrue(results.Any(r => r.Summary == "from B"));
+    }
+
+    [TestMethod]
+    public async Task QueryRecentAsync_EmptyStore_ReturnsEmpty()
+    {
+        var store = CreateStore();
+        var results = await store.QueryRecentAsync(since: DateTimeOffset.UtcNow.AddDays(-1), maxResults: 100);
+        Assert.AreEqual(0, results.Count);
+    }
+
+    [TestMethod]
+    public async Task QueryRecentAsync_OrdersByTimestampAscending()
+    {
+        var store = CreateStore();
+        var now = DateTimeOffset.UtcNow;
+
+        var first = MakeEntry("s", FeedbackSignalType.Correction, "first", timestamp: now.AddMinutes(-30));
+        var second = MakeEntry("s", FeedbackSignalType.ToolFailure, "second", timestamp: now.AddMinutes(-20));
+        var third = MakeEntry("s", FeedbackSignalType.SessionSummary, "third", timestamp: now.AddMinutes(-10));
+
+        // Append in non-chronological order
+        await store.AppendAsync(third);
+        await store.AppendAsync(first);
+        await store.AppendAsync(second);
+
+        var results = await store.QueryRecentAsync(since: now.AddHours(-1), maxResults: 100);
+
+        Assert.AreEqual(3, results.Count);
+        Assert.AreEqual("first", results[0].Summary);
+        Assert.AreEqual("second", results[1].Summary);
+        Assert.AreEqual("third", results[2].Summary);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private FileFeedbackStore CreateStore()
+    {
+        var feedbackOptions = Options.Create(new FeedbackOptions { BasePath = Path.Combine(_tempDir, "feedback") });
+        var profileOptions = Options.Create(new AgentProfileOptions { BasePath = _tempDir });
+        return new FileFeedbackStore(feedbackOptions, profileOptions, NullLogger<FileFeedbackStore>.Instance);
+    }
+
+    private static FeedbackEntry MakeEntry(
+        string sessionId,
+        FeedbackSignalType signalType,
+        string summary,
+        string? detail = null,
+        DateTimeOffset? timestamp = null)
+    {
+        return new FeedbackEntry(
+            Id: Guid.NewGuid().ToString("N")[..12],
+            SessionId: sessionId,
+            SignalType: signalType,
+            Summary: summary,
+            Detail: detail,
+            Timestamp: timestamp ?? DateTimeOffset.UtcNow);
+    }
+}

--- a/tests/RockBot.Host.Tests/SessionSummaryServiceTests.cs
+++ b/tests/RockBot.Host.Tests/SessionSummaryServiceTests.cs
@@ -1,0 +1,208 @@
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace RockBot.Host.Tests;
+
+[TestClass]
+public class SessionSummaryServiceTests
+{
+    private static readonly TimeSpan ShortPoll = TimeSpan.FromMilliseconds(50);
+    private static readonly TimeSpan WaitTimeout = TimeSpan.FromSeconds(5);
+
+    // ── Skips sessions that are still active ──────────────────────────────────
+
+    [TestMethod]
+    public async Task ActiveSession_IsNotEvaluated()
+    {
+        var memory = new FakeConversationMemory();
+        memory.AddSession("active-session", [
+            new ConversationTurn("user", "Hello", DateTimeOffset.UtcNow) // recent turn
+        ]);
+        var feedbackStore = new FakeFeedbackStore();
+        var llm = new FakeLlmClient();
+
+        var svc = CreateService(memory, feedbackStore, llm, idleThreshold: TimeSpan.FromMinutes(30));
+        await svc.StartAsync(CancellationToken.None);
+        await Task.Delay(TimeSpan.FromMilliseconds(150)); // wait for a couple poll cycles
+        await svc.StopAsync(CancellationToken.None);
+        svc.Dispose();
+
+        Assert.AreEqual(0, feedbackStore.AppendedEntries.Count, "Active session should not be evaluated");
+    }
+
+    // ── Evaluates sessions that have been idle long enough ────────────────────
+
+    [TestMethod]
+    public async Task IdleSession_IsEvaluated()
+    {
+        var memory = new FakeConversationMemory();
+        memory.AddSession("idle-session", [
+            new ConversationTurn("user", "Hello", DateTimeOffset.UtcNow.AddHours(-2)) // old turn
+        ]);
+        var feedbackStore = new FakeFeedbackStore();
+        var llm = new FakeLlmClient(responseJson: """{"summary":"session was good","overallQuality":"good"}""");
+
+        var svc = CreateService(memory, feedbackStore, llm, idleThreshold: TimeSpan.FromMinutes(30));
+        await svc.StartAsync(CancellationToken.None);
+
+        // Wait up to 5s for the evaluation to run
+        var deadline = DateTime.UtcNow.Add(WaitTimeout);
+        while (feedbackStore.AppendedEntries.Count == 0 && DateTime.UtcNow < deadline)
+            await Task.Delay(50);
+
+        await svc.StopAsync(CancellationToken.None);
+        svc.Dispose();
+
+        Assert.IsTrue(feedbackStore.AppendedEntries.Count > 0, "Idle session should be evaluated");
+        var entry = feedbackStore.AppendedEntries[0];
+        Assert.AreEqual("idle-session", entry.SessionId);
+        Assert.AreEqual(FeedbackSignalType.SessionSummary, entry.SignalType);
+    }
+
+    // ── Already-evaluated sessions are not re-evaluated (idempotency) ─────────
+
+    [TestMethod]
+    public async Task AlreadyEvaluatedSession_IsNotReEvaluated()
+    {
+        var memory = new FakeConversationMemory();
+        memory.AddSession("once-session", [
+            new ConversationTurn("user", "Hello", DateTimeOffset.UtcNow.AddHours(-2))
+        ]);
+        var feedbackStore = new FakeFeedbackStore();
+        var llm = new FakeLlmClient(responseJson: """{"summary":"ok","overallQuality":"good"}""");
+
+        var svc = CreateService(memory, feedbackStore, llm, idleThreshold: TimeSpan.FromMinutes(30));
+        await svc.StartAsync(CancellationToken.None);
+
+        // Wait for first evaluation
+        var deadline = DateTime.UtcNow.Add(WaitTimeout);
+        while (feedbackStore.AppendedEntries.Count == 0 && DateTime.UtcNow < deadline)
+            await Task.Delay(50);
+
+        // Wait for several more poll cycles
+        await Task.Delay(TimeSpan.FromMilliseconds(300));
+        var countAfterFirstEval = feedbackStore.AppendedEntries.Count;
+
+        await svc.StopAsync(CancellationToken.None);
+        svc.Dispose();
+
+        Assert.AreEqual(1, countAfterFirstEval, "Session should only be evaluated once");
+    }
+
+    // ── Gracefully handles LLM errors ─────────────────────────────────────────
+
+    [TestMethod]
+    public async Task LlmError_DoesNotCrashService()
+    {
+        var memory = new FakeConversationMemory();
+        memory.AddSession("error-session", [
+            new ConversationTurn("user", "Hello", DateTimeOffset.UtcNow.AddHours(-2))
+        ]);
+        var feedbackStore = new FakeFeedbackStore();
+        var llm = new FakeLlmClient(throwOnCall: true);
+
+        var svc = CreateService(memory, feedbackStore, llm, idleThreshold: TimeSpan.FromMinutes(30));
+
+        // Should not throw
+        await svc.StartAsync(CancellationToken.None);
+        await Task.Delay(TimeSpan.FromMilliseconds(300));
+        await svc.StopAsync(CancellationToken.None);
+        svc.Dispose();
+
+        // No entries appended (LLM failed), but no exception either
+        Assert.AreEqual(0, feedbackStore.AppendedEntries.Count);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static SessionSummaryService CreateService(
+        IConversationMemory memory,
+        IFeedbackStore feedbackStore,
+        ILlmClient llm,
+        TimeSpan idleThreshold)
+    {
+        var options = Options.Create(new FeedbackOptions
+        {
+            PollInterval = ShortPoll,
+            SessionIdleThreshold = idleThreshold,
+            // Point to a nonexistent directive so the built-in fallback is used
+            EvaluatorDirectivePath = "/nonexistent/session-evaluator.md"
+        });
+        var profileOptions = Options.Create(new AgentProfileOptions());
+        return new SessionSummaryService(
+            memory,
+            feedbackStore,
+            llm,
+            options,
+            profileOptions,
+            NullLogger<SessionSummaryService>.Instance);
+    }
+
+    // ── Fakes ─────────────────────────────────────────────────────────────────
+
+    private sealed class FakeConversationMemory : IConversationMemory
+    {
+        private readonly Dictionary<string, List<ConversationTurn>> _sessions = new();
+
+        public void AddSession(string sessionId, IEnumerable<ConversationTurn> turns)
+            => _sessions[sessionId] = [.. turns];
+
+        public Task AddTurnAsync(string sessionId, ConversationTurn turn, CancellationToken ct = default)
+        {
+            if (!_sessions.TryGetValue(sessionId, out var list))
+                _sessions[sessionId] = list = [];
+            list.Add(turn);
+            return Task.CompletedTask;
+        }
+
+        public Task<IReadOnlyList<ConversationTurn>> GetTurnsAsync(string sessionId, CancellationToken ct = default)
+        {
+            _sessions.TryGetValue(sessionId, out var list);
+            return Task.FromResult<IReadOnlyList<ConversationTurn>>(list ?? []);
+        }
+
+        public Task ClearAsync(string sessionId, CancellationToken ct = default)
+        {
+            _sessions.Remove(sessionId);
+            return Task.CompletedTask;
+        }
+
+        public Task<IReadOnlyList<string>> ListSessionsAsync(CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<string>>([.. _sessions.Keys]);
+    }
+
+    private sealed class FakeFeedbackStore : IFeedbackStore
+    {
+        public List<FeedbackEntry> AppendedEntries { get; } = [];
+
+        public Task AppendAsync(FeedbackEntry entry, CancellationToken ct = default)
+        {
+            AppendedEntries.Add(entry);
+            return Task.CompletedTask;
+        }
+
+        public Task<IReadOnlyList<FeedbackEntry>> GetBySessionAsync(string sessionId, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<FeedbackEntry>>(AppendedEntries.Where(e => e.SessionId == sessionId).ToList());
+
+        public Task<IReadOnlyList<FeedbackEntry>> QueryRecentAsync(DateTimeOffset since, int maxResults, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<FeedbackEntry>>(AppendedEntries.Where(e => e.Timestamp >= since).Take(maxResults).ToList());
+    }
+
+    private sealed class FakeLlmClient(string? responseJson = null, bool throwOnCall = false) : ILlmClient
+    {
+        public bool IsIdle => true;
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            if (throwOnCall)
+                throw new InvalidOperationException("Simulated LLM failure");
+
+            var content = responseJson ?? """{"summary":"session completed","overallQuality":"fair"}""";
+            return Task.FromResult(new ChatResponse([new ChatMessage(ChatRole.Assistant, content)]));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds foundational feedback capture layer (Issue #52) with implicit signals, tool failure tracking, and session quality evaluation
- All signals are stored in queryable JSONL files and injected into the dreaming system's consolidation prompt
- No explicit UI feedback (thumbs up/down) — signal capture is fully UI-agnostic

## Changes

### New Abstractions
- `FeedbackSignalType` enum: `Correction`, `ToolFailure`, `SessionSummary`
- `FeedbackEntry` sealed record: Id, SessionId, SignalType, Summary, Detail, Timestamp
- `IFeedbackStore` interface: `AppendAsync`, `GetBySessionAsync`, `QueryRecentAsync`
- `FeedbackOptions`: BasePath, SessionIdleThreshold (30 min), EvaluatorDirectivePath, PollInterval

### New Implementations
- `FileFeedbackStore`: per-session JSONL files, thread-safe appends via per-session semaphores
- `SessionSummaryService`: hosted service that polls for idle sessions, calls LLM with `session-evaluator.md` directive, writes `SessionSummary` entries; skips already-evaluated sessions (idempotent)

### Modified
- `IConversationMemory` + both implementations: added `ListSessionsAsync()`
- `UserMessageHandler`: correction detection via `CorrectionRegex`, tool failure recording in both native and text-based tool catch blocks (all fire-and-forget)
- `DreamService`: optional `IFeedbackStore?` injection; appends last-7-days feedback signals to the dream LLM prompt
- `AgentMemoryExtensions`: added `WithFeedback()` DI registration
- `Program.cs`: added `agent.WithFeedback()`

### New Directive
- `session-evaluator.md`: LLM prompt producing `{ summary, toolsWorkedWell, toolsFailedOrMissed, correctionsMade, overallQuality }`

## Test plan

- [x] All existing tests pass (no regressions)
- [x] `FileFeedbackStoreTests` (9 tests): append/read round-trip, session isolation, separate files per session, `QueryRecentAsync` date filter, max results, ordering, multi-session scan
- [x] `SessionSummaryServiceTests` (4 tests): active session skipped, idle session evaluated, idempotency (no re-evaluation), graceful LLM error handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)