### PR TITLE
diag: log prompt context on Azure content filter rejection

### DIFF
--- a/src/RockBot.Host/AgentLoopRunner.cs
+++ b/src/RockBot.Host/AgentLoopRunner.cs
@@ -314,7 +314,17 @@ public sealed partial class AgentLoopRunner(
             logger.LogInformation("Added pre-fetched first response to context for native path");
         }
 
-        var response = await llmClient.GetResponseAsync(chatMessages, tier, chatOptions, cancellationToken);
+        ChatResponse response;
+        try
+        {
+            response = await llmClient.GetResponseAsync(chatMessages, tier, chatOptions, cancellationToken);
+        }
+        catch (ClientResultException ex)
+            when (ex.Status == 400 && ex.Message.Contains("content_filter", StringComparison.OrdinalIgnoreCase))
+        {
+            LogContentFilterDiagnostics(chatMessages, ex);
+            throw;
+        }
 
         // Append response messages to chatMessages so re-prompts have full tool-call history.
         chatMessages.AddRange(response.Messages);
@@ -463,6 +473,12 @@ public sealed partial class AgentLoopRunner(
                         used, max);
                     TrimLargeToolResults(chatMessages, max);
                     response = await llmClient.GetResponseAsync(chatMessages, tier, chatOptions, cancellationToken);
+                }
+                catch (ClientResultException ex)
+                    when (ex.Status == 400 && ex.Message.Contains("content_filter", StringComparison.OrdinalIgnoreCase))
+                {
+                    LogContentFilterDiagnostics(chatMessages, ex);
+                    throw;
                 }
 
                 sw.Stop();
@@ -887,6 +903,44 @@ public sealed partial class AgentLoopRunner(
     }
 
     // ── Logging ──────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Dumps the full chat message context when Azure's content filter rejects the prompt,
+    /// so we can identify the offending text after the fact.
+    /// </summary>
+    private void LogContentFilterDiagnostics(List<ChatMessage> chatMessages, ClientResultException ex)
+    {
+        var roleCounts = chatMessages
+            .GroupBy(m => m.Role.Value)
+            .Select(g => $"{g.Key}={g.Count()}")
+            .ToArray();
+
+        logger.LogWarning(ex,
+            "Content filter triggered on prompt. Message breakdown: {Roles} ({Total} total)",
+            string.Join(", ", roleCounts), chatMessages.Count);
+
+        const int maxTextLen = 600;
+
+        for (var i = 0; i < chatMessages.Count; i++)
+        {
+            var msg = chatMessages[i];
+            var text = msg.Text ?? string.Empty;
+
+            // For tool results, also surface the function name from FunctionResultContent.
+            var functionInfo = string.Empty;
+            var frc = msg.Contents.OfType<FunctionResultContent>().FirstOrDefault();
+            if (frc is not null)
+                functionInfo = $" fn={frc.CallId}";
+
+            var truncated = text.Length > maxTextLen
+                ? $"{text[..maxTextLen]}... [{text.Length} chars total]"
+                : text;
+
+            logger.LogWarning(
+                "  ContentFilter[{Index}] role={Role}{FunctionInfo} ({Length} chars): {Text}",
+                i, msg.Role, functionInfo, text.Length, truncated);
+        }
+    }
 
     private void LogResponseMessages(ChatResponse response, string iterationLabel)
     {


### PR DESCRIPTION
## Summary
- When Azure OpenAI returns HTTP 400 `content_filter`, dumps every message in the chat context at Warning level (role, char length, truncated text, tool call IDs)
- Catches added on both the native and text-based tool-calling paths in `AgentLoopRunner`
- Re-throws after logging so existing error handling in `ScheduledTaskHandler` is unchanged

## Motivation
Patrol runs intermittently hit Azure's content filter with no way to identify the offending content after the fact. This adds diagnostic logging so the next occurrence reveals exactly which message triggered it.

## Test plan
- [x] `dotnet build RockBot.slnx` — clean (no new warnings)
- [x] Deployed to k8s cluster; agent pod running
- [ ] Wait for next content filter occurrence and verify logs contain `ContentFilter[*]` entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)