### PR TITLE
feat: serialize agent loops — user sessions preempt scheduled tasks

### DIFF
--- a/src/RockBot.Host.Abstractions/IAgentWorkSerializer.cs
+++ b/src/RockBot.Host.Abstractions/IAgentWorkSerializer.cs
@@ -1,0 +1,59 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Serializes full agent loops so that user sessions and scheduled background
+/// tasks never run concurrently, and user sessions always preempt background tasks.
+/// </summary>
+/// <remarks>
+/// The agent host holds a single execution slot. At most one full agent loop
+/// (user background tool loop or scheduled task loop) occupies the slot at a
+/// time. When a user session acquires the slot it first cancels any scheduled
+/// task that currently holds it, so the user always gets a fast response.
+/// </remarks>
+public interface IAgentWorkSerializer
+{
+    /// <summary>
+    /// Acquires the execution slot for a user background tool loop.
+    /// Cancels any scheduled task currently holding the slot, then waits for
+    /// the slot to become free before returning.
+    /// </summary>
+    /// <param name="ct">
+    /// Cancellation token for the calling session (linked to host lifetime and
+    /// to <see cref="SessionBackgroundTaskTracker"/> so a subsequent user
+    /// message cancels the waiting loop before it even starts).
+    /// </param>
+    /// <returns>
+    /// A disposable that releases the slot when the loop completes or is cancelled.
+    /// </returns>
+    Task<IAsyncDisposable> AcquireForUserAsync(CancellationToken ct);
+
+    /// <summary>
+    /// Tries to acquire the execution slot for a scheduled background task.
+    /// Returns <c>null</c> immediately if the slot is already held (by a user
+    /// loop or another task), in which case the caller should skip this run
+    /// and wait for the next scheduled tick.
+    /// </summary>
+    /// <param name="ct">Host lifetime cancellation token.</param>
+    /// <returns>
+    /// A handle containing a <see cref="CancellationToken"/> linked to both
+    /// <paramref name="ct"/> and the preemption signal (fired when a user
+    /// message arrives), plus a disposable that releases the slot.
+    /// Returns <c>null</c> if the slot could not be acquired.
+    /// </returns>
+    Task<IScheduledTaskSlot?> TryAcquireForScheduledAsync(CancellationToken ct);
+}
+
+/// <summary>
+/// Represents a successfully acquired execution slot for a scheduled task.
+/// The <see cref="Token"/> fires if a user session preempts the task or the
+/// host shuts down. Dispose to release the slot.
+/// </summary>
+public interface IScheduledTaskSlot : IAsyncDisposable
+{
+    /// <summary>
+    /// Combined cancellation token: fires on host shutdown or user preemption.
+    /// Pass this to <c>AgentLoopRunner.RunAsync</c> so the task stops cleanly
+    /// when a user message arrives.
+    /// </summary>
+    CancellationToken Token { get; }
+}

