### PR TITLE
fix: end session tracking when user processing loop completes

### DIFF
--- a/src/RockBot.Agent/UserMessageHandler.cs
+++ b/src/RockBot.Agent/UserMessageHandler.cs
@@ -72,7 +72,8 @@ internal sealed class UserMessageHandler(
         // Cancel any background loop still running for this session from a prior message.
         // This prevents stale tool calls (e.g. sending an email from a previous topic)
         // from executing after the user has already moved on.
-        var sessionCt = sessionTracker.BeginSession(message.SessionId, ct);
+        var sessionHandle = sessionTracker.BeginSession(message.SessionId, ct);
+        var sessionCt = sessionHandle.Token;
         logger.LogInformation("Received message from {UserId} in session {SessionId}: {Content}",
             message.UserId, message.SessionId, message.Content);
 
@@ -188,7 +189,7 @@ internal sealed class UserMessageHandler(
                     replyTo, correlationId, message.SessionId, isFinal: false, ct);
                 turnActivityHandedOff = true;
                 _ = NativeLlmLoopAsync(chatMessages, chatOptions, classification, postInjectionTokenEstimate,
-                    message.SessionId, replyTo, correlationId, turnActivity, sessionCt);
+                    message.SessionId, replyTo, correlationId, sessionHandle.Generation, turnActivity, sessionCt);
             }
             else
             {
@@ -247,7 +248,7 @@ internal sealed class UserMessageHandler(
                     turnActivityHandedOff = true;
                     _ = BackgroundToolLoopAsync(
                         chatMessages, chatOptions, firstResponse, tier,
-                        message.SessionId, replyTo, correlationId, turnActivity, sessionCt);
+                        message.SessionId, replyTo, correlationId, sessionHandle.Generation, turnActivity, sessionCt);
                 }
                 else
                 {
@@ -266,7 +267,7 @@ internal sealed class UserMessageHandler(
                         turnActivityHandedOff = true;
                         _ = BackgroundToolLoopAsync(
                             chatMessages, chatOptions, firstResponse, tier,
-                            message.SessionId, replyTo, correlationId, turnActivity, sessionCt);
+                            message.SessionId, replyTo, correlationId, sessionHandle.Generation, turnActivity, sessionCt);
                     }
                     else if (modelBehavior.NudgeOnHallucinatedToolCalls
                         && (HallucinatedActionRegex.IsMatch(text) || AgentLoopRunner.CapabilityDenialRegex.IsMatch(text)))
