### PR TITLE
feat: preserve non-text MCP content blocks and configurable HTTP transport mode

### DIFF
--- a/src/RockBot.Agent/McpBridge/McpBridgeServerConfig.cs
+++ b/src/RockBot.Agent/McpBridge/McpBridgeServerConfig.cs
@@ -41,7 +41,14 @@ public sealed class McpBridgeServerConfig
     public List<string> DeniedTools { get; set; } = [];
 
     /// <summary>
-    /// Whether this config uses SSE transport.
+    /// HTTP transport mode: "auto" (default, negotiates with server), "sse" (legacy session-based
+    /// SSE), or "streamable-http" (stateless per-request HTTP, preferred for modern servers).
+    /// Only applies when <see cref="Type"/> is an HTTP-based transport.
     /// </summary>
-    public bool IsSse => string.Equals(Type, "sse", StringComparison.OrdinalIgnoreCase);
+    public string TransportMode { get; set; } = "auto";
+
+    /// <summary>
+    /// Whether this config uses HTTP-based transport (SSE or streamable HTTP).
+    /// </summary>
+    public bool IsSse => Type?.ToLowerInvariant() is "sse" or "http" or "streamable-http";
 }

--- a/src/RockBot.Agent/McpBridge/McpBridgeService.cs
+++ b/src/RockBot.Agent/McpBridge/McpBridgeService.cs
@@ -188,9 +188,17 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
         {
             try
             {
+                var httpTransportMode = config.TransportMode?.ToLowerInvariant() switch
+                {
+                    "sse" => ModelContextProtocol.Client.HttpTransportMode.Sse,
+                    "streamable-http" or "streamable" or "http" => ModelContextProtocol.Client.HttpTransportMode.StreamableHttp,
+                    _ => ModelContextProtocol.Client.HttpTransportMode.AutoDetect
+                };
+
                 var transport = new HttpClientTransport(new HttpClientTransportOptions
                 {
-                    Endpoint = new Uri(config.Url)
+                    Endpoint = new Uri(config.Url),
+                    TransportMode = httpTransportMode
                 });
                 var newClient = await McpClient.CreateAsync(transport, cancellationToken: ct);
 
@@ -477,7 +485,8 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
                 request.ToolName, arguments, cancellationToken: timeoutCts.Token);
 
             sw.Stop();
-            var content = McpToolExecutor.FormatResult(result);
+            var blocks = McpToolExecutor.MapContentBlocks(result);
+            var content = blocks is not null ? McpToolExecutor.TextFromBlocks(blocks) : null;
 
             if (result.IsError == true)
             {
@@ -499,13 +508,21 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
                 }
             }
             else
-                _logger.LogInformation("← MCP {Server}/{Tool} OK in {ElapsedMs}ms ({ContentLen} chars)",
-                    serverName, request.ToolName, sw.ElapsedMilliseconds, content?.Length ?? 0);
+            {
+                var nonTextCount = blocks?.Count(b => b.Type != "text") ?? 0;
+                if (nonTextCount > 0)
+                    _logger.LogInformation("← MCP {Server}/{Tool} OK in {ElapsedMs}ms ({ContentLen} chars, {NonTextCount} non-text block(s))",
+                        serverName, request.ToolName, sw.ElapsedMilliseconds, content?.Length ?? 0, nonTextCount);
+                else
+                    _logger.LogInformation("← MCP {Server}/{Tool} OK in {ElapsedMs}ms ({ContentLen} chars)",
+                        serverName, request.ToolName, sw.ElapsedMilliseconds, content?.Length ?? 0);
+            }
 
             var response = new ToolInvokeResponse
             {
                 ToolCallId = request.ToolCallId,
                 ToolName = request.ToolName,
+                ContentBlocks = blocks,
                 Content = content,
                 IsError = result.IsError == true
             };
@@ -558,7 +575,8 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
                             request.ToolName, arguments, cancellationToken: retryCts.Token);
 
                         sw.Stop();
