### PR TITLE
feat: skill invocation tracking, usage-annotated consolidation, and optimization pass (#53)

### DIFF
--- a/src/RockBot.Cli/Program.cs
+++ b/src/RockBot.Cli/Program.cs
@@ -54,8 +54,7 @@ builder.Services.AddSingleton<MemoryTools>();
 builder.Services.AddSingleton<RulesTools>();
 // Tracks which memory IDs have been injected per session, enabling delta recall across topic shifts
 builder.Services.AddSingleton<InjectedMemoryTracker>();
-// Skill tools and session index tracker
-builder.Services.AddSingleton<SkillTools>();
+// Skill index tracker (SkillTools is created per-session in UserMessageHandler)
 builder.Services.AddSingleton<SkillIndexTracker>();
 builder.Services.AddSingleton<SkillRecallTracker>();
 // Tool guides for memory and skill subsystems

--- a/src/RockBot.Cli/agent/skill-dream.md
+++ b/src/RockBot.Cli/agent/skill-dream.md
@@ -4,7 +4,13 @@ You are a skill consolidation assistant performing a maintenance pass over an ag
 
 ## Your task
 
-You will receive a numbered list of ALL current skills, each with a name, summary, and full content. Review them and:
+You will receive a numbered list of ALL current skills, each with a name, usage statistics, and full content. Each skill entry includes:
+- `[usage: Nx in last 30d]` — how many times the skill was invoked in the last 30 days
+- `[co-used with: X, Y]` — other skills frequently invoked in the same sessions (when applicable)
+
+**Treat high-usage skills with extra care when merging**: a skill invoked many times is well-established. Only merge it if the semantic overlap is clear and the merged result will be strictly better. When in doubt about a high-usage skill, keep it unchanged.
+
+Review the skills and:
 
 1. **Find semantically overlapping skills** — skills that cover the same task domain or have substantially overlapping "When to use" sections.
    - "plan-meeting" and "schedule-meeting" → same domain, merge them

--- a/src/RockBot.Cli/agent/skill-optimize.md
+++ b/src/RockBot.Cli/agent/skill-optimize.md
@@ -1,0 +1,50 @@
+# Skill Optimization Directive
+
+You are a skill improvement assistant performing a targeted pass over skills associated with agent failures. Your job is to make each skill more effective — not to rewrite everything.
+
+## Your task
+
+You will receive a list of skills that were invoked in sessions where problems occurred (user corrections, poor session quality). For each skill you will also see the associated failure context. Review them and:
+
+1. **Identify the root cause** — what step, missing detail, or ambiguous instruction in the skill likely contributed to the failure?
+   - Did the skill omit a critical verification step?
+   - Did it provide incorrect tool names or parameters?
+   - Was the "When to use" guidance too broad, causing the skill to be applied in the wrong context?
+   - Was a procedure step missing that would have caught or prevented the error?
+
+2. **Produce an improved version** that directly addresses the identified root cause:
+   - Add the missing step, clarify the ambiguous instruction, or tighten the "When to use" guidance
+   - Preserve all existing correct steps and specifics — only change what caused the problem
+   - Keep the same name and subcategory structure as the original
+
+3. **Leave skills unchanged** if the failure is not clearly addressable by better instructions (e.g. the failure was caused by a transient external error or user input that no skill could prevent).
+
+## Critical rules
+
+- **Only improve, never fabricate**: Do not invent procedures, tool names, or steps not grounded in the original skill or clearly implied by the failure context.
+- **Surgical changes**: Change as little as possible. A single added step or clarified instruction is better than a complete rewrite.
+- **Preserve specificity**: Retain all specific tool names, parameter names, account identifiers, and exact phrasings from the original.
+- **List the original name in sourceNames**: This triggers replacement of the original skill with the improved version.
+- **Skip when uncertain**: If you cannot confidently identify a specific actionable improvement, return the skill in neither `toDelete` nor `toSave`.
+
+## Output format
+
+Return ONLY a valid JSON object. No markdown, no explanation, no code fences — just the raw JSON.
+
+```
+{
+  "toDelete": ["skill-a", ...],
+  "toSave": [
+    {
+      "name": "skill-a",
+      "summary": "One sentence, 15 words or fewer",
+      "content": "# Skill A\n\n## When to use\n...\n\n## Steps\n...",
+      "sourceNames": ["skill-a"]
+    }
+  ]
+}
+```
+
+- `toDelete`: Names of all skills being replaced. Every name in any `sourceNames` list must also appear here.
+- `toSave`: Improved skills (each listing the original name in `sourceNames`).
+- If no improvements are warranted, return: `{ "toDelete": [], "toSave": [] }`

--- a/src/RockBot.Host.Abstractions/DreamOptions.cs
+++ b/src/RockBot.Host.Abstractions/DreamOptions.cs
@@ -24,4 +24,11 @@ public sealed class DreamOptions
     /// When the file does not exist, a built-in fallback directive is used.
     /// </summary>
     public string SkillDirectivePath { get; set; } = "skill-dream.md";
+
+    /// <summary>
+    /// Path to the skill optimization directive file, relative to <see cref="AgentProfileOptions.BasePath"/>.
+    /// Used by the post-consolidation pass that improves skills associated with poor sessions.
+    /// When the file does not exist, a built-in fallback directive is used.
+    /// </summary>
+    public string SkillOptimizeDirectivePath { get; set; } = "skill-optimize.md";
 }

