### PR TITLE
Fix bulk operations failing due to JsonElement round-trip

### DIFF
--- a/src/RockBot.Tools.Mcp/McpManagementExecutor.cs
+++ b/src/RockBot.Tools.Mcp/McpManagementExecutor.cs
@@ -306,7 +306,9 @@ public sealed class McpManagementExecutor : IToolExecutor, IAsyncDisposable
         if (string.IsNullOrWhiteSpace(json)) return [];
         try
         {
-            return JsonSerializer.Deserialize<Dictionary<string, object?>>(json, JsonOptions) ?? [];
+            var raw = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json, JsonOptions);
+            if (raw is null) return [];
+            return raw.ToDictionary(kvp => kvp.Key, kvp => McpToolExecutor.ConvertJsonElement(kvp.Value));
         }
         catch
         {


### PR DESCRIPTION
## Summary
- Convert `JsonElement` values to native .NET types in `McpToolExecutor.ParseArguments()` so complex nested structures (arrays of objects) round-trip correctly through the MCP SDK's JSON-RPC serialization
- Add `ConvertJsonElement` recursive helper that maps `JsonElement` to `string`, `long`, `double`, `bool`, `null`, `List<object?>`, or `Dictionary<string, object?>`
- Update `McpManagementExecutor.ParseArguments()` to reuse the same conversion
- Add unit tests covering arrays of objects, all value kinds, and nested structures

Same fix as MarimerLLC/mcp-aggregator#18.

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test tests/RockBot.Tools.Tests` passes (96 tests, 0 failures)
- [ ] Deploy and verify bulk email operations work through rockbot's MCP bridge

🤖 Generated with [Claude Code](https://claude.com/claude-code)