### PR TITLE
fix: bring subagent directives and context to parity with primary agent

### DIFF
--- a/deploy/helm/rockbot/templates/agent/deployment.yaml
+++ b/deploy/helm/rockbot/templates/agent/deployment.yaml
@@ -44,7 +44,7 @@ spec:
               echo "Initializing agent data volume..."
 
               # Profile documents — live at /app/agent/ in the image
-              for f in soul.md directives.md style.md memory-rules.md dream.md skill-dream.md; do
+              for f in soul.md directives.md subagent-directives.md style.md memory-rules.md dream.md skill-dream.md; do
                 src="/app/agent/$f"
                 dst="/data/agent/$f"
                 if [ -f "$src" ] && [ ! -s "$dst" ]; then

--- a/src/RockBot.Agent/agent/subagent-directives.md
+++ b/src/RockBot.Agent/agent/subagent-directives.md
@@ -6,6 +6,38 @@ Call tools by their direct name (e.g. `get_calendar_events`, `search_emails`) �
 
 Tool arguments MUST be strict JSON: double-quoted keys and string values. Never use single-quoted strings or unquoted keys. Correct: `{"timeZone": "America/Chicago"}` — Wrong: `{timeZone: 'America/Chicago'}`.
 
+## Think in Workflows, Not Single Steps
+
+When you receive a task, mentally expand it to the full set of steps needed before starting. Do not execute only the literal ask — deliver a complete result.
+
+If you realize mid-task that additional steps would produce a more complete result, take them.
+
+## Make Reasonable Inferences
+
+You have context from the task description, injected memory, and available tools. Use it:
+
+- If a person is mentioned, check memory for who they are and their relationship to the user.
+- If a time is mentioned without a timezone, use the injected local timezone.
+- If context makes the answer obvious, do not ask — proceed with the reasonable inference.
+
+Do not ask clarifying questions unless you have exhausted reasonable search strategies and still cannot proceed.
+
+## Report Outcomes, Not Process
+
+Lead with what happened, not what you did:
+
+- **Good**: "Found 3 emails from Morris Ford. Most recent is from Jan 12 re: oil change — drafted a reply."
+- **Bad**: "I searched the inbox for Morris Ford and found some results. I then looked at the most recent one..."
+
+Include process details only when something unexpected happened or the primary agent needs to make a decision.
+
+## What the Framework Does Automatically
+
+These happen before you see the task — do not waste tool calls repeating them:
+
+- **Memory auto-surfacing**: Relevant long-term memory entries are already injected into your context. Do not call `search_memory` at the start of every task; only call it when you want to search with a specific query that differs from the task text.
+- **Skill index**: A summary of all available skills is already in your context. Do not call `list_skills` at the start; call it only if you need to search by a keyword not covered by the task description.
+
 ## Handling Tool Failures
 
 When a tool returns an error or unexpected result, do not give up immediately:

--- a/src/RockBot.Subagent/SubagentRunner.cs
+++ b/src/RockBot.Subagent/SubagentRunner.cs
@@ -59,13 +59,18 @@ internal sealed class SubagentRunner(
             "so the primary agent knows where to find the detailed data. " +
             "Do not return an empty or vague final response.";
 
-        // Behavioral directives — loaded from subagent-directives.md on the PVC so they
-        // can be updated without a redeploy. The file is optional; if absent the preamble
-        // alone is used (subagent still functions, just without the extended guidance).
-        var directives = agentProfile.SubagentDirectives?.RawContent;
-        var systemPrompt = directives is not null
-            ? $"{preamble}\n\n{directives}"
-            : preamble;
+        // Build system prompt from the same profile documents as the primary agent,
+        // but substitute subagent-directives.md for directives.md so subagents get the
+        // same soul/style/memory-rules context without primary-only instructions
+        // (multi-session plans, spawning subagents, etc.).
+        // Document order: soul → subagent-directives → memory-rules → style
+        var profileDocs = new[] {
+            agentProfile.Soul,
+            agentProfile.SubagentDirectives ?? agentProfile.Directives,
+            agentProfile.MemoryRules,
+            agentProfile.Style,
+        }.Where(d => d is not null).Select(d => d!.RawContent.TrimEnd());
+        var systemPrompt = preamble + "\n\n" + string.Join("\n\n", profileDocs);
 
         var chatMessages = new List<ChatMessage>
         {


### PR DESCRIPTION
## Summary

- **`deployment.yaml`**: `subagent-directives.md` was missing from the init container copy loop — it was never written to the PVC, so subagents ran with no behavioral guidance beyond the hardcoded preamble
- **`SubagentRunner.cs`**: Subagent system prompt now includes `soul.md`, `memory-rules.md`, and `style.md` alongside `subagent-directives.md`, matching the full document set the primary agent receives (minus primary-only docs like multi-session plan management)
- **`subagent-directives.md`**: Added four missing behavioral sections present in `directives.md`: *Think in Workflows*, *Make Reasonable Inferences*, *Report Outcomes Not Process*, and *What the Framework Does Automatically*

## Test plan

- [ ] Deploy to live cluster and spawn a subagent — confirm it receives soul/style/memory-rules in its system prompt (check logs for profile load confirmation)
- [ ] Verify subagent expands tasks beyond the literal ask (Think in Workflows)
- [ ] Verify subagent leads responses with outcomes, not step narration
- [ ] Verify subagent does not redundantly call `search_memory` or `list_skills` at task start
- [ ] Verify `subagent-directives.md` appears on PVC after a fresh pod start (init container copy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)