--- a/src/RockBot.Host.Abstractions/ISkillUsageStore.cs
+++ b/src/RockBot.Host.Abstractions/ISkillUsageStore.cs
@@ -1,0 +1,21 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Persistent store for skill invocation events.
+/// Entries are written when a skill is retrieved and queried by the dreaming system
+/// to annotate skill consolidation and optimization passes.
+/// </summary>
+public interface ISkillUsageStore
+{
+    /// <summary>Appends a skill invocation event to the store.</summary>
+    Task AppendAsync(SkillInvocationEvent evt, CancellationToken ct = default);
+
+    /// <summary>Returns all invocation events for the specified session.</summary>
+    Task<IReadOnlyList<SkillInvocationEvent>> GetBySessionAsync(string sessionId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns invocation events recorded on or after <paramref name="since"/>,
+    /// ordered by timestamp ascending, capped at <paramref name="maxResults"/>.
+    /// </summary>
+    Task<IReadOnlyList<SkillInvocationEvent>> QueryRecentAsync(DateTimeOffset since, int maxResults, CancellationToken ct = default);
+}

--- a/src/RockBot.Host.Abstractions/SkillInvocationEvent.cs
+++ b/src/RockBot.Host.Abstractions/SkillInvocationEvent.cs
@@ -1,0 +1,10 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Records a single invocation of an agent skill — when it was retrieved and in which session.
+/// </summary>
+public sealed record SkillInvocationEvent(
+    string Id,
+    string SkillName,
+    string SessionId,
+    DateTimeOffset Timestamp);

--- a/src/RockBot.Host.Abstractions/SkillOptions.cs
+++ b/src/RockBot.Host.Abstractions/SkillOptions.cs
@@ -10,4 +10,10 @@ public sealed class SkillOptions
     /// Defaults to <c>"skills"</c>.
     /// </summary>
     public string BasePath { get; set; } = "skills";
+
+    /// <summary>
+    /// Path for per-session skill invocation JSONL files, relative to the agent profile base path.
+    /// Defaults to <c>"skill-usage"</c>.
+    /// </summary>
+    public string UsageBasePath { get; set; } = "skill-usage";
 }

--- a/src/RockBot.Host/AgentMemoryExtensions.cs
+++ b/src/RockBot.Host/AgentMemoryExtensions.cs
@@ -89,6 +89,7 @@ public static class AgentMemoryExtensions
             builder.Services.Configure<SkillOptions>(_ => { });
 
         builder.Services.AddSingleton<ISkillStore, FileSkillStore>();
+        builder.Services.AddSingleton<ISkillUsageStore, FileSkillUsageStore>();
 
         return builder;
     }

