### PR TITLE
Add A2A protocol v1 support alongside existing v0.3

### DIFF
--- a/src/RockBot.A2A.Abstractions/AgentCard.cs
+++ b/src/RockBot.A2A.Abstractions/AgentCard.cs
@@ -32,6 +32,14 @@ public sealed record AgentCard
     public string? AuthHeaderValueBase64 { get; init; }
 
     /// <summary>
+    /// A2A protocol version advertised by the agent (e.g. "0.3", "1.0").
+    /// Null defaults to "0.3" for backward compatibility.
+    /// Set automatically by <c>RegisterAgentExecutor</c> when fetching
+    /// a remote agent card, or explicitly when registering.
+    /// </summary>
+    public string? ProtocolVersion { get; init; }
+
+    /// <summary>
     /// When true, the agent is shutting down and should be removed from the directory.
     /// Published by <c>AgentDiscoveryService.StopAsync</c> on graceful shutdown.
     /// </summary>

--- a/src/RockBot.A2A/A2ACallerToolRegistrar.cs
+++ b/src/RockBot.A2A/A2ACallerToolRegistrar.cs
@@ -106,6 +106,10 @@ internal sealed class A2ACallerToolRegistrar(
             "auth_header_value_base64": {
               "type": "string",
               "description": "Base64-encoded value for the auth header (e.g. base64 of 'Bearer sk-...'). Must be provided with auth_header_name."
+            },
+            "protocol_version": {
+              "type": "string",
+              "description": "A2A protocol version (e.g. '0.3', '1.0'). If omitted, auto-detected from the agent's well-known card endpoint."
             }
           },
           "required": ["agent_name", "url"]
