### PR TITLE
fix: raise iteration limit, fix MCP timeout cap, add retry guidance

### DIFF
--- a/src/RockBot.Cli/McpBridge/McpBridgeOptions.cs
+++ b/src/RockBot.Cli/McpBridge/McpBridgeOptions.cs
@@ -11,9 +11,15 @@ public sealed class McpBridgeOptions
     public string ConfigPath { get; set; } = "mcp.json";
 
     /// <summary>
-    /// Default timeout in milliseconds for MCP server calls.
+    /// Default timeout in milliseconds for MCP server calls when no per-request timeout is supplied.
     /// </summary>
-    public int DefaultTimeoutMs { get; set; } = 30_000;
+    public int DefaultTimeoutMs { get; set; } = 60_000;
+
+    /// <summary>
+    /// Maximum timeout in milliseconds that a caller may request via the TimeoutMs header.
+    /// Callers can exceed DefaultTimeoutMs up to this ceiling for large/slow operations.
+    /// </summary>
+    public int MaxTimeoutMs { get; set; } = 120_000;
 
     /// <summary>
     /// When true, the bridge calls the LLM to generate a one-sentence summary of each

--- a/src/RockBot.Cli/UserMessageHandler.cs
+++ b/src/RockBot.Cli/UserMessageHandler.cs
@@ -530,8 +530,9 @@ internal sealed class UserMessageHandler(
         // After that it's null, and the loop calls the LLM for each iteration.
         ChatResponse? pendingResponse = firstResponse;
         var anyToolCalled = false; // tracks whether any tool has fired this loop
+        var maxIterations = modelBehavior.MaxToolIterationsOverride ?? MaxToolIterations;
 
-        for (var iteration = 0; iteration < MaxToolIterations; iteration++)
+        for (var iteration = 0; iteration < maxIterations; iteration++)
         {
             ChatResponse response;
 
@@ -786,12 +787,12 @@ internal sealed class UserMessageHandler(
             }
 
             // On the last iteration, remove tools so the LLM must produce a text response
-            if (iteration == MaxToolIterations - 2)
+            if (iteration == maxIterations - 2)
                 chatOptions = new ChatOptions();
         }
 
         // Exhausted iterations — one last call without tools to force a text response
-        logger.LogWarning("Tool loop reached {Max} iterations; forcing final response", MaxToolIterations);
+        logger.LogWarning("Tool loop reached {Max} iterations; forcing final response", maxIterations);
         var finalResponse = await llmClient.GetResponseAsync(
             chatMessages, new ChatOptions(), cancellationToken);
         return ExtractAssistantText(finalResponse);

--- a/src/RockBot.Cli/appsettings.json
+++ b/src/RockBot.Cli/appsettings.json
@@ -8,6 +8,9 @@
       "deepseek": {
         "NudgeOnHallucinatedToolCalls": true,
         "ScheduledTaskResultMode": "VerbatimOutput"
+      },
+      "claude": {
+        "MaxToolIterationsOverride": 25
       }
     }
   }


### PR DESCRIPTION
## Summary

- Wire up `ModelBehavior.MaxToolIterationsOverride` in `UserMessageHandler` — it existed in the type but was never applied; the handler always used the hardcoded const 12
- Set `MaxToolIterationsOverride=25` for claude in `appsettings.json` so large tasks (e.g. bulk email operations) have enough iterations to complete
- Fix `McpBridgeOptions`: raise `DefaultTimeoutMs` 30s→60s, add `MaxTimeoutMs=120s` as a separate ceiling
- Fix `McpBridgeService` timeout cap: `Math.Min(caller, DefaultTimeoutMs)` was capping at 30s even when `McpToolProxy` requested 60s; now caps at `MaxTimeoutMs` so callers can legitimately request longer timeouts
- Add "retry the same tool call" guidance to MCP timeout error messages so the LLM knows to retry rather than stop on transient timeouts

## Test plan

- [ ] Send the agent a bulk operation task (e.g. mark 100+ emails as read) and verify it completes without hitting the iteration cap
- [ ] Verify MCP timeout errors include retry guidance in the tool result returned to the LLM
- [ ] Verify the agent retries after a transient MCP timeout rather than giving up

🤖 Generated with [Claude Code](https://claude.com/claude-code)