--- a/src/RockBot.Host/FileSkillUsageStore.cs
+++ b/src/RockBot.Host/FileSkillUsageStore.cs
@@ -1,0 +1,128 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace RockBot.Host;
+
+/// <summary>
+/// File-based skill usage store. Each session's invocation events are appended to a separate JSONL file:
+/// <c>{basePath}/{sessionId}.jsonl</c>. One JSON object per line.
+/// </summary>
+internal sealed class FileSkillUsageStore : ISkillUsageStore
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true
+    };
+
+    private readonly string _basePath;
+    private readonly ILogger<FileSkillUsageStore> _logger;
+
+    /// <summary>Per-session semaphores prevent concurrent writes racing on the same file.</summary>
+    private readonly ConcurrentDictionary<string, SemaphoreSlim> _writeLocks = new();
+
+    public FileSkillUsageStore(
+        IOptions<SkillOptions> options,
+        IOptions<AgentProfileOptions> profileOptions,
+        ILogger<FileSkillUsageStore> logger)
+    {
+        _basePath = ResolvePath(options.Value.UsageBasePath, profileOptions.Value.BasePath);
+        _logger = logger;
+
+        Directory.CreateDirectory(_basePath);
+        _logger.LogInformation("Skill usage store path: {Path}", _basePath);
+    }
+
+    public async Task AppendAsync(SkillInvocationEvent evt, CancellationToken ct = default)
+    {
+        var sem = _writeLocks.GetOrAdd(evt.SessionId, _ => new SemaphoreSlim(1, 1));
+        await sem.WaitAsync(ct);
+        try
+        {
+            var path = Path.Combine(_basePath, $"{evt.SessionId}.jsonl");
+            var line = JsonSerializer.Serialize(evt, JsonOptions);
+            await File.AppendAllTextAsync(path, line + Environment.NewLine, ct);
+
+            _logger.LogDebug("Skill usage appended [{SkillName}] for session {SessionId}", evt.SkillName, evt.SessionId);
+        }
+        finally
+        {
+            sem.Release();
+        }
+    }
+
+    public async Task<IReadOnlyList<SkillInvocationEvent>> GetBySessionAsync(string sessionId, CancellationToken ct = default)
+    {
+        var path = Path.Combine(_basePath, $"{sessionId}.jsonl");
+        if (!File.Exists(path))
+            return Array.Empty<SkillInvocationEvent>();
+
+        return await ReadEventsAsync(path, ct);
+    }
+
+    public async Task<IReadOnlyList<SkillInvocationEvent>> QueryRecentAsync(
+        DateTimeOffset since,
+        int maxResults,
+        CancellationToken ct = default)
+    {
+        if (!Directory.Exists(_basePath))
+            return Array.Empty<SkillInvocationEvent>();
+
+        var results = new List<SkillInvocationEvent>();
+
+        foreach (var file in Directory.EnumerateFiles(_basePath, "*.jsonl"))
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var events = await ReadEventsAsync(file, ct);
+            results.AddRange(events.Where(e => e.Timestamp >= since));
+        }
+
+        return results
+            .OrderBy(e => e.Timestamp)
+            .Take(maxResults)
+            .ToList();
+    }
+
+    private async Task<IReadOnlyList<SkillInvocationEvent>> ReadEventsAsync(string path, CancellationToken ct)
+    {
+        var events = new List<SkillInvocationEvent>();
+        try
+        {
+            var lines = await File.ReadAllLinesAsync(path, ct);
+            foreach (var line in lines)
+            {
+                if (string.IsNullOrWhiteSpace(line)) continue;
+                try
+                {
+                    var evt = JsonSerializer.Deserialize<SkillInvocationEvent>(line, JsonOptions);
+                    if (evt is not null)
+                        events.Add(evt);
+                }
+                catch (JsonException ex)
+                {
+                    _logger.LogWarning(ex, "Failed to deserialize skill usage event from {Path}", path);
+                }
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "Failed to read skill usage file {Path}", path);
+        }
+        return events;
+    }
+
+    private static string ResolvePath(string path, string basePath)
+    {
+        if (Path.IsPathRooted(path))
+            return path;
+
+        var baseDir = Path.IsPathRooted(basePath)
+            ? basePath
+            : Path.Combine(AppContext.BaseDirectory, basePath);
+
+        return Path.Combine(baseDir, path);
+    }
+}

