### PR TITLE
fix: A2A result handler session namespace, WM storage, and patrol controls

### DIFF
--- a/src/RockBot.A2A/A2ACallerSkillProvider.cs
+++ b/src/RockBot.A2A/A2ACallerSkillProvider.cs
@@ -38,7 +38,9 @@ public sealed class A2ACallerSkillProvider : IToolSkillProvider
         ## Usage pattern
         1. Call list_known_agents to see what agents and skills are available
         2. Call invoke_agent with the desired agent_name, skill, and message
-        3. Continue the conversation; the agent's result will arrive automatically
-           as a follow-up message and be incorporated into the conversation
+        3. When the agent completes, a follow-up message will arrive in the
+           conversation containing a working memory key. Call
+           get_from_working_memory with that key to retrieve the full result,
+           then present it to the user.
         """;
 }

--- a/src/RockBot.Host/AgentContextBuilder.cs
+++ b/src/RockBot.Host/AgentContextBuilder.cs
@@ -209,8 +209,13 @@ public sealed class AgentContextBuilder(
                     return meta.ToString();
                 });
                 var patrolContext =
-                    "Patrol findings in working memory (use get_from_working_memory with the full key to read):\n" +
-                    string.Join("\n", lines);
+                    "Patrol findings in working memory (keys listed below):\n" +
+                    string.Join("\n", lines) + "\n\n" +
+                    "- To read a finding: call get_from_working_memory with the full key.\n" +
+                    "- To dismiss a resolved finding: call delete_from_working_memory with the full key. " +
+                    "Do this when the user confirms something is resolved or not a real issue — dismissed entries stop being re-surfaced.\n" +
+                    "- To change what the patrol checks and reports: edit the 'patrol/proactive-actions' skill via save_skill. " +
+                    "The patrol runs on a schedule and loads that skill as its directive each run.";
                 chatMessages.Add(new ChatMessage(ChatRole.System, patrolContext));
                 logger.LogInformation("Injected {Count} patrol working memory entries into context", patrolEntries.Count);
             }

--- a/src/RockBot.Memory/WorkingMemoryTools.cs
+++ b/src/RockBot.Memory/WorkingMemoryTools.cs
@@ -30,6 +30,7 @@ public sealed class WorkingMemoryTools
         [
             AIFunctionFactory.Create(SaveToWorkingMemory),
             AIFunctionFactory.Create(GetFromWorkingMemory),
+            AIFunctionFactory.Create(DeleteFromWorkingMemory),
             AIFunctionFactory.Create(ListWorkingMemory),
             AIFunctionFactory.Create(SearchWorkingMemory)
         ];
@@ -71,6 +72,18 @@ public sealed class WorkingMemoryTools
         if (value is null)
             return $"Working memory entry '{fullKey}' not found or has expired.";
         return value;
+    }
+
+    [Description("Delete an entry from working memory by key. " +
+                 "Use this to dismiss resolved patrol findings, clear stale data, or remove entries that are no longer needed. " +
+                 "Use a plain key to delete from your own namespace, or a full path (e.g. 'patrol/heartbeat-patrol/...') to delete from another namespace.")]
+    public async Task<string> DeleteFromWorkingMemory(
+        [Description("Key to delete — plain key for own namespace, full path for cross-namespace (e.g. 'patrol/heartbeat-patrol/critical-actions-required')")] string key)
+    {
+        var fullKey = key.Contains('/') ? key : $"{_namespace}/{key}";
+        _logger.LogInformation("Tool call: DeleteFromWorkingMemory(key={Key})", fullKey);
+        await _workingMemory.DeleteAsync(fullKey);
+        return $"Working memory entry '{fullKey}' deleted.";
     }
 
     [Description("List all keys currently in working memory with their category, tags, and expiry times. " +


### PR DESCRIPTION
## Summary

- **Fix A2A double-prefix session namespace bug** — `PrimarySessionId` already contains the `session/` prefix (it comes from `RegistryToolFunction`'s `sessionId` parameter), so `A2ATaskResultHandler` was computing `session/session/blazor-session` everywhere. Fixed by using `PrimarySessionId` directly as `sessionNamespace` and stripping the prefix once to get `rawSessionId` for `AgentContextBuilder`, conversation memory, and skill tools.
- **Always store A2A results in working memory** — removed the inline-vs-WM size conditional. Results below the 16K chunking threshold were going into the synthetic user turn as plain text; the LLM then searched WM, found nothing, and concluded the result was unavailable. All results now go to `session/{id}/a2a/{agent}/{taskId}/result` (60-min TTL) and the synthetic turn always provides the exact key.
- **Add `DeleteFromWorkingMemory` tool** — exposes `IWorkingMemory.DeleteAsync` as an LLM-callable tool so the agent can dismiss resolved patrol findings instead of having them re-surfaced on every turn.
- **Improve patrol context message** — `AgentContextBuilder` now tells the agent it can delete resolved findings and that `patrol/proactive-actions` is the skill controlling patrol behavior.
- **Fix completion bubble text** — was always saying "in working memory" even for results that went inline; now always accurate since results always go to WM.
- **Update `A2ACallerSkillProvider` and `docs/a2a.md`** — both now correctly describe the result handoff: the follow-up conversation message is a notification containing a WM key, not the result itself.

## Test plan

- [ ] Invoke ResearchAgent and confirm result is logged as stored in WM at `session/{id}/a2a/ResearchAgent/{taskId}/result`
- [ ] Confirm primary agent calls `get_from_working_memory` with the provided key and presents the result
- [ ] Confirm `ListWorkingMemory` shows the A2A result entry in the session namespace
- [ ] Confirm patrol findings can be dismissed via `delete_from_working_memory`
- [ ] Confirm patrol context message includes dismissal and skill-edit instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)