### PR TITLE
feat: implicit user preference learning from conversation log (#54)

### DIFF
--- a/src/RockBot.Host.Abstractions/ConversationLogEntry.cs
+++ b/src/RockBot.Host.Abstractions/ConversationLogEntry.cs
@@ -1,0 +1,14 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// A single logged turn in a conversation, used by the preference-inference dream pass.
+/// </summary>
+/// <param name="SessionId">The session this turn belongs to.</param>
+/// <param name="Role">The role of the participant (e.g. "user", "assistant").</param>
+/// <param name="Content">The content of the turn.</param>
+/// <param name="Timestamp">When the turn occurred.</param>
+public sealed record ConversationLogEntry(
+    string SessionId,
+    string Role,
+    string Content,
+    DateTimeOffset Timestamp);

--- a/src/RockBot.Host.Abstractions/ConversationLogOptions.cs
+++ b/src/RockBot.Host.Abstractions/ConversationLogOptions.cs
@@ -1,0 +1,12 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Options for the long-term conversation log used by the preference-inference dream pass.
+/// </summary>
+public sealed class ConversationLogOptions
+{
+    /// <summary>
+    /// Directory for the conversation log file, relative to <see cref="AgentProfileOptions.BasePath"/>.
+    /// </summary>
+    public string BasePath { get; set; } = "conversation-log";
+}

--- a/src/RockBot.Host.Abstractions/DreamOptions.cs
+++ b/src/RockBot.Host.Abstractions/DreamOptions.cs
@@ -31,4 +31,15 @@ public sealed class DreamOptions
     /// When the file does not exist, a built-in fallback directive is used.
     /// </summary>
     public string SkillOptimizeDirectivePath { get; set; } = "skill-optimize.md";
+
+    /// <summary>
+    /// Whether the preference inference pass (requires <see cref="IConversationLog"/>) is enabled.
+    /// </summary>
+    public bool PreferenceInferenceEnabled { get; set; } = true;
+
+    /// <summary>
+    /// Path to the preference inference directive file, relative to <see cref="AgentProfileOptions.BasePath"/>.
+    /// When the file does not exist, a built-in fallback directive is used.
+    /// </summary>
+    public string PreferenceDirectivePath { get; set; } = "pref-dream.md";
 }

--- a/src/RockBot.Host.Abstractions/IConversationLog.cs
+++ b/src/RockBot.Host.Abstractions/IConversationLog.cs
@@ -1,0 +1,16 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Long-term conversation log used to accumulate turn history for preference inference.
+/// </summary>
+public interface IConversationLog
+{
+    /// <summary>Appends a single conversation turn to the log.</summary>
+    Task AppendAsync(ConversationLogEntry entry, CancellationToken cancellationToken = default);
+
+    /// <summary>Reads all entries currently in the log.</summary>
+    Task<IReadOnlyList<ConversationLogEntry>> ReadAllAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>Clears the log. Called by the dream pass after processing.</summary>
+    Task ClearAsync(CancellationToken cancellationToken = default);
+}

--- a/src/RockBot.Host/AgentMemoryExtensions.cs
+++ b/src/RockBot.Host/AgentMemoryExtensions.cs
@@ -115,6 +115,25 @@ public static class AgentMemoryExtensions
     }
 
     /// <summary>
+    /// Registers the file-based conversation log, enabling the preference-inference dream pass.
+    /// Call after <see cref="WithConversationMemory"/> and before <see cref="WithDreaming"/>.
+    /// <see cref="WithMemory"/> does NOT call this — callers opt in explicitly.
+    /// </summary>
+    public static AgentHostBuilder WithConversationLog(
+        this AgentHostBuilder builder,
+        Action<ConversationLogOptions>? configure = null)
+    {
+        if (configure is not null)
+            builder.Services.Configure(configure);
+        else
+            builder.Services.Configure<ConversationLogOptions>(_ => { });
+
+        builder.Services.AddSingleton<IConversationLog, FileConversationLog>();
+
+        return builder;
+    }
+
+    /// <summary>
     /// Registers the feedback capture system: <see cref="IFeedbackStore"/> (file-backed) and
     /// the <see cref="SessionSummaryService"/> background evaluator.
     /// Requires <see cref="IConversationMemory"/> and an LLM client to be registered.

