### PR TITLE
feat: add routing-stats MCP server for LLM tier routing observability

### DIFF
--- a/RockBot.slnx
+++ b/RockBot.slnx
@@ -6,6 +6,7 @@
   </Configurations>
   <Folder Name="/mcp-servers/">
     <Project Path="src/McpServer.OpenRouter/McpServer.OpenRouter.csproj" />
+    <Project Path="src/McpServer.RoutingStats/McpServer.RoutingStats.csproj" />
     <Project Path="src/McpServer.TodoApp/McpServer.TodoApp.csproj" />
   </Folder>
   <Folder Name="/src/">

--- a/deploy/helm/rockbot/templates/agent/deployment.yaml
+++ b/deploy/helm/rockbot/templates/agent/deployment.yaml
@@ -101,6 +101,34 @@ spec:
           resources:
             {{- toYaml .Values.agent.resources | nindent 12 }}
 
+        {{- if .Values.routingStatsMcp.enabled }}
+        - name: routing-stats-mcp
+          image: {{ .Values.routingStatsMcp.image.repository }}:{{ .Values.routingStatsMcp.image.tag }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+          volumeMounts:
+            - name: agent-data
+              mountPath: /data/agent
+              readOnly: true
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            {{- toYaml .Values.routingStatsMcp.resources | nindent 12 }}
+        {{- end }}
+
       volumes:
         - name: agent-data
           persistentVolumeClaim:

--- a/deploy/helm/rockbot/values.yaml
+++ b/deploy/helm/rockbot/values.yaml
@@ -103,6 +103,24 @@ openrouterMcp:
       cpu: 200m
       memory: 256Mi
 
+# ── Routing Stats MCP server ──────────────────────────────────────────────────
+# Sidecar container in the agent pod that exposes two MCP tools:
+#   get_routing_stats — aggregate counts/percentages per tier, latency, and token stats
+#   get_routing_log   — recent raw routing decisions for spotting individual misroutes
+# Runs alongside the agent and reads tier-routing-log.jsonl from the shared agent PVC.
+routingStatsMcp:
+  enabled: true
+  image:
+    repository: rockylhotka/mcpserver-routingstats
+    tag: latest
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
+
 # ── TodoApp MCP server ────────────────────────────────────────────────────────
 # Standalone MCP server that exposes a persistent to-do list to the agent.
 # Data is stored in a Longhorn PVC mounted at /data inside the container.

--- a/src/McpServer.RoutingStats/Dockerfile
+++ b/src/McpServer.RoutingStats/Dockerfile
@@ -1,0 +1,33 @@
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
+USER $APP_UID
+WORKDIR /app
+EXPOSE 8080
+ENV ASPNETCORE_URLS=http://+:8080
+ENV ASPNETCORE_ENVIRONMENT=Production
+
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+ARG BUILD_CONFIGURATION=Release
+WORKDIR /src
+
+# Clear Windows-specific NuGet fallback folders that break Linux builds
+RUN printf '<configuration><fallbackPackageFolders><clear /></fallbackPackageFolders></configuration>' \
+    > /src/NuGet.config
+
+# Copy project file for layer-cached restore
+COPY src/McpServer.RoutingStats/McpServer.RoutingStats.csproj src/McpServer.RoutingStats/
+
+RUN dotnet restore src/McpServer.RoutingStats/McpServer.RoutingStats.csproj
+
+COPY src/McpServer.RoutingStats/ src/McpServer.RoutingStats/
+
+WORKDIR /src/src/McpServer.RoutingStats
+RUN dotnet build McpServer.RoutingStats.csproj -c $BUILD_CONFIGURATION -o /app/build --no-restore
+
+FROM build AS publish
+ARG BUILD_CONFIGURATION=Release
+RUN dotnet publish McpServer.RoutingStats.csproj -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "McpServer.RoutingStats.dll"]

--- a/src/McpServer.RoutingStats/McpServer.RoutingStats.csproj
+++ b/src/McpServer.RoutingStats/McpServer.RoutingStats.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>McpServer.RoutingStats</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.8.0-preview.1" />
+  </ItemGroup>
+
+</Project>

