### PR TITLE
fix: cancel stale background tool loops when a new session message arrives

### DIFF
--- a/src/RockBot.Cli/Program.cs
+++ b/src/RockBot.Cli/Program.cs
@@ -50,6 +50,9 @@ else
     Console.WriteLine("Set LLM:Endpoint, LLM:ApiKey, and LLM:ModelId to configure.");
 }
 
+// Tracks in-flight background tool loops so they can be cancelled when a new message arrives
+builder.Services.AddSingleton<SessionBackgroundTaskTracker>();
+
 // Register memory tools as singleton — AIFunction instances are built once at construction
 builder.Services.AddSingleton<MemoryTools>();
 // Rules tools — requires WithRules() in the agent builder below

--- a/src/RockBot.Cli/SessionBackgroundTaskTracker.cs
+++ b/src/RockBot.Cli/SessionBackgroundTaskTracker.cs
@@ -1,0 +1,46 @@
+using System.Collections.Concurrent;
+
+namespace RockBot.Cli;
+
+/// <summary>
+/// Tracks one in-flight background tool loop per conversation session.
+/// When a new user message arrives, the previous loop's CancellationToken is
+/// cancelled so stale tool calls (e.g. an email send from a prior topic) cannot
+/// execute after the user has already moved on to a different subject.
+/// </summary>
+internal sealed class SessionBackgroundTaskTracker : IDisposable
+{
+    private readonly ConcurrentDictionary<string, CancellationTokenSource> _sessions = new();
+
+    /// <summary>
+    /// Cancels any in-flight background loop for <paramref name="sessionId"/> and returns
+    /// a new <see cref="CancellationToken"/> that is:
+    /// <list type="bullet">
+    ///   <item>linked to <paramref name="hostCt"/> so it cancels on host shutdown, and</item>
+    ///   <item>cancelled the next time <see cref="BeginSession"/> is called for the same session.</item>
+    /// </list>
+    /// </summary>
+    public CancellationToken BeginSession(string sessionId, CancellationToken hostCt)
+    {
+        // Cancel and discard the previous background loop for this session, if any.
+        if (_sessions.TryRemove(sessionId, out var old))
+        {
+            old.Cancel();
+            old.Dispose();
+        }
+
+        var cts = CancellationTokenSource.CreateLinkedTokenSource(hostCt);
+        _sessions[sessionId] = cts;
+        return cts.Token;
+    }
+
+    public void Dispose()
+    {
+        foreach (var kvp in _sessions)
+        {
+            kvp.Value.Cancel();
+            kvp.Value.Dispose();
+        }
+        _sessions.Clear();
+    }
+}


### PR DESCRIPTION
## Summary

- Background tool loops were fire-and-forget using the host `CancellationToken`, so they continued executing tool calls (API calls, emails, etc.) and publishing replies long after the user moved on to a different topic
- The `LlmClient` semaphore's queuing made this appear as responses arriving 2+ prompts late — a prior conversation's actions would execute while the user was deep into a new subject
- Adds `SessionBackgroundTaskTracker` (singleton) that issues a per-session `CancellationToken` to each `BackgroundToolLoopAsync` invocation; when the next user message arrives for the same session the tracker cancels the previous CTS, causing any queued or in-flight work to exit via `OperationCanceledException` before executing side effects or publishing stale replies

## Test plan

- [ ] Send a message that triggers a multi-step tool loop (e.g. send an email), then immediately send a new unrelated message — confirm the old tool calls do not execute and no stale reply appears
- [ ] Normal single-turn and multi-turn conversations continue to work correctly
- [ ] Agent shutdown cancels all in-flight session loops cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)