### PR TITLE
fix: use full namespace as SessionId in tool invocations; research/{taskId} for ResearchAgent

### DIFF
--- a/src/RockBot.A2A/A2ATaskErrorHandler.cs
+++ b/src/RockBot.A2A/A2ATaskErrorHandler.cs
@@ -58,11 +58,12 @@ internal sealed class A2ATaskErrorHandler(
         var chatMessages = await agentContextBuilder.BuildAsync(
             pending.PrimarySessionId, syntheticUserTurn, ct);
 
-        var sessionWorkingMemoryTools = new WorkingMemoryTools(workingMemory, pending.PrimarySessionId, logger);
+        var sessionNamespace = $"session/{pending.PrimarySessionId}";
+        var sessionWorkingMemoryTools = new WorkingMemoryTools(workingMemory, sessionNamespace, logger);
         var sessionSkillTools = new SkillTools(skillStore, llmClient, logger, pending.PrimarySessionId);
         var registryTools = toolRegistry.GetTools()
             .Select(r => (AIFunction)new RegistryToolFunction(
-                r, toolRegistry.GetExecutor(r.Name)!, pending.PrimarySessionId))
+                r, toolRegistry.GetExecutor(r.Name)!, sessionNamespace))
             .ToArray();
 
         var chatOptions = new ChatOptions

--- a/src/RockBot.A2A/A2ATaskResultHandler.cs
+++ b/src/RockBot.A2A/A2ATaskResultHandler.cs
@@ -133,7 +133,7 @@ internal sealed class A2ATaskResultHandler(
         var sessionSkillTools = new SkillTools(skillStore, llmClient, logger, pending.PrimarySessionId);
         var registryTools = toolRegistry.GetTools()
             .Select(r => (AIFunction)new RegistryToolFunction(
-                r, toolRegistry.GetExecutor(r.Name)!, pending.PrimarySessionId))
+                r, toolRegistry.GetExecutor(r.Name)!, $"session/{pending.PrimarySessionId}"))
             .ToArray();
 
         var chatOptions = new ChatOptions

--- a/src/RockBot.A2A/A2ATaskStatusHandler.cs
+++ b/src/RockBot.A2A/A2ATaskStatusHandler.cs
@@ -84,11 +84,12 @@ internal sealed class A2ATaskStatusHandler(
         var chatMessages = await agentContextBuilder.BuildAsync(
             pending.PrimarySessionId, syntheticUserTurn, ct);
 
-        var sessionWorkingMemoryTools = new WorkingMemoryTools(workingMemory, pending.PrimarySessionId, logger);
+        var sessionNamespace = $"session/{pending.PrimarySessionId}";
+        var sessionWorkingMemoryTools = new WorkingMemoryTools(workingMemory, sessionNamespace, logger);
         var sessionSkillTools = new SkillTools(skillStore, llmClient, logger, pending.PrimarySessionId);
         var registryTools = toolRegistry.GetTools()
             .Select(r => (AIFunction)new RegistryToolFunction(
-                r, toolRegistry.GetExecutor(r.Name)!, pending.PrimarySessionId))
+                r, toolRegistry.GetExecutor(r.Name)!, sessionNamespace))
             .ToArray();
 
         var chatOptions = new ChatOptions

--- a/src/RockBot.Agent/UserFeedbackHandler.cs
+++ b/src/RockBot.Agent/UserFeedbackHandler.cs
@@ -128,11 +128,12 @@ internal sealed class UserFeedbackHandler(
 
                 // Give the re-evaluation loop the full agent tool set so it can
                 // use memory, skills, web search, MCP tools, etc. as needed.
-                var sessionWorkingMemoryTools = new WorkingMemoryTools(workingMemory, message.SessionId, logger);
+                var sessionNamespace = $"session/{message.SessionId}";
+                var sessionWorkingMemoryTools = new WorkingMemoryTools(workingMemory, sessionNamespace, logger);
                 var sessionSkillTools = new SkillTools(skillStore, llmClient, logger, message.SessionId);
                 var registryTools = toolRegistry.GetTools()
                     .Select(r => (AIFunction)new RegistryToolFunction(
-                        r, toolRegistry.GetExecutor(r.Name)!, message.SessionId))
+                        r, toolRegistry.GetExecutor(r.Name)!, sessionNamespace))
                     .ToArray();
 
                 var chatOptions = new ChatOptions

--- a/src/RockBot.Agent/UserMessageHandler.cs
+++ b/src/RockBot.Agent/UserMessageHandler.cs
@@ -115,7 +115,7 @@ internal sealed class UserMessageHandler(
 
             // Registry tools (MCP, REST, etc.)
             var registryTools = toolRegistry.GetTools()
-                .Select(r => (AIFunction)new RegistryToolFunction(r, toolRegistry.GetExecutor(r.Name)!, message.SessionId))
+                .Select(r => (AIFunction)new RegistryToolFunction(r, toolRegistry.GetExecutor(r.Name)!, sessionNamespace))
                 .ToArray();
 
             var allTools = memoryTools.Tools

--- a/src/RockBot.Subagent/SubagentResultHandler.cs
+++ b/src/RockBot.Subagent/SubagentResultHandler.cs
@@ -102,7 +102,7 @@ internal sealed class SubagentResultHandler(
         var sessionSkillTools = new SkillTools(skillStore, llmClient, logger, message.PrimarySessionId);
         var registryTools = toolRegistry.GetTools()
             .Select(r => (AIFunction)new SubagentRegistryToolFunction(
-                r, toolRegistry.GetExecutor(r.Name)!, message.PrimarySessionId))
+                r, toolRegistry.GetExecutor(r.Name)!, $"session/{message.PrimarySessionId}"))
             .ToArray();
 
         var chatOptions = new ChatOptions

