### PR TITLE
feat: nudge LLM when it falsely claims it lacks a connected service

### DIFF
--- a/src/RockBot.Agent/UserMessageHandler.cs
+++ b/src/RockBot.Agent/UserMessageHandler.cs
@@ -264,10 +264,11 @@ internal sealed class UserMessageHandler(
                             chatMessages, chatOptions, firstResponse, tier,
                             message.SessionId, replyTo, correlationId, turnActivity, sessionCt);
                     }
-                    else if (modelBehavior.NudgeOnHallucinatedToolCalls && HallucinatedActionRegex.IsMatch(text))
+                    else if (modelBehavior.NudgeOnHallucinatedToolCalls
+                        && (HallucinatedActionRegex.IsMatch(text) || AgentLoopRunner.CapabilityDenialRegex.IsMatch(text)))
                     {
                         logger.LogWarning(
-                            "Hallucinated tool actions detected on first response ({Length} chars); routing to background loop for nudge",
+                            "Hallucinated action or capability denial on first response ({Length} chars); routing to background loop for nudge",
                             text.Length);
 
                         await PublishReplyAsync(
@@ -377,6 +378,30 @@ internal sealed class UserMessageHandler(
                 .SelectMany(m => m.Contents.OfType<FunctionCallContent>())
                 .ToList();
             var toolCallNames = toolCalls.Select(c => c.Name).Distinct().ToList();
+
+            // If the model made no tool calls and claimed it lacks a service, nudge once.
+            if (toolCalls.Count == 0
+                && modelBehavior.NudgeOnHallucinatedToolCalls
+                && AgentLoopRunner.CapabilityDenialRegex.IsMatch(text))
+            {
+                logger.LogWarning(
+                    "Capability denial in native path ({Length} chars); nudging to check available services",
+                    text.Length);
+                chatMessages.AddRange(response.Messages);
+                chatMessages.Add(new ChatMessage(ChatRole.User, AgentLoopRunner.CapabilityDenialNudge));
+                var retryResponse = await llmClient.GetResponseAsync(chatMessages, classification.Tier, chatOptions, ct);
+                text = agentLoopRunner.ExtractAssistantText(retryResponse);
+                var retryToolCalls = retryResponse.Messages
+                    .SelectMany(m => m.Contents.OfType<FunctionCallContent>())
+                    .Count();
+                logger.LogInformation(
+                    "Capability denial nudge complete — {ToolCallCount} tool call(s) on retry, {TextLen} chars",
+                    retryToolCalls, text.Length);
+                toolCalls = retryResponse.Messages
+                    .SelectMany(m => m.Contents.OfType<FunctionCallContent>())
+                    .ToList();
+                toolCallNames = toolCalls.Select(c => c.Name).Distinct().ToList();
+            }
 
             logger.LogInformation(
                 "Native path complete — {ToolCallCount} tool call(s) resolved, final text {TextLen} chars",

--- a/src/RockBot.Host/AgentLoopRunner.cs
+++ b/src/RockBot.Host/AgentLoopRunner.cs
@@ -40,6 +40,23 @@ public sealed class AgentLoopRunner(
         RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
     /// <summary>
+    /// Detects when a model claims it lacks a connected service or tool, prompting a
+    /// check via mcp_list_services before giving up. Public so NativeLlmLoopAsync and
+    /// the first-response routing in UserMessageHandler can apply the same check.
+    /// </summary>
+    public static readonly Regex CapabilityDenialRegex = new(
+        @"\bI\s+(?:don['\u2019]?t|do\s+not)\s+(?:currently\s+)?have\s+(?:(?:direct\s+)?access\s+to\s+(?:a\s+|an\s+|any\s+)?|a\s+|any\s+(?:connected\s+)?)(?:calendar|email|mail|scheduling|service|tool|integration|plugin)\b" +
+        @"|\bI(?:['\u2019]m|\s+am)\s+(?:not\s+able|unable)\s+to\s+(?:access|use)\s+(?:\w+\s+)?(?:calendar|email|mail|scheduling|service|tool|integration)\b" +
+        @"|\bno\s+(?:calendar|email|mail|scheduling|external)\s+(?:service|tool|integration)\b" +
+        @"|\bI\s+(?:don['\u2019]?t|do\s+not)\s+(?:currently\s+)?have\s+(?:the\s+)?(?:tools?|ability|capability|a\s+way)\s+to\s+(?:access|check|view|schedule|manage|connect\s+to)\b" +
+        @"|\bI\s+lack\s+(?:access\s+to|a)\s+(?:calendar|email|mail|service|tool)\b",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    public const string CapabilityDenialNudge =
+        "Before concluding you lack access, check what services are available using " +
+        "mcp_list_services or search_known_services, then use mcp_invoke_tool to call them.";
+
+    /// <summary>
     /// Context window limit in tokens, learned from the first overflow error (text-based path only).
     /// </summary>
     private int? _knownContextLimit;
@@ -246,6 +263,17 @@ public sealed class AgentLoopRunner(
                         chatMessages.Add(new ChatMessage(ChatRole.Assistant, text));
                         chatMessages.Add(new ChatMessage(ChatRole.User,
                             "You described taking actions but no tool calls were detected. Please call the required tools now."));
+                        continue;
+                    }
+
+                    if (modelBehavior.NudgeOnHallucinatedToolCalls
+                        && CapabilityDenialRegex.IsMatch(text))
+                    {
+                        logger.LogWarning(
+                            "Capability denial detected ({Length} chars); nudging LLM to check available services",
+                            text.Length);
+                        chatMessages.Add(new ChatMessage(ChatRole.Assistant, text));
+                        chatMessages.Add(new ChatMessage(ChatRole.User, CapabilityDenialNudge));
                         continue;
                     }
 


### PR DESCRIPTION
## Summary

- Add `CapabilityDenialRegex` to `AgentLoopRunner` — matches phrases like *"I don't have access to a calendar service"*, *"I'm unable to use that tool"*, *"no email service connected"*, etc.
- When the pattern fires with no tool calls in the response, inject `CapabilityDenialNudge` asking the model to check `mcp_list_services` or `search_known_services` before giving up
- Covers all three response paths: text-based loop, native loop (one-shot retry), and text-path first-response routing in `UserMessageHandler`

**Root cause:** After successfully creating a calendar event, the agent responded to a follow-up request ("protect 12-1 time slot") with 0 tool calls and a denial that it had calendar access. The existing `HallucinatedActionRegex` only catches the LLM *claiming to have done* something — it had no coverage for the inverse case where the model *claims it can't do* something it demonstrably can.

## Test plan

- [ ] Reproduce original scenario: ask agent to do something with calendar/email after it's already used those services
- [ ] Verify `Capability denial in native path` warning appears in logs and the retry succeeds
- [ ] Confirm no false positives on legitimate "I don't have enough information" responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)