### PR TITLE
feat: auto-seed in-cluster MCP servers from Helm config

### DIFF
--- a/deploy/helm/rockbot/templates/configmap.yaml
+++ b/deploy/helm/rockbot/templates/configmap.yaml
@@ -29,6 +29,23 @@ data:
   Memory__BasePath: "/data/agent/memory"
   Skill__BasePath: "/data/agent/skills"
   McpBridge__ConfigPath: "/data/agent/mcp.json"
+
+  # ── Default MCP servers (auto-seeded into mcp.json on startup) ────────────
+  {{- if .Values.routingStatsMcp.enabled }}
+  McpBridge__DefaultServers__routing-stats: "http://localhost:8080/"
+  {{- end }}
+  {{- if .Values.openrouterMcp.enabled }}
+  McpBridge__DefaultServers__openrouter: "http://{{ include "rockbot.fullname" . }}-openrouter-mcp.{{ .Values.namespace }}.svc.cluster.local/"
+  {{- end }}
+  {{- if .Values.azureFoundryMcp.enabled }}
+  McpBridge__DefaultServers__azure-foundry: "http://{{ include "rockbot.fullname" . }}-azure-foundry-mcp.{{ .Values.namespace }}.svc.cluster.local/"
+  {{- end }}
+  {{- if .Values.staging.enabled }}
+  McpBridge__DefaultServers__staging: "http://{{ include "rockbot.fullname" . }}-staging.{{ .Values.namespace }}.svc.cluster.local/"
+  {{- end }}
+  {{- if .Values.todoappMcp.enabled }}
+  McpBridge__DefaultServers__todo: "http://mcp-todo.{{ .Values.namespace }}.svc.cluster.local/"
+  {{- end }}
   ModelBehaviors__BasePath: "/data/agent/model-behaviors"
 
   # ── Runtime ───────────────────────────────────────────────────────────────

--- a/src/RockBot.Agent/McpBridge/McpBridgeOptions.cs
+++ b/src/RockBot.Agent/McpBridge/McpBridgeOptions.cs
@@ -45,4 +45,12 @@ public sealed class McpBridgeOptions
     /// and attempts to reconnect them. Set to zero to disable the sweep.
     /// </summary>
     public int ReconnectSweepIntervalSeconds { get; set; } = 60;
+
+    /// <summary>
+    /// Default MCP servers seeded from infrastructure config (e.g. Helm chart).
+    /// On startup, any server listed here that is NOT already in the config file
+    /// is added automatically. Existing entries are never overwritten.
+    /// Key = server name, Value = SSE URL.
+    /// </summary>
+    public Dictionary<string, string> DefaultServers { get; set; } = [];
 }

