### PR TITLE
fix: transparent channel reconnection in RabbitMqSubscription

### DIFF
--- a/src/RockBot.Messaging.RabbitMQ/RabbitMqConnectionManager.cs
+++ b/src/RockBot.Messaging.RabbitMQ/RabbitMqConnectionManager.cs
@@ -74,7 +74,11 @@ public sealed class RabbitMqConnectionManager : IAsyncDisposable
                 Port = _options.Port,
                 UserName = _options.UserName,
                 Password = _options.Password,
-                VirtualHost = _options.VirtualHost
+                VirtualHost = _options.VirtualHost,
+                // Disable library-level auto-recovery: RabbitMqSubscription handles
+                // transparent channel reconnection itself.  Enabling both would race
+                // and create duplicate consumers on the same queue.
+                AutomaticRecoveryEnabled = false
             };
 
             _connection = await factory.CreateConnectionAsync(cancellationToken);

--- a/src/RockBot.Messaging.RabbitMQ/RabbitMqSubscription.cs
+++ b/src/RockBot.Messaging.RabbitMQ/RabbitMqSubscription.cs
@@ -1,31 +1,118 @@
+using Microsoft.Extensions.Logging;
 using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
 
 namespace RockBot.Messaging.RabbitMQ;
 
 /// <summary>
 /// Represents an active RabbitMQ subscription.
-/// Disposing cancels the consumer and closes the channel.
+/// Transparently reconnects the channel and consumer if the channel is closed
+/// by the broker or a network event.  Disposing cancels the consumer and
+/// closes the channel without triggering a reconnect.
 /// </summary>
-internal sealed class RabbitMqSubscription : ISubscription
+internal sealed class RabbitMqSubscription : ISubscription, IAsyncDisposable
 {
-    private readonly IChannel _channel;
-    private readonly string _consumerTag;
-    private bool _disposed;
+    private readonly Func<CancellationToken, Task<(IChannel channel, string consumerTag)>> _channelFactory;
+    private readonly ILogger _logger;
+    private readonly CancellationTokenSource _disposeCts = new();
+
+    // Updated atomically by the reconnect loop; read in DisposeAsync.
+    private volatile IChannel _channel;
+    private volatile string _consumerTag;
+    private volatile bool _disposed;
 
     public string Topic { get; }
     public string SubscriptionName { get; }
-    public bool IsActive => !_disposed && _channel.IsOpen;
+
+    /// <summary>
+    /// True as long as the subscription has not been explicitly disposed.
+    /// Reconnection after a channel failure is transparent — callers do not
+    /// need to re-subscribe.
+    /// </summary>
+    public bool IsActive => !_disposed;
 
     public RabbitMqSubscription(
         IChannel channel,
         string consumerTag,
         string topic,
-        string subscriptionName)
+        string subscriptionName,
+        Func<CancellationToken, Task<(IChannel channel, string consumerTag)>> channelFactory,
+        ILogger logger)
     {
         _channel = channel;
         _consumerTag = consumerTag;
         Topic = topic;
         SubscriptionName = subscriptionName;
+        _channelFactory = channelFactory;
+        _logger = logger;
+
+        RegisterShutdownHandler(channel);
+    }
+
+    private void RegisterShutdownHandler(IChannel channel)
+    {
+        channel.ChannelShutdownAsync += OnChannelShutdownAsync;
+    }
+
+    private Task OnChannelShutdownAsync(object sender, ShutdownEventArgs args)
+    {
+        // Application-initiated close is the dispose path — no reconnect needed.
+        if (_disposed || args.Initiator == ShutdownInitiator.Application)
+            return Task.CompletedTask;
+
+        _logger.LogWarning(
+            "Subscription channel for {Topic} ({SubscriptionName}) closed unexpectedly " +
+            "({Initiator} {ReplyCode}: {ReplyText}) — reconnecting",
+            Topic, SubscriptionName, args.Initiator, args.ReplyCode, args.ReplyText);
+
+        _ = ReconnectAsync();
+        return Task.CompletedTask;
+    }
+
+    private async Task ReconnectAsync()
+    {
+        var delay = TimeSpan.FromSeconds(2);
+        const double backoffMultiplier = 2.0;
+        const int maxDelaySeconds = 30;
+
+        while (!_disposed)
+        {
+            try
+            {
+                await Task.Delay(delay, _disposeCts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                return; // disposed while waiting
+            }
+
+            try
+            {
+                var (newChannel, newConsumerTag) = await _channelFactory(_disposeCts.Token);
+                RegisterShutdownHandler(newChannel);
+
+                _channel = newChannel;
+                _consumerTag = newConsumerTag;
+
+                _logger.LogInformation(
+                    "Reconnected subscription for {Topic} ({SubscriptionName})",
+                    Topic, SubscriptionName);
+                return;
+            }
+            catch (OperationCanceledException) when (_disposed)
+            {
+                return; // disposed during reconnect attempt
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Reconnect attempt for {Topic} ({SubscriptionName}) failed — retrying in {Delay}s",
+                    Topic, SubscriptionName, delay.TotalSeconds);
+
+                delay = TimeSpan.FromSeconds(
+                    Math.Min(delay.TotalSeconds * backoffMultiplier, maxDelaySeconds));
+            }
+        }
     }
 
     public async ValueTask DisposeAsync()
@@ -33,10 +120,14 @@ internal sealed class RabbitMqSubscription : ISubscription
         if (_disposed) return;
         _disposed = true;
 
-        if (_channel.IsOpen)
+        await _disposeCts.CancelAsync();
+        _disposeCts.Dispose();
+
+        var channel = _channel;
+        if (channel.IsOpen)
         {
-            await _channel.BasicCancelAsync(_consumerTag);
-            await _channel.CloseAsync();
+            try { await channel.BasicCancelAsync(_consumerTag); } catch { /* best-effort */ }
+            await channel.CloseAsync();
         }
     }
 }


### PR DESCRIPTION
## Summary

- `RabbitMqSubscription` now self-heals when a channel closes unexpectedly: registers `ChannelShutdownAsync` and fires a background reconnect loop with exponential backoff (2s → 4s → 8s → 16s → 30s cap)
- `IsActive` changed to mean "not explicitly disposed" so all callers see the subscription as alive throughout reconnection — no consumer needs to re-subscribe
- `RabbitMqSubscriber` extracts channel+consumer creation into a factory delegate reused for reconnection; ack/nack calls switched to `CancellationToken.None`
- `AutomaticRecoveryEnabled = false` on the `ConnectionFactory` to prevent the RabbitMQ client library's own recovery from racing with ours and creating duplicate consumers

## Background

Diagnosed from k8s logs: the `rockbot.mcp-proxy.RockBot` queue had 0 consumers and 64 queued responses — the bridge was successfully executing MCP tool calls and publishing results, but the agent's subscription channel had silently died. Because `_initialized` was a one-way flag, the proxy kept publishing invoke requests that the bridge processed, but responses had nowhere to go. The same silent failure affected `mcp-management.RockBot` and `script-bridge.script-bridge` queues.

The fix lives entirely in the messaging layer — no consumer code needs to change.

## Test plan

- [ ] All existing unit tests pass (`dotnet test`)
- [ ] Deploy to k8s and restart `rockbot-agent` to drain the 64 stale queued responses
- [ ] Verify calendar-mcp tool calls complete successfully after deploy
- [ ] Confirm that a simulated channel drop (e.g. temporary RabbitMQ network partition) results in a reconnect log line and resumed message delivery without pod restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)