-                        var retryContent = McpToolExecutor.FormatResult(retryResult);
+                        var retryBlocks = McpToolExecutor.MapContentBlocks(retryResult);
+                        var retryContent = retryBlocks is not null ? McpToolExecutor.TextFromBlocks(retryBlocks) : null;
 
                         _logger.LogInformation(
                             "← MCP {Server}/{Tool} OK after transparent reconnect ({ContentLen} chars)",
@@ -568,6 +586,7 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
                         {
                             ToolCallId = request.ToolCallId,
                             ToolName = request.ToolName,
+                            ContentBlocks = retryBlocks,
                             Content = retryContent,
                             IsError = retryResult.IsError == true
                         };

--- a/src/RockBot.Tools.Abstractions/ToolContentBlock.cs
+++ b/src/RockBot.Tools.Abstractions/ToolContentBlock.cs
@@ -1,0 +1,23 @@
+namespace RockBot.Tools;
+
+/// <summary>
+/// Transport-agnostic representation of a single content block in a tool result.
+/// Mirrors the MCP protocol content block model without a dependency on the MCP SDK.
+/// </summary>
+public sealed record ToolContentBlock
+{
+    /// <summary>Block type: "text", "image", "audio", or "resource".</summary>
+    public required string Type { get; init; }
+
+    /// <summary>Text content (type "text").</summary>
+    public string? Text { get; init; }
+
+    /// <summary>Base64-encoded binary data (types "image" or "audio").</summary>
+    public string? Data { get; init; }
+
+    /// <summary>MIME type for binary content (types "image" or "audio").</summary>
+    public string? MimeType { get; init; }
+
+    /// <summary>Resource URI (type "resource").</summary>
+    public string? Uri { get; init; }
+}

--- a/src/RockBot.Tools.Abstractions/ToolInvokeResponse.cs
+++ b/src/RockBot.Tools.Abstractions/ToolInvokeResponse.cs
@@ -16,9 +16,18 @@ public sealed record ToolInvokeResponse
     public required string ToolName { get; init; }
 
     /// <summary>
-    /// Tool output content (JSON or text), or null if the tool produced no output.
+    /// Tool output content (text), or null if the tool produced no output.
+    /// For rich results (images, audio, etc.) see <see cref="ContentBlocks"/>.
     /// </summary>
     public string? Content { get; init; }
+
+    /// <summary>
+    /// Structured content blocks from the tool result. When present, preserves
+    /// non-text blocks (images, audio, etc.) that cannot be represented in
+    /// <see cref="Content"/>. Consumers that can handle rich content should
+    /// prefer this over <see cref="Content"/>.
+    /// </summary>
+    public IReadOnlyList<ToolContentBlock>? ContentBlocks { get; init; }
 
     /// <summary>
     /// Whether the tool execution resulted in an error.

--- a/src/RockBot.Tools.Mcp/McpToolExecutor.cs
+++ b/src/RockBot.Tools.Mcp/McpToolExecutor.cs
@@ -21,13 +21,14 @@ internal sealed class McpToolExecutor(CallToolDelegate callTool) : IToolExecutor
 
         var result = await callTool(arguments, ct);
 
-        var content = FormatResult(result);
+        var blocks = MapContentBlocks(result);
 
         return new ToolInvokeResponse
         {
             ToolCallId = request.ToolCallId,
             ToolName = request.ToolName,
-            Content = content,
+            ContentBlocks = blocks,
+            Content = blocks is not null ? TextFromBlocks(blocks) : null,
             IsError = result.IsError == true
         };
     }
@@ -62,16 +63,38 @@ internal sealed class McpToolExecutor(CallToolDelegate callTool) : IToolExecutor
         };
     }
 
-    internal static string? FormatResult(CallToolResult result)
+    /// <summary>
+    /// Maps all MCP content blocks to transport-agnostic <see cref="ToolContentBlock"/> records,
+    /// preserving non-text content (images, audio, etc.) rather than silently discarding it.
+    /// </summary>
+    internal static IReadOnlyList<ToolContentBlock>? MapContentBlocks(CallToolResult result)
     {
         if (result.Content is null || result.Content.Count == 0)
             return null;
 
-        var textParts = result.Content
-            .OfType<TextContentBlock>()
-            .Select(c => c.Text);
+        var blocks = new List<ToolContentBlock>(result.Content.Count);
+        foreach (var block in result.Content)
+        {
+            blocks.Add(block switch
+            {
+                TextContentBlock text => new ToolContentBlock { Type = "text", Text = text.Text },
+                ImageContentBlock img => new ToolContentBlock { Type = "image", Data = img.Data, MimeType = img.MimeType },
+                AudioContentBlock audio => new ToolContentBlock { Type = "audio", Data = audio.Data, MimeType = audio.MimeType },
+                _ => new ToolContentBlock { Type = block.Type ?? "unknown", Text = $"[{block.Type ?? "unknown"} content block]" }
+            });
+        }
+        return blocks;
+    }
 
-        var joined = string.Join("\n", textParts);
+    /// <summary>
+    /// Extracts and joins text from a list of content blocks. Returns null if there is no text.
+    /// </summary>
+    internal static string? TextFromBlocks(IReadOnlyList<ToolContentBlock> blocks)
+    {
+        var joined = string.Join("\n", blocks
+            .Where(b => b.Type == "text")
+            .Select(b => b.Text ?? "")
+            .Where(t => t.Length > 0));
         return string.IsNullOrEmpty(joined) ? null : joined;
     }
 }

--- a/src/RockBot.Tools/RegistryToolFunction.cs
+++ b/src/RockBot.Tools/RegistryToolFunction.cs
@@ -57,6 +57,36 @@ public sealed class RegistryToolFunction(
         };
 
         var response = await executor.ExecuteAsync(request, cancellationToken);
