### PR TITLE
Fix MCP reconnect sweep to retry servers that failed at startup

### DIFF
--- a/src/RockBot.Agent/McpBridge/McpBridgeService.cs
+++ b/src/RockBot.Agent/McpBridge/McpBridgeService.cs
@@ -275,6 +275,10 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
             return;
         }
 
+        // Store config before attempting connection so the reconnect sweep can
+        // retry servers that never connected successfully at startup.
+        _serverConfigs[name] = config;
+
         var maxAttempts = 1 + Math.Max(0, _options.ConnectRetryCount);
         var delayMs = _options.ConnectRetryBaseDelayMs;
 
@@ -337,7 +341,6 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
                 }
 
                 _clients[name] = newClient;
-                _serverConfigs[name] = config;
                 _serverTools[name] = filteredTools;
                 _serverPrompts[name] = prompts;
 


### PR DESCRIPTION
## Summary

- `ConnectServerAsync` only stored server config in `_serverConfigs` on successful connection. Servers that failed to connect at startup were invisible to the periodic reconnect sweep (which checks `_serverConfigs.Keys.Where(name => !_clients.ContainsKey(name))`).
- Now stores config **before** the connection attempt so the sweep picks up failed servers and retries them every 60 seconds.
- This is a one-line fix (moving `_serverConfigs[name] = config` earlier) that resolves the recurring issue where MCP servers like `calendar-mcp` become permanently unavailable when they're not ready at agent startup time.

## Test plan

- [x] `dotnet build RockBot.slnx` — zero errors
- [x] `dotnet test RockBot.slnx` — all tests pass
- [x] Verified existing reconnect-and-retry on tool invocation failure is unaffected
- [x] Verified transparent reconnect on `HandleToolInvokeAsync` exception path still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)