### PR TITLE
feat: staging API token auth with single-source contract

### DIFF
--- a/deploy/helm/rockbot/templates/manager/deployment.yaml
+++ b/deploy/helm/rockbot/templates/manager/deployment.yaml
@@ -78,6 +78,11 @@ spec:
                 configMapKeyRef:
                   name: {{ include "rockbot.configmapName" . }}
                   key: Scripts__Container__StagingUrl
+            - name: Scripts__Container__StagingToken
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "rockbot.secretName" . }}
+                  key: Staging__Token
             {{- end }}
             - name: DOTNET_ENVIRONMENT
               value: "Production"

--- a/deploy/helm/rockbot/templates/secret.yaml
+++ b/deploy/helm/rockbot/templates/secret.yaml
@@ -46,4 +46,8 @@ stringData:
   AzureFoundry__ClientId: {{ required "secrets.azureFoundry.clientId is required when azureFoundryMcp.enabled=true" .Values.secrets.azureFoundry.clientId | quote }}
   AzureFoundry__ClientSecret: {{ required "secrets.azureFoundry.clientSecret is required when azureFoundryMcp.enabled=true" .Values.secrets.azureFoundry.clientSecret | quote }}
   {{- end }}
+  {{- if .Values.staging.enabled }}
+  # ── Staging blob service auth token ───────────────────────────────────────────
+  Staging__Token: {{ required "secrets.staging.token is required when staging.enabled=true" .Values.secrets.staging.token | quote }}
+  {{- end }}
 {{- end }}

--- a/deploy/helm/rockbot/templates/staging/deployment.yaml
+++ b/deploy/helm/rockbot/templates/staging/deployment.yaml
@@ -33,6 +33,11 @@ spec:
               value: /rockbot/staging
             - name: Staging__ServiceUrl
               value: {{ include "rockbot.stagingServiceUrl" . | quote }}
+            - name: Staging__Token
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "rockbot.secretName" . }}
+                  key: Staging__Token
             - name: ASPNETCORE_URLS
               value: http://+:8080
           volumeMounts:

--- a/deploy/helm/rockbot/values.yaml
+++ b/deploy/helm/rockbot/values.yaml
@@ -49,6 +49,15 @@ rabbitmq:
   virtualHost: /
   managementApiBaseUrl: ""  # optional — e.g. http://rabbitmq-mgmt.default.svc.cluster.local:15672
                             # required for DLQ depth metrics (rockbot.messaging.dlq.depth)
+                            # required for dlqRetention policy application (below)
+
+  # DLQ retention policy — applied via RabbitMQ Management API on every helm install/upgrade.
+  # Matches all *.dlq queues and enforces TTL + max-length so messages cannot accumulate forever.
+  # Only active when managementApiBaseUrl is also set.
+  dlqRetention:
+    enabled: true
+    messageTtlMs: 259200000  # 72 hours — messages older than this are expired by the broker
+    maxLength: 10000          # drop oldest messages (drop-head) when queue exceeds this count
 
 # ── Script Manager pod ────────────────────────────────────────────────────────
 # Trusted sidecar that owns all pod RBAC in the scripts namespace.
@@ -247,6 +256,10 @@ secrets:
   openRouter:
     apiKey: ""              # required when openrouterMcp.enabled=true — OpenRouter management API key
                             # (separate from llm.apiKey — this is the account management key)
+
+  staging:
+    token: ""               # required when staging.enabled=true — shared secret for X-RockBot-Token auth
+                            # generate with: openssl rand -hex 32
 
   azureFoundry:
     tenantId: ""            # required when azureFoundryMcp.enabled=true — Azure AD tenant ID

--- a/src/McpServer.Staging/Program.cs
+++ b/src/McpServer.Staging/Program.cs
@@ -9,6 +9,36 @@ builder.Services.AddMcpServer().WithHttpTransport().WithTools<StagingTools>();
 
 var app = builder.Build();
 
+// Token auth — all paths except /health require X-RockBot-Token.
+// Fail secure: if no token is configured the server rejects every non-health request.
+app.Use(async (context, next) =>
+{
+    if (context.Request.Path.StartsWithSegments("/health"))
+    {
+        await next(context);
+        return;
+    }
+
+    var expectedToken = context.RequestServices
+        .GetRequiredService<IConfiguration>()["Staging:Token"];
+
+    if (string.IsNullOrEmpty(expectedToken))
+    {
+        context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+        await context.Response.WriteAsync("Staging server misconfigured: token not set");
+        return;
+    }
+
+    if (!context.Request.Headers.TryGetValue("X-RockBot-Token", out var provided)
+        || provided != expectedToken)
+    {
+        context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+        return;
+    }
+
+    await next(context);
+});
+
 app.MapHealthChecks("/health");
 app.MapMcp();
 