@@ -282,7 +283,7 @@ internal sealed class UserMessageHandler(
                         turnActivityHandedOff = true;
                         _ = BackgroundToolLoopAsync(
                             chatMessages, chatOptions, firstResponse, tier,
-                            message.SessionId, replyTo, correlationId, turnActivity, sessionCt);
+                            message.SessionId, replyTo, correlationId, sessionHandle.Generation, turnActivity, sessionCt);
                     }
                     else
                     {
@@ -292,6 +293,7 @@ internal sealed class UserMessageHandler(
                             ct);
 
                         await PublishReplyAsync(text, replyTo, correlationId, message.SessionId, isFinal: true, ct);
+                        sessionTracker.EndSession(message.SessionId, sessionHandle.Generation);
                         turnActivity?.SetTag("rockbot.turn.status", "ok");
                         turnActivity?.SetStatus(ActivityStatusCode.Ok);
                         turnSw.Stop();
@@ -332,6 +334,7 @@ internal sealed class UserMessageHandler(
             }
 
             await PublishReplyAsync(errorText, replyTo, correlationId, message.SessionId, isFinal: true, ct);
+            sessionTracker.EndSession(message.SessionId, sessionHandle.Generation);
             turnActivity?.SetTag("rockbot.turn.status", "error");
             turnActivity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             turnSw.Stop();
@@ -357,6 +360,7 @@ internal sealed class UserMessageHandler(
         string sessionId,
         string replyTo,
         string? correlationId,
+        long sessionGeneration,
         System.Diagnostics.Activity? turnActivity,
         CancellationToken ct)
     {
@@ -454,6 +458,7 @@ internal sealed class UserMessageHandler(
         }
         finally
         {
+            sessionTracker.EndSession(sessionId, sessionGeneration);
             turnActivity?.Dispose();
         }
     }
@@ -466,6 +471,7 @@ internal sealed class UserMessageHandler(
         string sessionId,
         string replyTo,
         string? correlationId,
+        long sessionGeneration,
         System.Diagnostics.Activity? turnActivity,
         CancellationToken ct)
     {
@@ -547,6 +553,7 @@ internal sealed class UserMessageHandler(
         }
         finally
         {
+            sessionTracker.EndSession(sessionId, sessionGeneration);
             turnActivity?.Dispose();
         }
     }

--- a/src/RockBot.Host.Abstractions/ISessionTracker.cs
+++ b/src/RockBot.Host.Abstractions/ISessionTracker.cs
@@ -1,6 +1,13 @@
 namespace RockBot.Host;
 
 /// <summary>
+/// A token returned by <see cref="ISessionTracker.BeginSession"/> that carries
+/// both the cancellation token for the session loop and a generation identifier
+/// used to safely call <see cref="ISessionTracker.EndSession"/>.
+/// </summary>
+public readonly record struct SessionHandle(CancellationToken Token, long Generation);
+
+/// <summary>
 /// Tracks active user-message processing loops per session.
 /// <para>
 /// Agent-side user message handlers call <see cref="BeginSession"/> when a new
@@ -13,11 +20,20 @@ public interface ISessionTracker
 {
     /// <summary>
     /// Cancels any in-flight background loop for <paramref name="sessionId"/> and
-    /// returns a new <see cref="CancellationToken"/> that is linked to
-    /// <paramref name="hostCt"/> and will be cancelled the next time this method
-    /// is called for the same session.
+    /// returns a <see cref="SessionHandle"/> containing a new
+    /// <see cref="CancellationToken"/> (linked to <paramref name="hostCt"/>) and
+    /// a generation identifier. The token will be cancelled the next time this
+    /// method is called for the same session.
     /// </summary>
-    CancellationToken BeginSession(string sessionId, CancellationToken hostCt);
+    SessionHandle BeginSession(string sessionId, CancellationToken hostCt);
+
+    /// <summary>
+    /// Marks the processing loop for <paramref name="sessionId"/> as complete.
+    /// Only takes effect when <paramref name="generation"/> matches the current
+    /// generation — a stale call from an earlier loop that was superseded by a
+    /// newer <see cref="BeginSession"/> is safely ignored.
+    /// </summary>
+    void EndSession(string sessionId, long generation);
 
     /// <summary>
     /// Returns <c>true</c> when a user-message processing loop is currently

--- a/src/RockBot.Host/SessionBackgroundTaskTracker.cs
+++ b/src/RockBot.Host/SessionBackgroundTaskTracker.cs
@@ -11,9 +11,11 @@ namespace RockBot.Host;
 internal sealed class SessionBackgroundTaskTracker : ISessionTracker, IDisposable
 {
     private readonly ConcurrentDictionary<string, CancellationTokenSource> _sessions = new();
+    private readonly ConcurrentDictionary<string, long> _activeGenerations = new();
+    private long _nextGeneration;
 
     /// <inheritdoc/>
-    public CancellationToken BeginSession(string sessionId, CancellationToken hostCt)
+    public SessionHandle BeginSession(string sessionId, CancellationToken hostCt)
     {
         // Cancel and discard the previous background loop for this session, if any.
         if (_sessions.TryRemove(sessionId, out var old))
@@ -22,14 +24,24 @@ internal sealed class SessionBackgroundTaskTracker : ISessionTracker, IDisposabl
             old.Dispose();
         }
 
+        var generation = Interlocked.Increment(ref _nextGeneration);
         var cts = CancellationTokenSource.CreateLinkedTokenSource(hostCt);
         _sessions[sessionId] = cts;
-        return cts.Token;
+        _activeGenerations[sessionId] = generation;
+        return new SessionHandle(cts.Token, generation);
+    }
+
+    /// <inheritdoc/>
+    public void EndSession(string sessionId, long generation)
+    {
+        // Atomically remove only if the generation matches — a stale EndSession
+        // from a superseded loop cannot deactivate a newer one.
+        _activeGenerations.TryRemove(new KeyValuePair<string, long>(sessionId, generation));
     }
 
     /// <inheritdoc/>
     public bool HasActiveUserLoop(string sessionId) =>
-        _sessions.TryGetValue(sessionId, out var cts) && !cts.IsCancellationRequested;
+        _activeGenerations.ContainsKey(sessionId);
 
     public void Dispose()
     {
@@ -39,5 +51,6 @@ internal sealed class SessionBackgroundTaskTracker : ISessionTracker, IDisposabl
             kvp.Value.Dispose();
         }
         _sessions.Clear();
+        _activeGenerations.Clear();
     }
 }

