### PR TITLE
feat: configure heartbeat patrol interval from PVC appsettings.json, default to 6h

### DIFF
--- a/src/RockBot.Agent/Program.cs
+++ b/src/RockBot.Agent/Program.cs
@@ -26,6 +26,14 @@ var builder = Host.CreateApplicationBuilder(args);
 // Always load user secrets (CreateApplicationBuilder only loads them in Development)
 builder.Configuration.AddUserSecrets<Program>();
 
+// Load optional appsettings.json from the PVC so cluster-side config (e.g. HeartbeatPatrol:CronExpression)
+// can be changed without rebuilding the image. Layered after env vars so it takes precedence.
+{
+    var pvcBase = builder.Configuration["AgentProfile__BasePath"] ?? builder.Configuration["AgentProfile:BasePath"];
+    if (pvcBase is not null)
+        builder.Configuration.AddJsonFile(Path.Combine(pvcBase, "appsettings.json"), optional: true, reloadOnChange: false);
+}
+
 builder.Services.AddRockBotRabbitMq(opts => builder.Configuration.GetSection("RabbitMq").Bind(opts));
 
 // ── LLM configuration — three-tier (Low / Balanced / High) ──────────────────

--- a/src/RockBot.Host/HeartbeatBootstrapOptions.cs
+++ b/src/RockBot.Host/HeartbeatBootstrapOptions.cs
@@ -15,5 +15,5 @@ public sealed class HeartbeatBootstrapOptions
     /// Cron expression controlling how often the patrol fires.
     /// Defaults to every 30 minutes.
     /// </summary>
-    public string CronExpression { get; set; } = "*/30 * * * *";
+    public string CronExpression { get; set; } = "0 */6 * * *";
 }

--- a/src/RockBot.Host/HeartbeatBootstrapService.cs
+++ b/src/RockBot.Host/HeartbeatBootstrapService.cs
@@ -22,9 +22,11 @@ internal sealed class HeartbeatBootstrapService(
         }
 
         var existing = await scheduler.ListAsync(ct);
-        if (existing.Any(t => t.Name == "heartbeat-patrol"))
+        var patrol = existing.FirstOrDefault(t => t.Name == "heartbeat-patrol");
+
+        if (patrol is not null && patrol.CronExpression == options.Value.CronExpression)
         {
-            logger.LogInformation("Heartbeat patrol task already registered; skipping");
+            logger.LogInformation("Heartbeat patrol already registered with cron '{Cron}'; skipping", patrol.CronExpression);
             return;
         }
 
@@ -32,10 +34,11 @@ internal sealed class HeartbeatBootstrapService(
             Name: "heartbeat-patrol",
             CronExpression: options.Value.CronExpression,
             Description: "Run the heartbeat patrol: check calendar, email, active plans, and scheduled task health.",
-            CreatedAt: DateTimeOffset.UtcNow,
+            CreatedAt: patrol?.CreatedAt ?? DateTimeOffset.UtcNow,
             RunOnce: false), ct);
 
-        logger.LogInformation("Registered heartbeat patrol (cron: {Cron})", options.Value.CronExpression);
+        var action = patrol is null ? "Registered" : "Updated";
+        logger.LogInformation("{Action} heartbeat patrol (cron: {Cron})", action, options.Value.CronExpression);
     }
 
     public Task StopAsync(CancellationToken ct) => Task.CompletedTask;


### PR DESCRIPTION
## Summary

- Changes default heartbeat patrol cron from `*/30 * * * *` (every 30 min) to `0 */6 * * *` (every 6 hours)
- Loads an optional `/data/agent/appsettings.json` from the PVC as a config source, layered after env vars, so the interval can be changed without rebuilding the image
- Bootstrap now diffs the stored cron against the configured one and updates the task on restart if they differ (preserving the original `CreatedAt` timestamp)

## Test plan

- [ ] Build passes (`dotnet build src/RockBot.Agent/RockBot.Agent.csproj`)
- [ ] All 245 host tests pass (`dotnet test tests/RockBot.Host.Tests/`)
- [ ] Deploy to cluster and verify patrol fires at 6-hour intervals
- [ ] Place a `appsettings.json` on the PVC with a custom `HeartbeatPatrol:CronExpression`, restart agent pod, and confirm the stored task is updated to the new cron

🤖 Generated with [Claude Code](https://claude.com/claude-code)