### PR TITLE
feat: LLM model fallback chain for balanced tier

### DIFF
--- a/src/RockBot.Agent/Program.cs
+++ b/src/RockBot.Agent/Program.cs
@@ -55,7 +55,12 @@ if (!tierOptions.Balanced.IsConfigured)
     tierOptions.Balanced.ModelId  = llmSection["ModelId"];
 }
 
-if (tierOptions.Balanced.IsConfigured)
+// If BalancedModels is used exclusively (no single Balanced key), seed Balanced from
+// the first entry so that Low/High tier fallback resolution continues to work.
+if (!tierOptions.Balanced.IsConfigured && tierOptions.BalancedModels.Count > 0)
+    tierOptions.Balanced = tierOptions.BalancedModels[0];
+
+if (tierOptions.Balanced.IsConfigured || tierOptions.BalancedModels.Count > 0)
 {
     IChatClient BuildClient(LlmTierConfig config)
     {
@@ -71,6 +76,30 @@ if (tierOptions.Balanced.IsConfigured)
             .GetChatClient(config.ModelId!).AsIChatClient();
     }
 
+    // Build the balanced inner client: use FallbackChatClient when multiple models are listed.
+    IChatClient balancedInner;
+    if (tierOptions.BalancedModels.Count > 1)
+    {
+        // Bootstrap logger factory (not disposed — lives for the application lifetime).
+        var fallbackLoggerFactory = LoggerFactory.Create(b =>
+            b.AddConsole().SetMinimumLevel(LogLevel.Warning));
+        var fallbackLogger = fallbackLoggerFactory.CreateLogger<FallbackChatClient>();
+
+        IReadOnlyList<(string ModelId, IChatClient Client)> entries = tierOptions.BalancedModels
+            .Select(cfg => (cfg.ModelId!, BuildClient(cfg)))
+            .ToList();
+
+        balancedInner = new FallbackChatClient(entries, fallbackLogger);
+    }
+    else if (tierOptions.BalancedModels.Count == 1)
+    {
+        balancedInner = BuildClient(tierOptions.BalancedModels[0]);
+    }
+    else
+    {
+        balancedInner = BuildClient(tierOptions.Balanced);
+    }
+
     // AddRockBotTieredChatClients must be called BEFORE AddModelBehaviors so that
     // its TryAddSingleton<ModelBehavior> (which uses the inner client closure directly)
     // wins over AddModelBehaviors' factory (which resolves IChatClient from DI and would
@@ -78,7 +107,7 @@ if (tierOptions.Balanced.IsConfigured)
     // → IChatClient → deadlock).
     builder.Services.AddRockBotTieredChatClients(
         lowInnerClient:      BuildClient(tierOptions.Resolve(ModelTier.Low)),
-        balancedInnerClient: BuildClient(tierOptions.Balanced),
+        balancedInnerClient: balancedInner,
         highInnerClient:     BuildClient(tierOptions.Resolve(ModelTier.High)));
 
     builder.Services.AddModelBehaviors(opts =>

--- a/src/RockBot.Host.Abstractions/LlmTierOptions.cs
+++ b/src/RockBot.Host.Abstractions/LlmTierOptions.cs
@@ -30,6 +30,11 @@ public sealed class LlmTierOptions
     public LlmTierConfig Balanced { get; set; } = new();
     public LlmTierConfig High     { get; set; } = new();
 
+    /// <summary>Ordered list of balanced-tier model configs for fallback chain.
+    /// When populated, takes precedence over the single <see cref="Balanced"/> entry.
+    /// First entry is preferred; subsequent entries are fallbacks in order.</summary>
+    public List<LlmTierConfig> BalancedModels { get; set; } = [];
+
     /// <summary>
     /// Returns the effective config for <paramref name="tier"/>, falling back
     /// to <see cref="Balanced"/> when the requested tier is not configured.

--- a/src/RockBot.Llm/FallbackChatClient.cs
+++ b/src/RockBot.Llm/FallbackChatClient.cs
@@ -1,0 +1,171 @@
+using System.Net;
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+
+namespace RockBot.Llm;
+
+internal enum FallbackErrorCategory { Transient, QuotaExhausted, HardError, Unknown }
+
+/// <summary>
+/// IChatClient decorator that holds an ordered list of model clients and falls back to
+/// the next when the current is permanently degraded (quota/auth errors), while retrying
+/// the same client with backoff for transient errors (429, timeout).
+/// </summary>
+public sealed class FallbackChatClient : IChatClient
+{
+    private readonly IReadOnlyList<(string ModelId, IChatClient Client)> _entries;
+    private readonly ILogger _logger;
+    private readonly bool[] _degraded;
+    private readonly TimeSpan _retryDelay;
+    private readonly int _maxRetries;
+    private volatile int _activeIndex;
+
+    public FallbackChatClient(
+        IReadOnlyList<(string ModelId, IChatClient Client)> entries,
+        ILogger logger,
+        TimeSpan? retryDelay = null,
+        int maxRetries = 1)
+    {
+        if (entries.Count == 0)
+            throw new ArgumentException("At least one entry is required.", nameof(entries));
+        _entries = entries;
+        _logger = logger;
+        _degraded = new bool[entries.Count];
+        _retryDelay = retryDelay ?? TimeSpan.FromSeconds(1);
+        _maxRetries = maxRetries;
+    }
+
+    public async Task<ChatResponse> GetResponseAsync(
+        IEnumerable<ChatMessage> chatMessages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        // Materialize once to avoid re-enumeration across retries/fallbacks.
+        var messages = chatMessages as IReadOnlyList<ChatMessage> ?? chatMessages.ToList();
+
+        for (int i = _activeIndex; i < _entries.Count; i++)
+        {
+            if (_degraded[i]) continue;
+
+            var (modelId, client) = _entries[i];
+
+            for (int attempt = 0; attempt <= _maxRetries; attempt++)
+            {
+                if (attempt > 0 && _retryDelay > TimeSpan.Zero)
+                    await Task.Delay(_retryDelay, cancellationToken);
+
+                try
+                {
+                    return await client.GetResponseAsync(messages, options, cancellationToken);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw; // User cancellation — do not retry or switch
+                }
+                catch (Exception ex)
+                {
+                    var category = ClassifyException(ex);
+
+                    if (category == FallbackErrorCategory.Unknown)
+                        throw; // Propagate immediately — don't retry or switch
+
+                    if (category == FallbackErrorCategory.Transient && attempt < _maxRetries)
+                        continue; // One more retry on the same client
+
+                    // Transient retries exhausted, or permanent degradation
+                    if (category is FallbackErrorCategory.QuotaExhausted or FallbackErrorCategory.HardError)
+                    {
+                        _degraded[i] = true;
+                        _logger.LogWarning(
+                            "FallbackChatClient: model {ModelId} marked degraded ({Category}); switching to next",
+                            modelId, category);
+
+                        // Advance _activeIndex past this permanently-degraded slot
+                        if (i == _activeIndex)
+                            _activeIndex = i + 1;
+                    }
+
+                    break; // Fall through to next model
+                }
+            }
+
+            // Log the fallback destination (if one exists)
+            int nextIdx = -1;
+            for (int j = i + 1; j < _entries.Count; j++)
+            {
+                if (!_degraded[j]) { nextIdx = j; break; }
+            }
+
+            if (nextIdx >= 0)
+            {
+                _logger.LogWarning(
+                    "FallbackChatClient: falling back from {FromModelId} to {ToModelId}",
+                    modelId, _entries[nextIdx].ModelId);
+            }
+        }
+
+        _logger.LogWarning(
+            "FallbackChatClient: all {Count} models degraded; no fallback available",
+            _entries.Count);
+
+        throw new InvalidOperationException(
+            $"FallbackChatClient: all {_entries.Count} models are degraded; no fallback available.");
+    }
+
+    public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+        IEnumerable<ChatMessage> chatMessages,
+        ChatOptions? options = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        int idx = _activeIndex;
+        if (idx >= _entries.Count || _degraded[idx])
+            throw new InvalidOperationException("FallbackChatClient: no active client available for streaming.");
+
+        await foreach (var update in _entries[idx].Client
+            .GetStreamingResponseAsync(chatMessages, options, cancellationToken))
+        {
+            yield return update;
+        }
+    }
+
+    public object? GetService(Type serviceType, object? serviceKey = null)
+    {
+        int idx = _activeIndex;
+        return idx < _entries.Count ? _entries[idx].Client.GetService(serviceType, serviceKey) : null;
+    }
+
+    public void Dispose()
+    {
+        foreach (var (_, client) in _entries)
+            client.Dispose();
+    }
+
+    private static FallbackErrorCategory ClassifyException(Exception ex)
+    {
+        if (ex is OperationCanceledException)
+            return FallbackErrorCategory.Transient; // Treat timeout as transient
+
+        if (ex is HttpRequestException { StatusCode: { } status })
+        {
+            return status switch
+            {
+                HttpStatusCode.TooManyRequests => FallbackErrorCategory.Transient,
+                HttpStatusCode.PaymentRequired  => FallbackErrorCategory.QuotaExhausted,
+                HttpStatusCode.Unauthorized     => FallbackErrorCategory.HardError,
+                HttpStatusCode.Forbidden        => FallbackErrorCategory.HardError,
+                HttpStatusCode.NotFound         => FallbackErrorCategory.HardError,
+                _                               => FallbackErrorCategory.Unknown
+            };
+        }
+
+        var msg = ex.Message;
+        if (ContainsAny(msg, "credit", "quota", "billing", "insufficient_quota", "exceeded"))
+            return FallbackErrorCategory.QuotaExhausted;
+
+        return FallbackErrorCategory.Unknown;
+    }
+
+    private static bool ContainsAny(string text, params string[] values) =>
+        values.Any(v => text.Contains(v, StringComparison.OrdinalIgnoreCase));
+}

--- a/tests/RockBot.Llm.Tests/FallbackChatClientTests.cs
+++ b/tests/RockBot.Llm.Tests/FallbackChatClientTests.cs
@@ -1,0 +1,188 @@
+using System.Net;
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace RockBot.Llm.Tests;
+
+[TestClass]
+public class FallbackChatClientTests
+{
+    // Zero delay + zero max-retries for the retry test (1 retry = attempt 0 then attempt 1)
+    private static FallbackChatClient Build(
+        IReadOnlyList<(string ModelId, IChatClient Client)> entries,
+        int maxRetries = 1) =>
+        new(entries, NullLogger.Instance, retryDelay: TimeSpan.Zero, maxRetries: maxRetries);
+
+    private static ChatResponse OkResponse(string text = "ok") =>
+        new(new ChatMessage(ChatRole.Assistant, text));
+
+    private static HttpRequestException HttpEx(HttpStatusCode status) =>
+        new("err", null, status);
+
+    // ── test stubs ───────────────────────────────────────────────────────────
+
+    /// <summary>Always returns the same response or throws the same exception.</summary>
+    private sealed class FixedStub(ChatResponse? response = null, Exception? ex = null) : IChatClient
+    {
+        public int CallCount { get; private set; }
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> chatMessages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            CallCount++;
+            if (ex is not null) return Task.FromException<ChatResponse>(ex);
+            return Task.FromResult(response ?? new ChatResponse(new ChatMessage(ChatRole.Assistant, string.Empty)));
+        }
+
+        public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> chatMessages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+        public void Dispose() { }
+    }
+
+    /// <summary>Returns results from a queue: dequeues each call in order.</summary>
+    private sealed class SequentialStub : IChatClient
+    {
+        private readonly Queue<(ChatResponse? Response, Exception? Ex)> _queue = new();
+        public int CallCount { get; private set; }
+
+        public void Enqueue(ChatResponse response) => _queue.Enqueue((response, null));
+        public void Enqueue(Exception ex) => _queue.Enqueue((null, ex));
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> chatMessages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            CallCount++;
+            if (_queue.TryDequeue(out var entry))
+            {
+                if (entry.Ex is not null) return Task.FromException<ChatResponse>(entry.Ex);
+                return Task.FromResult(entry.Response!);
+            }
+            return Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, string.Empty)));
+        }
+
+        public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> chatMessages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+        public void Dispose() { }
+    }
+
+    /// <summary>Returns a known value from GetService for a specific type.</summary>
+    private sealed class ServiceStub(Type serviceType, object? service) : IChatClient
+    {
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> chatMessages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, string.Empty)));
+
+        public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> chatMessages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+        public object? GetService(Type t, object? key = null) => t == serviceType ? service : null;
+        public void Dispose() { }
+    }
+
+    // ── tests ────────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task SwitchesToNextModel_OnQuotaError()
+    {
+        var first  = new FixedStub(ex: HttpEx(HttpStatusCode.PaymentRequired));
+        var second = new FixedStub(response: OkResponse("from-second"));
+
+        var client = Build([("m1", first), ("m2", second)], maxRetries: 0);
+
+        var response = await client.GetResponseAsync([]);
+
+        Assert.AreEqual("from-second", response.Messages[^1].Text);
+        Assert.AreEqual(1, first.CallCount);
+        Assert.AreEqual(1, second.CallCount);
+    }
+
+    [TestMethod]
+    public async Task SwitchesToNextModel_OnHardError()
+    {
+        var first  = new FixedStub(ex: HttpEx(HttpStatusCode.Unauthorized));
+        var second = new FixedStub(response: OkResponse("from-second"));
+
+        var client = Build([("m1", first), ("m2", second)], maxRetries: 0);
+
+        var response = await client.GetResponseAsync([]);
+
+        Assert.AreEqual("from-second", response.Messages[^1].Text);
+        Assert.AreEqual(1, first.CallCount);
+        Assert.AreEqual(1, second.CallCount);
+    }
+
+    [TestMethod]
+    public async Task RetriesSameModel_OnTransientError()
+    {
+        var stub = new SequentialStub();
+        stub.Enqueue(HttpEx(HttpStatusCode.TooManyRequests)); // attempt 0: 429
+        stub.Enqueue(OkResponse("retried"));                  // attempt 1: success
+
+        var client = Build([("m1", stub)], maxRetries: 1);
+
+        var response = await client.GetResponseAsync([]);
+
+        Assert.AreEqual("retried", response.Messages[^1].Text);
+        Assert.AreEqual(2, stub.CallCount);
+    }
+
+    [TestMethod]
+    public async Task PermanentDegradation_SkipsExhaustedModelOnSubsequentCalls()
+    {
+        var first  = new FixedStub(ex: HttpEx(HttpStatusCode.PaymentRequired));
+        var second = new FixedStub(response: OkResponse());
+
+        var client = Build([("m1", first), ("m2", second)], maxRetries: 0);
+
+        // First call: first model fails, second succeeds; first is now degraded
+        await client.GetResponseAsync([]);
+
+        // Second call: should go directly to second (first stays degraded)
+        await client.GetResponseAsync([]);
+
+        Assert.AreEqual(1, first.CallCount);   // only called once, then permanently skipped
+        Assert.AreEqual(2, second.CallCount);
+    }
+
+    [TestMethod]
+    public async Task AllModelsExhausted_ThrowsException()
+    {
+        var first  = new FixedStub(ex: HttpEx(HttpStatusCode.Unauthorized));
+        var second = new FixedStub(ex: HttpEx(HttpStatusCode.PaymentRequired));
+
+        var client = Build([("m1", first), ("m2", second)], maxRetries: 0);
+
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(
+            () => client.GetResponseAsync([]));
+    }
+
+    [TestMethod]
+    public void GetService_DelegatesToActiveClient()
+    {
+        var metadata = new ChatClientMetadata("test-provider", null, "model-x");
+        var stub     = new ServiceStub(typeof(ChatClientMetadata), metadata);
+
+        var client = Build([("model-x", stub)]);
+
+        var result = client.GetService(typeof(ChatClientMetadata));
+
+        Assert.AreSame(metadata, result);
+    }
+}