--- a/src/McpServer.RoutingStats/Program.cs
+++ b/src/McpServer.RoutingStats/Program.cs
@@ -1,0 +1,15 @@
+using McpServer.RoutingStats.Tools;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddHealthChecks();
+builder.Services.AddMcpServer()
+    .WithHttpTransport()
+    .WithTools<RoutingStatsTools>();
+
+var app = builder.Build();
+
+app.MapHealthChecks("/health");
+app.MapMcp();
+
+await app.RunAsync();

--- a/src/McpServer.RoutingStats/Tools/RoutingStatsTools.cs
+++ b/src/McpServer.RoutingStats/Tools/RoutingStatsTools.cs
@@ -1,0 +1,162 @@
+using System.ComponentModel;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using ModelContextProtocol.Server;
+
+namespace McpServer.RoutingStats.Tools;
+
+[McpServerToolType]
+public sealed class RoutingStatsTools(IConfiguration configuration)
+{
+    private static readonly JsonSerializerOptions ReadOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    private static readonly JsonSerializerOptions WriteOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
+    };
+
+    private string LogPath => configuration["RoutingLog:Path"] ?? "/data/agent/tier-routing-log.jsonl";
+
+    [McpServerTool(Name = "get_routing_stats")]
+    [Description(
+        "Returns aggregate statistics for the LLM tier routing log: counts and percentages " +
+        "routed to each tier (low/balanced/high), average complexity scores, latency, token " +
+        "usage, and tool call counts. Also shows the context breakdown (user-message vs subagent) " +
+        "and fallback count. The log holds up to 200 entries.")]
+    public async Task<string> GetRoutingStatsAsync()
+    {
+        var entries = await ReadEntriesAsync();
+
+        if (entries.Count == 0)
+            return JsonSerializer.Serialize(new { message = "No routing log entries found.", logPath = LogPath }, WriteOptions);
+
+        var tiers = new[] { "Low", "Balanced", "High" };
+        var tierStats = tiers.ToDictionary(
+            t => t.ToLowerInvariant(),
+            t =>
+            {
+                var group = entries.Where(e => string.Equals(e.Tier, t, StringComparison.OrdinalIgnoreCase)).ToList();
+                return BuildTierStats(group, entries.Count);
+            });
+
+        var userMessageCount = entries.Count(e => e.Context == "user-message");
+        var subagentCount = entries.Count(e => e.Context == "subagent");
+        var fallbackCount = entries.Count(e => e.IsFallbackTriggered);
+
+        var result = new
+        {
+            totalEntries = entries.Count,
+            logCapacity = 200,
+            dataFrom = entries.Min(e => e.Timestamp),
+            dataThrough = entries.Max(e => e.Timestamp),
+            tiers = tierStats,
+            context = new
+            {
+                userMessage = userMessageCount,
+                subagent = subagentCount
+            },
+            fallbacks = fallbackCount,
+            fallbackPct = Math.Round(fallbackCount * 100.0 / entries.Count, 1)
+        };
+
+        return JsonSerializer.Serialize(result, WriteOptions);
+    }
+
+    [McpServerTool(Name = "get_routing_log")]
+    [Description(
+        "Returns recent raw entries from the LLM tier routing log. Each entry includes the " +
+        "prompt preview, tier assigned, complexity score, matched keywords, token counts, " +
+        "latency, tool calls, and whether a model fallback was triggered. " +
+        "Useful for spotting individual misroutes or patterns.")]
+    public async Task<string> GetRoutingLogAsync(
+        [Description("Number of recent entries to return (1–50, default 20).")] int count = 20)
+    {
+        count = Math.Clamp(count, 1, 50);
+        var entries = await ReadEntriesAsync();
+        var recent = entries.TakeLast(count).ToList();
+
+        var result = new
+        {
+            totalInLog = entries.Count,
+            returned = recent.Count,
+            entries = recent
+        };
+
+        return JsonSerializer.Serialize(result, WriteOptions);
+    }
+
+    private async Task<List<RoutingEntry>> ReadEntriesAsync()
+    {
+        if (!File.Exists(LogPath))
+            return [];
+
+        try
+        {
+            var lines = await File.ReadAllLinesAsync(LogPath);
+            var entries = new List<RoutingEntry>();
+            foreach (var line in lines)
+            {
+                if (string.IsNullOrWhiteSpace(line)) continue;
+                try
+                {
+                    var entry = JsonSerializer.Deserialize<RoutingEntry>(line, ReadOptions);
+                    if (entry is not null)
+                        entries.Add(entry);
+                }
+                catch (JsonException) { /* skip malformed lines */ }
+            }
+            return entries;
+        }
+        catch (IOException)
+        {
+            return [];
+        }
+    }
+
+    private static object BuildTierStats(List<RoutingEntry> group, int total)
+    {
+        var count = group.Count;
+        var pct = total > 0 ? Math.Round(count * 100.0 / total, 1) : 0.0;
+
+        var withLatency = group.Where(e => e.LatencyMs.HasValue).ToList();
+        var withInputTokens = group.Where(e => e.InputTokens.HasValue).ToList();
+        var withOutputTokens = group.Where(e => e.OutputTokens.HasValue).ToList();
+        var withToolCalls = group.Where(e => e.ToolCallCount.HasValue).ToList();
+
+        return new
+        {
+            count,
+            pct,
+            avgComplexityScore = count > 0 ? Math.Round(group.Average(e => e.ComplexityScore), 3) : 0.0,
+            avgLatencyMs = withLatency.Count > 0 ? (long?)Math.Round(withLatency.Average(e => e.LatencyMs!.Value)) : null,
+            avgInputTokens = withInputTokens.Count > 0 ? (long?)Math.Round(withInputTokens.Average(e => e.InputTokens!.Value)) : null,
+            avgOutputTokens = withOutputTokens.Count > 0 ? (long?)Math.Round(withOutputTokens.Average(e => e.OutputTokens!.Value)) : null,
+            avgToolCalls = withToolCalls.Count > 0 ? Math.Round(withToolCalls.Average(e => e.ToolCallCount!.Value), 2) : 0.0
+        };
+    }
+}
+
+// Local mirror of TierRoutingEntry — matches the camelCase JSONL written by TierRoutingLogger.
+internal sealed record RoutingEntry
+{
+    public DateTimeOffset Timestamp { get; init; }
+    public string PromptPreview { get; init; } = "";
+    public string Tier { get; init; } = "";
+    public string Context { get; init; } = "";
+    public double ComplexityScore { get; init; }
+    public List<string> MatchedHighKeywords { get; init; } = [];
+    public List<string> MatchedLowKeywords { get; init; } = [];
+    public int? PostInjectionTokenEstimate { get; init; }
+    public long? InputTokens { get; init; }
+    public long? OutputTokens { get; init; }
+    public long? LatencyMs { get; init; }
+    public int? ToolCallCount { get; init; }
+    public List<string>? ToolsUsed { get; init; }
+    public bool IsFallbackTriggered { get; init; }
+}