--- a/src/McpServer.Staging/Tools/StagingTools.cs
+++ b/src/McpServer.Staging/Tools/StagingTools.cs
@@ -93,6 +93,9 @@ public sealed class StagingTools(StagingRepository repository, IConfiguration co
         }
     }
 
+    // Single source of truth for the staging REST API contract (URL, auth, subdirs).
+    // ScriptToolSkillProvider deliberately defers to this tool rather than duplicating
+    // the contract — update here only, not in both places.
     [McpServerTool(Name = "staging_script_info")]
     [Description("""
         Returns the REST API base URL and HTTP contract for the staging service.
@@ -102,8 +105,9 @@ public sealed class StagingTools(StagingRepository repository, IConfiguration co
           - Download: GET  {url}/api/staging/{path}
           - Delete:   DELETE {url}/api/staging/{path}
           - List:     GET  {url}/api/staging
-        The staging URL is also available inside every script pod as the environment
-        variable ROCKBOT_STAGING_URL, so scripts can discover it without hardcoding.
+        ALL requests (except /health) require the header: X-RockBot-Token: <token>
+        Inside every script pod the token is available as the environment variable
+        ROCKBOT_STAGING_TOKEN, and the URL as ROCKBOT_STAGING_URL.
         Use subpaths like 'tmp/', 'drafts/', or 'exports/' to organise files by TTL.
         """)]
     public string GetScriptInfo()
@@ -112,7 +116,8 @@ public sealed class StagingTools(StagingRepository repository, IConfiguration co
         var info = new
         {
             url,
-            envVar = "ROCKBOT_STAGING_URL",
+            urlEnvVar = "ROCKBOT_STAGING_URL",
+            auth = new { header = "X-RockBot-Token", tokenEnvVar = "ROCKBOT_STAGING_TOKEN" },
             subdirs = new { tmp = "1d", drafts = "14d", exports = "14d" }
         };
         return JsonSerializer.Serialize(info, _jsonOptions);

--- a/src/RockBot.Agent/McpBridge/McpBridgeServerConfig.cs
+++ b/src/RockBot.Agent/McpBridge/McpBridgeServerConfig.cs
@@ -48,6 +48,13 @@ public sealed class McpBridgeServerConfig
     public string TransportMode { get; set; } = "auto";
 
     /// <summary>
+    /// HTTP headers to include on every request to this server.
+    /// Values may use <c>${ENV_VAR_NAME}</c> syntax for environment variable substitution.
+    /// Example: <c>"X-RockBot-Token": "${Staging__Token}"</c>
+    /// </summary>
+    public Dictionary<string, string> Headers { get; set; } = [];
+
+    /// <summary>
     /// Whether this config uses HTTP-based transport (SSE or streamable HTTP).
     /// </summary>
     public bool IsSse => Type?.ToLowerInvariant() is "sse" or "http" or "streamable-http";

--- a/src/RockBot.Agent/McpBridge/McpBridgeService.cs
+++ b/src/RockBot.Agent/McpBridge/McpBridgeService.cs
@@ -195,11 +195,29 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
                     _ => ModelContextProtocol.Client.HttpTransportMode.AutoDetect
                 };
 
-                var transport = new HttpClientTransport(new HttpClientTransportOptions
+                var transportOptions = new HttpClientTransportOptions
                 {
                     Endpoint = new Uri(config.Url),
                     TransportMode = httpTransportMode
-                });
+                };
+
+                HttpClientTransport transport;
+                if (config.Headers.Count > 0)
+                {
+                    var httpClient = new HttpClient();
+                    foreach (var (key, rawValue) in config.Headers)
+                    {
+                        var expanded = ExpandEnvVars(rawValue);
+                        if (!string.IsNullOrEmpty(expanded))
+                            httpClient.DefaultRequestHeaders.TryAddWithoutValidation(key, expanded);
+                    }
+                    transport = new HttpClientTransport(transportOptions, httpClient, loggerFactory: null, ownsHttpClient: true);
+                }
+                else
+                {
+                    transport = new HttpClientTransport(transportOptions);
+                }
+
                 var newClient = await McpClient.CreateAsync(transport, cancellationToken: ct);
 
                 // Discover tools before committing the swap so a failure leaves the old client intact
