### PR TITLE
fix: protect todo MCP PVC from data loss on Helm uninstall

### DIFF
--- a/deploy/helm/rockbot/templates/todoapp-mcp/pvc.yaml
+++ b/deploy/helm/rockbot/templates/todoapp-mcp/pvc.yaml
@@ -1,9 +1,13 @@
-{{- if .Values.todoappMcp.enabled }}
+{{- if and .Values.todoappMcp.enabled (not (lookup "v1" "PersistentVolumeClaim" .Values.namespace "mcp-todo-data")) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: mcp-todo-data
   namespace: {{ .Values.namespace }}
+  annotations:
+    # Helm will not delete this PVC on uninstall — todo data must
+    # survive chart upgrades and releases.
+    helm.sh/resource-policy: keep
   labels:
     {{- include "rockbot.labels" . | nindent 4 }}
     app.kubernetes.io/component: mcp-todo

--- a/deploy/helm/rockbot/values.yaml
+++ b/deploy/helm/rockbot/values.yaml
@@ -198,7 +198,7 @@ staging:
 # Standalone MCP server that exposes a persistent to-do list to the agent.
 # Data is stored in a Longhorn PVC mounted at /data inside the container.
 todoappMcp:
-  enabled: false
+  enabled: true
   image:
     repository: rockylhotka/mcpserver-todoapp
     tag: latest


### PR DESCRIPTION
## Summary
- Add `helm.sh/resource-policy: keep` annotation to `mcp-todo-data` PVC so Helm won't delete it on uninstall
- Add `lookup` guard to skip PVC creation if it already exists, matching the pattern used by agent and staging PVCs
- Enable `todoappMcp` in values.yaml

## Test plan
- [ ] Verify `helm template` renders correctly when PVC doesn't exist
- [ ] Verify `helm upgrade` skips PVC when it already exists in cluster
- [ ] Confirm existing PVC annotation is in place via `kubectl get pvc mcp-todo-data -n rockbot -o yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)