-        return response.IsError ? $"Error: {response.Content}" : response.Content;
+
+        // For errors, always return plain text so the LLM receives a clear error message.
+        if (response.IsError)
+            return $"Error: {response.Content}";
+
+        // When the result contains non-text blocks (images, audio, etc.), return a list of
+        // AIContent items so the LLM provider can serialize them as multimodal content blocks
+        // rather than losing the data.
+        if (response.ContentBlocks is { Count: > 0 }
+            && response.ContentBlocks.Any(b => b.Type != "text"))
+        {
+            var aiContents = response.ContentBlocks
+                .Select(ToAIContent)
+                .OfType<AIContent>()
+                .ToList();
+
+            if (aiContents.Count > 0)
+                return aiContents;
+        }
+
+        return response.Content;
     }
+
+    private static AIContent? ToAIContent(ToolContentBlock block) => block.Type switch
+    {
+        "text" => new TextContent(block.Text ?? string.Empty),
+        "image" when block.Data is not null && block.MimeType is not null
+            => new DataContent($"data:{block.MimeType};base64,{block.Data}", block.MimeType),
+        "audio" when block.Data is not null && block.MimeType is not null
+            => new DataContent($"data:{block.MimeType};base64,{block.Data}", block.MimeType),
+        _ => block.Text is not null ? new TextContent(block.Text) : null
+    };
 }

--- a/tests/RockBot.Tools.Tests/McpToolExecutorTests.cs
+++ b/tests/RockBot.Tools.Tests/McpToolExecutorTests.cs
@@ -216,19 +216,46 @@ public class McpToolExecutorTests
     }
 
     [TestMethod]
-    public void FormatResult_ReturnsNull_ForEmptyContent()
+    public void MapContentBlocks_ReturnsNull_ForEmptyContent()
     {
         var result = new CallToolResult { Content = [] };
-        Assert.IsNull(McpToolExecutor.FormatResult(result));
+        Assert.IsNull(McpToolExecutor.MapContentBlocks(result));
     }
 
     [TestMethod]
-    public void FormatResult_ExtractsTextContent()
+    public void MapContentBlocks_ExtractsTextContent()
     {
         var result = new CallToolResult
         {
             Content = [new TextContentBlock { Text = "hello" }]
         };
-        Assert.AreEqual("hello", McpToolExecutor.FormatResult(result));
+        var blocks = McpToolExecutor.MapContentBlocks(result);
+        Assert.IsNotNull(blocks);
+        Assert.AreEqual(1, blocks.Count);
+        Assert.AreEqual("text", blocks[0].Type);
+        Assert.AreEqual("hello", blocks[0].Text);
+        Assert.AreEqual("hello", McpToolExecutor.TextFromBlocks(blocks));
+    }
+
+    [TestMethod]
+    public void MapContentBlocks_PreservesImageContent()
+    {
+        var result = new CallToolResult
+        {
+            Content =
+            [
+                new TextContentBlock { Text = "Here is an image:" },
+                new ImageContentBlock { Data = "abc123", MimeType = "image/png" }
+            ]
+        };
+        var blocks = McpToolExecutor.MapContentBlocks(result);
+        Assert.IsNotNull(blocks);
+        Assert.AreEqual(2, blocks.Count);
+        Assert.AreEqual("text", blocks[0].Type);
+        Assert.AreEqual("image", blocks[1].Type);
+        Assert.AreEqual("abc123", blocks[1].Data);
+        Assert.AreEqual("image/png", blocks[1].MimeType);
+        // TextFromBlocks only returns text parts
+        Assert.AreEqual("Here is an image:", McpToolExecutor.TextFromBlocks(blocks));
     }
 }


### PR DESCRIPTION
## Summary

- **Non-text content pass-through**: MCP tools returning images, audio, or other non-text content blocks no longer have that data silently discarded. A new `ToolContentBlock` record (no MCP SDK dependency) and `ContentBlocks` property on `ToolInvokeResponse` carry the full structured result across the message bus. `RegistryToolFunction` returns `List<AIContent>` with `DataContent` items for image/audio blocks, so the LLM provider receives proper multimodal tool results via the native function-calling path.
- **SSE / streamable HTTP transport**: New `TransportMode` config option in `McpBridgeServerConfig` (`"auto"` default, `"sse"`, or `"streamable-http"`) maps to `HttpTransportMode` on the MCP client transport. Defaults to `AutoDetect`, so connections to the updated mcp-aggregator (stateless streamable-HTTP mode) work without config changes, eliminating session-expiry reconnects.

Mirrors the non-text content and SSE/streaming changes recently made in `mcp-aggregator`.

## Test plan

- [x] All existing tests pass (`dotnet test RockBot.slnx`)
- [x] `McpToolExecutorTests` updated: `FormatResult` → `MapContentBlocks`/`TextFromBlocks`, new test asserting image blocks are preserved and text is correctly extracted
- [ ] Manual: invoke an MCP tool that returns an image block (e.g. a screenshot tool) and verify the LLM receives it as a multimodal content block
- [ ] Manual: set `transportMode: "streamable-http"` in `mcp.json` and confirm the bridge connects to the aggregator without session errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)