### PR TITLE
Document optional embedding configuration for hybrid vector search

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ The result is a swarm of agents that coordinate through messages, where the fail
 ### Memory (three tiers)
 
 - **Conversation memory** — sliding window of recent turns per session (default 50), auto-cleaned after idle timeout. Ephemeral and in-process.
-- **Long-term memory** — persistent file-based store organized by category. The framework automatically surfaces relevant entries each turn via BM25 keyword search against the user's message (delta injection — only unseen entries are added).
-- **Working memory** — fast session-scoped cache for intermediate results. Tools can save and retrieve data during a conversation without polluting long-term storage.
+- **Long-term memory** — persistent file-based store organized by category. The framework automatically surfaces relevant entries each turn via BM25 keyword search against the user's message (delta injection — only unseen entries are added). Optionally enhanced with **hybrid vector search** (BM25 + cosine similarity) when a text embedding model is configured — see [Embedding configuration](#embedding-optional--hybrid-vector-search) below.
+- **Working memory** — fast session-scoped cache for intermediate results. Tools can save and retrieve data during a conversation without polluting long-term storage. Also supports hybrid vector search when embedding is configured.
 
 ### Skills
 
@@ -286,6 +286,13 @@ secrets:
     #   apiKey: "<your-openrouter-api-key>"
     #   modelId: "anthropic/claude-opus-4-6"
 
+  # Embedding — OPTIONAL. Enables hybrid BM25 + vector search for memory, skills,
+  # and working memory. Falls back to BM25-only when not configured.
+  # embedding:
+  #   endpoint: "http://ollama.default.svc.cluster.local:11434"
+  #   model: "nomic-embed-text"
+  #   apiKey: ""   # optional for Ollama; required for cloud providers
+
   webTools:
     apiKey: "<your-brave-search-api-key>"
   rabbitmq:
@@ -428,6 +435,45 @@ kubectl cp src/RockBot.Agent/mcp.json <pod-name>:/data/agent/mcp.json -n rockbot
 ### MCP tool configuration
 
 Edit `/data/agent/mcp.json` on the PVC (or copy it in as shown above) to configure MCP server connections. The embedded MCP bridge discovers and registers available tools automatically on startup. Servers can also be registered and unregistered at runtime through the agent's `mcp_register_server` and `mcp_unregister_server` tools.
+
+---
+
+### Embedding (optional — hybrid vector search)
+
+By default the agent uses BM25 keyword search for memory, skills, and working memory recall. You can optionally configure a text embedding model to enable **hybrid search** (BM25 + cosine similarity), which improves recall for semantically similar but lexically different content.
+
+Any OpenAI-compatible embedding endpoint works — OpenAI, Ollama, Azure OpenAI, etc. When not configured, the agent falls back to BM25-only search with no loss of functionality.
+
+**Helm (`values.personal.yaml`):**
+
+```yaml
+secrets:
+  embedding:
+    endpoint: "http://ollama.default.svc.cluster.local:11434"
+    model: "nomic-embed-text"
+    apiKey: ""   # optional for Ollama; required for cloud providers
+```
+
+**Docker Compose / environment variables:**
+
+```env
+Embedding__Endpoint=http://ollama:11434
+Embedding__Model=nomic-embed-text
+Embedding__ApiKey=              # optional for Ollama
+```
+
+The agent logs confirm the configuration on startup:
+
+```
+Embedding model configured: nomic-embed-text @ http://ollama:11434
+```
+
+Or when not configured:
+
+```
+No embedding config found — using BM25-only search.
+Set Embedding:Endpoint and Embedding:Model to enable hybrid vector search.
+```
 
 ---
 

--- a/deploy/helm/rockbot/templates/secret.yaml
+++ b/deploy/helm/rockbot/templates/secret.yaml
@@ -32,6 +32,14 @@ stringData:
   LLM__ApiKey: {{ .Values.secrets.llm.apiKey | quote }}
   LLM__ModelId: {{ .Values.secrets.llm.modelId | quote }}
   {{- end }}
+  {{- if ((.Values.secrets.embedding).model) }}
+  # ── Embedding (optional) — hybrid BM25 + vector search ──────────────────────
+  Embedding__Endpoint: {{ required "secrets.embedding.endpoint is required when embedding.model is set" .Values.secrets.embedding.endpoint | quote }}
+  Embedding__Model: {{ .Values.secrets.embedding.model | quote }}
+  {{- if .Values.secrets.embedding.apiKey }}
+  Embedding__ApiKey: {{ .Values.secrets.embedding.apiKey | quote }}
+  {{- end }}
+  {{- end }}
   # ── Web search ────────────────────────────────────────────────────────────────
   WebTools__ApiKey: {{ required "secrets.webTools.apiKey is required" .Values.secrets.webTools.apiKey | quote }}
   # ── RabbitMQ ──────────────────────────────────────────────────────────────────