--- a/src/RockBot.Subagent/SubagentRunner.cs
+++ b/src/RockBot.Subagent/SubagentRunner.cs
@@ -88,7 +88,7 @@ internal sealed class SubagentRunner(
                      && r.Name != "mcp_register_server"
                      && r.Name != "mcp_unregister_server")
             .Select(r => (AIFunction)new SubagentRegistryToolFunction(
-                r, toolRegistry.GetExecutor(r.Name)!, subagentSessionId))
+                r, toolRegistry.GetExecutor(r.Name)!, subagentNamespace))
             .ToArray();
 
         // report_progress tool — baked with taskId and primarySessionId

--- a/src/RockBot.Tools.Web/WebBrowseToolExecutor.cs
+++ b/src/RockBot.Tools.Web/WebBrowseToolExecutor.cs
@@ -92,7 +92,8 @@ internal sealed class WebBrowseToolExecutor(
         for (var i = 0; i < chunks.Count; i++)
         {
             var (heading, content) = chunks[i];
-            var key = $"session/{request.SessionId}/web-{sanitizedUrl}-chunk{i}";
+            // SessionId is the full working memory namespace (e.g. "session/abc123", "patrol/heartbeat")
+            var key = $"{request.SessionId}/web-{sanitizedUrl}-chunk{i}";
 
             await workingMemory!.SetAsync(key, content, ttl, category: "web");
 

--- a/tests/RockBot.Tools.Web.Tests/WebBrowseToolExecutorTests.cs
+++ b/tests/RockBot.Tools.Web.Tests/WebBrowseToolExecutorTests.cs
@@ -112,8 +112,9 @@ public class WebBrowseToolExecutorTests
         var options = new WebToolOptions { ChunkingThreshold = 8_000, ChunkMaxLength = 5_000, ChunkTtlMinutes = 20 };
         var executor = new WebBrowseToolExecutor(provider, memory, options);
 
+        // Callers pass the full namespace as SessionId (e.g. "session/abc123", "patrol/heartbeat")
         var response = await executor.ExecuteAsync(
-            MakeRequest("""{"url": "https://example.com/big"}""", sessionId: "session-1"),
+            MakeRequest("""{"url": "https://example.com/big"}""", sessionId: "session/session-1"),
             CancellationToken.None);
 
         Assert.IsFalse(response.IsError);


### PR DESCRIPTION
## Summary

- `WebBrowseToolExecutor` was hardcoding `session/` as a prefix for chunk keys, so patrol and subagent tool calls were landing in `session/patrol/...` instead of their actual namespaces
- All `RegistryToolFunction` / `SubagentRegistryToolFunction` callers now pass the full working memory namespace as `SessionId`, consistent with the path-namespaced design from #119
- `ResearchAgent` uses `research/{taskId}` namespace instead of `session/{taskId}`

## Changes

**`WebBrowseToolExecutor`**: `SessionId` in `ToolInvokeRequest` is now the full namespace prefix — key stored as `{SessionId}/web-{url}-chunk{n}` (no `session/` hardcode)

**`UserMessageHandler`**: passes `sessionNamespace` (`session/{id}`) to `RegistryToolFunction`  
**`UserFeedbackHandler`**: same fix + `WorkingMemoryTools` also gets `sessionNamespace`  
**`ScheduledTaskHandler`**: already passed `patrol/{name}` — no change needed  
**`SubagentRunner`**: passes `subagentNamespace` (`subagent/{taskId}`) to `SubagentRegistryToolFunction`  
**`SubagentResultHandler`**: passes `session/{primarySessionId}` to `SubagentRegistryToolFunction`  
**`A2ATaskResultHandler/StatusHandler/ErrorHandler`**: pass `session/{primarySessionId}` to `RegistryToolFunction` + `WorkingMemoryTools`  

**`ResearchAgentTaskHandler`**: uses `research/{taskId}` namespace — semantically correct for A2A tasks. `ResearchToolFunction` receives the full namespace so web chunks land at `research/{taskId}/web-...`, consistent with `WorkingMemoryTools`

**`SampleAgent`**: no changes needed (no working memory usage)

## Test plan

- [x] All tests pass (`dotnet test RockBot.slnx`)
- [ ] Verify patrol web browse chunks land in `patrol/{name}/web-...`
- [ ] Verify subagent web browse chunks land in `subagent/{taskId}/web-...`
- [ ] Verify ResearchAgent chunks land in `research/{taskId}/web-...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)