--- a/src/RockBot.Host/FileConversationLog.cs
+++ b/src/RockBot.Host/FileConversationLog.cs
@@ -1,0 +1,112 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace RockBot.Host;
+
+/// <summary>
+/// JSONL-based implementation of <see cref="IConversationLog"/>.
+/// All turns are appended to a single file: <c>{BasePath}/turns.jsonl</c>.
+/// Thread-safe via a single <see cref="SemaphoreSlim"/>.
+/// </summary>
+internal sealed class FileConversationLog : IConversationLog
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true
+    };
+
+    private readonly string _filePath;
+    private readonly ILogger<FileConversationLog> _logger;
+    private readonly SemaphoreSlim _semaphore = new(1, 1);
+
+    public FileConversationLog(
+        IOptions<ConversationLogOptions> options,
+        IOptions<AgentProfileOptions> profileOptions,
+        ILogger<FileConversationLog> logger)
+    {
+        var basePath = ResolvePath(options.Value.BasePath, profileOptions.Value.BasePath);
+        Directory.CreateDirectory(basePath);
+        _filePath = Path.Combine(basePath, "turns.jsonl");
+        _logger = logger;
+
+        _logger.LogInformation("Conversation log path: {Path}", _filePath);
+    }
+
+    public async Task AppendAsync(ConversationLogEntry entry, CancellationToken cancellationToken = default)
+    {
+        await _semaphore.WaitAsync(cancellationToken);
+        try
+        {
+            var line = JsonSerializer.Serialize(entry, JsonOptions);
+            await File.AppendAllTextAsync(_filePath, line + Environment.NewLine, cancellationToken);
+            _logger.LogDebug("ConversationLog: appended [{Role}] for session {SessionId}", entry.Role, entry.SessionId);
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+    }
+
+    public async Task<IReadOnlyList<ConversationLogEntry>> ReadAllAsync(CancellationToken cancellationToken = default)
+    {
+        await _semaphore.WaitAsync(cancellationToken);
+        try
+        {
+            if (!File.Exists(_filePath))
+                return Array.Empty<ConversationLogEntry>();
+
+            var entries = new List<ConversationLogEntry>();
+            var lines = await File.ReadAllLinesAsync(_filePath, cancellationToken);
+            foreach (var line in lines)
+            {
+                if (string.IsNullOrWhiteSpace(line)) continue;
+                try
+                {
+                    var entry = JsonSerializer.Deserialize<ConversationLogEntry>(line, JsonOptions);
+                    if (entry is not null)
+                        entries.Add(entry);
+                }
+                catch (JsonException ex)
+                {
+                    _logger.LogWarning(ex, "ConversationLog: failed to deserialize entry from {Path}", _filePath);
+                }
+            }
+            return entries;
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+    }
+
+    public async Task ClearAsync(CancellationToken cancellationToken = default)
+    {
+        await _semaphore.WaitAsync(cancellationToken);
+        try
+        {
+            if (File.Exists(_filePath))
+            {
+                File.Delete(_filePath);
+                _logger.LogDebug("ConversationLog: log file cleared");
+            }
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+    }
+
+    private static string ResolvePath(string path, string basePath)
+    {
+        if (Path.IsPathRooted(path))
+            return path;
+
+        var baseDir = Path.IsPathRooted(basePath)
+            ? basePath
+            : Path.Combine(AppContext.BaseDirectory, basePath);
+
+        return Path.Combine(baseDir, path);
+    }
+}

--- a/tests/RockBot.Host.Tests/FileConversationLogTests.cs
+++ b/tests/RockBot.Host.Tests/FileConversationLogTests.cs
@@ -1,0 +1,154 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace RockBot.Host.Tests;
+
+[TestClass]
+public class FileConversationLogTests
+{
+    private string _tempDir = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "rockbot-convlog-test-" + Guid.NewGuid().ToString("N"));
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    // ── Append / read round-trip ──────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task AppendAsync_And_ReadAllAsync_RoundTrips()
+    {
+        var log = CreateLog();
+        var e1 = MakeEntry("session-1", "user", "Hello, world!");
+        var e2 = MakeEntry("session-1", "assistant", "Hi there!");
+
+        await log.AppendAsync(e1);
+        await log.AppendAsync(e2);
+
+        var results = await log.ReadAllAsync();
+
+        Assert.AreEqual(2, results.Count);
+        Assert.AreEqual(e1.SessionId, results[0].SessionId);
+        Assert.AreEqual(e1.Role, results[0].Role);
+        Assert.AreEqual(e1.Content, results[0].Content);
+        Assert.AreEqual(e2.Role, results[1].Role);
+        Assert.AreEqual(e2.Content, results[1].Content);
+    }
+
+    [TestMethod]
+    public async Task AppendAsync_MultipleSessionsAndRoles_AllPersisted()
+    {
+        var log = CreateLog();
+
+        await log.AppendAsync(MakeEntry("session-A", "user", "A user message"));
+        await log.AppendAsync(MakeEntry("session-B", "user", "B user message"));
+        await log.AppendAsync(MakeEntry("session-A", "assistant", "A assistant reply"));
+
+        var results = await log.ReadAllAsync();
+        Assert.AreEqual(3, results.Count);
+    }
+
+    // ── ClearAsync ────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task ClearAsync_EmptiesLog()
+    {
+        var log = CreateLog();
+
+        await log.AppendAsync(MakeEntry("session-1", "user", "some content"));
+        await log.AppendAsync(MakeEntry("session-1", "assistant", "some reply"));
+
+        await log.ClearAsync();
+
+        var results = await log.ReadAllAsync();
+        Assert.AreEqual(0, results.Count);
+    }
+
+    [TestMethod]
+    public async Task ClearAsync_WhenFileDoesNotExist_DoesNotThrow()
+    {
+        var log = CreateLog();
+
+        // Should not throw even if no file exists
+        await log.ClearAsync();
+        var results = await log.ReadAllAsync();
+        Assert.AreEqual(0, results.Count);
+    }
+
+    [TestMethod]
+    public async Task AppendAsync_AfterClear_StartsFromEmpty()
+    {
+        var log = CreateLog();
+
+        await log.AppendAsync(MakeEntry("session-1", "user", "old content"));
+        await log.ClearAsync();
+        await log.AppendAsync(MakeEntry("session-2", "user", "new content"));
+
+        var results = await log.ReadAllAsync();
+        Assert.AreEqual(1, results.Count);
+        Assert.AreEqual("new content", results[0].Content);
+    }
+
+    // ── ReadAllAsync on missing file ──────────────────────────────────────────
+
+    [TestMethod]
+    public async Task ReadAllAsync_OnMissingFile_ReturnsEmpty()
+    {
+        var log = CreateLog();
+
+        var results = await log.ReadAllAsync();
+
+        Assert.AreEqual(0, results.Count);
+    }
+
+    // ── Concurrent appends ────────────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task ConcurrentAppends_DoNotCorruptFile()
+    {
+        var log = CreateLog();
+        const int count = 20;
+
+        var tasks = Enumerable.Range(0, count)
+            .Select(i => log.AppendAsync(MakeEntry("session-1", "user", $"message-{i}")))
+            .ToList();
+
+        await Task.WhenAll(tasks);
+
+        var results = await log.ReadAllAsync();
+        Assert.AreEqual(count, results.Count, "All concurrent appends should be persisted without corruption");
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private FileConversationLog CreateLog()
+    {
+        var logOptions = Options.Create(new ConversationLogOptions
+        {
+            BasePath = Path.Combine(_tempDir, "conversation-log")
+        });
+        var profileOptions = Options.Create(new AgentProfileOptions { BasePath = _tempDir });
+        return new FileConversationLog(logOptions, profileOptions, NullLogger<FileConversationLog>.Instance);
+    }
+
+    private static ConversationLogEntry MakeEntry(
+        string sessionId,
+        string role,
+        string content,
+        DateTimeOffset? timestamp = null)
+    {
+        return new ConversationLogEntry(
+            SessionId: sessionId,
+            Role: role,
+            Content: content,
+            Timestamp: timestamp ?? DateTimeOffset.UtcNow);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a long-term conversation log (`IConversationLog` / `FileConversationLog`) that accumulates all conversation turns as JSONL
- Adds a new dream-sequence pass (`RunPreferenceInferencePassAsync`) that analyzes the log for durable user preference patterns and saves them as tagged `inferred` memory entries
- Log is always cleared after each pass to prevent unbounded growth
- Preference inference is opt-in via `WithConversationLog()` — existing agents are unaffected

## New files

| File | Purpose |
|------|---------|
| `ConversationLogEntry.cs` | Sealed record `(SessionId, Role, Content, Timestamp)` |
| `IConversationLog.cs` | Interface: `AppendAsync`, `ReadAllAsync`, `ClearAsync` |
| `ConversationLogOptions.cs` | Options: `BasePath = "conversation-log"` |
| `FileConversationLog.cs` | JSONL implementation (`turns.jsonl`), thread-safe via `SemaphoreSlim` |
| `FileConversationLogTests.cs` | 7 tests: round-trip, clear, missing file, concurrent appends |

## Modified files

- **`DreamOptions.cs`** — added `PreferenceInferenceEnabled` (default `true`) and `PreferenceDirectivePath` (`"pref-dream.md"`)
- **`FileConversationMemory.cs`** — fire-and-forgets `AppendAsync` on every `AddTurnAsync` when log is wired in
- **`DreamService.cs`** — preference inference pass with sentiment-based thresholds, built-in directive, `finally`-guarded log clear
- **`AgentMemoryExtensions.cs`** — added `WithConversationLog()` explicit opt-in extension

## Usage

```csharp
builder.WithMemory();
builder.WithConversationLog();   // opt-in
builder.WithDreaming();
```

## Test plan

- [x] `dotnet build RockBot.slnx` — clean build, 0 errors
- [x] `dotnet test RockBot.slnx` — all 539 tests pass, 0 failures
- [x] 7 new `FileConversationLogTests` all pass (round-trip, clear, concurrent appends, missing file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)