@@ -169,7 +173,7 @@ internal sealed class A2ACallerToolRegistrar(
                           "The agent is persisted and available for invoke_agent immediately.",
             ParametersSchema = RegisterAgentSchema,
             Source = "a2a"
-        }, new RegisterAgentExecutor(directory, loggerFactory.CreateLogger<RegisterAgentExecutor>()));
+        }, new RegisterAgentExecutor(directory, httpClientFactory, loggerFactory.CreateLogger<RegisterAgentExecutor>()));
         registrarLogger.LogInformation("Registered tool: register_agent");
 
         registry.Register(new ToolRegistration

--- a/src/RockBot.A2A/InvokeAgentExecutor.cs
+++ b/src/RockBot.A2A/InvokeAgentExecutor.cs
@@ -4,7 +4,8 @@ using Microsoft.Extensions.Logging;
 using RockBot.Host;
 using RockBot.Messaging;
 using RockBot.Tools;
-using A2AProtocol = A2A.V0_3;
+using A2AV03 = A2A.V0_3;
+using A2AV1 = A2A;
 
 namespace RockBot.A2A;
 
@@ -13,6 +14,8 @@ namespace RockBot.A2A;
 /// pending task in <see cref="A2ATaskTracker"/>. Returns the task ID immediately.
 /// Supports both queue-based (RabbitMQ) and HTTP-based transport. HTTP transport is
 /// used when the target agent's <see cref="AgentCard"/> has a non-empty <c>Url</c>.
+/// Protocol version is detected from <see cref="AgentCard.ProtocolVersion"/>:
+/// "1.0" uses the A2A v1 SDK, anything else (including null) uses v0.3.
 /// </summary>
 internal sealed class InvokeAgentExecutor(
     IMessagePublisher publisher,
@@ -28,6 +31,13 @@ internal sealed class InvokeAgentExecutor(
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
         PropertyNameCaseInsensitive = true
     };
+
+    /// <summary>
+    /// Returns true when the agent card indicates A2A protocol v1.
+    /// </summary>
+    internal static bool IsV1(AgentCard? card) =>
+        card?.ProtocolVersion is { } v &&
+        (v.StartsWith("1.", StringComparison.Ordinal) || v == "1");
 
     public async Task<ToolInvokeResponse> ExecuteAsync(ToolInvokeRequest request, CancellationToken ct)
     {
@@ -86,12 +96,14 @@ internal sealed class InvokeAgentExecutor(
         // Prefer HTTP transport when the agent has a URL registered.
         var agentCard = directory.GetAgent(agentName);
         var protocol = !string.IsNullOrEmpty(agentCard?.Url) ? "http" : "queue";
+        var a2aVersion = IsV1(agentCard) ? "1.0" : "0.3";
 
         using var a2aActivity = A2ADiagnostics.Source.StartActivity("rockbot.a2a.invoke");
         a2aActivity?.SetTag("rockbot.a2a.target_agent", agentName);
         a2aActivity?.SetTag("rockbot.a2a.skill", skill);
         a2aActivity?.SetTag("rockbot.a2a.task_id", taskId);
         a2aActivity?.SetTag("rockbot.a2a.protocol", protocol);
+        a2aActivity?.SetTag("rockbot.a2a.a2a_version", a2aVersion);
 
         if (protocol == "http")
         {
@@ -152,33 +164,25 @@ internal sealed class InvokeAgentExecutor(
             }
 
             var endpoint = new Uri(agentCard.Url!.TrimEnd('/'));
-            logger.LogInformation("Dispatching task {TaskId} to A2A agent '{AgentName}' at {Endpoint}",
-                taskId, agentName, endpoint);
+            var useV1 = IsV1(agentCard);
+            logger.LogInformation(
+                "Dispatching task {TaskId} to A2A agent '{AgentName}' at {Endpoint} (protocol={Version})",
+                taskId, agentName, endpoint, useV1 ? "v1" : "v0.3");
 
             using var httpActivity = A2ADiagnostics.Source.StartActivity("rockbot.a2a.http_dispatch");
             httpActivity?.SetTag("rockbot.a2a.target_agent", agentName);
             httpActivity?.SetTag("rockbot.a2a.task_id", taskId);
+            httpActivity?.SetTag("rockbot.a2a.a2a_version", useV1 ? "1.0" : "0.3");
             var httpSw = System.Diagnostics.Stopwatch.StartNew();
 
-            // Use the standard A2A protocol SDK (JSON-RPC 2.0 / v0.3) for HTTP dispatch
-            var a2aClient = new A2AProtocol.A2AClient(endpoint, httpClient);
             var messageText = taskRequest.Message.Parts.FirstOrDefault(p => p.Kind == "text")?.Text
                 ?? string.Empty;
-            var sendParams = new A2AProtocol.MessageSendParams
-            {
-                Message = new A2AProtocol.AgentMessage
-                {
-                    Role = A2AProtocol.MessageRole.User,
-                    MessageId = taskId,
-                    Parts = [new A2AProtocol.TextPart { Text = messageText }]
-                },
-                Metadata = new Dictionary<string, JsonElement>
-                {
-                    ["skill"] = JsonSerializer.SerializeToElement(taskRequest.Skill)
-                }
-            };
 
-            var a2aResponse = await a2aClient.SendMessageAsync(sendParams, ct);
+            AgentTaskResult? result;
+            if (useV1)
+                result = await DispatchV1Async(httpClient, endpoint, taskRequest, taskId, messageText, ct);
+            else
+                result = await DispatchV03Async(httpClient, endpoint, taskRequest, taskId, messageText, ct);
 
             httpSw.Stop();
             var latencyGrade = httpSw.Elapsed.TotalSeconds > 5 ? "slow" : "fast";
@@ -188,8 +192,6 @@ internal sealed class InvokeAgentExecutor(
                 new KeyValuePair<string, object?>("rockbot.a2a.target_agent", agentName),
                 new KeyValuePair<string, object?>("rockbot.a2a.latency_grade", latencyGrade));
 
-            // Map the A2A protocol response back to RockBot's internal types
-            var result = MapA2AResponse(a2aResponse, taskId);
             if (result is null)
             {
                 logger.LogWarning("A2A agent '{AgentName}' returned no usable result for task {TaskId}",
@@ -219,9 +221,26 @@ internal sealed class InvokeAgentExecutor(
         {
             logger.LogInformation("A2A task {TaskId} to agent '{AgentName}' was cancelled", taskId, agentName);
         }
-        catch (A2AProtocol.A2AException a2aEx)
+        catch (A2AV03.A2AException a2aEx)
         {
-            logger.LogError(a2aEx, "A2A protocol error for task {TaskId} to agent '{AgentName}' (code={ErrorCode})",
+            logger.LogError(a2aEx, "A2A v0.3 protocol error for task {TaskId} to agent '{AgentName}' (code={ErrorCode})",
+                taskId, agentName, a2aEx.ErrorCode);
+
+            var error = new AgentTaskError
+            {
+                TaskId = taskId,
+                Code = AgentTaskError.Codes.ExecutionFailed,
+                Message = $"A2A protocol error ({a2aEx.ErrorCode}): {a2aEx.Message}",
+                IsRetryable = false
+            };
+            var errorEnvelope = error.ToEnvelope<AgentTaskError>(
+                source: agentName,
+                correlationId: taskId);
+            await publisher.PublishAsync(replyTo, errorEnvelope, CancellationToken.None);
+        }
+        catch (A2AV1.A2AException a2aEx)
+        {
+            logger.LogError(a2aEx, "A2A v1 protocol error for task {TaskId} to agent '{AgentName}' (code={ErrorCode})",
                 taskId, agentName, a2aEx.ErrorCode);
 
             var error = new AgentTaskError
@@ -255,33 +274,62 @@ internal sealed class InvokeAgentExecutor(
         }
     }
 
-    /// <summary>
-    /// Maps an A2A protocol SDK response to RockBot's internal <see cref="AgentTaskResult"/>.
-    /// The V0.3 response is polymorphic: either an <see cref="A2AProtocol.AgentMessage"/>
-    /// (immediate reply) or an <see cref="A2AProtocol.AgentTask"/> (task with status).
-    /// </summary>
-    private static AgentTaskResult? MapA2AResponse(A2AProtocol.A2AResponse response, string taskId)
+    // ── V0.3 dispatch ────────────────────────────────────────────────────────────
+
+    private static async Task<AgentTaskResult?> DispatchV03Async(
+        HttpClient httpClient,
+        Uri endpoint,
+        AgentTaskRequest taskRequest,
+        string taskId,
+        string messageText,
+        CancellationToken ct)
     {
-        if (response is A2AProtocol.AgentMessage msg)
+        var a2aClient = new A2AV03.A2AClient(endpoint, httpClient);
+        var sendParams = new A2AV03.MessageSendParams
+        {
+            Message = new A2AV03.AgentMessage
+            {
+                Role = A2AV03.MessageRole.User,
+                MessageId = taskId,
+                Parts = [new A2AV03.TextPart { Text = messageText }]
+            },
+            Metadata = new Dictionary<string, JsonElement>
+            {
+                ["skill"] = JsonSerializer.SerializeToElement(taskRequest.Skill)
+            }
+        };
+
+        var a2aResponse = await a2aClient.SendMessageAsync(sendParams, ct);
+        return MapV03Response(a2aResponse, taskId);
+    }
+
+    /// <summary>
+    /// Maps an A2A v0.3 protocol SDK response to RockBot's internal <see cref="AgentTaskResult"/>.
+    /// The V0.3 response is polymorphic: either an <see cref="A2AV03.AgentMessage"/>
+    /// (immediate reply) or an <see cref="A2AV03.AgentTask"/> (task with status).
+    /// </summary>
+    internal static AgentTaskResult? MapV03Response(A2AV03.A2AResponse response, string taskId)
+    {
+        if (response is A2AV03.AgentMessage msg)
         {
             return new AgentTaskResult
             {
                 TaskId = taskId,
                 State = AgentTaskState.Completed,
-                Message = MapMessage(msg)
+                Message = MapV03Message(msg)
             };
         }
 
-        if (response is A2AProtocol.AgentTask task)
+        if (response is A2AV03.AgentTask task)
         {
             var state = task.Status.State switch
             {
-                A2AProtocol.TaskState.Completed => AgentTaskState.Completed,
-                A2AProtocol.TaskState.Failed => AgentTaskState.Failed,
-                A2AProtocol.TaskState.Canceled => AgentTaskState.Canceled,
-                A2AProtocol.TaskState.Working => AgentTaskState.Working,
-                A2AProtocol.TaskState.InputRequired => AgentTaskState.InputRequired,
-                A2AProtocol.TaskState.Submitted => AgentTaskState.Submitted,
+                A2AV03.TaskState.Completed => AgentTaskState.Completed,
+                A2AV03.TaskState.Failed => AgentTaskState.Failed,
+                A2AV03.TaskState.Canceled => AgentTaskState.Canceled,
+                A2AV03.TaskState.Working => AgentTaskState.Working,
+                A2AV03.TaskState.InputRequired => AgentTaskState.InputRequired,
+                A2AV03.TaskState.Submitted => AgentTaskState.Submitted,
                 _ => AgentTaskState.Completed
             };
 
@@ -290,21 +338,105 @@ internal sealed class InvokeAgentExecutor(
                 TaskId = taskId,
                 ContextId = task.ContextId,
                 State = state,
-                Message = task.Status.Message is { } statusMsg ? MapMessage(statusMsg) : null
+                Message = task.Status.Message is { } statusMsg ? MapV03Message(statusMsg) : null
             };
         }
 
         return null;
     }
 
-    private static AgentMessage MapMessage(A2AProtocol.AgentMessage msg) => new()
+    private static AgentMessage MapV03Message(A2AV03.AgentMessage msg) => new()
     {
-        Role = msg.Role == A2AProtocol.MessageRole.Agent ? "assistant" : "user",
+        Role = msg.Role == A2AV03.MessageRole.Agent ? "assistant" : "user",
         Parts = msg.Parts.Select(p => new AgentMessagePart
         {
-            Kind = p is A2AProtocol.TextPart ? "text" : "data",
-            Text = p is A2AProtocol.TextPart tp ? tp.Text : null,
-            Data = p is A2AProtocol.DataPart dp ? JsonSerializer.Serialize(dp.Data) : null
+            Kind = p is A2AV03.TextPart ? "text" : "data",
+            Text = p is A2AV03.TextPart tp ? tp.Text : null,
+            Data = p is A2AV03.DataPart dp ? JsonSerializer.Serialize(dp.Data) : null
+        }).ToList()
+    };
+
+    // ── V1 dispatch ──────────────────────────────────────────────────────────────
+
+    private static async Task<AgentTaskResult?> DispatchV1Async(
+        HttpClient httpClient,
+        Uri endpoint,
+        AgentTaskRequest taskRequest,
+        string taskId,
+        string messageText,
+        CancellationToken ct)
+    {
+        var a2aClient = new A2AV1.A2AClient(endpoint, httpClient);
+        var sendRequest = new A2AV1.SendMessageRequest
+        {
+            Message = new A2AV1.Message
+            {
+                Role = A2AV1.Role.User,
+                MessageId = taskId,
+                Parts = [new A2AV1.Part { Text = messageText }]
+            },
+            Metadata = new Dictionary<string, JsonElement>
+            {
+                ["skill"] = JsonSerializer.SerializeToElement(taskRequest.Skill)
+            }
+        };
+
+        var a2aResponse = await a2aClient.SendMessageAsync(sendRequest, ct);
+        return MapV1Response(a2aResponse, taskId);
+    }
+
+    /// <summary>
+    /// Maps an A2A v1 protocol SDK response to RockBot's internal <see cref="AgentTaskResult"/>.
+    /// The V1 response uses <see cref="A2AV1.SendMessageResponseCase"/> to discriminate
+    /// between a <see cref="A2AV1.Message"/> and an <see cref="A2AV1.AgentTask"/>.
+    /// </summary>
+    internal static AgentTaskResult? MapV1Response(A2AV1.SendMessageResponse response, string taskId)
+    {
+        switch (response.PayloadCase)
+        {
+            case A2AV1.SendMessageResponseCase.Message when response.Message is { } msg:
+                return new AgentTaskResult
+                {
+                    TaskId = taskId,
+                    State = AgentTaskState.Completed,
+                    Message = MapV1Message(msg)
+                };
+
+            case A2AV1.SendMessageResponseCase.Task when response.Task is { } task:
+                var state = task.Status.State switch
+                {
+                    A2AV1.TaskState.Completed => AgentTaskState.Completed,
+                    A2AV1.TaskState.Failed => AgentTaskState.Failed,
+                    A2AV1.TaskState.Canceled => AgentTaskState.Canceled,
+                    A2AV1.TaskState.Working => AgentTaskState.Working,
+                    A2AV1.TaskState.InputRequired => AgentTaskState.InputRequired,
+                    A2AV1.TaskState.Submitted => AgentTaskState.Submitted,
+                    A2AV1.TaskState.Rejected => AgentTaskState.Failed,
+                    A2AV1.TaskState.AuthRequired => AgentTaskState.InputRequired,
+                    _ => AgentTaskState.Completed
+                };
+
+                return new AgentTaskResult
+                {
+                    TaskId = taskId,
+                    ContextId = task.ContextId,
+                    State = state,
+                    Message = task.Status.Message is { } statusMsg ? MapV1Message(statusMsg) : null
+                };
+
+            default:
+                return null;
+        }
+    }
+
+    private static AgentMessage MapV1Message(A2AV1.Message msg) => new()
+    {
+        Role = msg.Role == A2AV1.Role.Agent ? "assistant" : "user",
+        Parts = msg.Parts.Select(p => new AgentMessagePart
+        {
+            Kind = p.ContentCase == A2AV1.PartContentCase.Text ? "text" : "data",
+            Text = p.ContentCase == A2AV1.PartContentCase.Text ? p.Text : null,
+            Data = p.ContentCase == A2AV1.PartContentCase.Data ? JsonSerializer.Serialize(p.Data) : null
         }).ToList()
     };
 

--- a/src/RockBot.A2A/RegisterAgentExecutor.cs
+++ b/src/RockBot.A2A/RegisterAgentExecutor.cs
@@ -7,9 +7,12 @@ namespace RockBot.A2A;
 /// <summary>
 /// Registers or updates an HTTP-based A2A agent in the directory.
 /// Supports optional auth header configuration for agents that require API keys.
+/// Auto-detects the A2A protocol version by probing the remote agent's well-known
+/// card endpoint (v1: <c>/.well-known/a2a/agent-card</c>, v0.3: <c>/.well-known/agent-card.json</c>).
 /// </summary>
 internal sealed class RegisterAgentExecutor(
     IAgentDirectory directory,
+    IHttpClientFactory httpClientFactory,
     ILogger<RegisterAgentExecutor> logger) : IToolExecutor
 {
     private static readonly JsonSerializerOptions JsonOptions = new()
@@ -18,7 +21,7 @@ internal sealed class RegisterAgentExecutor(
         PropertyNameCaseInsensitive = true
     };
 
-    public Task<ToolInvokeResponse> ExecuteAsync(ToolInvokeRequest request, CancellationToken ct)
+    public async Task<ToolInvokeResponse> ExecuteAsync(ToolInvokeRequest request, CancellationToken ct)
     {
         Dictionary<string, JsonElement> args;
         try
@@ -29,17 +32,18 @@ internal sealed class RegisterAgentExecutor(
         }
         catch
         {
-            return Task.FromResult(Error(request, "Invalid arguments JSON."));
+            return Error(request, "Invalid arguments JSON.");
         }
 
         if (!TryGetString(args, "agent_name", out var agentName))
-            return Task.FromResult(Error(request, "Missing required parameter: agent_name"));
+            return Error(request, "Missing required parameter: agent_name");
         if (!TryGetString(args, "url", out var url))
-            return Task.FromResult(Error(request, "Missing required parameter: url"));
+            return Error(request, "Missing required parameter: url");
 
         TryGetString(args, "description", out var description);
         TryGetString(args, "auth_header_name", out var authHeaderName);
         TryGetString(args, "auth_header_value_base64", out var authHeaderValueBase64);
+        TryGetString(args, "protocol_version", out var explicitProtocolVersion);
 
         // Parse optional skills array
         List<AgentSkill>? skills = null;
@@ -51,13 +55,13 @@ internal sealed class RegisterAgentExecutor(
             }
             catch
             {
-                return Task.FromResult(Error(request, "Invalid skills array format. Expected: [{\"id\": \"...\", \"name\": \"...\", \"description\": \"...\"}]"));
+                return Error(request, "Invalid skills array format. Expected: [{\"id\": \"...\", \"name\": \"...\", \"description\": \"...\"}]");
             }
         }
 
         // Validate auth: both header name and value must be provided together
         if (!string.IsNullOrEmpty(authHeaderName) != !string.IsNullOrEmpty(authHeaderValueBase64))
-            return Task.FromResult(Error(request, "auth_header_name and auth_header_value_base64 must be provided together."));
+            return Error(request, "auth_header_name and auth_header_value_base64 must be provided together.");
 
         // Validate base64 encoding
         if (!string.IsNullOrEmpty(authHeaderValueBase64))
@@ -68,9 +72,21 @@ internal sealed class RegisterAgentExecutor(
             }
             catch (FormatException)
             {
-                return Task.FromResult(Error(request, "auth_header_value_base64 is not valid base64."));
+                return Error(request, "auth_header_value_base64 is not valid base64.");
             }
         }
+
+        // Auto-detect protocol version from the remote agent's well-known card
+        // unless the caller explicitly specified one.
+        string? detectedVersion = null;
+        if (string.IsNullOrEmpty(explicitProtocolVersion))
+        {
+            detectedVersion = await DetectProtocolVersionAsync(url, authHeaderName, authHeaderValueBase64, ct);
+        }
+
+        var protocolVersion = !string.IsNullOrEmpty(explicitProtocolVersion)
+            ? explicitProtocolVersion
+            : detectedVersion;
 
         // When updating an existing agent, preserve fields that weren't provided in this call
         // (e.g. auth config, description, skills) so a simple URL update doesn't wipe them.
@@ -83,22 +99,154 @@ internal sealed class RegisterAgentExecutor(
             Description = string.IsNullOrEmpty(description) ? existing?.Description : description,
             Skills = skills ?? existing?.Skills,
             AuthHeaderName = string.IsNullOrEmpty(authHeaderName) ? existing?.AuthHeaderName : authHeaderName,
-            AuthHeaderValueBase64 = string.IsNullOrEmpty(authHeaderValueBase64) ? existing?.AuthHeaderValueBase64 : authHeaderValueBase64
+            AuthHeaderValueBase64 = string.IsNullOrEmpty(authHeaderValueBase64) ? existing?.AuthHeaderValueBase64 : authHeaderValueBase64,
+            ProtocolVersion = protocolVersion ?? existing?.ProtocolVersion
         };
 
         directory.AddOrUpdate(card);
 
         var authNote = !string.IsNullOrEmpty(authHeaderName) ? $" Auth header '{authHeaderName}' configured." : "";
         var skillNote = skills is { Count: > 0 } ? $" {skills.Count} skill(s) registered." : "";
-        logger.LogInformation("Registered agent '{AgentName}' at {Url}{Auth}", agentName, url, authNote);
+        var versionNote = !string.IsNullOrEmpty(protocolVersion) ? $" Protocol version: {protocolVersion}." : "";
+        logger.LogInformation("Registered agent '{AgentName}' at {Url}{Auth}{Version}",
+            agentName, url, authNote, versionNote);
 
-        return Task.FromResult(new ToolInvokeResponse
+        return new ToolInvokeResponse
         {
             ToolCallId = request.ToolCallId,
             ToolName = request.ToolName,
-            Content = $"Agent '{agentName}' registered at {url}.{skillNote}{authNote}",
+            Content = $"Agent '{agentName}' registered at {url}.{skillNote}{authNote}{versionNote}",
             IsError = false
-        });
+        };
+    }
+
+    /// <summary>
+    /// Probes the remote agent's well-known card endpoints to detect the A2A protocol version.
+    /// Tries v1 (<c>/.well-known/a2a/agent-card</c>) first, then v0.3 (<c>/.well-known/agent-card.json</c>).
+    /// Returns null if detection fails (caller falls back to existing behavior).
+    /// </summary>
+    internal async Task<string?> DetectProtocolVersionAsync(
+        string baseUrl,
+        string? authHeaderName,
+        string? authHeaderValueBase64,
+        CancellationToken ct)
+    {
+        try
+        {
+            var httpClient = httpClientFactory.CreateClient();
+            httpClient.Timeout = TimeSpan.FromSeconds(10);
+
+            if (!string.IsNullOrEmpty(authHeaderName) &&
+                !string.IsNullOrEmpty(authHeaderValueBase64))
+            {
+                var headerValue = System.Text.Encoding.UTF8.GetString(
+                    Convert.FromBase64String(authHeaderValueBase64));
+                httpClient.DefaultRequestHeaders.TryAddWithoutValidation(authHeaderName, headerValue);
+            }
+
+            var trimmedUrl = baseUrl.TrimEnd('/');
+
+            // Try v1 well-known endpoint first
+            var v1Version = await TryDetectV1Async(httpClient, trimmedUrl, ct);
+            if (v1Version is not null)
+                return v1Version;
+
+            // Try v0.3 well-known endpoint
+            var v03Version = await TryDetectV03Async(httpClient, trimmedUrl, ct);
+            if (v03Version is not null)
+                return v03Version;
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Protocol version auto-detection failed for {Url}", baseUrl);
+        }
+
+        return null;
+    }
+
+    private async Task<string?> TryDetectV1Async(HttpClient httpClient, string trimmedUrl, CancellationToken ct)
+    {
+        try
+        {
+            var response = await httpClient.GetAsync($"{trimmedUrl}/.well-known/a2a/agent-card", ct);
+            if (!response.IsSuccessStatusCode)
+                return null;
+
+            var json = await response.Content.ReadAsStringAsync(ct);
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            // v1 cards have "supportedInterfaces" array
+            if (root.TryGetProperty("supportedInterfaces", out var interfaces) &&
+                interfaces.ValueKind == JsonValueKind.Array)
+            {
+                // Extract the protocol version from the first interface if available
+                foreach (var iface in interfaces.EnumerateArray())
+                {
+                    if (iface.TryGetProperty("protocolVersion", out var pv) &&
+                        pv.ValueKind == JsonValueKind.String)
+                    {
+                        var version = pv.GetString();
+                        if (!string.IsNullOrEmpty(version))
+                        {
+                            logger.LogInformation(
+                                "Detected A2A protocol version '{Version}' from v1 agent card at {Url}",
+                                version, trimmedUrl);
+                            return version;
+                        }
+                    }
+                }
+
+                // Has supportedInterfaces but no explicit protocolVersion — assume 1.0
+                logger.LogInformation(
+                    "Detected A2A v1 agent card (supportedInterfaces present) at {Url}", trimmedUrl);
+                return "1.0";
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            logger.LogDebug(ex, "v1 well-known probe failed for {Url}", trimmedUrl);
+        }
+
+        return null;
+    }
+
+    private async Task<string?> TryDetectV03Async(HttpClient httpClient, string trimmedUrl, CancellationToken ct)
+    {
+        try
+        {
+            var response = await httpClient.GetAsync($"{trimmedUrl}/.well-known/agent-card.json", ct);
+            if (!response.IsSuccessStatusCode)
+                return null;
+
+            var json = await response.Content.ReadAsStringAsync(ct);
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            // v0.3 cards may have a top-level "protocolVersion" field
+            if (root.TryGetProperty("protocolVersion", out var pv) &&
+                pv.ValueKind == JsonValueKind.String)
+            {
+                var version = pv.GetString();
+                if (!string.IsNullOrEmpty(version))
+                {
+                    logger.LogInformation(
+                        "Detected A2A protocol version '{Version}' from v0.3 agent card at {Url}",
+                        version, trimmedUrl);
+                    return version;
+                }
+            }
+
+            // Card exists at v0.3 endpoint but no explicit version — assume 0.3
+            logger.LogInformation("Detected A2A v0.3 agent card at {Url}", trimmedUrl);
+            return "0.3";
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            logger.LogDebug(ex, "v0.3 well-known probe failed for {Url}", trimmedUrl);
+        }
+
+        return null;
     }
 
     private static bool TryGetString(Dictionary<string, JsonElement> args, string key, out string value)

--- a/src/RockBot.A2A/RockBot.A2A.csproj
+++ b/src/RockBot.A2A/RockBot.A2A.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="A2A" Version="1.0.0-preview" />
     <PackageReference Include="A2A.V0_3" Version="1.0.0-preview" />
     <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.*" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.*" />

--- a/tests/RockBot.A2A.Tests/A2ACallerTests.cs
+++ b/tests/RockBot.A2A.Tests/A2ACallerTests.cs
@@ -2,6 +2,8 @@ using Microsoft.Extensions.Logging.Abstractions;
 using RockBot.Host;
 using RockBot.Messaging;
 using RockBot.Tools;
+using A2AV1 = A2A;
+using A2AV03 = A2A.V0_3;
 
 namespace RockBot.A2A.Tests;
 
@@ -280,6 +282,218 @@ public class A2ACallerTests
         }
 
         Assert.AreEqual(3, tracker.ListActive().Count);
+    }
+
+    // ─── Protocol version detection ────────────────────────────────────────────
+
+    [TestMethod]
+    public void IsV1_ReturnsTrue_WhenProtocolVersionIs1()
+    {
+        var card = new AgentCard { AgentName = "a", ProtocolVersion = "1.0" };
+        Assert.IsTrue(InvokeAgentExecutor.IsV1(card));
+    }
+
+    [TestMethod]
+    public void IsV1_ReturnsTrue_WhenProtocolVersionIs1_NoMinor()
+    {
+        var card = new AgentCard { AgentName = "a", ProtocolVersion = "1" };
+        Assert.IsTrue(InvokeAgentExecutor.IsV1(card));
+    }
+
+    [TestMethod]
+    public void IsV1_ReturnsTrue_WhenProtocolVersionIs1_1()
+    {
+        var card = new AgentCard { AgentName = "a", ProtocolVersion = "1.1" };
+        Assert.IsTrue(InvokeAgentExecutor.IsV1(card));
+    }
+
+    [TestMethod]
+    public void IsV1_ReturnsFalse_WhenProtocolVersionIs03()
+    {
+        var card = new AgentCard { AgentName = "a", ProtocolVersion = "0.3" };
+        Assert.IsFalse(InvokeAgentExecutor.IsV1(card));
+    }
+
+    [TestMethod]
+    public void IsV1_ReturnsFalse_WhenProtocolVersionIsNull()
+    {
+        var card = new AgentCard { AgentName = "a" };
+        Assert.IsFalse(InvokeAgentExecutor.IsV1(card));
+    }
+
+    [TestMethod]
+    public void IsV1_ReturnsFalse_WhenCardIsNull()
+    {
+        Assert.IsFalse(InvokeAgentExecutor.IsV1(null));
+    }
+
+    [TestMethod]
+    public void InvokeAgentExecutor_UsesQueueTransport_WhenUrlIsNullRegardlessOfVersion()
+    {
+        // Even if ProtocolVersion is 1.0, queue transport should be used when no URL is set
+        var directory = new AgentDirectory(
+            new A2AOptions { DirectoryPersistencePath = string.Empty },
+            NullLogger<AgentDirectory>.Instance);
+        directory.AddOrUpdate(new AgentCard
+        {
+            AgentName = "QueueAgent",
+            ProtocolVersion = "1.0"
+        });
+
+        var publisher = new TrackingPublisher();
+        var tracker = new A2ATaskTracker();
+        var executor = BuildExecutor(publisher, tracker, directory: directory);
+
+        var request = BuildToolRequest("""
+            { "agent_name": "QueueAgent", "skill": "chat", "message": "Hello." }
+            """);
+
+        var response = executor.ExecuteAsync(request, CancellationToken.None).Result;
+
+        Assert.IsFalse(response.IsError);
+        // Should publish to queue, not HTTP
+        Assert.AreEqual(1, publisher.Published.Count);
+        Assert.AreEqual("agent.task.QueueAgent", publisher.Published[0].Topic);
+    }
+
+    // ─── V1 response mapping ────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void MapV1Response_MapsMessageResponse_ToCompleted()
+    {
+        var response = new A2AV1.SendMessageResponse
+        {
+            Message = new A2AV1.Message
+            {
+                Role = A2AV1.Role.Agent,
+                Parts = [new A2AV1.Part { Text = "Hello from v1" }]
+            }
+        };
+
+        var result = InvokeAgentExecutor.MapV1Response(response, "task-1");
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual("task-1", result.TaskId);
+        Assert.AreEqual(AgentTaskState.Completed, result.State);
+        Assert.IsNotNull(result.Message);
+        Assert.AreEqual("assistant", result.Message.Role);
+        Assert.AreEqual("Hello from v1", result.Message.Parts[0].Text);
+    }
+
+    [TestMethod]
+    public void MapV1Response_MapsTaskResponse_ToCorrectState()
+    {
+        var response = new A2AV1.SendMessageResponse
+        {
+            Task = new A2AV1.AgentTask
+            {
+                Id = "task-2",
+                ContextId = "ctx-1",
+                Status = new A2AV1.TaskStatus
+                {
+                    State = A2AV1.TaskState.Working,
+                    Message = new A2AV1.Message
+                    {
+                        Role = A2AV1.Role.Agent,
+                        Parts = [new A2AV1.Part { Text = "Still processing" }]
+                    }
+                }
+            }
+        };
+
+        var result = InvokeAgentExecutor.MapV1Response(response, "task-2");
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual("task-2", result.TaskId);
+        Assert.AreEqual("ctx-1", result.ContextId);
+        Assert.AreEqual(AgentTaskState.Working, result.State);
+        Assert.AreEqual("Still processing", result.Message?.Parts[0].Text);
+    }
+
+    [TestMethod]
+    public void MapV1Response_MapsRejected_ToFailed()
+    {
+        var response = new A2AV1.SendMessageResponse
+        {
+            Task = new A2AV1.AgentTask
+            {
+                Id = "task-3",
+                Status = new A2AV1.TaskStatus { State = A2AV1.TaskState.Rejected }
+            }
+        };
+
+        var result = InvokeAgentExecutor.MapV1Response(response, "task-3");
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual(AgentTaskState.Failed, result.State);
+    }
+
+    [TestMethod]
+    public void MapV1Response_MapsAuthRequired_ToInputRequired()
+    {
+        var response = new A2AV1.SendMessageResponse
+        {
+            Task = new A2AV1.AgentTask
+            {
+                Id = "task-4",
+                Status = new A2AV1.TaskStatus { State = A2AV1.TaskState.AuthRequired }
+            }
+        };
+
+        var result = InvokeAgentExecutor.MapV1Response(response, "task-4");
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual(AgentTaskState.InputRequired, result.State);
+    }
+
+    [TestMethod]
+    public void MapV1Response_ReturnsNull_WhenPayloadCaseIsNone()
+    {
+        var response = new A2AV1.SendMessageResponse();
+
+        var result = InvokeAgentExecutor.MapV1Response(response, "task-5");
+
+        Assert.IsNull(result);
+    }
+
+    // ─── V0.3 response mapping ──────────────────────────────────────────────────
+
+    [TestMethod]
+    public void MapV03Response_MapsAgentMessage_ToCompleted()
+    {
+        var response = (A2AV03.A2AResponse)new A2AV03.AgentMessage
+        {
+            Role = A2AV03.MessageRole.Agent,
+            Parts = [new A2AV03.TextPart { Text = "Done v0.3" }]
+        };
+
+        var result = InvokeAgentExecutor.MapV03Response(response, "task-6");
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual(AgentTaskState.Completed, result.State);
+        Assert.AreEqual("assistant", result.Message?.Role);
+        Assert.AreEqual("Done v0.3", result.Message?.Parts[0].Text);
+    }
+
+    // ─── AgentCard ProtocolVersion persistence ──────────────────────────────────
+
+    [TestMethod]
+    public void AgentCard_ProtocolVersion_IsPreservedInDirectory()
+    {
+        var directory = new AgentDirectory(
+            new A2AOptions { DirectoryPersistencePath = string.Empty },
+            NullLogger<AgentDirectory>.Instance);
+
+        directory.AddOrUpdate(new AgentCard
+        {
+            AgentName = "V1Agent",
+            Url = "http://localhost:5000",
+            ProtocolVersion = "1.0"
+        });
+
+        var card = directory.GetAgent("V1Agent");
+        Assert.IsNotNull(card);
+        Assert.AreEqual("1.0", card.ProtocolVersion);
     }
 
     // ─── A2ATaskStatusHandler ────────────────────────────────────────────────────

--- a/tests/RockBot.A2A.Tests/RockBot.A2A.Tests.csproj
+++ b/tests/RockBot.A2A.Tests/RockBot.A2A.Tests.csproj
@@ -9,6 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="A2A" Version="1.0.0-preview" />
+    <PackageReference Include="A2A.V0_3" Version="1.0.0-preview" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.*" />
     <PackageReference Include="MSTest.TestFramework" Version="3.*" />


### PR DESCRIPTION
## Summary

- **Detect protocol version from agent card**: Added `ProtocolVersion` property to `AgentCard`. When registering an HTTP agent, the version is auto-detected by probing the remote agent's well-known card endpoints (`/.well-known/a2a/agent-card` for v1, `/.well-known/agent-card.json` for v0.3), with an explicit `protocol_version` parameter as override.
- **Dual-protocol dispatch**: `InvokeAgentExecutor` now dispatches using the A2A v1 SDK (`A2A` 1.0.0-preview) when `ProtocolVersion` starts with `1.`, and continues using the v0.3 SDK (`A2A.V0_3`) otherwise. Response mapping handles v1-specific states (`Rejected` → `Failed`, `AuthRequired` → `InputRequired`).
- **14 new tests** covering version detection logic, v1/v0.3 response mapping, and backward compatibility.

## Test plan

- [x] All 53 A2A tests pass (39 existing + 14 new)
- [x] Full solution test suite passes (0 failures)
- [ ] Manual test: register a v0.3 HTTP agent and verify dispatch works as before
- [ ] Manual test: register a v1 HTTP agent and verify v1 dispatch path is used
- [ ] Manual test: verify auto-detection probes the correct well-known endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)