### PR TITLE
feat: add configurable max timeout cap for execute_python_script

### DIFF
--- a/src/RockBot.Scripts.Local/LocalScriptOptions.cs
+++ b/src/RockBot.Scripts.Local/LocalScriptOptions.cs
@@ -23,4 +23,10 @@ public sealed class LocalScriptOptions
     /// Defaults to 30 seconds.
     /// </summary>
     public int DefaultTimeoutSeconds { get; set; } = 30;
+
+    /// <summary>
+    /// Maximum timeout in seconds. Any script request exceeding this is clamped down.
+    /// Defaults to 300 seconds (5 minutes).
+    /// </summary>
+    public int MaxTimeoutSeconds { get; set; } = 300;
 }

--- a/src/RockBot.Scripts.Local/LocalScriptRunner.cs
+++ b/src/RockBot.Scripts.Local/LocalScriptRunner.cs
@@ -29,7 +29,8 @@ internal sealed class LocalScriptRunner(
             if (createdWorkDir)
                 Directory.CreateDirectory(workDir);
 
-            var timeout = request.TimeoutSeconds > 0 ? request.TimeoutSeconds : options.DefaultTimeoutSeconds;
+            var rawTimeout = request.TimeoutSeconds > 0 ? request.TimeoutSeconds : options.DefaultTimeoutSeconds;
+            var timeout = Math.Clamp(rawTimeout, 1, options.MaxTimeoutSeconds);
 
             // Install pip packages into a per-execution temp directory so they don't
             // pollute the host environment. Packages are cleaned up with workDir.

--- a/src/RockBot.Scripts.Remote/ScriptToolOptions.cs
+++ b/src/RockBot.Scripts.Remote/ScriptToolOptions.cs
@@ -1,0 +1,15 @@
+namespace RockBot.Scripts.Remote;
+
+/// <summary>
+/// Configuration for the <c>execute_python_script</c> tool exposed to the LLM.
+/// Controls limits enforced before passing the request to the underlying runner.
+/// </summary>
+public sealed class ScriptToolOptions
+{
+    /// <summary>
+    /// Maximum value the LLM may request for <c>timeout_seconds</c>.
+    /// Any request exceeding this is silently clamped down.
+    /// Defaults to 300 seconds (5 minutes).
+    /// </summary>
+    public int MaxTimeoutSeconds { get; set; } = 300;
+}

--- a/src/RockBot.Scripts.Remote/ScriptToolRegistrar.cs
+++ b/src/RockBot.Scripts.Remote/ScriptToolRegistrar.cs
@@ -34,7 +34,7 @@ internal sealed class ScriptToolRegistrar(
             },
             "timeout_seconds": {
               "type": "integer",
-              "description": "Maximum execution time in seconds (default: 30)"
+              "description": "Maximum execution time in seconds (default: 30, capped by operator configuration)"
             },
             "pip_packages": {
               "type": "array",

--- a/src/RockBot.Scripts.Remote/ServiceCollectionExtensions.cs
+++ b/src/RockBot.Scripts.Remote/ServiceCollectionExtensions.cs
@@ -22,8 +22,13 @@ public static class ServiceCollectionExtensions
     /// </param>
     public static IServiceCollection AddRemoteScriptRunner(
         this IServiceCollection services,
-        string agentName)
+        string agentName,
+        Action<ScriptToolOptions>? configure = null)
     {
+        var toolOptions = new ScriptToolOptions();
+        configure?.Invoke(toolOptions);
+        services.AddSingleton(toolOptions);
+
         // Core message-bus runner (singleton so pending-request dictionary is shared)
         services.AddSingleton<MessageBusScriptRunner>(sp =>
             new MessageBusScriptRunner(


### PR DESCRIPTION
## Problem

`timeout_seconds` was passed through unchecked — the LLM (or a misbehaving prompt) could request any value, potentially tying up a script pod for hours.

## Changes

- **`ScriptToolOptions`** (new) — `MaxTimeoutSeconds` defaults to 300s (5 min); registered as a singleton via `AddRemoteScriptRunner(agentName, opts => ...)`
- **`ScriptToolExecutor`** — clamps the LLM-requested timeout to `[1, MaxTimeoutSeconds]` before building the `ScriptInvokeRequest`
- **`LocalScriptOptions`** — same `MaxTimeoutSeconds` property (300s default) for the local dev runner
- **`LocalScriptRunner`** — enforces the cap as a belt-and-suspenders measure
- Tool schema description updated to mention the cap

## Configuration

```json
{
  "ScriptTool": {
    "MaxTimeoutSeconds": 120
  }
}
```

Or via `AddRemoteScriptRunner`:
```csharp
agent.AddRemoteScriptRunner(identity.Name, opts => opts.MaxTimeoutSeconds = 120);
```

## Test plan

- [ ] Script requesting `timeout_seconds: 9999` is clamped to 300 and times out at 300s
- [ ] Script requesting `timeout_seconds: 60` runs with 60s timeout (within cap)
- [ ] Existing timeout tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)