--- a/tests/RockBot.Host.Tests/FileSkillUsageStoreTests.cs
+++ b/tests/RockBot.Host.Tests/FileSkillUsageStoreTests.cs
@@ -1,0 +1,157 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace RockBot.Host.Tests;
+
+[TestClass]
+public class FileSkillUsageStoreTests
+{
+    private string _tempDir = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "rockbot-skill-usage-test-" + Guid.NewGuid().ToString("N"));
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    // ── Append / read round-trip ──────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task Append_And_GetBySession_RoundTrips()
+    {
+        var store = CreateStore();
+        var evt1 = MakeEvent("session-1", "plan-meeting");
+        var evt2 = MakeEvent("session-1", "send-email");
+
+        await store.AppendAsync(evt1);
+        await store.AppendAsync(evt2);
+
+        var results = await store.GetBySessionAsync("session-1");
+
+        Assert.AreEqual(2, results.Count);
+        Assert.IsTrue(results.Any(e => e.Id == evt1.Id && e.SkillName == "plan-meeting"));
+        Assert.IsTrue(results.Any(e => e.Id == evt2.Id && e.SkillName == "send-email"));
+    }
+
+    [TestMethod]
+    public async Task GetBySession_NotFound_ReturnsEmpty()
+    {
+        var store = CreateStore();
+        var results = await store.GetBySessionAsync("nonexistent-session");
+        Assert.AreEqual(0, results.Count);
+    }
+
+    // ── QueryRecent filtering ─────────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task QueryRecent_FiltersOldEvents()
+    {
+        var store = CreateStore();
+        var now = DateTimeOffset.UtcNow;
+
+        var old = MakeEvent("session-1", "old-skill", timestamp: now.AddDays(-35));
+        var recent = MakeEvent("session-1", "recent-skill", timestamp: now.AddDays(-5));
+
+        await store.AppendAsync(old);
+        await store.AppendAsync(recent);
+
+        var results = await store.QueryRecentAsync(since: now.AddDays(-30), maxResults: 100);
+
+        Assert.AreEqual(1, results.Count);
+        Assert.AreEqual("recent-skill", results[0].SkillName);
+    }
+
+    [TestMethod]
+    public async Task QueryRecent_AcrossMultipleSessions()
+    {
+        var store = CreateStore();
+        var now = DateTimeOffset.UtcNow;
+
+        await store.AppendAsync(MakeEvent("session-A", "skill-x", timestamp: now.AddDays(-1)));
+        await store.AppendAsync(MakeEvent("session-B", "skill-y", timestamp: now.AddDays(-2)));
+        await store.AppendAsync(MakeEvent("session-C", "skill-z", timestamp: now.AddDays(-3)));
+
+        var results = await store.QueryRecentAsync(since: now.AddDays(-30), maxResults: 100);
+
+        Assert.AreEqual(3, results.Count);
+        Assert.IsTrue(results.Any(e => e.SkillName == "skill-x" && e.SessionId == "session-A"));
+        Assert.IsTrue(results.Any(e => e.SkillName == "skill-y" && e.SessionId == "session-B"));
+        Assert.IsTrue(results.Any(e => e.SkillName == "skill-z" && e.SessionId == "session-C"));
+    }
+
+    [TestMethod]
+    public async Task QueryRecent_RespectsMaxResults()
+    {
+        var store = CreateStore();
+        var now = DateTimeOffset.UtcNow;
+
+        for (var i = 0; i < 5; i++)
+            await store.AppendAsync(MakeEvent("session-1", $"skill-{i}", timestamp: now.AddMinutes(-i)));
+
+        var results = await store.QueryRecentAsync(since: now.AddHours(-1), maxResults: 3);
+
+        Assert.AreEqual(3, results.Count);
+    }
+
+    [TestMethod]
+    public async Task QueryRecent_OrdersByTimestampAscending()
+    {
+        var store = CreateStore();
+        var now = DateTimeOffset.UtcNow;
+
+        var first = MakeEvent("s", "skill-first", timestamp: now.AddMinutes(-30));
+        var second = MakeEvent("s", "skill-second", timestamp: now.AddMinutes(-20));
+        var third = MakeEvent("s", "skill-third", timestamp: now.AddMinutes(-10));
+
+        // Append out of order
+        await store.AppendAsync(third);
+        await store.AppendAsync(first);
+        await store.AppendAsync(second);
+
+        var results = await store.QueryRecentAsync(since: now.AddHours(-1), maxResults: 100);
+
+        Assert.AreEqual(3, results.Count);
+        Assert.AreEqual("skill-first", results[0].SkillName);
+        Assert.AreEqual("skill-second", results[1].SkillName);
+        Assert.AreEqual("skill-third", results[2].SkillName);
+    }
+
+    [TestMethod]
+    public async Task QueryRecent_EmptyStore_ReturnsEmpty()
+    {
+        var store = CreateStore();
+        var results = await store.QueryRecentAsync(since: DateTimeOffset.UtcNow.AddDays(-30), maxResults: 100);
+        Assert.AreEqual(0, results.Count);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private FileSkillUsageStore CreateStore()
+    {
+        var skillOptions = Options.Create(new SkillOptions
+        {
+            UsageBasePath = Path.Combine(_tempDir, "skill-usage")
+        });
+        var profileOptions = Options.Create(new AgentProfileOptions { BasePath = _tempDir });
+        return new FileSkillUsageStore(skillOptions, profileOptions, NullLogger<FileSkillUsageStore>.Instance);
+    }
+
+    private static SkillInvocationEvent MakeEvent(
+        string sessionId,
+        string skillName,
+        DateTimeOffset? timestamp = null)
+    {
+        return new SkillInvocationEvent(
+            Id: Guid.NewGuid().ToString("N")[..12],
+            SkillName: skillName,
+            SessionId: sessionId,
+            Timestamp: timestamp ?? DateTimeOffset.UtcNow);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `SkillInvocationEvent` record and `ISkillUsageStore` interface (mirrors `IFeedbackStore` pattern)
- Add `FileSkillUsageStore`: per-session JSONL files under `{profile}/skill-usage/`; registered automatically by `WithSkills()`
- Change `SkillTools` to **per-session instantiation** (matches `WorkingMemoryTools` pattern); `GetSkill` fire-and-forgets a `SkillInvocationEvent` when a session ID and usage store are present
- Remove singleton `SkillTools` DI registration from `Program.cs`; `UserMessageHandler` creates `sessionSkillTools` per message with the usage store injected
- `DreamService.ConsolidateSkillsAsync` now annotates each skill entry with `[usage: Nx in last 30d]` and `[co-used with: ...]` and appends a co-occurrence section; high-usage skills are treated conservatively during merging
- New `DreamService.OptimizeSkillsAsync`: identifies skills used in at-risk sessions (Correction signals or poor/fair `SessionSummary`), then asks the LLM to produce improved versions
- Add `skill-optimize.md` LLM directive (and built-in fallback in `DreamService`)
- Add `DreamOptions.SkillOptimizeDirectivePath` and `SkillOptions.UsageBasePath`
- 7 unit tests in `FileSkillUsageStoreTests` covering round-trips, filtering, cross-session queries, and ordering

## Test plan

- [x] `dotnet build RockBot.slnx` — no errors
- [x] `dotnet test RockBot.slnx --filter "ClassName~FileSkillUsageStore"` — 7/7 passed
- [x] `dotnet test RockBot.slnx` — all tests passed (224 in RockBot.Host.Tests)
- [ ] End-to-end: call `get_skill` a few times across sessions, verify `{profile}/skill-usage/*.jsonl` files are populated and the next dream cycle injects usage annotations into the consolidation prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)