### PR TITLE
fix: heartbeat patrol asks for clarification instead of executing

### DIFF
--- a/src/RockBot.Cli/agent/heartbeat-patrol.md
+++ b/src/RockBot.Cli/agent/heartbeat-patrol.md
@@ -2,6 +2,8 @@
 
 You are executing a periodic heartbeat patrol. This fires every 30 minutes to keep you situationally aware and proactively manage the user's commitments.
 
+**Execute immediately.** The scope is fully defined below. Do not ask for clarification, do not ask the user to configure anything — just run the checklist now.
+
 ## Patrol Checklist
 
 Work through each item below. Use your available tools. Act within your standing authority where you can; queue everything else as a briefing item.

--- a/src/RockBot.Host/HeartbeatBootstrapService.cs
+++ b/src/RockBot.Host/HeartbeatBootstrapService.cs
@@ -31,7 +31,7 @@ internal sealed class HeartbeatBootstrapService(
         await scheduler.ScheduleAsync(new ScheduledTask(
             Name: "heartbeat-patrol",
             CronExpression: options.Value.CronExpression,
-            Description: "Execute the heartbeat patrol directive.",
+            Description: "Run the heartbeat patrol: check calendar, email, active plans, and scheduled task health.",
             CreatedAt: DateTimeOffset.UtcNow,
             RunOnce: false), ct);
 


### PR DESCRIPTION
## Summary

- Added **"Execute immediately"** framing to `heartbeat-patrol.md` so the model acts on the checklist rather than asking the user to configure the patrol scope
- Changed the scheduled task `Description` in `HeartbeatBootstrapService` from the vague `"Execute the heartbeat patrol directive."` to a concrete summary of what the patrol does — improves BM25 memory recall and removes the word "directive" which was triggering conversational interpretation

## Root Cause

The task description `"Execute the heartbeat patrol directive."` was used as the LLM user turn. The model treated it as a user asking about an unfamiliar concept and responded with clarifying questions, even though the `heartbeat-patrol.md` directive was already injected as a system message. The directive lacked explicit instruction to suppress clarification-seeking.

## Test plan

- [ ] Trigger a heartbeat patrol and confirm the agent executes the checklist without asking clarifying questions
- [ ] Confirm silent output when there is nothing to report

🤖 Generated with [Claude Code](https://claude.com/claude-code)