### PR DESCRIPTION
Closes #133

## Summary

Adds a `FallbackChatClient` decorator that holds an ordered list of balanced-tier clients and switches to the next when the current is permanently degraded (quota exhausted, hard auth errors), while retrying the same client with backoff for transient errors (429, timeout).

## Changes

### New: `src/RockBot.Llm/FallbackChatClient.cs`
- Implements `IChatClient` over an ordered list of `(ModelId, IChatClient)` entries
- `_activeIndex` / `_degraded[]` track permanent per-slot degradation
- Error classification:
  - **Transient** (429, `OperationCanceledException`): retry same client up to 1x with ~1s delay, then fall through to next
  - **QuotaExhausted** (402, or message contains credit/quota/billing keywords): mark degraded, switch permanently
  - **HardError** (401, 403, 404): mark degraded, switch permanently
  - **Unknown**: propagate immediately
- `GetService()` delegates to active client for transparent metadata pass-through
- Structured `LogWarning` events for degradation, fallback, and exhaustion

### Modified: `src/RockBot.Host.Abstractions/LlmTierOptions.cs`
- Added `BalancedModels` list — fully backward-compatible, empty by default

### Modified: `src/RockBot.Agent/Program.cs`
- `BalancedModels.Count > 1` → wraps entries in `FallbackChatClient`
- `BalancedModels.Count == 1` → single client, no wrapping
- Otherwise → existing behaviour unchanged
- Seeds `Balanced` from first `BalancedModels` entry when used exclusively, so Low/High tier fallback resolution continues to work

### New: `tests/RockBot.Llm.Tests/FallbackChatClientTests.cs`
6 unit tests (zero retry delay, no sleeps in CI):
- `SwitchesToNextModel_OnQuotaError`
- `SwitchesToNextModel_OnHardError`
- `RetriesSameModel_OnTransientError`
- `PermanentDegradation_SkipsExhaustedModelOnSubsequentCalls`
- `AllModelsExhausted_ThrowsException`
- `GetService_DelegatesToActiveClient`

## Configuration

To enable the fallback chain, add multiple entries under `LLM:BalancedModels` in `appsettings.json`:

```json
{
  "LLM": {
    "BalancedModels": [
      { "Endpoint": "https://primary.example.com/v1", "ApiKey": "key1", "ModelId": "gpt-4o" },
      { "Endpoint": "https://fallback.example.com/v1", "ApiKey": "key2", "ModelId": "claude-3-5-sonnet" }
    ]
  }
}
```

The existing single-key `LLM:Balanced` configuration is unchanged and continues to work.