### PR TITLE
fix: ack UserMessage before LLM tool loop on native path

### DIFF
--- a/src/RockBot.Agent/UserMessageHandler.cs
+++ b/src/RockBot.Agent/UserMessageHandler.cs
@@ -157,53 +157,38 @@ internal sealed class UserMessageHandler(
                 }
             }
 
-            logger.LogInformation("Calling LLM — iteration 1 ({MessageCount} messages in context)",
-                chatMessages.Count);
-            var sw = System.Diagnostics.Stopwatch.StartNew();
-            var firstResponse = await llmClient.GetResponseAsync(chatMessages, tier, chatOptions, ct);
-            sw.Stop();
-
-            logger.LogInformation(
-                "LLM responded in {ElapsedMs}ms — {MsgCount} message(s), iteration 1",
-                sw.ElapsedMilliseconds, firstResponse.Messages.Count);
-
-            // Log response messages
-            for (var i = 0; i < firstResponse.Messages.Count; i++)
-            {
-                var msg = firstResponse.Messages[i];
-                var contentParts = string.Join(", ", msg.Contents.Select(c => c.GetType().Name));
-                logger.LogInformation(
-                    "  Message[{Index}] role={Role} text={TextLen} chars, contents=[{ContentParts}]",
-                    i, msg.Role, msg.Text?.Length ?? 0, contentParts);
-            }
-
             if (!modelBehavior.UseTextBasedToolCalling)
             {
-                // Native path: FunctionInvokingChatClient already executed all tool
-                // calls during the GetResponseAsync above. The response is complete —
-                // just extract the final assistant text and publish it.
-                var text = agentLoopRunner.ExtractAssistantText(firstResponse);
-
-                var toolCallCount = firstResponse.Messages
-                    .SelectMany(m => m.Contents.OfType<FunctionCallContent>())
-                    .Count();
-
-                logger.LogInformation(
-                    "Native path complete — {ToolCallCount} tool call(s) resolved, final text {TextLen} chars",
-                    toolCallCount, text.Length);
-
-                await conversationMemory.AddTurnAsync(
-                    message.SessionId,
-                    new ConversationTurn("assistant", text, DateTimeOffset.UtcNow),
-                    ct);
-
-                await PublishReplyAsync(text, replyTo, correlationId, message.SessionId, isFinal: true, ct);
-
-                logger.LogInformation("Published reply to {ReplyTo} for correlation {CorrelationId}",
-                    replyTo, correlationId);
+                // Native path: fire-and-forget the LLM call so HandleAsync returns promptly,
+                // allowing RabbitMQ to ack the UserMessage before tool calls run.
+                // This prevents subagent re-spawn on pod restart (issue #122).
+                logger.LogInformation("Native path: launching background LLM loop for session {SessionId}", message.SessionId);
+                await PublishReplyAsync("I'm working on that — I'll follow up shortly.",
+                    replyTo, correlationId, message.SessionId, isFinal: false, ct);
+                _ = NativeLlmLoopAsync(chatMessages, chatOptions, tier, message.SessionId, replyTo, correlationId, sessionCt);
             }
             else
             {
+                logger.LogInformation("Calling LLM — iteration 1 ({MessageCount} messages in context)",
+                    chatMessages.Count);
+                var sw = System.Diagnostics.Stopwatch.StartNew();
+                var firstResponse = await llmClient.GetResponseAsync(chatMessages, tier, chatOptions, ct);
+                sw.Stop();
+
+                logger.LogInformation(
+                    "LLM responded in {ElapsedMs}ms — {MsgCount} message(s), iteration 1",
+                    sw.ElapsedMilliseconds, firstResponse.Messages.Count);
+
+                // Log response messages
+                for (var i = 0; i < firstResponse.Messages.Count; i++)
+                {
+                    var msg = firstResponse.Messages[i];
+                    var contentParts = string.Join(", ", msg.Contents.Select(c => c.GetType().Name));
+                    logger.LogInformation(
+                        "  Message[{Index}] role={Role} text={TextLen} chars, contents=[{ContentParts}]",
+                        i, msg.Role, msg.Text?.Length ?? 0, contentParts);
+                }
+
                 // Text-based path: check whether the first response contains tool
                 // calls that still need to be executed by the manual loop.
                 var (hasToolCalls, ackText) = GetFirstIterationAck(firstResponse, chatOptions);
@@ -297,6 +282,59 @@ internal sealed class UserMessageHandler(
             }
 
             await PublishReplyAsync(errorText, replyTo, correlationId, message.SessionId, isFinal: true, ct);
+        }
+    }
+
+    private async Task NativeLlmLoopAsync(
+        List<ChatMessage> chatMessages,
+        ChatOptions chatOptions,
+        ModelTier tier,
+        string sessionId,
+        string replyTo,
+        string? correlationId,
+        CancellationToken ct)
+    {
+        try
+        {
+            await using var slot = await workSerializer.AcquireForUserAsync(ct);
+
+            logger.LogInformation("Native LLM loop started for session {SessionId}", sessionId);
+
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            var response = await llmClient.GetResponseAsync(chatMessages, tier, chatOptions, ct);
+            sw.Stop();
+
+            logger.LogInformation(
+                "LLM responded in {ElapsedMs}ms — {MsgCount} message(s)",
+                sw.ElapsedMilliseconds, response.Messages.Count);
+
+            var text = agentLoopRunner.ExtractAssistantText(response);
+
+            var toolCallCount = response.Messages
+                .SelectMany(m => m.Contents.OfType<FunctionCallContent>())
+                .Count();
+
+            logger.LogInformation(
+                "Native path complete — {ToolCallCount} tool call(s) resolved, final text {TextLen} chars",
+                toolCallCount, text.Length);
+
+            await conversationMemory.AddTurnAsync(
+                sessionId,
+                new ConversationTurn("assistant", text, DateTimeOffset.UtcNow),
+                ct);
+
+            await PublishReplyAsync(text, replyTo, correlationId, sessionId, isFinal: true, ct);
+
+            logger.LogInformation("Published reply to {ReplyTo} for correlation {CorrelationId}",
+                replyTo, correlationId);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            logger.LogError(ex, "Native LLM loop failed for session {SessionId}", sessionId);
+
+            await PublishReplyAsync(
+                $"Sorry, I ran into an error while working on your request: {ex.Message}",
+                replyTo, correlationId, sessionId, isFinal: true, ct);
         }
     }
 


