### PR TITLE
Discard follow-up responses containing capability denials

### DIFF
--- a/src/RockBot.Host/AgentLoopRunner.cs
+++ b/src/RockBot.Host/AgentLoopRunner.cs
@@ -1135,6 +1135,16 @@ public sealed partial class AgentLoopRunner(
         logger.LogInformation(
             "Follow-up pass complete — {TextLen} chars", result.Response.Length);
 
+        // If the follow-up response is a capability denial (model claimed it can't access
+        // services without even trying), discard it rather than appending misinformation.
+        if (CapabilityDenialRegex.IsMatch(result.Response))
+        {
+            logger.LogWarning(
+                "Follow-up pass produced a capability denial ({TextLen} chars); discarding",
+                result.Response.Length);
+            return null;
+        }
+
         // Combine the original response with the follow-up.
         return $"{completedResponse}\n\n{result.Response}";
     }


### PR DESCRIPTION
## Summary

The model sometimes hallucinates that tools like `mcp_invoke_tool` or `mcp_get_service_details` don't exist — even when they're right there in the 40-tool list. When this happens on a follow-up pass, the false denial gets appended to an otherwise good response.

Now checks the follow-up result against `CapabilityDenialRegex` and silently discards it rather than showing the user misinformation like "the runtime does not expose mcp_get_service_details."

## Test plan

- [x] `dotnet build RockBot.slnx` — zero errors
- [x] `dotnet test RockBot.slnx` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)