### PR TITLE
docs: add dream service and Blazor UI subsystem docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,8 @@ Deep-dive documentation for individual subsystems lives in [`docs/`](docs/):
 |---|---|
 | [`docs/skills.md`](docs/skills.md) | Skills data model, BM25 recall, see-also, dream consolidation, prefix clusters, optimization, gap detection |
 | [`docs/memory.md`](docs/memory.md) | Three-tier memory architecture, long-term storage, anti-patterns, working memory, dream passes |
+| [`docs/dream-service.md`](docs/dream-service.md) | Dream cycle passes, scheduling, directive files, LLM response contracts, configuration |
+| [`docs/blazor-ui.md`](docs/blazor-ui.md) | Blazor chat UI architecture, UserProxyService, feedback, history replay, deployment |
 
 ---
 

--- a/docs/blazor-ui.md
+++ b/docs/blazor-ui.md
@@ -1,0 +1,190 @@
+# Blazor UI (`RockBot.UserProxy.Blazor`)
+
+The Blazor UI is a standalone ASP.NET Core Blazor Server application that provides a real-time
+chat interface to the agent. It communicates with the agent exclusively through the RabbitMQ
+message bus — it has no direct reference to the agent host and no access to agent internals.
+
+---
+
+## Architecture
+
+```
+Browser (SignalR)
+    │
+    ▼
+Blazor Server (RockBot.UserProxy.Blazor)
+    │   ChatStateService  ─── in-memory chat state, event-driven UI updates
+    │   BlazorUserFrontend ── IUserFrontend impl, routes replies into ChatStateService
+    │
+    ▼
+UserProxyService (RockBot.UserProxy)
+    │   Publishes: user.message, user.feedback, conversation.history.request
+    │   Subscribes: user.response.{proxyId}, conversation.history.response.{proxyId}
+    │
+    ▼
+RabbitMQ (rockbot topic exchange)
+    │
+    ▼
+Agent (RockBot.Cli)
+```
+
+The Blazor UI is stateless with respect to the agent — it holds only the current browser
+session's message history in memory (`ChatStateService`). Agent-side persistence (memory,
+skills, conversation history) lives on the agent's PVC.
+
+---
+
+## Key components
+
+### `UserProxyService`
+
+Hosted service that owns the RabbitMQ connection on the Blazor side:
+
+- **Subscribe** to `user.response.{proxyId}` on startup — all agent replies arrive here
+- **Publish** `user.message` to send user input to the agent
+- **Publish** `user.feedback` to send thumbs-up / thumbs-down signals
+- **Publish** `conversation.history.request` and await a correlated history response on
+  first render
+
+Each outbound message carries a `CorrelationId`. Incoming replies are matched by correlation
+ID to a pending `TaskCompletionSource<AgentReply>`. Unmatched replies (unsolicited agent
+messages) are routed to `IUserFrontend.DisplayReplyAsync`.
+
+`IsConnected` and `OnConnectionChanged` are exposed so the UI can show a connection indicator.
+
+**Default reply timeout:** configurable via `UserProxyOptions.DefaultReplyTimeout`.
+
+### `ChatStateService`
+
+Singleton in-process state store for the current browser session:
+
+| Method | Purpose |
+|---|---|
+| `LoadHistory(turns, sessionId)` | Populate from agent's conversation history on first render |
+| `AddUserMessage(content, userId, sessionId)` | Echo the user's message immediately (optimistic) |
+| `AddAgentReply(reply)` | Add the agent's final reply |
+| `SetThinkingMessage(message)` | Update the "thinking" spinner text from intermediate replies |
+| `SetProcessing(bool)` | Show/hide the thinking indicator |
+| `RecordFeedback(messageId, isPositive)` | Mark a message with thumbs-up or thumbs-down |
+| `AddError(message)` | Add an error bubble |
+
+`OnStateChanged` fires after every mutation — the `Chat.razor` component subscribes and calls
+`StateHasChanged` to trigger a re-render.
+
+### `BlazorUserFrontend`
+
+`IUserFrontend` implementation that bridges the `UserProxyService` callback into
+`ChatStateService`. Handles both normal replies (`DisplayReplyAsync`) and error messages
+(`DisplayErrorAsync`).
+
+---
+
+## Chat page (`Chat.razor`)
+
+Single-page application at `/`.
+
+### Message rendering
+
+Agent replies are rendered as Markdown using [Markdig](https://github.com/xoofx/markdig) with
+`AdvancedExtensions` (tables, task lists, footnotes, etc.). User messages are rendered as plain
+text. Error messages use a danger-styled bubble.
+
+### Input behaviour
+
+| Interaction | Effect |
+|---|---|
+| `Enter` | Submit message |
+| `Shift+Enter` | Insert newline (multiline input) |
+| `Up` / `Down` arrow | Cycle through input history (last 50 messages, stored in JS) |
+| Window focus | Re-focus the input automatically |
+
+### Thinking indicator
+
+While the agent is processing, a spinner bubble appears. The text updates in real-time from
+intermediate `AgentReply` messages (`IsFinal = false`) — these show the agent's current tool
+call or reasoning step without a full re-render.
+
+### Scroll behaviour
+
+When a new message arrives the page scrolls to the **top** of the new message bubble, not the
+bottom — so long agent responses are read top-to-bottom rather than starting mid-reply.
+
+### Feedback
+
+Every agent reply shows a 👍 / 👎 bar. Clicking either:
+1. Marks the message in `ChatStateService` (disabling the buttons to prevent double-voting)
+2. Publishes a `UserFeedback` message to RabbitMQ
+3. The agent receives it as a `FeedbackSignalType.Correction` (👎) or `ThumbsUp` signal
+
+Feedback flows into the agent's `IFeedbackStore` and influences the dream optimization pass.
+
+### Conversation history on reconnect
+
+On first render (after SignalR circuit establishment — not during static prerendering),
+`GetHistoryAsync` requests the full conversation history from the agent via RabbitMQ. This
+means a page reload or new browser tab restores the conversation from the agent's in-memory
+store rather than starting blank.
+
+### Dark mode
+
+Detects the browser's `prefers-color-scheme` on load and allows manual toggle. Dark mode state
+is scoped to the component lifetime (not persisted across refreshes).
+
+### Timezone
+
+Reads the browser's IANA timezone via `Intl.DateTimeFormat().resolvedOptions().timeZone` and
+converts message timestamps to the local timezone for display.
+
+---
+
+## Deployment
+
+The Blazor UI runs as a separate Kubernetes deployment (`rockbot-blazor`) with its own
+Docker image (`rockylhotka/rockbot-blazor`). It requires only:
+
+- `RABBITMQ__HOST`, `RABBITMQ__PORT`, `RABBITMQ__USERNAME`, `RABBITMQ__PASSWORD` — message bus
+  connection (injected via ConfigMap + Secret)
+
+It does **not** need access to the agent data PVC or any agent-internal configuration.
+
+The UI is exposed on the Tailscale network via the Tailscale Kubernetes Operator:
+
+```yaml
+blazor:
+  tailscale:
+    hostname: "rockbot"   # accessible at http://rockbot on your tailnet
+```
+
+---
+
+## Configuration
+
+```csharp
+public sealed class UserProxyOptions
+{
+    public string ProxyId { get; set; }          // Unique identifier for this proxy instance
+    public TimeSpan DefaultReplyTimeout { get; set; }  // How long to wait for an agent reply
+}
+```
+
+DI registration in `Program.cs`:
+
+```csharp
+builder.Services.AddRockBotRabbitMq(opts =>
+    builder.Configuration.GetSection("RabbitMq").Bind(opts));
+builder.Services.AddUserProxy();
+builder.Services.AddSingleton<IUserFrontend, BlazorUserFrontend>();
+builder.Services.AddSingleton<ChatStateService>();
+```
+
+---
+
+## Message bus topics
+
+| Topic | Direction | Purpose |
+|---|---|---|
+| `user.message` | Blazor → Agent | User input |
+| `user.response.{proxyId}` | Agent → Blazor | Agent replies (final and intermediate) |
+| `user.feedback` | Blazor → Agent | Thumbs-up / thumbs-down |
+| `conversation.history.request` | Blazor → Agent | Request history on reconnect |
+| `conversation.history.response.{proxyId}` | Agent → Blazor | Correlated history response |

--- a/docs/dream-service.md
+++ b/docs/dream-service.md
@@ -1,0 +1,273 @@
+# Dream service
+
+The dream service is a background `IHostedService` that runs on a configurable timer to
+autonomously refine the agent's accumulated knowledge — consolidating memory, improving skills,
+inferring preferences, and detecting gaps — without any user interaction.
+
+The key design principle: the dream cycle **refactors the knowledge graph**, it does not update
+the agent's goals or system prompt. Every change it makes is to the persistent stores (memory,
+skills) that get surfaced at runtime via BM25 recall.
+
+---
+
+## Scheduling
+
+The service backs off if the LLM client is busy. While the LLM is processing a user request,
+the dream cycle polls every 5 seconds and waits rather than queuing behind an active turn.
+
+```
+Startup
+  └── InitialDelay (default 5 min)
+        └── DreamCycle
+              └── Interval (default 4 hrs)
+                    └── DreamCycle
+                          └── ...
+```
+
+---
+
+## Passes
+
+Each dream cycle runs five passes in sequence. Passes that depend on optional services
+(`IConversationLog`, `IFeedbackStore`, `ISkillUsageStore`) are skipped when those services are
+not registered.
+
+### Pass 1 — Memory consolidation
+
+**Input:** all long-term memory entries (up to 1000) + recent feedback signals (last 7 days,
+up to 50)
+
+**What the LLM does:**
+- Merges duplicate and near-duplicate entries into single improved entries
+- Refines categories (e.g. promotes `general` entries to more specific categories)
+- Deletes noisy, low-value, or fully superseded entries
+- Mines `Correction` feedback for anti-patterns and writes them to `anti-patterns/{domain}`
+
+**Exhaustive deletion contract:** The union of explicit `toDelete` IDs and all `sourceIds`
+referenced in merged entries are deleted. This prevents orphaned source entries when the LLM
+omits IDs from `toDelete` but lists them in `sourceIds`.
+
+**Directive file:** `dream.md` (relative to agent data path). Built-in fallback is used when
+the file does not exist.
+
+---
+
+### Pass 2 — Skill gap detection
+
+Runs **before** consolidation so any newly-created skills are included in the deduplication
+pass that follows.
+
+**Input:** full conversation log entries grouped by session + existing skill catalog
+
+**What the LLM does:**
+- Scans for recurring request patterns not covered by an existing skill
+- Creates new skills only when the same type of request appears in 2+ sessions
+
+**Pattern-frequency signal:** The first user message per session is tokenized and cross-session
+term frequencies are computed. Terms appearing in 2+ sessions are injected as an explicit
+signal:
+
+```
+Recurring topics across sessions (term frequency ≥ 2 sessions):
+- "email": 4 session(s)
+- "summarize": 3 session(s)
+```
+
+This gives the LLM a quantitative nudge — high-frequency terms indicate recurring needs the
+agent should formalize.
+
+**Directive file:** `skill-gap.md`. Built-in fallback if not present.
+
+**Enabled/disabled by:** `DreamOptions.SkillGapEnabled` (default `true`). Requires
+`IConversationLog`.
+
+---
+
+### Pass 3 — Skill consolidation
+
+**Input:** all skills with content, plus:
+- Usage counts per skill (last 30 days from `ISkillUsageStore`)
+- `[sparse-content]` annotation on skills with < 200 chars of content older than 7 days
+- Top 10 co-used skill pairs (skills invoked in the same session)
+- Prefix cluster section — skills grouped by name prefix (`mcp/*`, `research/*`, etc.)
+
+**What the LLM does:**
+1. Merges semantically overlapping skills into improved combined ones
+2. Detects prefix clusters and optionally creates abstract parent guide skills
+   (e.g. `mcp/guide` — a "when to use which" dispatch reference for all `mcp/*` siblings)
+3. Populates `seeAlso` on each skill with related skill names (siblings, co-used, complements)
+4. Prunes skills that are clearly redundant
+
+**Safety guard:** Deletions are refused if no replacement skills are being saved. An LLM that
+proposes `toDelete` entries with an empty `toSave` is treated as a directive violation and the
+entire consolidation is skipped.
+
+**Metadata preservation:** Merged skills carry forward the earliest `CreatedAt` and most recent
+`LastUsedAt` from their source skills.
+
+**Directive file:** `skill-dream.md`. Built-in fallback if not present.
+
+---
+
+### Pass 4 — Skill optimization
+
+Improves skills based on quality signals. Two types of skills are reviewed:
+
+**At-risk skills** (failure-driven): Skills used in sessions that have:
+- `Correction` feedback signals (explicit user corrections)
+- `SessionSummary` feedback rated `poor` or `fair`
+
+These are sent to the LLM with their associated failure context appended. The LLM is asked to
+identify what step or gap likely caused the failure and produce an improved version.
+
+**Sparse skills** (proactive): Skills with < 200 chars of content created more than 7 days ago,
+even with no failure signals. These are sent with a structural review note:
+
+```
+### Review note: This skill has minimal content.
+Expand it with concrete steps, examples, and edge cases.
+```
+
+This ensures skills that are frequently recalled but never improved get expanded before they
+cause problems.
+
+Skipped entirely if no at-risk or sparse skills are found.
+
+**Directive file:** `skill-optimize.md`. Built-in fallback if not present. Requires
+`ISkillUsageStore` and `IFeedbackStore`.
+
+---
+
+### Pass 5 — Preference inference
+
+**Input:** full conversation log grouped by session + recent feedback signals (last 7 days)
+
+**What the LLM does:**
+- Identifies durable user preference patterns: formatting, tool corrections, communication
+  style, topic clusters
+- Applies sentiment-based thresholds before writing a preference:
+  - Very irritated (repeated strong correction): 1 occurrence
+  - Mildly frustrated (gentle pushback): 2 occurrences
+  - Minor/casual suggestion: 3+ occurrences
+- Writes preferences as long-term memory entries with `category: user-preferences/inferred`
+  and `tags: ["inferred"]`
+- Adds `metadata["requires_user_permission"] = "true"` for preferences touching security,
+  credentials, or financial decisions
+
+The conversation log is **always cleared** after this pass regardless of LLM success or
+failure, to prevent unbounded growth.
+
+**Directive file:** `pref-dream.md`. Built-in fallback if not present. Requires
+`IConversationLog`. Enabled/disabled by `DreamOptions.PreferenceInferenceEnabled`.
+
+---
+
+## Directive files
+
+Each pass has a corresponding directive file on the agent data volume. If the file does not
+exist, a built-in fallback directive is used. Custom files override the built-in prompts
+entirely — write a complete replacement, not a diff.
+
+| File | Pass | Purpose |
+|---|---|---|
+| `dream.md` | Memory consolidation + anti-pattern mining | How to merge, categorize, and anti-pattern mine |
+| `skill-gap.md` | Skill gap detection | When to create skills from conversation patterns |
+| `skill-dream.md` | Skill consolidation | How to merge, abstract, and cross-reference skills |
+| `skill-optimize.md` | Skill optimization | How to improve skills from failure context |
+| `pref-dream.md` | Preference inference | How to infer and record preferences |
+
+---
+
+## Configuration
+
+```csharp
+public sealed class DreamOptions
+{
+    public bool Enabled { get; set; } = true;
+    public TimeSpan InitialDelay { get; set; } = TimeSpan.FromMinutes(5);
+    public TimeSpan Interval { get; set; } = TimeSpan.FromHours(4);
+
+    // Directive file paths (relative to agent data path)
+    public string DirectivePath { get; set; } = "dream.md";
+    public string SkillDirectivePath { get; set; } = "skill-dream.md";
+    public string SkillOptimizeDirectivePath { get; set; } = "skill-optimize.md";
+    public string PreferenceDirectivePath { get; set; } = "pref-dream.md";
+    public string SkillGapDirectivePath { get; set; } = "skill-gap.md";
+
+    // Feature flags
+    public bool PreferenceInferenceEnabled { get; set; } = true;
+    public bool SkillGapEnabled { get; set; } = true;
+}
+```
+
+---
+
+## DI registration
+
+```csharp
+builder
+    .WithMemory()              // ILongTermMemory — required
+    .WithSkills()              // ISkillStore + ISkillUsageStore — required for skill passes
+    .WithConversationLog()     // IConversationLog — required for gap detection + preference inference
+    .WithFeedback()            // IFeedbackStore — required for optimization + anti-pattern mining
+    .WithDreaming(opts =>
+    {
+        opts.Interval = TimeSpan.FromHours(2);   // run more frequently
+        opts.SkillGapEnabled = false;            // disable gap detection
+    });
+```
+
+Each optional dependency is injected with a `? = null` default. The dream service degrades
+gracefully — passes that need a missing service are simply skipped.
+
+---
+
+## LLM response format
+
+All passes use a JSON response contract. The dream service extracts the outermost JSON object
+from the LLM response, tolerating DeepSeek-style `<think>...</think>` reasoning blocks and
+prose preamble.
+
+**Memory consolidation / preference inference:**
+```json
+{
+  "toDelete": ["id1", "id2"],
+  "toSave": [
+    {
+      "content": "...",
+      "category": "user-preferences/timezone",
+      "tags": ["timezone"],
+      "sourceIds": ["id1", "id2"]
+    }
+  ]
+}
+```
+
+**Skill consolidation / optimization:**
+```json
+{
+  "toDelete": ["skill-name-1"],
+  "toSave": [
+    {
+      "name": "mcp/guide",
+      "summary": "Choose between MCP email, calendar, and weather tools",
+      "content": "...",
+      "sourceNames": ["skill-name-1"],
+      "seeAlso": ["mcp/email", "mcp/calendar"]
+    }
+  ]
+}
+```
+
+**Skill gap detection:**
+```json
+{
+  "toSave": [
+    {
+      "name": "summarize-emails",
+      "summary": "Summarize an inbox digest into key action items",
+      "content": "..."
+    }
+  ]
+}
+```


### PR DESCRIPTION
## Summary

- **`docs/dream-service.md`** — complete reference for the dream cycle: all five passes (memory consolidation with anti-pattern mining, skill gap detection with pattern-frequency signal, skill consolidation with prefix clusters and see-also, skill optimization for at-risk and sparse skills, preference inference), scheduling behavior, directive file customization, LLM response JSON contracts, and DI configuration
- **`docs/blazor-ui.md`** — Blazor chat UI architecture: UserProxyService message bus bridge, ChatStateService event-driven state, BlazorUserFrontend, Chat.razor features (markdown rendering, thinking indicator, feedback bar, history replay on reconnect, dark mode, timezone, scroll behavior, input history), deployment and Helm configuration, message bus topic reference
- **README**: adds both new docs to the subsystem documentation table

## Test plan

- [ ] Verify all doc links in README resolve correctly
- [ ] Review docs for accuracy against source code

🤖 Generated with [Claude Code](https://claude.com/claude-code)