### PR TITLE
fix: enforce word-boundary matching in tier routing keyword selector

### DIFF
--- a/src/RockBot.Host/DreamService.cs
+++ b/src/RockBot.Host/DreamService.cs
@@ -1791,6 +1791,19 @@ internal sealed class DreamService : IHostedService, IDisposable
         - antiPatterns: include entries for any systematic misroute pattern detected, even when
           noChangeNeeded is true. Each content must be ≤ 120 chars; use detail for full explanation.
         - When routing looks correct and no anti-patterns found: {"noChangeNeeded": true, "antiPatterns": []}
+
+        Keyword quality rules (CRITICAL — keywords that violate these will be silently dropped):
+        - Every keyword MUST be at least 4 characters long. Keywords under 3 characters are
+          automatically filtered out by the loader. Short words like "to", "is", "add", "try",
+          "ok", "hi", "get" cause massive substring collision problems and must NEVER be used.
+        - Keywords are matched using WORD BOUNDARY rules — they match only when surrounded by
+          non-word characters (spaces, punctuation, start/end of text). A keyword like "rest"
+          will NOT match inside "restoration". Design keywords accordingly.
+        - Use complete English words or multi-word phrases, not partial word prefixes.
+        - NEVER use personal names, proper nouns, or user-specific content as keywords.
+          Keywords must be domain-generic routing signals, not derived from specific user data.
+        - Prefer multi-word phrases (e.g., "security implication") over single common words
+          (e.g., "security") to reduce false-positive matches.
         """;
 
     private sealed record TierRoutingReviewResultDto(

--- a/src/RockBot.Llm/KeywordTierSelector.cs
+++ b/src/RockBot.Llm/KeywordTierSelector.cs
@@ -31,7 +31,7 @@ public sealed class KeywordTierSelector : ILlmTierSelector
         "prove", "derive", "demonstrate why", "reason through",
         "implement a system", "build a system", "step by step",
         "microservice", "distributed", "concurrent", "asynchronous", "async",
-        "optimize", "performance bottleneck", "scalab",
+        "optimize", "performance bottleneck", "scalable", "scalability",
         "security implication", "threat model",
         "explain in depth", "comprehensive", "thorough analysis",
         "multiple approaches", "pros and cons", "disadvantage",
@@ -45,9 +45,9 @@ public sealed class KeywordTierSelector : ILlmTierSelector
     private static readonly string[] DefaultLowSignalKeywords =
     [
         "what is", "what's", "who is", "who was", "when was", "where is",
-        "define ", "definition of", "spell ", "translate ",
+        "define", "definition of", "spell", "translate",
         "capital of", "how many", "list the", "give me a list",
-        "yes or no", "true or false", "convert ", "format ",
+        "yes or no", "true or false", "convert", "format",
     ];
 
     private static readonly EffectiveConfig Defaults = new(
@@ -110,10 +110,10 @@ public sealed class KeywordTierSelector : ILlmTierSelector
         var lower = promptText.ToLowerInvariant();
 
         var matchedHigh = config.HighSignalKeywords
-            .Where(k => lower.Contains(k, StringComparison.Ordinal))
+            .Where(k => ContainsWholePhrase(lower, k))
             .ToArray();
         var matchedLow = config.LowSignalKeywords
-            .Where(k => lower.Contains(k, StringComparison.Ordinal))
+            .Where(k => ContainsWholePhrase(lower, k))
             .ToArray();
 
         var score = ComputeScore(promptText, config, matchedHigh.Length, matchedLow.Length);
@@ -161,11 +161,14 @@ public sealed class KeywordTierSelector : ILlmTierSelector
             if (dto is null)
                 return Defaults;
 
+            var highKeywords = SanitizeKeywords(dto.HighSignalKeywords, "highSignalKeywords");
+            var lowKeywords  = SanitizeKeywords(dto.LowSignalKeywords, "lowSignalKeywords");
+
             var result = new EffectiveConfig(
                 LowCeiling:          dto.LowCeiling      ?? DefaultLowCeiling,
                 BalancedCeiling:     dto.BalancedCeiling  ?? DefaultBalancedCeiling,
-                HighSignalKeywords:  dto.HighSignalKeywords?.ToArray() ?? DefaultHighSignalKeywords,
-                LowSignalKeywords:   dto.LowSignalKeywords?.ToArray()  ?? DefaultLowSignalKeywords);
+                HighSignalKeywords:  highKeywords ?? DefaultHighSignalKeywords,
+                LowSignalKeywords:   lowKeywords  ?? DefaultLowSignalKeywords);
 
             _logger?.LogInformation(
                 "KeywordTierSelector: reloaded config from {Path} " +
@@ -201,9 +204,9 @@ public sealed class KeywordTierSelector : ILlmTierSelector
             : string.Empty;
 
         var complexSignals = complexSignalCount
-            ?? config.HighSignalKeywords.Count(k => lower.Contains(k, StringComparison.Ordinal));
+            ?? config.HighSignalKeywords.Count(k => ContainsWholePhrase(lower, k));
         var simplexSignals = simplexSignalCount
-            ?? config.LowSignalKeywords.Count(k => lower.Contains(k, StringComparison.Ordinal));
+            ?? config.LowSignalKeywords.Count(k => ContainsWholePhrase(lower, k));
 
         // Length component (0 – 0.40): longer prompts tend to be more complex.
         // Fine-grained buckets in the 10-30 word range so concise-but-complex task
@@ -236,6 +239,72 @@ public sealed class KeywordTierSelector : ILlmTierSelector
 
     private static int CountWords(string text) =>
         text.Split([' ', '\t', '\n', '\r'], StringSplitOptions.RemoveEmptyEntries).Length;
+
+    // ── Keyword validation ────────────────────────────────────────────────────
+
+    private const int MinKeywordLength = 3;
+
+    /// <summary>
+    /// Filters out keywords that are too short to be useful routing signals.
+    /// Returns null when the input list is null (caller falls back to defaults).
+    /// </summary>
+    private string[]? SanitizeKeywords(List<string>? keywords, string listName)
+    {
+        if (keywords is null) return null;
+
+        var filtered = keywords
+            .Where(k => !string.IsNullOrWhiteSpace(k) && k.Trim().Length >= MinKeywordLength)
+            .Select(k => k.Trim().ToLowerInvariant())
+            .Distinct()
+            .ToArray();
+
+        var removed = keywords.Count - filtered.Length;
+        if (removed > 0)
+        {
+            var rejected = keywords.Where(k => string.IsNullOrWhiteSpace(k) || k.Trim().Length < MinKeywordLength);
+            _logger?.LogWarning(
+                "KeywordTierSelector: dropped {Count} keyword(s) from {List} (too short or blank): [{Keywords}]",
+                removed, listName, string.Join(", ", rejected.Select(k => $"\"{k}\"")));
+        }
+
+        return filtered.Length > 0 ? filtered : null;
+    }
+
+    // ── Word-boundary matching ─────────────────────────────────────────────────
+
+    /// <summary>
+    /// Returns true when <paramref name="keyword"/> appears in <paramref name="text"/>
+    /// with word boundaries on each side where the keyword itself starts/ends with a
+    /// word character. This prevents "to" matching inside "tomorrow" or "try" inside
+    /// "country", while still allowing multi-word phrases like "trade off" and
+    /// intentional trailing-space keywords to work naturally.
+    /// </summary>
+    internal static bool ContainsWholePhrase(string text, string keyword)
+    {
+        if (keyword.Length == 0) return false;
+
+        var checkStart = char.IsLetterOrDigit(keyword[0]);
+        var checkEnd   = char.IsLetterOrDigit(keyword[^1]);
+        var index = 0;
+
+        while ((index = text.IndexOf(keyword, index, StringComparison.Ordinal)) >= 0)
+        {
+            var startOk = !checkStart
+                          || index == 0
+                          || !char.IsLetterOrDigit(text[index - 1]);
+            var end = index + keyword.Length;
+            var endOk = !checkEnd
+                        || end >= text.Length
+                        || !char.IsLetterOrDigit(text[end]);
+
+            if (startOk && endOk)
+                return true;
+
+            index++;
+        }
+
+        return false;
+    }
 
     // ── Private types ─────────────────────────────────────────────────────────
 

--- a/tests/RockBot.Llm.Tests/KeywordTierSelectorTests.cs
+++ b/tests/RockBot.Llm.Tests/KeywordTierSelectorTests.cs
@@ -197,6 +197,86 @@ public class KeywordTierSelectorTests
             "High-keyword prompt should have a higher complexity score");
     }
 
+    // ── Word-boundary matching tests ─────────────────────────────────────────
+
+    [TestMethod]
+    [DataRow("to", "tomorrow", false, DisplayName = "\"to\" must not match inside \"tomorrow\"")]
+    [DataRow("to", "go to bed", true, DisplayName = "\"to\" matches as standalone word")]
+    [DataRow("try", "country", false, DisplayName = "\"try\" must not match inside \"country\"")]
+    [DataRow("try", "please try this", true, DisplayName = "\"try\" matches as standalone word")]
+    [DataRow("rest", "restoration", false, DisplayName = "\"rest\" must not match inside \"restoration\"")]
+    [DataRow("rest", "use rest api", true, DisplayName = "\"rest\" matches as standalone word")]
+    [DataRow("add", "address", false, DisplayName = "\"add\" must not match inside \"address\"")]
+    [DataRow("add", "add a feature", true, DisplayName = "\"add\" matches as standalone word")]
+    [DataRow("is", "history", false, DisplayName = "\"is\" must not match inside \"history\"")]
+    [DataRow("is", "is it ready", true, DisplayName = "\"is\" matches at start of text")]
+    [DataRow("compare", "compare the options", true, DisplayName = "\"compare\" matches at word boundary")]
+    [DataRow("trade off", "consider the trade off here", true, DisplayName = "multi-word phrase matches")]
+    [DataRow("async", "use async tasks", true, DisplayName = "\"async\" matches as standalone word")]
+    [DataRow("define", "define photosynthesis", true, DisplayName = "\"define\" matches without trailing space")]
+    [DataRow("define", "predefined", false, DisplayName = "\"define\" must not match inside \"predefined\"")]
+    public void ContainsWholePhrase_EnforcesWordBoundaries(
+        string keyword, string text, bool expected)
+    {
+        var actual = KeywordTierSelector.ContainsWholePhrase(text, keyword);
+        Assert.AreEqual(expected, actual,
+            $"ContainsWholePhrase(\"{text}\", \"{keyword}\") should be {expected}");
+    }
+
+    [TestMethod]
+    public void SelectTier_SubstringKeywordDoesNotInflateScore()
+    {
+        // "when is my flight tomorrow?" should not be inflated by substring matches
+        // against short keywords like "to", "is", etc. Even if such keywords were
+        // present in a runtime config, word-boundary matching prevents false hits.
+        var result = _selector.Classify("when is my flight tomorrow?");
+
+        // No high-signal keywords should match in this simple travel question
+        Assert.AreEqual(0, result.MatchedHighKeywords.Count,
+            "Simple travel question should not match any high-signal keywords");
+    }
+
+    // ── Config-file tests ─────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void SelectTier_WithConfigFile_ShortKeywordsFiltered()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            // Config with short keywords that should be filtered out
+            var configJson = """
+                {
+                    "version": 1,
+                    "highSignalKeywords": ["to", "is", "analyze", "ok", "design", "hi"],
+                    "lowSignalKeywords": ["what is", "a", "define"]
+                }
+                """;
+            File.WriteAllText(Path.Combine(tempDir, "tier-selector.json"), configJson);
+
+            var options = Options.Create(new AgentProfileOptions { BasePath = tempDir });
+            var selector = new KeywordTierSelector(options, NullLogger<KeywordTierSelector>.Instance);
+
+            // "analyze" and "design" should survive filtering; "to", "is", "ok", "hi" should not
+            var result = selector.Classify(
+                "Analyze the design of this system.");
+
+            Assert.IsTrue(result.MatchedHighKeywords.Contains("analyze"),
+                "\"analyze\" (≥3 chars) should survive keyword filtering");
+            Assert.IsTrue(result.MatchedHighKeywords.Contains("design"),
+                "\"design\" (≥3 chars) should survive keyword filtering");
+            Assert.IsFalse(result.MatchedHighKeywords.Contains("to"),
+                "\"to\" (<3 chars) should be filtered out");
+            Assert.IsFalse(result.MatchedHighKeywords.Contains("is"),
+                "\"is\" (<3 chars) should be filtered out");
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
     [TestMethod]
     public void SelectTier_WithMissingConfigFile_BehavesLikeCompiledDefaults()
     {


### PR DESCRIPTION
## Summary
- Replace substring `Contains()` with `ContainsWholePhrase()` that enforces word boundaries at keyword edges, preventing "to" matching inside "tomorrow", "rest" inside "restoration", etc.
- Add `SanitizeKeywords()` to filter out keywords shorter than 3 characters on config load, with warning logs for rejected keywords
- Add keyword quality rules to the dream directive so `RunTierRoutingReviewPassAsync` stops generating short, collision-prone, and personal-content keywords
- Fix `"scalab"` prefix hack → explicit `"scalable"` + `"scalability"`; remove trailing-space hacks from low-signal keywords

## Context
Rockbot's weekly routing digest identified ~$21k/year in misroute waste caused by substring keyword collisions. The dream-generated `tier-selector.json` on the PVC had 130+ keywords including 2-char collision bombs (`to`, `is`), memorized user prompts, and leaked personal content (`xebia`). That config has been cleared; the new guardrails prevent recurrence.

## Test plan
- [x] 15 new `DataRow` test cases for `ContainsWholePhrase` (substring rejection + valid matches)
- [x] Test that simple prompts don't false-match high-signal keywords
- [x] Test that short keywords from config files are filtered out
- [x] All 94 Llm tests pass, full suite green (308 passed)
- [x] Deployed to k8s cluster, agent running on compiled defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)