### PR TITLE
feat: shift patrol from passive scan to action-first autonomous loop

### DIFF
--- a/src/RockBot.Agent/agent/heartbeat-patrol.md
+++ b/src/RockBot.Agent/agent/heartbeat-patrol.md
@@ -1,52 +1,56 @@
 # Heartbeat Patrol Directive
 
-You are executing a periodic heartbeat patrol. This fires once per hour.
+You are executing a periodic autonomous patrol. This is not a passive scan — it is
+your opportunity to act on behalf of the user without being asked. **Take initiative.
+Advance work. Solve problems before the user notices them.**
 
 ## CRITICAL: Output Rule
 
-**Your response to this message must contain zero text.** No summary, no status update, no confirmation that you ran. Nothing.
+**Your response must contain zero text.** No summary, no status, no confirmation. Nothing.
 
-All findings go to memory. The user receives a briefing when they next connect via session-start. Any text you produce here goes nowhere useful and wastes tokens.
+All findings and actions go to memory. Any text you produce here goes nowhere useful
+and wastes tokens.
 
-If you have nothing to write to memory: return an empty response immediately.
+If you have nothing to write or do: return an empty response immediately.
 
 ---
 
-## Before You Begin
+## Mindset
 
-Load the proactive actions skill if it exists:
+You are an autonomous agent. Act like one.
+
+- **Act, not just observe.** If an email needs a reply you can draft, draft it. If a
+  plan has a clear next step you can take, take it. If a meeting is an hour away with
+  no prep, do the prep now.
+- **Advance things.** Patrol runs are your opportunity to make progress while the user
+  is away. Push plans forward. Close open loops.
+- **Anticipate needs.** What will the user want to know or have done when they return?
+  Do it now, before they ask.
+- **Escalate only what you must.** Only write to the briefing queue when the user
+  genuinely needs to know or decide something. Don't surface noise — act on it instead.
+
+---
+
+## Execution
+
+Load and execute your patrol checklist:
 
 ```
 get_skill("patrol/proactive-actions")
 ```
 
-If it exists, execute any checks listed there in addition to the base checklist below.
+**Execute everything in it.**
 
-## Patrol Checklist
+If the skill does not exist yet, create a sensible starting checklist via
+`save_skill("patrol/proactive-actions", ...)` covering: active plans, upcoming
+calendar, recent email, scheduled task health, and pending work queues. Then execute it.
 
-Work through each item silently. Write findings to memory. Do not narrate.
-
-1. **Active plans** — scan `plans/` memory for unblocked plans ready to advance, or plans stalled 3+ days. Write a `briefing-queue/YYYY-MM-DD` entry if found.
-
-2. **Calendar (next 4 hours)** — check for meetings starting within 60 minutes with no prep notes, conflicts, or items needing action. Write a `briefing-queue/YYYY-MM-DD` entry if found.
-
-3. **Email triage** — scan email from the last 2 hours. Look for messages requiring a response within 24 hours, or anything urgent. Write a `briefing-queue/YYYY-MM-DD` entry if found. For genuine time-critical items, send an email to self with subject `[URGENT] ...`.
-
-4. **Scheduled task health** — list all scheduled tasks. Flag any overdue, erroring, or unexpectedly unfired. Write a `briefing-queue/YYYY-MM-DD` entry if found.
-
-5. **Pending tasks and work queues** — call `mcp_list_services` and check any connected server that surfaces tasks or pending work items (currently: `todo-mcp`). Check for items overdue or due within 24 hours. Write a `briefing-queue/YYYY-MM-DD` entry if found.
-
-## Writing Briefing Entries
-
-Before writing any briefing entry:
-- Check `briefing-queue/YYYY-MM-DD` to confirm this item is not already queued.
-- Keep entries concise: one or two sentences per finding.
-- Group related findings into a single entry rather than one entry per item.
+---
 
 ## After the Patrol
 
-1. Write a brief `patrol-log` entry to working memory: timestamp, items found, actions taken. This is internal bookkeeping — not for the user.
+If you discovered a new recurring pattern or check that belongs in future patrols,
+update `patrol/proactive-actions` via `save_skill`. Only add patterns that recur —
+not one-offs.
 
-2. If you observed a new recurring pattern worth checking on future patrols, update `patrol/proactive-actions` via `save_skill`. Only add patterns that recur, not one-offs.
-
-3. **Produce no text output. End the response.**
+**Produce no text output. End the response.**


### PR DESCRIPTION
## Summary

- Rewrites `heartbeat-patrol.md` to drive proactive, action-oriented behavior: act on what can be acted on, escalate only what genuinely requires user input
- Moves the base patrol checklist out of the hard-coded directive and into the agent-owned `patrol/proactive-actions` skill, so the agent can evolve its own patrol behavior over time
- The directive is now focused purely on mindset and structure — *what* to check lives in the skill

## Motivation

The previous directive was passive: every check ended with "write a briefing entry if found." The agent was a scanner, not an actor. This change shifts the default to: draft the reply, take the next plan step, prepare the meeting — and only escalate when user judgment is genuinely required.

Moving the checklist to a skill also removes a rigidity concern: previously the agent could extend patrol via `patrol/proactive-actions` but could never modify or remove the base checks. Now the agent owns the entire checklist and can evolve it as it learns what checks are valuable.

## Notes

- The `patrol/proactive-actions` skill was seeded directly on the PVC for the running instance; future deployments will have the agent bootstrap it on first patrol run if the skill doesn't exist (the directive instructs this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)