--- a/src/RockBot.Host/AgentWorkSerializer.cs
+++ b/src/RockBot.Host/AgentWorkSerializer.cs
@@ -1,0 +1,87 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Default implementation of <see cref="IAgentWorkSerializer"/>.
+/// Uses a single semaphore slot to ensure at most one full agent loop runs
+/// at a time, and a preemption <see cref="CancellationTokenSource"/> that is
+/// cancelled whenever a user session acquires the slot.
+/// </summary>
+internal sealed class AgentWorkSerializer : IAgentWorkSerializer, IDisposable
+{
+    private readonly SemaphoreSlim _slot = new(1, 1);
+
+    // Replaced each time a user loop acquires the slot; cancels any scheduled
+    // task that holds the slot at that moment.
+    private CancellationTokenSource _preemptCts = new();
+    private readonly object _preemptLock = new();
+
+    // ── User loop ─────────────────────────────────────────────────────────────
+
+    public async Task<IAsyncDisposable> AcquireForUserAsync(CancellationToken ct)
+    {
+        // Signal any running scheduled task to stop so the slot becomes free.
+        CancellationTokenSource newPreempt;
+        lock (_preemptLock)
+        {
+            _preemptCts.Cancel();
+            _preemptCts.Dispose();
+            newPreempt = _preemptCts = new CancellationTokenSource();
+        }
+
+        // Wait for the slot — the preempted task releases it on cancellation.
+        await _slot.WaitAsync(ct);
+
+        return new SlotHandle(_slot);
+    }
+
+    // ── Scheduled task ────────────────────────────────────────────────────────
+
+    public Task<IScheduledTaskSlot?> TryAcquireForScheduledAsync(CancellationToken ct)
+    {
+        // Non-blocking: if the slot is held by a user loop, skip this run.
+        if (!_slot.Wait(0))
+            return Task.FromResult<IScheduledTaskSlot?>(null);
+
+        CancellationToken preemptToken;
+        lock (_preemptLock)
+        {
+            preemptToken = _preemptCts.Token;
+        }
+
+        var linked = CancellationTokenSource.CreateLinkedTokenSource(ct, preemptToken);
+        return Task.FromResult<IScheduledTaskSlot?>(new ScheduledTaskSlot(_slot, linked));
+    }
+
+    public void Dispose()
+    {
+        lock (_preemptLock)
+        {
+            _preemptCts.Dispose();
+        }
+        _slot.Dispose();
+    }
+
+    // ── Handles ───────────────────────────────────────────────────────────────
+
+    private sealed class SlotHandle(SemaphoreSlim slot) : IAsyncDisposable
+    {
+        public ValueTask DisposeAsync()
+        {
+            slot.Release();
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class ScheduledTaskSlot(SemaphoreSlim slot, CancellationTokenSource cts)
+        : IScheduledTaskSlot
+    {
+        public CancellationToken Token => cts.Token;
+
+        public ValueTask DisposeAsync()
+        {
+            slot.Release();
+            cts.Dispose();
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/src/RockBot.Host/ServiceCollectionExtensions.cs
+++ b/src/RockBot.Host/ServiceCollectionExtensions.cs
@@ -29,6 +29,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<AgentContextBuilder>();
         services.AddSingleton<SessionStartTracker>();
         services.AddSingleton<IUserActivityMonitor, UserActivityMonitor>();
+        services.AddSingleton<IAgentWorkSerializer, AgentWorkSerializer>();
         services.AddSingleton<IMessagePipeline, MessagePipeline>();
         services.AddSingleton<IHostedService, AgentHost>();
 


### PR DESCRIPTION
## Summary

Adds `IAgentWorkSerializer` to prevent scheduled tasks (patrol, etc.) from running concurrently with active user conversations. At most one full agent loop runs at a time; user sessions always win.

## Problem

`ScheduledTaskHandler` runs `agentLoopRunner.RunAsync()` — the full tool-calling loop with every tool — with no coordination against the user's active background loop. When a patrol fires mid-conversation both loops simultaneously call the LLM, write to long-term memory, and call MCP servers (calendar, todo-mcp, etc.), causing interleaved and inconsistent behavior.

## Design

A single execution slot (`SemaphoreSlim(1,1)`) plus a preemption `CancellationTokenSource` enforce the invariant. Follows the same layering pattern as `IUserActivityMonitor`:

| File | Layer | Change |
|---|---|---|
| `src/RockBot.Host.Abstractions/IAgentWorkSerializer.cs` | Abstractions | New interface + `IScheduledTaskSlot` |
| `src/RockBot.Host/AgentWorkSerializer.cs` | Framework | Implementation |
| `src/RockBot.Host/ServiceCollectionExtensions.cs` | Framework | Register as singleton |
| `src/RockBot.Cli/UserMessageHandler.cs` | Application | Acquire slot in `BackgroundToolLoopAsync` |
| `src/RockBot.Cli/ScheduledTaskHandler.cs` | Application | Try-acquire before running; skip or yield on preemption |

## Behavior

| Scenario | Before | After |
|---|---|---|
| Patrol fires, user idle | Runs | Runs |
| Patrol fires while user is active | Both run concurrently ❌ | Patrol skipped, waits for next tick ✅ |
| User types while patrol is running | Both run concurrently ❌ | Patrol cancelled, user gets fast response ✅ |
| Two scheduled tasks fire at once | Both run concurrently ❌ | Second is skipped ✅ |

Scheduled tasks are opportunistic: they run when you're idle and yield immediately when you start a conversation. No rescheduling — just wait for the next normal cron tick.

## Test plan

- [ ] `dotnet test RockBot.slnx` — 132 tests, all pass
- [ ] Start a conversation in Blazor; trigger a patrol manually — verify log shows `Skipping scheduled task — user session is active`
- [ ] Let patrol run while idle — verify it runs normally and completes
- [ ] Start typing mid-patrol — verify log shows `preempted by a user session` and response comes back promptly

🤖 Generated with [Claude Code](https://claude.com/claude-code)