--- a/deploy/helm/rockbot/values.yaml
+++ b/deploy/helm/rockbot/values.yaml
@@ -247,6 +247,16 @@ secrets:
     apiKey: ""
     modelId: ""
 
+  # ── Embedding (optional) — hybrid BM25 + vector search ──────────────────────
+  # When configured, memory, skills, and working memory use cosine similarity
+  # alongside BM25 keyword search for improved recall. Falls back to BM25-only
+  # when not configured — no functionality is lost.
+  # Any OpenAI-compatible embedding endpoint works (OpenAI, Ollama, Azure, etc.)
+  embedding:
+    endpoint: ""            # e.g. "http://ollama:11434" or "https://api.openai.com/v1"
+    apiKey: ""              # optional for Ollama; required for cloud providers
+    model: ""               # e.g. "nomic-embed-text", "text-embedding-3-small"
+
   webTools:
     apiKey: ""              # REQUIRED — Brave Search API key
 

--- a/deploy/values.personal.example.yaml
+++ b/deploy/values.personal.example.yaml
@@ -33,6 +33,14 @@ secrets:
     #   apiKey: "<your-openrouter-api-key>"
     #   modelId: "anthropic/claude-opus-4-6"
 
+  # Embedding — OPTIONAL. Enables hybrid BM25 + vector search for memory, skills,
+  # and working memory. Falls back to BM25-only when not configured.
+  # Any OpenAI-compatible embedding endpoint works (OpenAI, Ollama, Azure, etc.)
+  # embedding:
+  #   endpoint: "http://ollama.default.svc.cluster.local:11434"  # or "https://api.openai.com/v1"
+  #   model: "nomic-embed-text"                                   # or "text-embedding-3-small"
+  #   apiKey: ""                                                   # optional for Ollama
+
   webTools:
     apiKey: "<your-brave-search-api-key>"
   rabbitmq:

--- a/design/agent-memory.md
+++ b/design/agent-memory.md
@@ -99,6 +99,6 @@ builder.Services.AddRockBotHost(agent =>
 
 ## Future Considerations
 
-- Swap `FileMemoryStore` for vector/embedding store (interface is async and query-based)
+- ~~Swap `FileMemoryStore` for vector/embedding store~~ — **Implemented.** `EmbeddingCache` + `HybridRanker` add optional cosine-similarity search alongside BM25. Configure via `EmbeddingOptions` (Endpoint, Model, ApiKey). Falls back to BM25-only when not configured.
 - Add memory compaction/summarization for entries exceeding size thresholds
 - Add memory import/export for agent migration

--- a/docs/getting-started-docker-desktop.md
+++ b/docs/getting-started-docker-desktop.md
@@ -103,6 +103,12 @@ services:
       LLM__Balanced__ModelId: ${LLM_MODEL_ID:-anthropic/claude-haiku-4.5}
       # ── Web search ──
       WebTools__ApiKey: ${BRAVE_API_KEY:?Set BRAVE_API_KEY in your .env file}
+      # ── Embedding (optional — enables hybrid vector search) ──
+      # When set, memory/skills/working memory use cosine similarity alongside BM25.
+      # Falls back to BM25-only when not configured — no functionality is lost.
+      # Embedding__Endpoint: ${EMBEDDING_ENDPOINT:-}
+      # Embedding__Model: ${EMBEDDING_MODEL:-}
+      # Embedding__ApiKey: ${EMBEDDING_API_KEY:-}
       # ── Agent data paths ──
       AgentProfile__BasePath: /data/agent
       Memory__BasePath: /data/agent/memory
@@ -150,6 +156,14 @@ BRAVE_API_KEY=BSA-your-brave-key-here
 
 # OPTIONAL — your IANA timezone (defaults to America/Chicago)
 # AGENT_TIMEZONE=America/New_York
+
+# OPTIONAL — text embedding model for hybrid vector search (BM25 + cosine similarity).
+# When configured, memory, skills, and working memory recall improves via vector search.
+# Falls back to BM25-only keyword search when not set — no functionality is lost.
+# Any OpenAI-compatible embedding endpoint works (OpenAI, Ollama, Azure, etc.)
+# EMBEDDING_ENDPOINT=http://host.docker.internal:11434   # Ollama running on the host
+# EMBEDDING_MODEL=nomic-embed-text
+# EMBEDDING_API_KEY=                                      # not needed for Ollama
 ```
 
 > **Do not commit the `.env` file to version control.** It contains your API keys.
@@ -235,6 +249,25 @@ LLM_ENDPOINT=http://host.docker.internal:11434/v1
 LLM_API_KEY=ollama
 LLM_MODEL_ID=llama3.1
 ```
+
+## Enabling hybrid vector search (optional)
+
+By default the agent uses BM25 keyword search for memory, skills, and working memory recall. You can optionally add a text embedding model to enable **hybrid search** (BM25 + cosine similarity), which improves recall for semantically similar but lexically different content.
+
+Any OpenAI-compatible embedding endpoint works. The easiest local option is [Ollama](https://ollama.com/):
+
+1. Install and start Ollama on your host machine
+2. Pull an embedding model: `ollama pull nomic-embed-text`
+3. Uncomment the embedding lines in your `docker-compose.yml` agent environment and in your `.env`:
+
+```env
+EMBEDDING_ENDPOINT=http://host.docker.internal:11434
+EMBEDDING_MODEL=nomic-embed-text
+```
+
+4. Restart the agent: `docker compose restart agent`
+
+The agent logs will confirm: `Embedding model configured: nomic-embed-text @ http://host.docker.internal:11434`. If the embedding config is missing or the endpoint is unreachable, the agent falls back to BM25-only search with no loss of functionality.
 
 ## Connecting MCP servers and A2A agents
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -10,7 +10,7 @@ token bloat.
 
 | Tier | Class | Scope | Lifetime | Injection |
 |---|---|---|---|---|
-| **Long-term** | `FileMemoryStore` | Cross-session | Permanent | BM25 delta per turn |
+| **Long-term** | `FileMemoryStore` | Cross-session | Permanent | BM25 (+ vector) delta per turn |
 | **Working** | `HybridCacheWorkingMemory` | Global, path-namespaced | TTL (default 5 min) | Own-namespace inventory per turn |
 | **Conversation** | `InMemoryConversationMemory` | Session | Process lifetime | Last N turns (default 20) |
 
@@ -42,7 +42,9 @@ public sealed record MemoryEntry(
 
 The store maintains a lazy-loaded in-memory index protected by a `SemaphoreSlim`.
 
-### BM25 recall and delta injection
+### Search and recall
+
+#### BM25 keyword search
 
 Every user message triggers a BM25 search against all memory entries. Only entries not yet
 injected this session are added to context (delta injection via `InjectedMemoryTracker`):
@@ -58,6 +60,46 @@ replaced by spaces).
 
 **Fallback on first turn:** If BM25 returns no results on the opening turn, up to 5 entries are
 injected without a query — ensuring the agent always has some memory context at session start.
+
+#### Hybrid vector search (optional)
+
+When a text embedding model is configured (`EmbeddingOptions`), all three stores — long-term
+memory, skills, and working memory — use **hybrid ranking** that combines BM25 keyword scores
+with cosine similarity from vector embeddings. This improves recall for semantically similar
+content that may not share the same keywords.
+
+**How it works:**
+
+1. `EmbeddingCache` generates embeddings on demand via any OpenAI-compatible endpoint and
+   caches them as binary float arrays in `{basePath}/.embeddings/{id}.bin`.
+2. `HybridRanker` normalizes both BM25 and cosine similarity scores to [0, 1] and averages
+   them for a consolidated ranking.
+3. Vector results below `MinSimilarityThreshold` (default 0.5) are excluded to prevent loosely
+   related content from diluting keyword matches.
+
+**Configuration:**
+
+```csharp
+public sealed class EmbeddingOptions
+{
+    public string? Endpoint { get; set; }               // e.g. "http://ollama:11434"
+    public string? Model { get; set; }                  // e.g. "nomic-embed-text"
+    public string? ApiKey { get; set; }                 // optional for Ollama
+    public int MaxInputChars { get; set; } = 30_000;    // truncation limit (~7500 tokens)
+    public float MinSimilarityThreshold { get; set; } = 0.5f;
+}
+```
+
+Set via environment variables or `appsettings.json`:
+
+```
+Embedding__Endpoint=http://ollama:11434
+Embedding__Model=nomic-embed-text
+Embedding__ApiKey=              # optional for Ollama
+```
+
+When not configured, all stores fall back to BM25-only search with no loss of functionality.
+Embeddings are generated asynchronously in the background and never block the agent's response.
 
 ### Categories
 


### PR DESCRIPTION
## Summary
- Add `Embedding` (endpoint, model, apiKey) to Helm values, secret template, and personal values example
- Add embedding env vars and "Enabling hybrid vector search" section to Docker Compose getting-started guide
- Add embedding config section and hybrid search mention to README deployment and memory features
- Add hybrid vector search subsection to `docs/memory.md` documenting `EmbeddingCache`, `HybridRanker`, and `EmbeddingOptions`
- Mark vector/embedding store as implemented in `design/agent-memory.md`

## Test plan
- [ ] Verify `helm template` renders correctly with and without `secrets.embedding.model` set
- [ ] Verify Docker Compose starts cleanly with embedding env vars commented out (default)
- [ ] Verify docs render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)