### PR TITLE
feat: seed starter skills from tool providers at agent startup (#70)

### DIFF
--- a/src/RockBot.Host/AgentMemoryExtensions.cs
+++ b/src/RockBot.Host/AgentMemoryExtensions.cs
@@ -90,6 +90,7 @@ public static class AgentMemoryExtensions
 
         builder.Services.AddSingleton<ISkillStore, FileSkillStore>();
         builder.Services.AddSingleton<ISkillUsageStore, FileSkillUsageStore>();
+        builder.Services.AddSingleton<IHostedService, StarterSkillService>();
 
         return builder;
     }

--- a/src/RockBot.Host/RockBot.Host.csproj
+++ b/src/RockBot.Host/RockBot.Host.csproj
@@ -24,6 +24,7 @@
   <ItemGroup>
     <ProjectReference Include="..\RockBot.Host.Abstractions\RockBot.Host.Abstractions.csproj" />
     <ProjectReference Include="..\RockBot.Messaging.Abstractions\RockBot.Messaging.Abstractions.csproj" />
+    <ProjectReference Include="..\RockBot.Tools.Abstractions\RockBot.Tools.Abstractions.csproj" />
     <ProjectReference Include="..\RockBot.UserProxy.Abstractions\RockBot.UserProxy.Abstractions.csproj" />
   </ItemGroup>
 

--- a/src/RockBot.Host/StarterSkillService.cs
+++ b/src/RockBot.Host/StarterSkillService.cs
@@ -1,0 +1,69 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using RockBot.Tools;
+
+namespace RockBot.Host;
+
+/// <summary>
+/// On startup, seeds the skill store with a skill for each registered
+/// <see cref="IToolSkillProvider"/> that doesn't already have one.
+///
+/// This makes tool-service guides (memory, MCP, web, etc.) discoverable through
+/// the normal skill injection paths — session index injection and per-turn BM25
+/// recall — rather than requiring the agent to proactively call list_tool_guides.
+///
+/// Seeding is intentionally additive: an existing skill is never overwritten, so
+/// the agent (or dream cycle) can refine the content over time without it being
+/// reset on every restart.
+/// </summary>
+internal sealed class StarterSkillService : IHostedService
+{
+    private readonly ISkillStore? _skillStore;
+    private readonly IReadOnlyList<IToolSkillProvider> _providers;
+    private readonly ILogger<StarterSkillService> _logger;
+
+    public StarterSkillService(
+        IEnumerable<ISkillStore> skillStores,
+        IEnumerable<IToolSkillProvider> providers,
+        ILogger<StarterSkillService> logger)
+    {
+        _skillStore = skillStores.FirstOrDefault();
+        _providers = providers.ToList();
+        _logger = logger;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (_skillStore is null || _providers.Count == 0)
+            return;
+
+        var seeded = 0;
+        foreach (var provider in _providers)
+        {
+            var existing = await _skillStore.GetAsync(provider.Name);
+            if (existing is not null)
+            {
+                _logger.LogDebug("StarterSkillService: skill '{Name}' already exists; skipping", provider.Name);
+                continue;
+            }
+
+            var skill = new Skill(
+                Name: provider.Name,
+                Summary: provider.Summary,
+                Content: provider.GetDocument(),
+                CreatedAt: DateTimeOffset.UtcNow,
+                UpdatedAt: DateTimeOffset.UtcNow,
+                LastUsedAt: null);
+
+            await _skillStore.SaveAsync(skill);
+            seeded++;
+            _logger.LogInformation("StarterSkillService: seeded starter skill '{Name}'", provider.Name);
+        }
+
+        _logger.LogInformation(
+            "StarterSkillService: startup complete — {Seeded} skill(s) seeded, {Existing} already present",
+            seeded, _providers.Count - seeded);
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}


### PR DESCRIPTION
## Summary

- Adds `StarterSkillService` (`IHostedService`) that seeds the skill store on startup with a skill for each registered `IToolSkillProvider` that doesn't already have one
- Tool guides (memory, MCP, web, scheduling, scripts, skills) now flow through the normal skill discovery paths — session index injection and per-turn BM25 recall — making them as discoverable as user-created skills
- Seeding is additive-only: existing skills are never overwritten, so the agent and dream cycle can refine content over time without being reset on every restart
- Registered automatically via `AgentMemoryExtensions.WithSkills()` — no call-site changes needed

## Problem solved

Tool guides were only accessible via on-demand tools (`list_tool_guides` / `get_tool_guide`), requiring the agent to proactively discover them. The agent naturally reaches for skills (pushed into context via session index + BM25 recall) but rarely thought to check for guides — leading to spotty MCP skill creation and missing foundational skills for memory and skill management.

## Test plan
- [x] `dotnet build RockBot.slnx` — clean build, 0 errors
- [x] `dotnet test RockBot.slnx` — all tests pass
- [x] Deployed to k8s — confirmed all 6 skills seeded on first boot: `memory`, `skills`, `mcp`, `web`, `scheduling`, `scripts`
- [x] On subsequent restarts: "0 seeded, 6 already present" (no overwrite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)