### PR TITLE
refactor: remove LlmClient semaphore, make transient, add IUserActivityMonitor

### DIFF
--- a/src/RockBot.Cli/UserMessageHandler.cs
+++ b/src/RockBot.Cli/UserMessageHandler.cs
@@ -48,6 +48,7 @@ internal sealed class UserMessageHandler(
     ToolGuideTools toolGuideTools,
     ModelBehavior modelBehavior,
     IFeedbackStore feedbackStore,
+    IUserActivityMonitor userActivityMonitor,
     ILogger<UserMessageHandler> logger,
     ISkillUsageStore? skillUsageStore = null) : IMessageHandler<UserMessage>
 {
@@ -123,6 +124,7 @@ internal sealed class UserMessageHandler(
         var correlationId = context.Envelope.CorrelationId;
         var ct = context.CancellationToken;
 
+        userActivityMonitor.RecordActivity();
         logger.LogInformation("Received message from {UserId} in session {SessionId}: {Content}",
             message.UserId, message.SessionId, message.Content);
 

--- a/src/RockBot.Host.Abstractions/IUserActivityMonitor.cs
+++ b/src/RockBot.Host.Abstractions/IUserActivityMonitor.cs
@@ -1,0 +1,22 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Tracks when the most recent user message was received.
+/// Used by low-priority background services (dreaming, session evaluation)
+/// to back off while the user is actively waiting for a response.
+/// </summary>
+public interface IUserActivityMonitor
+{
+    /// <summary>
+    /// Records that a user message has just arrived. Call this at the start
+    /// of every <c>UserMessage</c> handler invocation.
+    /// </summary>
+    void RecordActivity();
+
+    /// <summary>
+    /// Returns true when a user message was received within <paramref name="idleThreshold"/>
+    /// of the current time — i.e. the user is likely still waiting for a response.
+    /// Background services should delay their work while this returns true.
+    /// </summary>
+    bool IsUserActive(TimeSpan idleThreshold);
+}

--- a/src/RockBot.Host/ServiceCollectionExtensions.cs
+++ b/src/RockBot.Host/ServiceCollectionExtensions.cs
@@ -24,7 +24,8 @@ public static class ServiceCollectionExtensions
         configure(builder);
         builder.Build();
 
-        services.AddSingleton<ILlmClient, LlmClient>();
+        services.AddTransient<ILlmClient, LlmClient>();
+        services.AddSingleton<IUserActivityMonitor, UserActivityMonitor>();
         services.AddSingleton<IMessagePipeline, MessagePipeline>();
         services.AddSingleton<IHostedService, AgentHost>();
 

--- a/src/RockBot.Host/UserActivityMonitor.cs
+++ b/src/RockBot.Host/UserActivityMonitor.cs
@@ -1,0 +1,23 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Thread-safe implementation of <see cref="IUserActivityMonitor"/>.
+/// Stores the timestamp of the most recent user message using a <c>long</c>
+/// (UTC ticks) so reads and writes are atomic without a lock.
+/// </summary>
+internal sealed class UserActivityMonitor : IUserActivityMonitor
+{
+    private long _lastActivityTicks = 0;
+
+    /// <inheritdoc/>
+    public void RecordActivity() =>
+        Interlocked.Exchange(ref _lastActivityTicks, DateTimeOffset.UtcNow.Ticks);
+
+    /// <inheritdoc/>
+    public bool IsUserActive(TimeSpan idleThreshold)
+    {
+        var ticks = Interlocked.Read(ref _lastActivityTicks);
+        if (ticks == 0) return false;
+        return DateTimeOffset.UtcNow - new DateTimeOffset(ticks, TimeSpan.Zero) < idleThreshold;
+    }
+}

--- a/tests/RockBot.Host.Tests/SessionSummaryServiceTests.cs
+++ b/tests/RockBot.Host.Tests/SessionSummaryServiceTests.cs
@@ -134,6 +134,7 @@ public class SessionSummaryServiceTests
             memory,
             feedbackStore,
             llm,
+            new UserActivityMonitor(),
             options,
             profileOptions,
             NullLogger<SessionSummaryService>.Instance);


### PR DESCRIPTION
Closes #91

## Summary

- **Remove `SemaphoreSlim`** from `LlmClient` — concurrent LLM calls now proceed independently; no queuing
- **`ILlmClient` → transient** — each consumer gets its own wrapper instance with its own retry logic; `IChatClient` remains singleton
- **Remove `IsIdle`** from `ILlmClient` — it was checking "is an HTTP call in flight?" not "is the user waiting?"
- **Add `IUserActivityMonitor`** (new interface + `UserActivityMonitor` impl) — records timestamp of last user message via interlocked atomic write; `IsUserActive(threshold)` answers what `DreamService` and `SessionSummaryService` actually mean
- **`UserMessageHandler`** calls `RecordActivity()` on every incoming `UserMessage`
- **`DreamService` + `SessionSummaryService`** replace `while (!_llmClient.IsIdle)` with `while (_userActivityMonitor.IsUserActive(TimeSpan.FromSeconds(30)))`

## Why this is correct

| Old | New |
|-----|-----|
| "Is any HTTP call in flight?" | "Did a user message arrive in the last 30s?" |
| A dreaming call blocks the user loop | User loop and dreaming proceed concurrently |
| Background tasks (#90) would deadlock the primary agent | Each task gets its own `ILlmClient` instance |

## Test plan

- [ ] All existing tests pass ✅ (verified locally)
- [ ] Dreaming and session evaluation still back off after a user message arrives
- [ ] Concurrent LLM calls no longer queue (observable in logs — multiple iterations can overlap with background dream/eval work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)