### PR TITLE
feat: subagent result consolidation gate

### DIFF
--- a/src/RockBot.Agent/UserMessageHandler.cs
+++ b/src/RockBot.Agent/UserMessageHandler.cs
@@ -140,9 +140,13 @@ internal sealed class UserMessageHandler(
             // Per-session skill tools with usage tracking
             var sessionSkillTools = new SkillTools(skillStore, llmClient, logger, message.SessionId, skillUsageStore);
 
+            // Batch ID for subagent result consolidation — all spawn_subagent calls
+            // within this agent loop share the same batchId so results are grouped.
+            var batchId = Guid.NewGuid().ToString("N")[..12];
+
             // Registry tools (MCP, REST, etc.)
             var registryTools = toolRegistry.GetTools()
-                .Select(r => (AIFunction)new RegistryToolFunction(r, toolRegistry.GetExecutor(r.Name)!, sessionNamespace))
+                .Select(r => (AIFunction)new RegistryToolFunction(r, toolRegistry.GetExecutor(r.Name)!, sessionNamespace, batchId))
                 .ToArray();
 
             var allTools = memoryTools.Tools

--- a/src/RockBot.Host.Abstractions/SubagentResultMessage.cs
+++ b/src/RockBot.Host.Abstractions/SubagentResultMessage.cs
@@ -12,4 +12,6 @@ public sealed record SubagentResultMessage
     public required bool IsSuccess { get; init; }
     public string? Error { get; init; }
     public required DateTimeOffset Timestamp { get; init; }
+    public string? BatchId { get; init; }
+    public bool Consolidate { get; init; } = true;
 }

--- a/src/RockBot.Subagent/ISubagentManager.cs
+++ b/src/RockBot.Subagent/ISubagentManager.cs
@@ -10,7 +10,8 @@ public interface ISubagentManager
     /// Returns an error message string if the concurrency limit is reached.
     /// </summary>
     Task<string> SpawnAsync(string description, string? context, int? timeoutMinutes,
-        string primarySessionId, CancellationToken ct);
+        string primarySessionId, CancellationToken ct,
+        string? batchId = null, bool consolidate = true);
 
     /// <summary>
     /// Cancels a running subagent by task ID. Returns true if found and cancelled.

--- a/src/RockBot.Subagent/SpawnSubagentExecutor.cs
+++ b/src/RockBot.Subagent/SpawnSubagentExecutor.cs
@@ -25,10 +25,12 @@ internal sealed class SpawnSubagentExecutor(ISubagentManager manager) : IToolExe
         var description = descEl.GetString()!;
         var context = args.TryGetValue("context", out var ctxEl) ? ctxEl.GetString() : null;
         int? timeoutMinutes = args.TryGetValue("timeout_minutes", out var toEl) && toEl.TryGetInt32(out var to) ? to : null;
+        bool consolidate = !args.TryGetValue("consolidate", out var consEl) || consEl.ValueKind != JsonValueKind.False;
 
         var primarySessionId = request.SessionId ?? "unknown";
 
-        var taskId = await manager.SpawnAsync(description, context, timeoutMinutes, primarySessionId, ct);
+        var taskId = await manager.SpawnAsync(description, context, timeoutMinutes, primarySessionId, ct,
+            batchId: request.BatchId, consolidate: consolidate);
 
         return new ToolInvokeResponse
         {

--- a/src/RockBot.Subagent/SubagentEntry.cs
+++ b/src/RockBot.Subagent/SubagentEntry.cs
@@ -12,4 +12,6 @@ public sealed class SubagentEntry
     public required DateTimeOffset StartedAt { get; init; }
     public required CancellationTokenSource CancellationTokenSource { get; init; }
     public required Task Task { get; init; }
+    public string? BatchId { get; init; }
+    public bool Consolidate { get; init; } = true;
 }