--- a/tests/RockBot.Host.Tests/SessionBackgroundTaskTrackerTests.cs
+++ b/tests/RockBot.Host.Tests/SessionBackgroundTaskTrackerTests.cs
@@ -1,0 +1,122 @@
+namespace RockBot.Host.Tests;
+
+[TestClass]
+public class SessionBackgroundTaskTrackerTests
+{
+    [TestMethod]
+    public void HasActiveUserLoop_ReturnsFalse_WhenNoSessionStarted()
+    {
+        using var tracker = new SessionBackgroundTaskTracker();
+
+        Assert.IsFalse(tracker.HasActiveUserLoop("session-1"));
+    }
+
+    [TestMethod]
+    public void HasActiveUserLoop_ReturnsTrue_AfterBeginSession()
+    {
+        using var tracker = new SessionBackgroundTaskTracker();
+
+        tracker.BeginSession("session-1", CancellationToken.None);
+
+        Assert.IsTrue(tracker.HasActiveUserLoop("session-1"));
+    }
+
+    [TestMethod]
+    public void HasActiveUserLoop_ReturnsFalse_AfterEndSession()
+    {
+        using var tracker = new SessionBackgroundTaskTracker();
+        var handle = tracker.BeginSession("session-1", CancellationToken.None);
+
+        tracker.EndSession("session-1", handle.Generation);
+
+        Assert.IsFalse(tracker.HasActiveUserLoop("session-1"));
+    }
+
+    [TestMethod]
+    public void HasActiveUserLoop_ReturnsTrue_WhenNewSessionStartedAfterEnd()
+    {
+        using var tracker = new SessionBackgroundTaskTracker();
+        var handle1 = tracker.BeginSession("session-1", CancellationToken.None);
+        tracker.EndSession("session-1", handle1.Generation);
+
+        tracker.BeginSession("session-1", CancellationToken.None);
+
+        Assert.IsTrue(tracker.HasActiveUserLoop("session-1"));
+    }
+
+    [TestMethod]
+    public void EndSession_StaleGeneration_DoesNotDeactivateNewerLoop()
+    {
+        using var tracker = new SessionBackgroundTaskTracker();
+        var handle1 = tracker.BeginSession("session-1", CancellationToken.None);
+
+        // New message arrives before old loop calls EndSession
+        var handle2 = tracker.BeginSession("session-1", CancellationToken.None);
+
+        // Old loop finishes and calls EndSession with stale generation
+        tracker.EndSession("session-1", handle1.Generation);
+
+        // New loop should still be active
+        Assert.IsTrue(tracker.HasActiveUserLoop("session-1"));
+    }
+
+    [TestMethod]
+    public void BeginSession_CancelsPreviousToken()
+    {
+        using var tracker = new SessionBackgroundTaskTracker();
+        var handle1 = tracker.BeginSession("session-1", CancellationToken.None);
+
+        tracker.BeginSession("session-1", CancellationToken.None);
+
+        Assert.IsTrue(handle1.Token.IsCancellationRequested);
+    }
+
+    [TestMethod]
+    public void BeginSession_ReturnsUncancelledToken()
+    {
+        using var tracker = new SessionBackgroundTaskTracker();
+
+        var handle = tracker.BeginSession("session-1", CancellationToken.None);
+
+        Assert.IsFalse(handle.Token.IsCancellationRequested);
+    }
+
+    [TestMethod]
+    public void BeginSession_LinkedToHostToken_CancelsWhenHostCancels()
+    {
+        using var tracker = new SessionBackgroundTaskTracker();
+        using var hostCts = new CancellationTokenSource();
+
+        var handle = tracker.BeginSession("session-1", hostCts.Token);
+        hostCts.Cancel();
+
+        Assert.IsTrue(handle.Token.IsCancellationRequested);
+    }
+
+    [TestMethod]
+    public void GenerationsAreUnique_AcrossSessions()
+    {
+        using var tracker = new SessionBackgroundTaskTracker();
+
+        var handle1 = tracker.BeginSession("session-1", CancellationToken.None);
+        var handle2 = tracker.BeginSession("session-2", CancellationToken.None);
+        var handle3 = tracker.BeginSession("session-1", CancellationToken.None);
+
+        Assert.AreNotEqual(handle1.Generation, handle2.Generation);
+        Assert.AreNotEqual(handle2.Generation, handle3.Generation);
+        Assert.AreNotEqual(handle1.Generation, handle3.Generation);
+    }
+
+    [TestMethod]
+    public void IndependentSessions_DoNotInterfere()
+    {
+        using var tracker = new SessionBackgroundTaskTracker();
+        var handle1 = tracker.BeginSession("session-1", CancellationToken.None);
+        var handle2 = tracker.BeginSession("session-2", CancellationToken.None);
+
+        tracker.EndSession("session-1", handle1.Generation);
+
+        Assert.IsFalse(tracker.HasActiveUserLoop("session-1"));
+        Assert.IsTrue(tracker.HasActiveUserLoop("session-2"));
+    }
+}


### PR DESCRIPTION
## Summary

- `HasActiveUserLoop` was returning `true` even when the user hadn't sent a new message — the CTS from `BeginSession` sat un-cancelled until the next `BeginSession` call, so subagent results always got the "circling back" framing
- Added generation-based `EndSession` to `ISessionTracker` so `HasActiveUserLoop` returns `false` once the user's processing loop finishes
- A stale `EndSession` from a cancelled older loop cannot deactivate a newer one (atomic compare-and-remove on generation)

## Test plan

- [x] 10 new unit tests for `SessionBackgroundTaskTracker` covering: active after begin, inactive after end, stale generation safety, independent sessions, token cancellation
- [x] Full test suite passes (260 Host tests, all solution tests green)
- [ ] Deploy to k8s and verify: subagent returning while user is idle → no "circling back" framing
- [ ] Deploy to k8s and verify: subagent returning after user sent new message → still gets "circling back" framing

🤖 Generated with [Claude Code](https://claude.com/claude-code)