--- a/src/RockBot.Agent/McpBridge/McpBridgeService.cs
+++ b/src/RockBot.Agent/McpBridge/McpBridgeService.cs
@@ -134,41 +134,78 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
 
     private async Task LoadConfigAndConnectAsync(CancellationToken ct)
     {
+        McpBridgeConfig config;
+
         if (!File.Exists(_configPath))
         {
-            _logger.LogWarning("MCP config file not found at {Path}", _configPath);
-            return;
+            _logger.LogInformation("MCP config file not found at {Path}; starting with empty config", _configPath);
+            config = new McpBridgeConfig();
         }
-
-        McpBridgeConfig config;
-        try
+        else
         {
-            var json = await File.ReadAllTextAsync(_configPath, ct);
-            config = JsonSerializer.Deserialize<McpBridgeConfig>(json, JsonOptions)
-                ?? new McpBridgeConfig();
-
-            // If the primary file deserialized to empty but had content, try the backup
-            if (config.McpServers.Count == 0 && json.Trim().Length > 0)
+            try
             {
-                _logger.LogWarning(
-                    "MCP config at {Path} deserialized to empty McpServers but file was non-empty ({Length} chars) — attempting backup",
-                    _configPath, json.Length);
-                config = await TryLoadFromBackupAsync(ct) ?? config;
+                var json = await File.ReadAllTextAsync(_configPath, ct);
+                config = JsonSerializer.Deserialize<McpBridgeConfig>(json, JsonOptions)
+                    ?? new McpBridgeConfig();
+
+                // If the primary file deserialized to empty but had content, try the backup
+                if (config.McpServers.Count == 0 && json.Trim().Length > 0)
+                {
+                    _logger.LogWarning(
+                        "MCP config at {Path} deserialized to empty McpServers but file was non-empty ({Length} chars) — attempting backup",
+                        _configPath, json.Length);
+                    config = await TryLoadFromBackupAsync(ct) ?? config;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to read MCP config from {Path}", _configPath);
+
+                // Attempt to recover from backup
+                var backupConfig = await TryLoadFromBackupAsync(ct);
+                if (backupConfig is not null)
+                {
+                    config = backupConfig;
+                }
+                else
+                {
+                    return;
+                }
             }
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to read MCP config from {Path}", _configPath);
 
-            // Attempt to recover from backup
-            var backupConfig = await TryLoadFromBackupAsync(ct);
-            if (backupConfig is not null)
+        // Seed default servers from infrastructure config (Helm values)
+        var seeded = false;
+        foreach (var (name, url) in _options.DefaultServers)
+        {
+            if (!config.McpServers.ContainsKey(name))
             {
-                config = backupConfig;
+                _logger.LogInformation("Seeding default MCP server {Name} at {Url}", name, url);
+                config.McpServers[name] = new McpBridgeServerConfig
+                {
+                    Type = "sse",
+                    Url = url
+                };
+                seeded = true;
             }
-            else
+        }
+
+        if (seeded)
+        {
+            try
             {
-                return;
+                var updatedJson = JsonSerializer.Serialize(config, new JsonSerializerOptions
+                {
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                    WriteIndented = true
+                });
+                await File.WriteAllTextAsync(_configPath, updatedJson, ct);
+                _logger.LogInformation("Persisted seeded MCP servers to {Path}", _configPath);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to persist seeded MCP servers to {Path}", _configPath);
             }
         }
 


### PR DESCRIPTION
## Summary
- **Helm-driven MCP service declaration**: The configmap now injects `McpBridge__DefaultServers__<name>` entries for each enabled MCP service, bound to `McpBridgeOptions.DefaultServers` via .NET configuration
- **Auto-seed on startup**: `LoadConfigAndConnectAsync` merges any default servers missing from `mcp.json` and persists them, so entries survive restarts without re-seeding
- **Fresh deploy support**: When `mcp.json` doesn't exist yet, the agent now creates it from default servers instead of returning early with a warning

## Context
In-cluster MCP services (openrouter, azure-foundry, staging, todo) had to be manually registered in the agent's `mcp.json` on the PVC. When entries were lost (due to persistence bugs addressed in #165), they had to be manually re-added — a recurring whack-a-mole problem.

Now the Helm chart is the source of truth for which MCP services exist. On every pod startup, the agent ensures all Helm-declared services are present in `mcp.json`. User-added or user-modified entries are never overwritten.

## Services auto-seeded (when enabled)
| Service | Config Key | Condition |
|---------|-----------|-----------|
| routing-stats | `localhost:8080` (sidecar) | `routingStatsMcp.enabled` |
| openrouter | `rockbot-openrouter-mcp.<ns>.svc` | `openrouterMcp.enabled` |
| azure-foundry | `rockbot-azure-foundry-mcp.<ns>.svc` | `azureFoundryMcp.enabled` |
| staging | `rockbot-staging.<ns>.svc` | `staging.enabled` |
| todo | `mcp-todo.<ns>.svc` | `todoappMcp.enabled` |

## Test plan
- [x] `dotnet build RockBot.slnx` — 0 errors
- [x] `dotnet test RockBot.slnx` — 594 passed
- [ ] Deploy with `todoappMcp.enabled: true` and verify todo pod starts
- [ ] Delete `/data/agent/mcp.json` on PVC, restart agent pod, verify all services re-seeded
- [ ] Verify existing user-added entries are preserved after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)