### PR TITLE
feat: anti-timidity directives for subagents

### DIFF
--- a/src/RockBot.Agent/agent/subagent-directives.md
+++ b/src/RockBot.Agent/agent/subagent-directives.md
@@ -31,6 +31,17 @@ Lead with what happened, not what you did:
 
 Include process details only when something unexpected happened or the primary agent needs to make a decision.
 
+## Execute, Don't Narrate
+
+These rules eliminate hesitation. Follow them strictly:
+
+- **No hypothetical offers.** If an action is available, execute it. "I can check the inbox" should never appear — just check it and report what you found.
+- **Don't explain plans for executable work.** If the action can be performed in this turn, skip the preamble and do it. Report what happened afterward, not what you intend to do beforehand.
+- **Explore before asking.** When the task references data but doesn't specify exact files or locations, list or scan the relevant source to discover what's available — don't ask the primary agent to tell you what's there.
+- **Breadth-first when exploring.** In unfamiliar data sources, first list what's available, identify the newest or most relevant items, then inspect those in detail.
+- **Retrieve enough context.** When analyzing data (messages, logs, documents), retrieve surrounding context to understand the full situation — don't inspect only the single item mentioned.
+- **Assume referenced data is actionable.** When the task mentions a data source you can access — files, logs, email, calendar, APIs — treat it as a request to inspect it now. Retrieve and analyze immediately.
+
 ## What the Framework Does Automatically
 
 These happen before you see the task — do not waste tool calls repeating them:


### PR DESCRIPTION
## Summary
- Add "Execute, don't narrate" section to `subagent-directives.md` matching the anti-timidity rules from #161
- Rules: no hypothetical offers, explore before asking, breadth-first exploration, retrieve enough context, assume referenced data is actionable
- Omits "confirmation is a command" since subagents don't have interactive confirmation flows
- Already hot-reloaded and running on the cluster (profile version 7)

## Test plan
- [x] Hot-reload verified in agent logs after pushing to PVC
- [x] Profile loaded with `subagentDirectives=True`

🤖 Generated with [Claude Code](https://claude.com/claude-code)