### PR TITLE
chore: set low and high LLM tiers to google/gemini-3.1-pro-preview in Helm values

### DIFF
--- a/deploy/helm/rockbot/values.yaml
+++ b/deploy/helm/rockbot/values.yaml
@@ -145,11 +145,11 @@ secrets:
     low:                    # Optional — fast/cheap model for simple factual questions
       endpoint: ""
       apiKey: ""
-      modelId: ""           # leave empty to fall back to balanced
+      modelId: "google/gemini-3.1-pro-preview"
     high:                   # Optional — powerful model for dream/research/complex tasks
       endpoint: ""
       apiKey: ""
-      modelId: ""           # leave empty to fall back to balanced
+      modelId: "google/gemini-3.1-pro-preview"           # leave empty to fall back to balanced
 
     # Legacy flat keys — kept for backward compatibility; remove after all deployments migrated
     endpoint: ""


### PR DESCRIPTION
## Summary

- Sets `secrets.llm.low.modelId` and `secrets.llm.high.modelId` to `google/gemini-3.1-pro-preview` in `values.yaml`, syncing with the live cluster configuration
- Endpoint and API key fields remain empty — must be supplied at deploy time via `--set` or a gitignored override values file to avoid leaking secrets into the repo

## Test plan

- [ ] Verify `helm template` renders correctly when endpoint/apiKey are supplied via `--set`
- [ ] Confirm next `helm upgrade` picks up the correct model IDs for low and high tiers

🤖 Generated with [Claude Code](https://claude.com/claude-code)