@@ -919,6 +937,16 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
         _serverTools.Clear();
         _serverConfigs.Clear();
     }
+
+    /// <summary>
+    /// Expands <c>${VAR_NAME}</c> placeholders in <paramref name="value"/> using
+    /// <see cref="Environment.GetEnvironmentVariable"/>. Unset variables expand to an empty string.
+    /// </summary>
+    private static string ExpandEnvVars(string value) =>
+        System.Text.RegularExpressions.Regex.Replace(
+            value,
+            @"\$\{([^}]+)\}",
+            m => Environment.GetEnvironmentVariable(m.Groups[1].Value) ?? string.Empty);
 
     /// <summary>
     /// Extracts a string value from a parsed argument dictionary, handling

--- a/src/RockBot.Scripts.Container/ContainerScriptHandler.cs
+++ b/src/RockBot.Scripts.Container/ContainerScriptHandler.cs
@@ -176,6 +176,9 @@ internal sealed class ContainerScriptHandler(
         if (!string.IsNullOrEmpty(options.StagingUrl))
             pod.Spec.Containers[0].Env.Add(new V1EnvVar { Name = "ROCKBOT_STAGING_URL", Value = options.StagingUrl });
 
+        if (!string.IsNullOrEmpty(options.StagingToken))
+            pod.Spec.Containers[0].Env.Add(new V1EnvVar { Name = "ROCKBOT_STAGING_TOKEN", Value = options.StagingToken });
+
         return pod;
     }
 

--- a/src/RockBot.Scripts.Container/ContainerScriptOptions.cs
+++ b/src/RockBot.Scripts.Container/ContainerScriptOptions.cs
@@ -35,4 +35,10 @@ public sealed class ContainerScriptOptions
     /// a ROCKBOT_STAGING_URL environment variable so scripts can upload files via REST.
     /// </summary>
     public string StagingUrl { get; set; } = "";
+
+    /// <summary>
+    /// Auth token for the staging blob service. When non-empty, ephemeral pods receive
+    /// a ROCKBOT_STAGING_TOKEN environment variable for use in the X-RockBot-Token header.
+    /// </summary>
+    public string StagingToken { get; set; } = "";
 }

--- a/src/RockBot.Scripts.Remote/ScriptToolSkillProvider.cs
+++ b/src/RockBot.Scripts.Remote/ScriptToolSkillProvider.cs
@@ -152,60 +152,18 @@ internal sealed class ScriptToolSkillProvider : IToolSkillProvider
         by other tools (e.g. uploading to OneDrive), upload it to the **staging service**
         via HTTP before the script exits.
 
-        The staging service URL is available inside every script pod as:
-
-        ```
-        ROCKBOT_STAGING_URL   e.g. http://rockbot-staging.rockbot.svc.cluster.local
-        ```
-
-        **HTTP contract:**
-        - Upload:   `PUT  {ROCKBOT_STAGING_URL}/api/staging/{path}`  — body is the raw file bytes
-        - Download: `GET  {ROCKBOT_STAGING_URL}/api/staging/{path}`
-        - Delete:   `DELETE {ROCKBOT_STAGING_URL}/api/staging/{path}`
-        - List:     `GET  {ROCKBOT_STAGING_URL}/api/staging`
-
-        Use subpaths to organise by intended TTL:
-        - `tmp/`     — cleaned up after 1 day
-        - `drafts/`  — kept for 14 days
-        - `exports/` — kept for 14 days
+        **Always call `staging_script_info` before writing a script that uses staging.**
+        It returns the authoritative URL, auth header name, token env var, and subdir TTLs.
+        Do not hardcode any of those details — they come from `staging_script_info`.
 
         **Typical workflow:**
 