### PR DESCRIPTION
Closes #122

## Summary

- The native tool-calling path (`!UseTextBasedToolCalling`) previously ran the entire LLM loop — including all `spawn_subagent` calls — synchronously inside `HandleAsync`, holding the RabbitMQ ack for the full duration (potentially minutes)
- A pod restart during this window caused RabbitMQ to redeliver the `UserMessage`, re-spawning all subagents on the new pod
- The text-based path already handled this correctly via `BackgroundToolLoopAsync`

## Changes

- Extracted the native LLM work into a new `NativeLlmLoopAsync` method (mirrors `BackgroundToolLoopAsync`)
- In `HandleAsync`, the native path now publishes an immediate ack reply and fire-and-forgets `NativeLlmLoopAsync`, returning promptly so RabbitMQ acks the message before any tool calls run
- `GetResponseAsync` (and its stopwatch/logging) moved into the `else` (text-based) branch where it still runs inline

## Test plan

- [x] `dotnet build RockBot.slnx` — no errors
- [x] `dotnet test RockBot.slnx` — all tests pass (245 Host, 45 Agent, etc.)
- [ ] Manual: rolling-restart a pod while a subagent-spawning message is in flight — subagents should not re-spawn on the new pod

🤖 Generated with [Claude Code](https://claude.com/claude-code)