--- a/src/RockBot.Agent/mcp.json
+++ b/src/RockBot.Agent/mcp.json
@@ -3,6 +3,10 @@
     "aggregator": {
       "type": "sse",
       "url": "https://mcp-aggregator.<your-tailnet>.ts.net/"
+    },
+    "routing-stats": {
+      "type": "sse",
+      "url": "http://localhost:8080/"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Adds `McpServer.RoutingStats` — a sidecar MCP server that runs in the agent pod and exposes two tools to the agent: `get_routing_stats` (aggregate counts, percentages, latency, and token stats per tier) and `get_routing_log` (recent raw routing decisions for spotting individual misroutes)
- Deploys as a sidecar rather than a separate pod because the agent PVC is `ReadWriteOnce` — the sidecar mounts it read-only and shares the pod's network namespace (`http://localhost:8080/`)
- Helm chart updated with a `routingStatsMcp` section (`enabled: true` by default) that injects the sidecar container into the agent deployment
- `mcp.json` updated with the `routing-stats` server entry

## Test plan

- [ ] Agent pod shows `2/2 Running` after deployment
- [ ] Agent logs show `Connected to MCP server routing-stats with 2 tools`
- [ ] Ask the agent "What percentage of my prompts are routed to each tier?" and confirm it returns stats from the routing log
- [ ] Ask the agent "Show me the recent routing log" and confirm raw entries are returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)