-        1. Call `staging_script_info` to confirm the URL and contract (optional — the env var
-           is always present, but the tool returns the same info as a reminder).
-        2. Have the script upload the file, then print the staging path to stdout.
-        3. After the script completes, use `staging_get_path` to get the absolute local path
-           on the staging volume (needed by tools such as an OneDrive upload tool that accept
-           a local file path rather than an HTTP URL).
-
-        **Example — generate an Excel file and upload to staging:**
-        ```
-        execute_python_script(
-          script: \"\"\"
-        import os, requests
-        import openpyxl
-
-        wb = openpyxl.Workbook()
-        ws = wb.active
-        ws.append(["Name", "Score"])
-        ws.append(["Alice", 95])
-        ws.append(["Bob", 87])
-        wb.save("/tmp/report.xlsx")
-
-        staging_url = os.environ["ROCKBOT_STAGING_URL"]
-        with open("/tmp/report.xlsx", "rb") as f:
-            r = requests.put(f"{staging_url}/api/staging/exports/report.xlsx", data=f)
-            r.raise_for_status()
-
-        print("exports/report.xlsx")
-        \"\"\",
-          pip_packages: ["openpyxl", "requests"],
-          timeout_seconds: 60
-        )
-        ```
-
-        After this succeeds, call `staging_get_path("exports/report.xlsx")` to get the
-        absolute filesystem path for use with file-path-based tools.
+        1. Call `staging_script_info` — read the returned `auth` and `urlEnvVar` fields.
+        2. Write the script using exactly the header name and env var names from that response.
+        3. Have the script print the staging path to stdout on success.
+        4. After the script completes, call `staging_get_path` to get the absolute local path
+           on the staging volume (needed by tools that accept a local file path rather than
+           an HTTP URL).
 
 
         ## Common Pitfalls
@@ -219,5 +177,6 @@ internal sealed class ScriptToolSkillProvider : IToolSkillProvider
           `import sys; print("debug", file=sys.stderr)`
         - Writing scripts that assume local files persist between runs — each execution is a
           fresh ephemeral container; use the staging service to persist output files
+        - Hardcoding staging URL or auth details instead of reading them from `staging_script_info`
         """;
 }

--- a/tests/McpServer.Staging.Tests/StagingApiTests.cs
+++ b/tests/McpServer.Staging.Tests/StagingApiTests.cs
@@ -12,14 +12,21 @@ public class StagingApiTests
     private HttpClient _client = null!;
     private string _tempDir = null!;
 
+    private const string TestToken = "test-staging-token";
+
     [TestInitialize]
     public void Initialize()
     {
         _tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
         Directory.CreateDirectory(_tempDir);
         _factory = new WebApplicationFactory<Program>()
-            .WithWebHostBuilder(b => b.UseSetting("Staging__BasePath", _tempDir));
+            .WithWebHostBuilder(b =>
+            {
+                b.UseSetting("Staging__BasePath", _tempDir);
+                b.UseSetting("Staging:Token", TestToken);
+            });
         _client = _factory.CreateClient();
+        _client.DefaultRequestHeaders.Add("X-RockBot-Token", TestToken);
     }
 
     [TestCleanup]
@@ -86,5 +93,30 @@ public class StagingApiTests
         var path = repo.GetAbsolutePath("drafts/report.xlsx");
         Assert.IsTrue(Path.IsPathRooted(path));
         Assert.IsTrue(path.Replace('\\', '/').Contains("drafts/report.xlsx"));
+    }
+
+    [TestMethod]
+    public async Task Request_Without_Token_Returns_401()
+    {
+        var noAuth = _factory.CreateClient();
+        var response = await noAuth.GetAsync("/api/staging/test.txt");
+        Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [TestMethod]
+    public async Task Request_With_Wrong_Token_Returns_401()
+    {
+        var wrongAuth = _factory.CreateClient();
+        wrongAuth.DefaultRequestHeaders.Add("X-RockBot-Token", "wrong-token");
+        var response = await wrongAuth.GetAsync("/api/staging/test.txt");
+        Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [TestMethod]
+    public async Task Health_Endpoint_Accessible_Without_Token()
+    {
+        var noAuth = _factory.CreateClient();
+        var response = await noAuth.GetAsync("/health");
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
     }
 }


### PR DESCRIPTION
## Summary
- Adds `X-RockBot-Token` auth to the staging REST API — all non-health requests require the header; fail-secure if token is not configured
- Injects `ROCKBOT_STAGING_TOKEN` into script pods so scripts can authenticate without hardcoding
- Makes `staging_script_info` the single source of truth for the API contract (URL, auth header, env vars, TTLs); `ScriptToolSkillProvider` defers to it rather than duplicating the spec

## Test plan
- [x] `StagingApiTests` — 9 tests passing including 401 without token, 401 with wrong token, 200 on `/health` without token
- [x] Staging and agent images built, pushed, and rolled out to cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)