--- a/src/RockBot.Subagent/SubagentManager.cs
+++ b/src/RockBot.Subagent/SubagentManager.cs
@@ -23,7 +23,9 @@ public sealed class SubagentManager(
         string? context,
         int? timeoutMinutes,
         string primarySessionId,
-        CancellationToken ct)
+        CancellationToken ct,
+        string? batchId = null,
+        bool consolidate = true)
     {
         // Clean up completed tasks first
         foreach (var key in _active.Keys.ToList())
@@ -50,7 +52,7 @@ public sealed class SubagentManager(
         var cts = new CancellationTokenSource();
         cts.CancelAfter(TimeSpan.FromMinutes(timeout));
 
-        var task = RunSubagentAsync(taskId, subagentSessionId, description, context, primarySessionId, cts.Token);
+        var task = RunSubagentAsync(taskId, subagentSessionId, description, context, primarySessionId, batchId, consolidate, cts.Token);
 
         var newEntry = new SubagentEntry
         {
@@ -60,7 +62,9 @@ public sealed class SubagentManager(
             Description = description,
             StartedAt = DateTimeOffset.UtcNow,
             CancellationTokenSource = cts,
-            Task = task
+            Task = task,
+            BatchId = batchId,
+            Consolidate = consolidate
         };
 
         _active[taskId] = newEntry;
@@ -104,6 +108,8 @@ public sealed class SubagentManager(
         string description,
         string? context,
         string primarySessionId,
+        string? batchId,
+        bool consolidate,
         CancellationToken ct)
     {
         // SubagentRunner.RunAsync handles all its own exit paths (success, failure,
@@ -114,7 +120,7 @@ public sealed class SubagentManager(
         {
             await using var scope = scopeFactory.CreateAsyncScope();
             var runner = scope.ServiceProvider.GetRequiredService<SubagentRunner>();
-            await runner.RunAsync(taskId, subagentSessionId, description, context, primarySessionId, ct);
+            await runner.RunAsync(taskId, subagentSessionId, description, context, primarySessionId, batchId, consolidate, ct);
         }
         catch (Exception ex)
         {
@@ -132,7 +138,9 @@ public sealed class SubagentManager(
                     Output = $"Subagent failed to start: {ex.Message}",
                     IsSuccess = false,
                     Error = ex.Message,
-                    Timestamp = DateTimeOffset.UtcNow
+                    Timestamp = DateTimeOffset.UtcNow,
+                    BatchId = batchId,
+                    Consolidate = consolidate
                 };
                 var envelope = result.ToEnvelope<SubagentResultMessage>(source: $"subagent-{taskId}");
                 await publisher.PublishAsync(SubagentTopics.Result, envelope, CancellationToken.None);

--- a/src/RockBot.Subagent/SubagentOptions.cs
+++ b/src/RockBot.Subagent/SubagentOptions.cs
@@ -7,4 +7,5 @@ public sealed class SubagentOptions
 {
     public int MaxConcurrentSubagents { get; set; } = 3;
     public int DefaultTimeoutMinutes { get; set; } = 10;
+    public int ConsolidationTimeoutSeconds { get; set; } = 10;
 }

--- a/src/RockBot.Subagent/SubagentResultGate.cs
+++ b/src/RockBot.Subagent/SubagentResultGate.cs
@@ -1,0 +1,146 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+using RockBot.Host;
+
+namespace RockBot.Subagent;
+
+/// <summary>
+/// Buffers <see cref="SubagentResultMessage"/> objects per batch and coordinates
+/// which handler invocation performs the consolidated synthesis.
+/// </summary>
+internal sealed class SubagentResultGate(ILogger<SubagentResultGate> logger)
+{
+    private readonly ConcurrentDictionary<string, PendingBatch> _pending = new();
+
+    /// <summary>
+    /// Accumulates a subagent result into its batch. Returns:
+    /// <list type="bullet">
+    ///   <item>A non-null list → this caller should perform consolidated synthesis with these results.</item>
+    ///   <item>Null → another caller is synthesizing; just return.</item>
+    /// </list>
+    /// </summary>
+    public async Task<IReadOnlyList<SubagentResultMessage>?> AccumulateAsync(
+        SubagentResultMessage result,
+        ISubagentManager subagentManager,
+        int timeoutSeconds,
+        CancellationToken ct)
+    {
+        // No batchId or consolidate=false → solo synthesis
+        if (result.BatchId is null || !result.Consolidate)
+            return [result];
+
+        var batchKey = $"{result.PrimarySessionId}:{result.BatchId}";
+
+        var batch = _pending.GetOrAdd(batchKey, _ => new PendingBatch());
+
+        // If a stale batch (already fired > 30s ago), replace it
+        if (batch.Fired && batch.FiredAt is { } firedAt
+            && DateTimeOffset.UtcNow - firedAt > TimeSpan.FromSeconds(30))
+        {
+            var fresh = new PendingBatch();
+            if (_pending.TryUpdate(batchKey, fresh, batch))
+                batch = fresh;
+            else
+                batch = _pending.GetOrAdd(batchKey, _ => new PendingBatch());
+        }
+
+        lock (batch.Lock)
+        {
+            if (batch.Fired)
+            {
+                // Late arrival — already fired
+                if (batch.Results.Any(r => r.TaskId == result.TaskId))
+                    return null; // already included
+                logger.LogInformation(
+                    "Late arrival for batch {BatchKey} task {TaskId} — solo synthesis",
+                    batchKey, result.TaskId);
+                return [result]; // solo synthesis
+            }
+
+            batch.Results.Add(result);
+        }
+
+        // Check for active siblings
+        var activeSiblings = subagentManager.ListActive()
+            .Where(e => e.PrimarySessionId == result.PrimarySessionId
+                     && e.BatchId == result.BatchId
+                     && e.Consolidate
+                     && e.TaskId != result.TaskId)
+            .ToList();
+
+        if (activeSiblings.Count == 0)
+        {
+            // No active siblings — try to fire immediately
+            var fired = TryFire(batch);
+            if (fired is not null)
+            {
+                logger.LogInformation(
+                    "Batch {BatchKey} fired immediately with {Count} result(s)",
+                    batchKey, fired.Count);
+                CleanupBatch(batchKey);
+                return fired;
+            }
+            return null;
+        }
+
+        // Active siblings exist — wait for signal, timeout, or cancellation
+        logger.LogInformation(
+            "Batch {BatchKey} waiting for {SiblingCount} active sibling(s) (timeout={Timeout}s)",
+            batchKey, activeSiblings.Count, timeoutSeconds);
+
+        try
+        {
+            await batch.Signal.Task.WaitAsync(
+                TimeSpan.FromSeconds(timeoutSeconds), ct);
+        }
+        catch (TimeoutException)
+        {
+            logger.LogWarning("Batch {BatchKey} timed out waiting for siblings", batchKey);
+        }
+        catch (OperationCanceledException)
+        {
+            // Handler CT cancelled (e.g. new user message) — let the caller exit
+            throw;
+        }
+
+        // Try to fire (we may or may not win the race)
+        var results = TryFire(batch);
+        if (results is not null)
+        {
+            logger.LogInformation(
+                "Batch {BatchKey} fired after wait with {Count} result(s)",
+                batchKey, results.Count);
+            CleanupBatch(batchKey);
+            return results;
+        }
+
+        return null; // someone else fired
+    }
+
+    private static IReadOnlyList<SubagentResultMessage>? TryFire(PendingBatch batch)
+    {
+        lock (batch.Lock)
+        {
+            if (batch.Fired) return null;
+            batch.Fired = true;
+            batch.FiredAt = DateTimeOffset.UtcNow;
+            batch.Signal.TrySetResult(true);
+            return batch.Results.ToList();
+        }
+    }
+
+    private void CleanupBatch(string batchKey)
+    {
+        // Don't remove immediately — keep for late-arrival detection (30s staleness window)
+        _ = Task.Delay(TimeSpan.FromSeconds(35)).ContinueWith(_ => _pending.TryRemove(batchKey, out PendingBatch? _));
+    }
+
+    private sealed class PendingBatch
+    {
+        public List<SubagentResultMessage> Results { get; } = [];
+        public bool Fired { get; set; }
+        public DateTimeOffset? FiredAt { get; set; }
+        public Lock Lock { get; } = new();
+        public TaskCompletionSource<bool> Signal { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+}

--- a/src/RockBot.Subagent/SubagentResultHandler.cs
+++ b/src/RockBot.Subagent/SubagentResultHandler.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using RockBot.Host;
 using RockBot.Llm;
 using RockBot.Memory;
@@ -12,6 +13,8 @@ namespace RockBot.Subagent;
 
 /// <summary>
 /// Handles subagent result messages on the primary agent side.
+/// Uses a two-phase approach: Phase 1 records the result immediately,
+/// Phase 2 runs consolidated synthesis only when all sibling results are in.
 /// </summary>
 internal sealed class SubagentResultHandler(
     AgentLoopRunner agentLoopRunner,
@@ -26,6 +29,9 @@ internal sealed class SubagentResultHandler(
     RulesTools rulesTools,
     ToolGuideTools toolGuideTools,
     IConversationMemory conversationMemory,
+    SubagentResultGate gate,
+    ISubagentManager subagentManager,
+    IOptions<SubagentOptions> options,
     ILogger<SubagentResultHandler> logger) : IMessageHandler<SubagentResultMessage>
 {
     public async Task HandleAsync(SubagentResultMessage message, MessageHandlerContext context)
@@ -33,38 +39,21 @@ internal sealed class SubagentResultHandler(
         var ct = context.CancellationToken;
 
         logger.LogInformation(
-            "Subagent result for task {TaskId} in primary session {SessionId}: success={Success}, output={OutputLen} chars",
-            message.TaskId, message.PrimarySessionId, message.IsSuccess, message.Output.Length);
+            "Subagent result for task {TaskId} in primary session {SessionId}: success={Success}, output={OutputLen} chars, batchId={BatchId}, consolidate={Consolidate}",
+            message.TaskId, message.PrimarySessionId, message.IsSuccess, message.Output.Length,
+            message.BatchId, message.Consolidate);
 
         if (string.IsNullOrWhiteSpace(message.Output))
             logger.LogWarning("Subagent {TaskId} returned empty output — primary agent will have nothing to relay", message.TaskId);
 
-        // The subagent's final text is the primary result. Large data (reports, lists, documents)
-        // may have been saved to the subagent's working memory namespace "subagent/{taskId}/".
-        // Only tell the LLM to retrieve from working memory if entries actually exist — an
-        // unconditional hint causes the LLM to call get_from_working_memory and conclude the
-        // cache "expired" when nothing was ever written there.
-        var subagentPrefix = $"subagent/{message.TaskId}/";
-        var whiteboardEntries = await workingMemory.ListAsync(subagentPrefix);
+        // ── Phase 1: immediate per-result work (every result) ──────────────────
 
-        var whiteboardHint = whiteboardEntries.Count > 0
-            ? $" The subagent stored {whiteboardEntries.Count} output(s) in working memory under namespace '{subagentPrefix.TrimEnd('/')}'. " +
-              $"Keys: {string.Join(", ", whiteboardEntries.Select(e => $"'{e.Key}'"))}. " +
-              "Retrieve and present them to the user using get_from_working_memory with the full key."
-            : string.Empty;
-
-        // If the subagent ran out of iterations its final text may be an incomplete setup
-        // phrase ("Now let me save the findings to shared memory:"). Annotate it so the
-        // primary LLM knows no data was actually written — prevents hallucinated
-        // "working memory expired" responses.
         var safeOutput = message.IsSuccess && AgentLoopRunner.IsIncompleteSetupPhrase(message.Output)
             ? message.Output.TrimEnd(':').TrimEnd() +
               " — but the task ran out of steps before completing this action. No data was saved to shared memory."
             : message.Output;
 
-        // Publish the subagent's raw completion output as a non-final bubble so it is
-        // visible in the Blazor UI under the subagent's own name before the primary agent
-        // synthesises and presents the final reply.
+        // Publish completion bubble to UI (non-final)
         try
         {
             var completionContent = message.IsSuccess
@@ -86,6 +75,17 @@ internal sealed class SubagentResultHandler(
             logger.LogWarning(ex, "Failed to publish completion bubble for subagent {TaskId}", message.TaskId);
         }
 
+        // Build whiteboard hint for this result
+        var subagentPrefix = $"subagent/{message.TaskId}/";
+        var whiteboardEntries = await workingMemory.ListAsync(subagentPrefix);
+
+        var whiteboardHint = whiteboardEntries.Count > 0
+            ? $" The subagent stored {whiteboardEntries.Count} output(s) in working memory under namespace '{subagentPrefix.TrimEnd('/')}'. " +
+              $"Keys: {string.Join(", ", whiteboardEntries.Select(e => $"'{e.Key}'"))}. " +
+              "Retrieve and present them to the user using get_from_working_memory with the full key."
+            : string.Empty;
+
+        // Add synthetic user turn to conversation memory
         var syntheticUserTurn = message.IsSuccess
             ? $"[Subagent task {message.TaskId} completed]: {safeOutput}{whiteboardHint}"
             : $"[Subagent task {message.TaskId} completed with error: {message.Error}]: {message.Output}";
@@ -95,8 +95,62 @@ internal sealed class SubagentResultHandler(
             new ConversationTurn("user", syntheticUserTurn, DateTimeOffset.UtcNow),
             ct);
 
+        // ── Gate: accumulate and decide who synthesizes ─────────────────────────
+
+        var batchedResults = await gate.AccumulateAsync(
+            message, subagentManager, options.Value.ConsolidationTimeoutSeconds, ct);
+
+        if (batchedResults is null)
+        {
+            // Another handler invocation will perform consolidated synthesis
+            logger.LogInformation(
+                "Subagent result {TaskId} deferred to batch consolidation winner", message.TaskId);
+            return;
+        }
+
+        // ── Phase 2: consolidated synthesis (winner only) ───────────────────────
+
+        logger.LogInformation(
+            "Running consolidated synthesis for {Count} result(s) in session {SessionId}",
+            batchedResults.Count, message.PrimarySessionId);
+
+        // For multi-result batches, collect whiteboard hints for ALL results
+        // and add a final synthetic turn requesting consolidation
+        if (batchedResults.Count > 1)
+        {
+            var allHints = new List<string>();
+            foreach (var r in batchedResults.Where(r => r.TaskId != message.TaskId))
+            {
+                var prefix = $"subagent/{r.TaskId}/";
+                var entries = await workingMemory.ListAsync(prefix);
+                if (entries.Count > 0)
+                {
+                    allHints.Add(
+                        $"Subagent {r.TaskId} stored {entries.Count} output(s) under '{prefix.TrimEnd('/')}': " +
+                        string.Join(", ", entries.Select(e => $"'{e.Key}'")));
+                }
+            }
+
+            var consolidationNote = allHints.Count > 0
+                ? " " + string.Join(" ", allHints)
+                : string.Empty;
+
+            var consolidationTurn =
+                $"[All {batchedResults.Count} subagent tasks completed. " +
+                $"Synthesize the results above into a single unified response.]{consolidationNote}";
+
+            await conversationMemory.AddTurnAsync(
+                message.PrimarySessionId,
+                new ConversationTurn("user", consolidationTurn, DateTimeOffset.UtcNow),
+                ct);
+        }
+
         var chatMessages = await agentContextBuilder.BuildAsync(
-            message.PrimarySessionId, syntheticUserTurn, ct);
+            message.PrimarySessionId,
+            batchedResults.Count > 1
+                ? $"[Consolidating {batchedResults.Count} subagent results]"
+                : syntheticUserTurn,
+            ct);
 
         var sessionWorkingMemoryTools = new WorkingMemoryTools(workingMemory, $"session/{message.PrimarySessionId}", logger);
         var sessionSkillTools = new SkillTools(skillStore, llmClient, logger, message.PrimarySessionId);
@@ -141,7 +195,8 @@ internal sealed class SubagentResultHandler(
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            logger.LogError(ex, "Failed to handle subagent result for task {TaskId}", message.TaskId);
+            logger.LogError(ex, "Failed to handle subagent result consolidation for session {SessionId}",
+                message.PrimarySessionId);
         }
         // Note: subagent working memory entries ("subagent/{taskId}/...") are intentionally NOT
         // deleted here. They persist until their TTL expires so the primary agent can reference

--- a/src/RockBot.Subagent/SubagentRunner.cs
+++ b/src/RockBot.Subagent/SubagentRunner.cs
@@ -37,6 +37,8 @@ internal sealed class SubagentRunner(
         string description,
         string? context,
         string primarySessionId,
+        string? batchId,
+        bool consolidate,
         CancellationToken ct)
     {
         var classification = tierSelector.Classify(description);
@@ -218,7 +220,9 @@ internal sealed class SubagentRunner(
             Output = finalOutput,
             IsSuccess = isSuccess,
             Error = error,
-            Timestamp = DateTimeOffset.UtcNow
+            Timestamp = DateTimeOffset.UtcNow,
+            BatchId = batchId,
+            Consolidate = consolidate
         };
 
         var envelope = result.ToEnvelope<SubagentResultMessage>(source: subagentId);

--- a/src/RockBot.Subagent/SubagentServiceCollectionExtensions.cs
+++ b/src/RockBot.Subagent/SubagentServiceCollectionExtensions.cs
@@ -23,6 +23,7 @@ public static class SubagentServiceCollectionExtensions
 
         // Core infrastructure
         builder.Services.AddSingleton<ISubagentManager, SubagentManager>();
+        builder.Services.AddSingleton<SubagentResultGate>();
         builder.Services.AddTransient<SubagentRunner>();
 
         // Message handlers for primary agent side

--- a/src/RockBot.Subagent/SubagentToolRegistrar.cs
+++ b/src/RockBot.Subagent/SubagentToolRegistrar.cs
@@ -27,6 +27,10 @@ internal sealed class SubagentToolRegistrar(
             "timeout_minutes": {
               "type": "integer",
               "description": "Optional timeout in minutes (default: 10)."
+            },
+            "consolidate": {
+              "type": "boolean",
+              "description": "When true (default), this subagent's result will be batched with sibling subagent results into a single consolidated response. Set to false to deliver this subagent's result immediately as its own response."
             }
           },
           "required": ["description"]

--- a/src/RockBot.Subagent/SubagentToolSkillProvider.cs
+++ b/src/RockBot.Subagent/SubagentToolSkillProvider.cs
@@ -30,6 +30,11 @@ public sealed class SubagentToolSkillProvider : IToolSkillProvider
           search terms, timezone, expected output format).
         - context (optional): Additional data or context the subagent needs
         - timeout_minutes (optional): How long to allow (default 10 minutes)
+        - consolidate (optional, default true): When true, this subagent's result is
+          batched with sibling results into a single consolidated response. Set to false
+          to deliver this subagent's result immediately as its own independent response.
+          Use consolidate: false when the user asks for results "as they come in",
+          "one at a time", or indicates they want streaming/immediate delivery.
 
         Returns: task_id — use this to track or cancel the subagent.
 
@@ -42,7 +47,8 @@ public sealed class SubagentToolSkillProvider : IToolSkillProvider
         ## Decomposition patterns
         - **Single delegation**: One subagent for the whole task.
         - **Parallel fan-out**: Spawn 2-3 subagents for independent subtasks (e.g.,
-          one for calendar, one for email). Synthesize when results arrive.
+          one for calendar, one for email). Sibling results are automatically
+          consolidated into a single unified response by default.
         - **Sequential pipeline**: Spawn one subagent, then spawn the next when its
           result arrives (e.g., find email → schedule follow-up).
 
@@ -57,6 +63,8 @@ public sealed class SubagentToolSkillProvider : IToolSkillProvider
         1. Acknowledge the user's request immediately
         2. Spawn subagent(s) with detailed instructions
         3. Return control to the user — your response should take seconds
-        4. When '[Subagent task <id> completed]' arrives, synthesize and present results
+        4. The system automatically consolidates sibling subagent results into a
+           single unified response. You do not need to manually synthesize each
+           result as it arrives — just let the consolidation happen.
         """;
 }

--- a/src/RockBot.Tools.Abstractions/ToolInvokeRequest.cs
+++ b/src/RockBot.Tools.Abstractions/ToolInvokeRequest.cs
@@ -25,4 +25,10 @@ public sealed record ToolInvokeRequest
     /// Null when invoked outside a session context (e.g. tests, CLI tools).
     /// </summary>
     public string? SessionId { get; init; }
+
+    /// <summary>
+    /// Optional batch ID for grouping subagent results spawned from the same agent loop.
+    /// Null when batching is not active.
+    /// </summary>
+    public string? BatchId { get; init; }
 }

--- a/src/RockBot.Tools/RegistryToolFunction.cs
+++ b/src/RockBot.Tools/RegistryToolFunction.cs
@@ -11,7 +11,8 @@ namespace RockBot.Tools;
 public sealed class RegistryToolFunction(
     ToolRegistration registration,
     IToolExecutor executor,
-    string? sessionId) : AIFunction
+    string? sessionId,
+    string? batchId = null) : AIFunction
 {
     private static readonly JsonSerializerOptions SerializerOptions = new();
 
@@ -53,7 +54,8 @@ public sealed class RegistryToolFunction(
             ToolCallId = Guid.NewGuid().ToString("N"),
             ToolName = registration.Name,
             Arguments = argsJson,
-            SessionId = sessionId
+            SessionId = sessionId,
+            BatchId = batchId
         };
 
         var response = await executor.ExecuteAsync(request, cancellationToken);

--- a/tests/RockBot.Subagent.Tests/SubagentResultGateTests.cs
+++ b/tests/RockBot.Subagent.Tests/SubagentResultGateTests.cs
@@ -1,0 +1,229 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using RockBot.Host;
+
+namespace RockBot.Subagent.Tests;
+
+[TestClass]
+public class SubagentResultGateTests
+{
+    private static SubagentResultGate CreateGate() =>
+        new(NullLogger<SubagentResultGate>.Instance);
+
+    private static SubagentResultMessage MakeResult(
+        string taskId,
+        string primarySessionId = "session-1",
+        string? batchId = "batch-1",
+        bool consolidate = true) => new()
+    {
+        TaskId = taskId,
+        SubagentSessionId = $"subagent-{taskId}",
+        PrimarySessionId = primarySessionId,
+        Output = $"Output from {taskId}",
+        IsSuccess = true,
+        Timestamp = DateTimeOffset.UtcNow,
+        BatchId = batchId,
+        Consolidate = consolidate
+    };
+
+    // ── Null batchId → solo synthesis ──────────────────────────────────────
+
+    [TestMethod]
+    public async Task AccumulateAsync_NullBatchId_ReturnsSoloResult()
+    {
+        var gate = CreateGate();
+        var result = MakeResult("task-1", batchId: null);
+        var manager = new FakeSubagentManager([]);
+
+        var batch = await gate.AccumulateAsync(result, manager, 10, CancellationToken.None);
+
+        Assert.IsNotNull(batch);
+        Assert.AreEqual(1, batch.Count);
+        Assert.AreEqual("task-1", batch[0].TaskId);
+    }
+
+    // ── Consolidate=false → solo synthesis ─────────────────────────────────
+
+    [TestMethod]
+    public async Task AccumulateAsync_ConsolidateFalse_ReturnsSoloResult()
+    {
+        var gate = CreateGate();
+        var result = MakeResult("task-1", consolidate: false);
+        var manager = new FakeSubagentManager([]);
+
+        var batch = await gate.AccumulateAsync(result, manager, 10, CancellationToken.None);
+
+        Assert.IsNotNull(batch);
+        Assert.AreEqual(1, batch.Count);
+        Assert.AreEqual("task-1", batch[0].TaskId);
+    }
+
+    // ── Single subagent with batchId, no siblings → fires immediately ──────
+
+    [TestMethod]
+    public async Task AccumulateAsync_SingleSubagent_NoSiblings_FiresImmediately()
+    {
+        var gate = CreateGate();
+        var result = MakeResult("task-1");
+        var manager = new FakeSubagentManager([]);
+
+        var batch = await gate.AccumulateAsync(result, manager, 10, CancellationToken.None);
+
+        Assert.IsNotNull(batch);
+        Assert.AreEqual(1, batch.Count);
+        Assert.AreEqual("task-1", batch[0].TaskId);
+    }
+
+    // ── Two subagents finishing: first waits (has sibling), second fires ────
+
+    [TestMethod]
+    public async Task AccumulateAsync_TwoSubagents_LastOneFires()
+    {
+        var gate = CreateGate();
+        var result1 = MakeResult("task-1");
+        var result2 = MakeResult("task-2");
+
+        // When task-1 arrives, task-2 is still active
+        var activeEntry2 = new SubagentEntry
+        {
+            TaskId = "task-2",
+            SubagentSessionId = "subagent-task-2",
+            PrimarySessionId = "session-1",
+            Description = "Task 2",
+            StartedAt = DateTimeOffset.UtcNow,
+            CancellationTokenSource = new CancellationTokenSource(),
+            Task = Task.Delay(TimeSpan.FromSeconds(30)),
+            BatchId = "batch-1",
+            Consolidate = true
+        };
+        var managerWithSibling = new FakeSubagentManager([activeEntry2]);
+
+        // First result arrives — has an active sibling, will wait
+        var task1 = Task.Run(() => gate.AccumulateAsync(result1, managerWithSibling, 5, CancellationToken.None));
+
+        // Give task1 time to enter the wait
+        await Task.Delay(200);
+
+        // Second result arrives — no active siblings left
+        var managerNoSiblings = new FakeSubagentManager([]);
+        var batch2 = await gate.AccumulateAsync(result2, managerNoSiblings, 5, CancellationToken.None);
+
+        // The second handler should win the fire
+        Assert.IsNotNull(batch2);
+        Assert.AreEqual(2, batch2.Count);
+        Assert.IsTrue(batch2.Any(r => r.TaskId == "task-1"));
+        Assert.IsTrue(batch2.Any(r => r.TaskId == "task-2"));
+
+        // The first handler should get null (someone else fired)
+        var batch1 = await task1;
+        Assert.IsNull(batch1);
+    }
+
+    // ── Timeout fires with partial batch ───────────────────────────────────
+
+    [TestMethod]
+    public async Task AccumulateAsync_Timeout_FiresPartialBatch()
+    {
+        var gate = CreateGate();
+        var result1 = MakeResult("task-1");
+
+        // task-2 is "active" and never completes
+        var activeEntry2 = new SubagentEntry
+        {
+            TaskId = "task-2",
+            SubagentSessionId = "subagent-task-2",
+            PrimarySessionId = "session-1",
+            Description = "Task 2",
+            StartedAt = DateTimeOffset.UtcNow,
+            CancellationTokenSource = new CancellationTokenSource(),
+            Task = Task.Delay(TimeSpan.FromMinutes(10)),
+            BatchId = "batch-1",
+            Consolidate = true
+        };
+        var manager = new FakeSubagentManager([activeEntry2]);
+
+        // Short timeout — should fire after 1 second
+        var batch = await gate.AccumulateAsync(result1, manager, 1, CancellationToken.None);
+
+        Assert.IsNotNull(batch);
+        Assert.AreEqual(1, batch.Count);
+        Assert.AreEqual("task-1", batch[0].TaskId);
+    }
+
+    // ── Different batchIds → separate batches ──────────────────────────────
+
+    [TestMethod]
+    public async Task AccumulateAsync_DifferentBatchIds_SeparateBatches()
+    {
+        var gate = CreateGate();
+        var result1 = MakeResult("task-1", batchId: "batch-A");
+        var result2 = MakeResult("task-2", batchId: "batch-B");
+        var manager = new FakeSubagentManager([]);
+
+        var batch1 = await gate.AccumulateAsync(result1, manager, 10, CancellationToken.None);
+        var batch2 = await gate.AccumulateAsync(result2, manager, 10, CancellationToken.None);
+
+        Assert.IsNotNull(batch1);
+        Assert.AreEqual(1, batch1.Count);
+        Assert.AreEqual("task-1", batch1[0].TaskId);
+
+        Assert.IsNotNull(batch2);
+        Assert.AreEqual(1, batch2.Count);
+        Assert.AreEqual("task-2", batch2[0].TaskId);
+    }
+
+    // ── Late arrival after gate fired → solo synthesis ──────────────────────
+
+    [TestMethod]
+    public async Task AccumulateAsync_LateArrival_AfterFired_GetsSoloSynthesis()
+    {
+        var gate = CreateGate();
+        var result1 = MakeResult("task-1");
+        var manager = new FakeSubagentManager([]);
+
+        // First result fires immediately (no siblings)
+        var batch1 = await gate.AccumulateAsync(result1, manager, 10, CancellationToken.None);
+        Assert.IsNotNull(batch1);
+
+        // Late arrival for the same batch
+        var result2 = MakeResult("task-2");
+        var batch2 = await gate.AccumulateAsync(result2, manager, 10, CancellationToken.None);
+
+        // Late arrival should get solo synthesis
+        Assert.IsNotNull(batch2);
+        Assert.AreEqual(1, batch2.Count);
+        Assert.AreEqual("task-2", batch2[0].TaskId);
+    }
+
+    // ── Duplicate result (already included) returns null ────────────────────
+
+    [TestMethod]
+    public async Task AccumulateAsync_DuplicateResult_ReturnsNull()
+    {
+        var gate = CreateGate();
+        var result1 = MakeResult("task-1");
+        var manager = new FakeSubagentManager([]);
+
+        // First call fires immediately
+        var batch1 = await gate.AccumulateAsync(result1, manager, 10, CancellationToken.None);
+        Assert.IsNotNull(batch1);
+
+        // Same taskId again — already included in the fired batch
+        var batch2 = await gate.AccumulateAsync(result1, manager, 10, CancellationToken.None);
+        Assert.IsNull(batch2);
+    }
+
+    // ── Fake ────────────────────────────────────────────────────────────────
+
+    private sealed class FakeSubagentManager(IReadOnlyList<SubagentEntry> activeEntries) : ISubagentManager
+    {
+        public Task<string> SpawnAsync(string description, string? context, int? timeoutMinutes,
+            string primarySessionId, CancellationToken ct,
+            string? batchId = null, bool consolidate = true) =>
+            Task.FromResult("fake-task-id");
+
+        public Task<bool> CancelAsync(string taskId) =>
+            Task.FromResult(false);
+
+        public IReadOnlyList<SubagentEntry> ListActive() => activeEntries;
+    }
+}

--- a/tests/RockBot.Subagent.Tests/SubagentToolExecutorTests.cs
+++ b/tests/RockBot.Subagent.Tests/SubagentToolExecutorTests.cs
@@ -197,7 +197,8 @@ public class SubagentToolExecutorTests
         public bool CancelResult { get; set; }
 
         public Task<string> SpawnAsync(string description, string? context, int? timeoutMinutes,
-            string primarySessionId, CancellationToken ct) =>
+            string primarySessionId, CancellationToken ct,
+            string? batchId = null, bool consolidate = true) =>
             Task.FromResult(SpawnResult);
 
         public Task<bool> CancelAsync(string taskId) =>


### PR DESCRIPTION
## Summary

- Adds a wave-based consolidation gate that batches sibling subagent results (same user message) into a single synthesis LLM pass, replacing N independent "final" replies with one unified response
- `UserMessageHandler` generates a `batchId` per agent loop; it flows through `RegistryToolFunction` → `ToolInvokeRequest` → `SpawnSubagentExecutor` → `SubagentManager` → `SubagentRunner` → `SubagentResultMessage`
- New `SubagentResultGate` singleton accumulates results by `(primarySessionId, batchId)` with configurable timeout, ensuring exactly one handler wins the consolidated synthesis
- LLM-controlled `consolidate` boolean on `spawn_subagent` (default `true`) lets the model opt individual subagents out of batching for immediate delivery
- Null `batchId` (scheduled tasks, other handlers) falls back to existing solo synthesis — zero behavior change for non-opted-in paths

## Test plan

- [x] `dotnet build RockBot.slnx` — compiles clean
- [x] `dotnet test RockBot.slnx` — all 660 tests pass (0 failures), including 8 new gate tests
- [ ] Deploy to k8s, send message spawning multiple subagents → verify single consolidated final response
- [ ] Verify single-subagent case has no added delay
- [ ] Verify `consolidate: false` delivers individual final responses
- [ ] Verify overlapping user messages consolidate independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)