### PR TITLE
fix: stop mislabelling primary agent progress as A2A in Blazor UI

### DIFF
--- a/src/RockBot.UserProxy.Blazor/Services/BlazorUserFrontend.cs
+++ b/src/RockBot.UserProxy.Blazor/Services/BlazorUserFrontend.cs
@@ -5,8 +5,19 @@ namespace RockBot.UserProxy.Blazor.Services;
 /// </summary>
 public sealed class BlazorUserFrontend(ChatStateService chatState) : IUserFrontend
 {
+    /// <summary>
+    /// Learned from the first IsFinal=true reply. Used to distinguish primary agent
+    /// progress from external A2A agent progress (both arrive as unsolicited non-final
+    /// messages with a non-empty AgentName).
+    /// </summary>
+    private string? _primaryAgentName;
+
     public Task DisplayReplyAsync(AgentReply reply, CancellationToken cancellationToken = default)
     {
+        // Learn the primary agent name from the first final reply we see.
+        if (reply.IsFinal && _primaryAgentName is null && !string.IsNullOrEmpty(reply.AgentName))
+            _primaryAgentName = reply.AgentName;
+
         var category = CategorizeReply(reply);
 
         if (reply.IsFinal)
@@ -30,7 +41,7 @@ public sealed class BlazorUserFrontend(ChatStateService chatState) : IUserFronte
         return Task.CompletedTask;
     }
 
-    private static MessageCategory CategorizeReply(AgentReply reply)
+    private MessageCategory CategorizeReply(AgentReply reply)
     {
         if (reply.SessionId == "scheduled-system")
             return MessageCategory.ScheduledSystem;
@@ -44,8 +55,13 @@ public sealed class BlazorUserFrontend(ChatStateService chatState) : IUserFronte
         if (reply.IsFinal)
             return MessageCategory.PrimaryFinal;
 
-        // Non-final from a non-subagent, non-primary source — treat as A2A activity
-        if (!string.IsNullOrEmpty(reply.AgentName))
+        // Non-final with an agent name: A2A only if we know the primary agent name AND
+        // the reply is from a different agent. Before the first final reply arrives we
+        // haven't learned the primary name yet — default to PrimaryProgress in that case
+        // rather than mislabelling the primary agent's own tool progress as A2A.
+        if (_primaryAgentName is not null &&
+            !string.IsNullOrEmpty(reply.AgentName) &&
+            !string.Equals(reply.AgentName, _primaryAgentName, StringComparison.OrdinalIgnoreCase))
             return MessageCategory.A2AActivity;
 
         return MessageCategory.PrimaryProgress;


### PR DESCRIPTION
## Summary
- `CategorizeReply` treated any non-final message with a non-empty `AgentName` as `A2AActivity`, but the primary agent's own tool progress (via `ToolProgressNotifier`) also arrives as unsolicited non-final messages with `AgentName = agent.Name` — during subagent result synthesis, A2A result synthesis, and scheduled task processing
- Learn the primary agent name from the first `IsFinal=true` reply, then only categorize as `A2AActivity` when the `AgentName` differs from the primary agent
- Before the name is learned, default to `PrimaryProgress` to avoid mislabelling

## Test plan
- [x] `dotnet build` — clean
- [x] Deployed to k8s cluster; Blazor pod running
- [ ] Trigger subagent/scheduled task processing and verify tool progress shows as primary progress, not "A2A"

🤖 Generated with [Claude Code](https://claude.com/claude-code)