### PR TITLE
perf: raise default chunking threshold to 64k and scale chunk size

### DIFF
--- a/docs/agent-host.md
+++ b/docs/agent-host.md
@@ -351,19 +351,19 @@ Additional properties are configurable in `appsettings.json` under `ModelBehavio
 |---|---|---|---|
 | `NudgeOnHallucinatedToolCalls` | bool | false | Inject a nudge when the model describes tool actions without emitting calls |
 | `MaxToolIterationsOverride` | int? | null (uses `AgentHost:MaxToolIterations`) | Override the per-request tool-loop iteration cap |
-| `ToolResultChunkingThreshold` | int? | null (uses 16 000) | Char count above which tool results are chunked into working memory instead of appended inline |
+| `ToolResultChunkingThreshold` | int? | null (uses 64 000) | Char count above which tool results are chunked into working memory instead of appended inline |
 | `ScheduledTaskResultMode` | enum | `Summarize` | How scheduled task output is presented (`Summarize`, `VerbatimOutput`, `SummarizeWithOutput`) |
 | `MaxCompletionRepromptsOverride` | int? | null (uses `AgentHost:MaxCompletionReprompts`) | Override the per-request completion-evaluator re-prompt cap |
 | `MaxFollowUpPassesOverride` | int? | null (uses `AgentHost:MaxFollowUpPasses`) | Override the per-request proactive follow-up pass cap |
 
-Example — raising the chunking threshold for a large-context model:
+Example — lowering the chunking threshold for a small-context model:
 
 ```json
 {
   "ModelBehaviors": {
     "Models": {
-      "openrouter/google/gemini-2.0-flash": {
-        "ToolResultChunkingThreshold": 64000
+      "openrouter/deepseek": {
+        "ToolResultChunkingThreshold": 32000
       }
     }
   }

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -442,27 +442,27 @@ with a `[result truncated — N chars omitted]` notice — same fallback as `web
 
 **Per-model threshold configuration:**
 
-The default threshold is **16 000 characters** (~4 000 tokens), suitable for most 32K–128K
-context models. Tune it per model in `appsettings.json`:
+The default threshold is **64 000 characters** (~16 000 tokens), appropriate for models with
+120K+ token context windows. When chunking occurs, each chunk is sized up to the threshold
+(minimum 20 000 chars) to minimise the number of working-memory retrievals.
+
+Tune it per model in `appsettings.json`:
 
 ```json
 {
   "ModelBehaviors": {
     "Models": {
-      "openrouter/google/gemini-2.0-flash": {
-        "ToolResultChunkingThreshold": 64000
-      },
       "openrouter/deepseek": {
-        "ToolResultChunkingThreshold": 8000
+        "ToolResultChunkingThreshold": 32000
       }
     }
   }
 }
 ```
 
-Raise the threshold for large-context models (1M tokens) or lower it for small-context models.
-Setting it very high effectively disables proactive chunking while still relying on the reactive
-`TrimLargeToolResults` overflow recovery as a safety net.
+Lower the threshold for small-context models. Setting it very high effectively disables
+proactive chunking while still relying on the reactive `TrimLargeToolResults` overflow
+recovery as a safety net.
 
 ---
 

--- a/src/RockBot.Host/ChunkingAIFunction.cs
+++ b/src/RockBot.Host/ChunkingAIFunction.cs
@@ -19,7 +19,12 @@ public sealed class ChunkingAIFunction(
     int chunkingThreshold,
     ILogger logger) : AIFunction
 {
-    private const int ToolResultChunkMaxLength = 20_000;
+    /// <summary>
+    /// Each chunk can be up to the chunking threshold in size — since we've declared
+    /// that amount "fits inline", each working-memory retrieval should be at most that
+    /// large. Floor of 20k prevents degenerate tiny chunks if threshold is very low.
+    /// </summary>
+    private readonly int _chunkMaxLength = Math.Max(chunkingThreshold, 20_000);
     private static readonly TimeSpan ToolResultChunkTtl = TimeSpan.FromMinutes(20);
 
     private static readonly HashSet<string> ChunkingExemptTools = new(StringComparer.OrdinalIgnoreCase)
@@ -53,7 +58,7 @@ public sealed class ChunkingAIFunction(
     {
         if (@namespace is not null)
         {
-            var chunks = ContentChunker.Chunk(result, ToolResultChunkMaxLength);
+            var chunks = ContentChunker.Chunk(result, _chunkMaxLength);
             var sanitizedName = SanitizeKeySegment(toolName);
             var runId = Guid.NewGuid().ToString("N")[..8];
             var keyBase = $"{@namespace}/tool-{sanitizedName}-{runId}";

--- a/src/RockBot.Llm.Abstractions/ModelBehavior.cs
+++ b/src/RockBot.Llm.Abstractions/ModelBehavior.cs
@@ -11,9 +11,10 @@ public sealed class ModelBehavior
     /// Character count above which a tool result is chunked into working memory
     /// rather than appended inline to the chat history. Operators can raise this
     /// for models with large context windows or lower it for small-context models.
-    /// Defaults to 16 000 characters (~4 000 tokens).
+    /// Defaults to 64 000 characters (~16 000 tokens), appropriate for models with
+    /// 120k+ token context windows.
     /// </summary>
-    public int ToolResultChunkingThreshold { get; init; } = 16_000;
+    public int ToolResultChunkingThreshold { get; init; } = 64_000;
 
     /// <summary>Behavior profile that applies no tweaks — used when no overrides are configured.</summary>
     public static readonly ModelBehavior Default = new() { NudgeOnHallucinatedToolCalls = true };


### PR DESCRIPTION
## Summary

- Raise `ToolResultChunkingThreshold` default from 16k to 64k chars — even Low-tier models have 120k+ context windows, so MCP service details (typically 20-40k chars) should flow inline without chunking
- Derive chunk max size from the threshold (`max(threshold, 20k)`) instead of hardcoding 20k — when chunking occurs, each chunk is as large as possible to minimize working-memory round-trips
- Update docs to reflect new defaults

## Test plan

- [x] `dotnet build RockBot.slnx` — 0 errors
- [x] `dotnet test RockBot.slnx` — all tests pass
- [ ] Manual: invoke MCP tool returning ~30k chars → verify result goes inline (no chunking log)
- [ ] Manual: invoke MCP tool returning >64k chars → verify chunked into 1-2 chunks, not 4+

🤖 Generated with [Claude Code](https://claude.com/claude-code)