### PR TITLE
feat: delegate slow MCP queries to subagents for better UX

### DIFF
--- a/src/RockBot.Agent/agent/directives.md
+++ b/src/RockBot.Agent/agent/directives.md
@@ -146,11 +146,14 @@ complete, delegate it to a background subagent with `spawn_subagent`.
 - The user asks to do something "in the background" or "while we talk"
 - The task is exploratory and its duration is unpredictable
 - Multiple independent workstreams can run in parallel
+- The task involves **2 or more external MCP tool calls** (email, calendar, or any remote service) — these calls are slow by nature and blocking the conversation on them is poor UX even when the user is waiting
 
 **Do not use spawn_subagent when:**
-- The task is a single tool call or a short chain
-- The user is waiting for the result to continue the conversation
-- You need the output immediately to answer the current message
+- The task is a single local tool call (memory, skills, working memory)
+- A single MCP call is truly all that's needed and the user is clearly waiting for a direct one-liner answer
+- You need the output immediately to answer the current message and it is provably a single fast operation
+
+**Pattern for slow external queries:** Acknowledge the request immediately with a brief note ("Pulling your calendar now…"), spawn the subagent, and let the progress/result messages carry the actual response. This is always better than silently blocking.
 
 **After spawning:** Acknowledge with the task_id and continue the conversation
 normally. You will receive `[Subagent task <id> reports]: ...` progress messages


### PR DESCRIPTION
## Summary

- Adds **MCP call latency** as a trigger criterion for `spawn_subagent` — any task requiring 2+ external MCP calls (email, calendar, remote services) now delegates to a background subagent
- Tightens the \"don't use subagent\" rule to specifically exclude single *local* tool calls, removing the overly broad \"user is waiting\" exception that was causing the primary agent to block on slow remote calls
- Adds an explicit pattern: acknowledge immediately with a brief note, then let subagent progress/result messages carry the response

## Why

Email and calendar MCP calls can take 5–15 seconds each. The old directive only triggered subagent delegation for chains of >8 tool calls, so a typical 2–4 call email/calendar query was always handled inline, silently blocking the conversation.

## Test plan

- [ ] Ask RockBot a calendar question ("what's on my calendar today?") — should acknowledge immediately and delegate
- [ ] Ask a single-lookup question ("what time is my 3pm meeting?") — should handle inline without spawning a subagent
- [ ] Ask a multi-account email search — should delegate to subagent

🤖 Generated with [Claude Code](https://claude.com/claude-code)