### PR TITLE
Add content filter recovery to survive poisoned conversation history

### DIFF
--- a/src/RockBot.Host/AgentLoopRunner.cs
+++ b/src/RockBot.Host/AgentLoopRunner.cs
@@ -24,6 +24,7 @@ public sealed partial class AgentLoopRunner(
     IOptions<AgentHostOptions> hostOptions,
     ISkillStore skillStore,
     IEnumerable<IServiceSearchIndex> serviceSearchIndexProviders,
+    IConversationMemory conversationMemory,
     ILogger<AgentLoopRunner> logger)
 {
     private readonly IServiceSearchIndex? _serviceSearchIndex = serviceSearchIndexProviders.FirstOrDefault();
@@ -202,7 +203,7 @@ public sealed partial class AgentLoopRunner(
                     chatMessages, chatOptions, sessionId, firstResponse, tier,
                     onPreToolCall, onProgress, onToolTimeout, cancellationToken)
                 : await RunNativeLoopAsync(
-                    chatMessages, chatOptions, firstResponse, tier, cancellationToken);
+                    chatMessages, chatOptions, firstResponse, tier, sessionId, cancellationToken);
 
             // Clear first response after the first iteration — it's already been consumed.
             firstResponse = null;
@@ -300,6 +301,7 @@ public sealed partial class AgentLoopRunner(
         ChatOptions chatOptions,
         ChatResponse? firstResponse,
         ModelTier tier,
+        string? sessionId,
         CancellationToken cancellationToken)
     {
         logger.LogInformation(
@@ -323,7 +325,8 @@ public sealed partial class AgentLoopRunner(
             when (ex.Status == 400 && ex.Message.Contains("content_filter", StringComparison.OrdinalIgnoreCase))
         {
             LogContentFilterDiagnostics(chatMessages, ex);
-            throw;
+            response = await RecoverFromContentFilterAsync(
+                chatMessages, tier, chatOptions, sessionId, ex, cancellationToken);
         }
 
         // Append response messages to chatMessages so re-prompts have full tool-call history.
@@ -478,7 +481,8 @@ public sealed partial class AgentLoopRunner(
                     when (ex.Status == 400 && ex.Message.Contains("content_filter", StringComparison.OrdinalIgnoreCase))
                 {
                     LogContentFilterDiagnostics(chatMessages, ex);
-                    throw;
+                    response = await RecoverFromContentFilterAsync(
+                        chatMessages, tier, chatOptions, sessionId, ex, cancellationToken);
                 }
 
                 sw.Stop();
@@ -902,6 +906,132 @@ public sealed partial class AgentLoopRunner(
         return true;
     }
 
+    // ── Content filter recovery ───────────────────────────────────────────────
+
+    /// <summary>
+    /// Attempts to recover from an Azure content filter rejection by stripping conversation
+    /// history (which may contain a poisonous message from a prior turn) and retrying with
+    /// only system messages and the current user request. On success, clears the session's
+    /// conversation memory so the offending turn doesn't re-poison future requests.
+    /// </summary>
+    private async Task<ChatResponse> RecoverFromContentFilterAsync(
+        List<ChatMessage> chatMessages,
+        ModelTier tier,
+        ChatOptions chatOptions,
+        string? sessionId,
+        ClientResultException originalException,
+        CancellationToken cancellationToken)
+    {
+        var stripped = StripConversationHistory(chatMessages);
+        if (stripped == 0)
+        {
+            // Nothing to strip — the current message itself is the problem.
+            logger.LogWarning("Content filter triggered with no conversation history to strip; cannot recover");
+            throw originalException;
+        }
+
+        logger.LogWarning(
+            "Content filter recovery: stripped {Removed} history message(s), retrying with {Remaining} messages",
+            stripped, chatMessages.Count);
+
+        try
+        {
+            var response = await llmClient.GetResponseAsync(chatMessages, tier, chatOptions, cancellationToken);
+
+            // Retry succeeded — the poison was in conversation history. Clean the session memory
+            // so the offending turn(s) don't re-poison the next request.
+            if (sessionId is not null)
+            {
+                await CleanSessionMemoryAfterContentFilterAsync(sessionId, cancellationToken);
+            }
+
+            logger.LogInformation("Content filter recovery succeeded after stripping history");
+            return response;
+        }
+        catch (ClientResultException retryEx)
+            when (retryEx.Status == 400 && retryEx.Message.Contains("content_filter", StringComparison.OrdinalIgnoreCase))
+        {
+            // Still filtered after stripping history — the current user message is the trigger.
+            logger.LogWarning("Content filter triggered again after stripping history; current message is the cause");
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Removes conversation history (user and assistant messages that aren't the current request)
+    /// from the chat message list. Keeps system messages, tool messages, and the last user message.
+    /// Returns the number of messages removed.
+    /// </summary>
+    internal static int StripConversationHistory(List<ChatMessage> chatMessages)
+    {
+        // Find the last user message — this is the current request.
+        var lastUserIdx = -1;
+        for (var i = chatMessages.Count - 1; i >= 0; i--)
+        {
+            if (chatMessages[i].Role == ChatRole.User)
+            {
+                lastUserIdx = i;
+                break;
+            }
+        }
+
+        if (lastUserIdx < 0) return 0;
+
+        var removed = 0;
+        for (var i = chatMessages.Count - 1; i >= 0; i--)
+        {
+            if (i == lastUserIdx) continue;
+
+            var role = chatMessages[i].Role;
+            if (role == ChatRole.User || role == ChatRole.Assistant)
+            {
+                chatMessages.RemoveAt(i);
+                removed++;
+                if (i < lastUserIdx) lastUserIdx--;
+            }
+        }
+
+        return removed;
+    }
+
+    /// <summary>
+    /// Clears conversation memory for a session after a successful content filter recovery,
+    /// keeping only the most recent user turn so the poisoned history doesn't come back.
+    /// </summary>
+    private async Task CleanSessionMemoryAfterContentFilterAsync(string sessionId, CancellationToken ct)
+    {
+        try
+        {
+            var turns = await conversationMemory.GetTurnsAsync(sessionId, ct);
+            ConversationTurn? lastUserTurn = null;
+            for (var i = turns.Count - 1; i >= 0; i--)
+            {
+                if (turns[i].Role == "user")
+                {
+                    lastUserTurn = turns[i];
+                    break;
+                }
+            }
+
+            await conversationMemory.ClearAsync(sessionId, ct);
+
+            if (lastUserTurn is not null)
+            {
+                await conversationMemory.AddTurnAsync(sessionId, lastUserTurn, ct);
+            }
+
+            logger.LogWarning(
+                "Cleared conversation memory for session {SessionId} after content filter recovery " +
+                "(kept last user turn only)", sessionId);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "Failed to clean conversation memory for session {SessionId} after content filter recovery",
+                sessionId);
+        }
+    }
+
     // ── Logging ──────────────────────────────────────────────────────────────
 
     /// <summary>
@@ -1243,7 +1373,7 @@ public sealed partial class AgentLoopRunner(
                 chatMessages, chatOptions, sessionId, null, tier,
                 onPreToolCall, onProgress, onToolTimeout, cancellationToken)
             : await RunNativeLoopAsync(
-                chatMessages, chatOptions, null, tier, cancellationToken);
+                chatMessages, chatOptions, null, tier, sessionId, cancellationToken);
 
         // Native path: FunctionCallContent in response messages.
         // Text-based path: tool results appear as "[Tool result for ...]" user messages.

--- a/tests/RockBot.Agent.Tests/UserFeedbackHandlerTests.cs
+++ b/tests/RockBot.Agent.Tests/UserFeedbackHandlerTests.cs
@@ -53,6 +53,7 @@ public class UserFeedbackHandlerTests
             Options.Create(new AgentHostOptions()),
             new StubSkillStore(),
             Enumerable.Empty<IServiceSearchIndex>(),
+            new StubConversationMemory(),
             NullLogger<AgentLoopRunner>.Instance);
         var clock = new AgentClock(config, profileOptions, NullLogger<AgentClock>.Instance);
 

--- a/tests/RockBot.Host.Tests/ContentFilterRecoveryTests.cs
+++ b/tests/RockBot.Host.Tests/ContentFilterRecoveryTests.cs
@@ -1,0 +1,143 @@
+using Microsoft.Extensions.AI;
+
+namespace RockBot.Host.Tests;
+
+[TestClass]
+public class ContentFilterRecoveryTests
+{
+    // ── StripConversationHistory ─────────────────────────────────────────────
+
+    [TestMethod]
+    public void StripConversationHistory_RemovesHistoryKeepsLastUser()
+    {
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.System, "You are a helpful assistant."),
+            new(ChatRole.User, "old user message 1"),
+            new(ChatRole.Assistant, "old assistant response 1"),
+            new(ChatRole.User, "old user message 2"),
+            new(ChatRole.Assistant, "old assistant response 2"),
+            new(ChatRole.User, "current request"),
+        };
+
+        var removed = AgentLoopRunner.StripConversationHistory(messages);
+
+        Assert.AreEqual(4, removed);
+        Assert.AreEqual(2, messages.Count);
+        Assert.AreEqual(ChatRole.System, messages[0].Role);
+        Assert.AreEqual("current request", messages[1].Text);
+        Assert.AreEqual(ChatRole.User, messages[1].Role);
+    }
+
+    [TestMethod]
+    public void StripConversationHistory_KeepsSystemMessages()
+    {
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.System, "system prompt"),
+            new(ChatRole.System, "datetime context"),
+            new(ChatRole.System, "reasoning scaffolding"),
+            new(ChatRole.User, "history turn"),
+            new(ChatRole.Assistant, "history response"),
+            new(ChatRole.System, "memory recall"),
+            new(ChatRole.User, "current request"),
+        };
+
+        var removed = AgentLoopRunner.StripConversationHistory(messages);
+
+        Assert.AreEqual(2, removed);
+        Assert.AreEqual(5, messages.Count);
+        Assert.IsTrue(messages.All(m => m.Role == ChatRole.System || m.Text == "current request"));
+    }
+
+    [TestMethod]
+    public void StripConversationHistory_NoHistoryReturnsZero()
+    {
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.System, "system prompt"),
+            new(ChatRole.User, "only message"),
+        };
+
+        var removed = AgentLoopRunner.StripConversationHistory(messages);
+
+        Assert.AreEqual(0, removed);
+        Assert.AreEqual(2, messages.Count);
+    }
+
+    [TestMethod]
+    public void StripConversationHistory_NoUserMessageReturnsZero()
+    {
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.System, "system prompt"),
+            new(ChatRole.Assistant, "orphan assistant message"),
+        };
+
+        var removed = AgentLoopRunner.StripConversationHistory(messages);
+
+        Assert.AreEqual(0, removed);
+    }
+
+    [TestMethod]
+    public void StripConversationHistory_KeepsToolMessages()
+    {
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.System, "system prompt"),
+            new(ChatRole.User, "old message"),
+            new(ChatRole.Assistant, "old response"),
+            new(ChatRole.Tool, "tool result from current interaction"),
+            new(ChatRole.User, "current request"),
+        };
+
+        var removed = AgentLoopRunner.StripConversationHistory(messages);
+
+        Assert.AreEqual(2, removed);
+        Assert.AreEqual(3, messages.Count);
+        Assert.AreEqual(ChatRole.System, messages[0].Role);
+        Assert.AreEqual(ChatRole.Tool, messages[1].Role);
+        Assert.AreEqual("current request", messages[2].Text);
+    }
+
+    [TestMethod]
+    public void StripConversationHistory_EmptyListReturnsZero()
+    {
+        var messages = new List<ChatMessage>();
+
+        var removed = AgentLoopRunner.StripConversationHistory(messages);
+
+        Assert.AreEqual(0, removed);
+    }
+
+    [TestMethod]
+    public void StripConversationHistory_MultipleSystemInterleavedWithHistory()
+    {
+        // Simulates real context: system messages interspersed with history
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.System, "soul"),
+            new(ChatRole.System, "directives"),
+            new(ChatRole.System, "datetime"),
+            new(ChatRole.User, "hi"),
+            new(ChatRole.Assistant, "hello!"),
+            new(ChatRole.User, "toxic injection text"),
+            new(ChatRole.Assistant, "poisoned response"),
+            new(ChatRole.System, "memory recall"),
+            new(ChatRole.System, "reasoning scaffolding"),
+            new(ChatRole.User, "what's my schedule?"),
+        };
+
+        var removed = AgentLoopRunner.StripConversationHistory(messages);
+
+        Assert.AreEqual(4, removed);
+        Assert.AreEqual(6, messages.Count);
+        // All remaining should be system or the current user request
+        foreach (var msg in messages)
+        {
+            Assert.IsTrue(
+                msg.Role == ChatRole.System || msg.Text == "what's my schedule?",
+                $"Unexpected message: role={msg.Role}, text={msg.Text}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- When Azure's content filter rejects a prompt due to a toxic message stuck in conversation history, the agent now automatically strips history from the context and retries with just system messages + the current user request
- On successful retry, clears the session's persisted conversation memory so the offending turn doesn't re-poison future requests
- If the current user message itself triggers the filter, the error propagates normally to the user

## Problem
A prompt injection or content-filter-triggering message could get into conversation history (from any source). Once there, **every subsequent LLM call** included it in the context, and Azure blocked the entire request — even when the user's new input was completely innocent. There was zero recovery; the session was permanently bricked until it expired.

## Changes
- **`AgentLoopRunner.cs`** — Added `RecoverFromContentFilterAsync`, `StripConversationHistory`, and `CleanSessionMemoryAfterContentFilterAsync`. Both native and text-based LLM paths now catch content_filter errors and attempt recovery. Added `IConversationMemory` dependency.
- **`UserFeedbackHandlerTests.cs`** — Updated constructor call for new dependency
- **`ContentFilterRecoveryTests.cs`** — 7 unit tests covering history stripping logic

## Test plan
- [x] All 735 existing tests pass (0 failures)
- [x] 7 new unit tests for `StripConversationHistory` covering:
  - History removal while preserving last user message
  - System message preservation
  - Tool message preservation
  - Edge cases (empty list, no history, no user messages)
- [ ] Deploy and verify: send a message after a content filter rejection — should recover and respond

🤖 Generated with [Claude Code](https://claude.com/claude-code)