### PR TITLE
feat: configure dream cycle via cron schedule, default every 12h

### DIFF
--- a/src/RockBot.Agent/Program.cs
+++ b/src/RockBot.Agent/Program.cs
@@ -122,11 +122,7 @@ builder.Services.AddRockBotHost(agent =>
     agent.WithConversationLog();
     agent.WithFeedback();
     agent.WithSkills();
-    agent.WithDreaming(opts =>
-    {
-        opts.Interval = TimeSpan.FromHours(4);
-        opts.InitialDelay = TimeSpan.FromMinutes(5);
-    });
+    agent.WithDreaming();
     agent.AddToolHandler();
     agent.AddMcpToolProxy();
     agent.AddWebTools(opts => builder.Configuration.GetSection("WebTools").Bind(opts));

--- a/src/RockBot.Agent/appsettings.json
+++ b/src/RockBot.Agent/appsettings.json
@@ -2,6 +2,9 @@
   "McpBridge": {
     "ConfigPath": "mcp.json"
   },
+  "Dream": {
+    "CronSchedule": "0 */12 * * *"
+  },
   "ModelBehaviors": {
     "BasePath": "model-behaviors",
     "Models": {

--- a/src/RockBot.Host.Abstractions/DreamOptions.cs
+++ b/src/RockBot.Host.Abstractions/DreamOptions.cs
@@ -11,8 +11,12 @@ public sealed class DreamOptions
     /// <summary>How long to wait after startup before the first dream cycle.</summary>
     public TimeSpan InitialDelay { get; set; } = TimeSpan.FromMinutes(5);
 
-    /// <summary>How often dream cycles run.</summary>
-    public TimeSpan Interval { get; set; } = TimeSpan.FromHours(4);
+    /// <summary>
+    /// Cron expression (5-field or 6-field with seconds) controlling how often dream cycles run.
+    /// Evaluated in the agent's configured timezone (see <c>Agent:Timezone</c>).
+    /// Default: every 12 hours at the top of the hour.
+    /// </summary>
+    public string CronSchedule { get; set; } = "0 */12 * * *";
 
     /// <summary>
     /// Path to the memory consolidation directive file, relative to <see cref="AgentProfileOptions.BasePath"/>.

--- a/src/RockBot.Host/DreamService.cs
+++ b/src/RockBot.Host/DreamService.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.Json;
+using Cronos;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -27,10 +28,12 @@ internal sealed class DreamService : IHostedService, IDisposable
     private readonly TierRoutingLogger? _tierRoutingLogger;
     private readonly ILlmClient _llmClient;
     private readonly IUserActivityMonitor _userActivityMonitor;
+    private readonly AgentClock _clock;
     private readonly DreamOptions _options;
     private readonly AgentProfileOptions _profileOptions;
     private readonly ILogger<DreamService> _logger;
     private Timer? _timer;
+    private CronExpression? _cron;
     private string? _dreamDirective;
     private string? _skillDreamDirective;
     private string? _skillOptimizeDirective;
@@ -43,6 +46,7 @@ internal sealed class DreamService : IHostedService, IDisposable
         IEnumerable<ISkillStore> skillStores,
         ILlmClient llmClient,
         IUserActivityMonitor userActivityMonitor,
+        AgentClock clock,
         IOptions<DreamOptions> options,
         IOptions<AgentProfileOptions> profileOptions,
         ILogger<DreamService> logger,
@@ -59,6 +63,7 @@ internal sealed class DreamService : IHostedService, IDisposable
         _tierRoutingLogger = tierRoutingLogger;
         _llmClient = llmClient;
         _userActivityMonitor = userActivityMonitor;
+        _clock = clock;
         _options = options.Value;
         _profileOptions = profileOptions.Value;
         _logger = logger;
@@ -154,15 +159,30 @@ internal sealed class DreamService : IHostedService, IDisposable
                 _logger.LogInformation("DreamService: loaded tier routing directive from {Path}", tierRoutingDirectivePath);
         }
 
+        try
+        {
+            _cron = CronExpression.Parse(_options.CronSchedule,
+                _options.CronSchedule.Split(' ').Length == 6
+                    ? CronFormat.IncludeSeconds
+                    : CronFormat.Standard);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "DreamService: invalid cron expression '{Cron}'; dreaming disabled",
+                _options.CronSchedule);
+            return Task.CompletedTask;
+        }
+
         _timer = new Timer(
-            state => { _ = DreamAsync(); },
+            state => { _ = OnTimerTickAsync(); },
             null,
             _options.InitialDelay,
-            _options.Interval);
+            Timeout.InfiniteTimeSpan);
 
         _logger.LogInformation(
-            "DreamService: scheduled — first cycle in {InitialDelay}, then every {Interval}",
-            _options.InitialDelay, _options.Interval);
+            "DreamService: scheduled — first cycle in {InitialDelay}, then on cron '{Cron}'",
+            _options.InitialDelay, _options.CronSchedule);
 
         return Task.CompletedTask;
     }
@@ -174,6 +194,31 @@ internal sealed class DreamService : IHostedService, IDisposable
     }
 
     public void Dispose() => _timer?.Dispose();
+
+    private async Task OnTimerTickAsync()
+    {
+        await DreamAsync();
+        ArmNextCronTimer();
+    }
+
+    private void ArmNextCronTimer()
+    {
+        if (_cron is null) return;
+
+        var next = _cron.GetNextOccurrence(_clock.Now, _clock.Zone);
+        if (next is null)
+        {
+            _logger.LogWarning("DreamService: cron '{Cron}' has no future occurrences; dreaming stopped",
+                _options.CronSchedule);
+            return;
+        }
+
+        var delay = next.Value - _clock.Now;
+        if (delay < TimeSpan.Zero) delay = TimeSpan.Zero;
+
+        _timer?.Change(delay, Timeout.InfiniteTimeSpan);
+        _logger.LogInformation("DreamService: next dream cycle at {Next} (in {Delay:g})", next.Value, delay);
+    }
 
     private async Task DreamAsync()
     {


### PR DESCRIPTION
## Summary

- Replaces `DreamOptions.Interval` (fixed `TimeSpan`) with `CronSchedule` (cron expression string, default `"0 */12 * * *"`)
- `DreamService` now parses the cron with Cronos and uses a one-shot timer that re-arms to the next occurrence after each cycle, using `AgentClock` for timezone-aware scheduling
- `appsettings.json` in `RockBot.Agent` exposes `Dream:CronSchedule` so the schedule is visible and editable in config without code changes
- Invalid cron expressions are caught at startup with a logged error (dreaming disabled gracefully)

## Test plan

- [x] Build passes (`dotnet build RockBot.slnx`)
- [x] All 140 unit tests pass (`dotnet test RockBot.slnx`)
- [ ] Verify log output shows `"first cycle in 00:05:00, then on cron '0 */12 * * *'"` on startup
- [ ] Verify log shows `"next dream cycle at ..."` after each dream completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)