### PR TITLE
fix: rephrase datetime injection to be context-neutral and explicit about UTC conversion

### DIFF
--- a/src/RockBot.Host/AgentContextBuilder.cs
+++ b/src/RockBot.Host/AgentContextBuilder.cs
@@ -51,8 +51,9 @@ public sealed class AgentContextBuilder(
         {
             new(ChatRole.System, systemPrompt),
             new(ChatRole.System,
-                $"The user's local date and time is: {clock.Now:dddd, MMMM d, yyyy} {clock.Now:HH:mm:ss zzz} ({clock.Zone.Id}). " +
-                "Always express dates and times to the user in this timezone. Never assume UTC or any other timezone.")
+                $"Current local date and time: {clock.Now:dddd, MMMM d, yyyy} {clock.Now:HH:mm:ss zzz} ({clock.Zone.Id}). " +
+                "All dates and times must use this timezone. " +
+                "When any tool returns a UTC timestamp, convert it to this local timezone before using or displaying it.")
         };
 
         // Active rules


### PR DESCRIPTION
## Summary

- Remove `"The user's local date and time"` / `"express dates and times to the user"` phrasing — patrol and scheduled tasks have no user, making this semantically confusing and potentially causing the LLM to misapply the instruction in background contexts.
- Strengthen to `"All dates and times must use this timezone"` — a clear obligation rather than a display hint.
- Add explicit `"When any tool returns a UTC timestamp, convert it to this local timezone before using or displaying it"` — directly addresses the calendar-mcp pattern where events are returned as UTC, which was causing intermittent timezone drift in patrol output.

## Test plan

- [ ] Confirm patrol correctly converts UTC calendar event times to local timezone
- [ ] Confirm user session datetime display is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)