### PR TITLE
Fall back to non-Azure provider on content filter rejection

### DIFF
--- a/src/RockBot.Llm/FallbackChatClient.cs
+++ b/src/RockBot.Llm/FallbackChatClient.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging;
 
 namespace RockBot.Llm;
 
-internal enum FallbackErrorCategory { Transient, QuotaExhausted, HardError, Unknown }
+internal enum FallbackErrorCategory { Transient, QuotaExhausted, ContentFilter, HardError, Unknown }
 
 /// <summary>
 /// IChatClient decorator that holds an ordered list of model clients and falls back to
@@ -81,6 +81,16 @@ public sealed class FallbackChatClient : IChatClient
 
                     if (category == FallbackErrorCategory.Transient && attempt < _maxRetries)
                         continue; // One more retry on the same client
+
+                    // Content filter: fall back to next model for this request only.
+                    // Don't degrade — the model is fine, Azure's filter blocked the content.
+                    if (category == FallbackErrorCategory.ContentFilter)
+                    {
+                        _logger.LogWarning(
+                            "FallbackChatClient: content filter triggered on {ModelId}; trying next model without degrading",
+                            modelId);
+                        break;
+                    }
 
                     // Transient retries exhausted, or permanent degradation
                     if (category is FallbackErrorCategory.QuotaExhausted or FallbackErrorCategory.HardError)
@@ -196,6 +206,8 @@ public sealed class FallbackChatClient : IChatClient
         }
 
         var msg = ex.Message;
+        if (ContainsAny(msg, "content_filter"))
+            return FallbackErrorCategory.ContentFilter;
         if (ContainsAny(msg, "credit", "quota", "billing", "insufficient_quota", "exceeded"))
             return FallbackErrorCategory.QuotaExhausted;
 

--- a/tests/RockBot.Llm.Tests/FallbackChatClientTests.cs
+++ b/tests/RockBot.Llm.Tests/FallbackChatClientTests.cs
@@ -233,6 +233,54 @@ public class FallbackChatClientTests
     }
 
     [TestMethod]
+    public async Task ContentFilter_FallsBackWithoutDegrading()
+    {
+        var first  = new FixedStub(ex: new Exception("HTTP 400 (: content_filter)"));
+        var second = new FixedStub(response: OkResponse("from-second"));
+
+        var client = Build([("azure-model", first), ("openrouter-model", second)], maxRetries: 0);
+
+        var response = await client.GetResponseAsync([]);
+
+        Assert.AreEqual("from-second", response.Messages[^1].Text);
+        Assert.AreEqual(1, first.CallCount);
+        Assert.AreEqual(1, second.CallCount);
+    }
+
+    [TestMethod]
+    public async Task ContentFilter_DoesNotDegradeModel_SubsequentCallsRetryPrimary()
+    {
+        var first = new SequentialStub();
+        first.Enqueue(new Exception("HTTP 400 (: content_filter)")); // call 1: filtered
+        first.Enqueue(OkResponse("azure-ok"));                       // call 2: normal request works
+
+        var second = new FixedStub(response: OkResponse("fallback"));
+
+        var client = Build([("azure-model", first), ("openrouter-model", second)], maxRetries: 0);
+
+        // Call 1: content filter → falls back to second
+        var r1 = await client.GetResponseAsync([]);
+        Assert.AreEqual("fallback", r1.Messages[^1].Text);
+
+        // Call 2: first model should be tried again (not degraded)
+        var r2 = await client.GetResponseAsync([]);
+        Assert.AreEqual("azure-ok", r2.Messages[^1].Text);
+        Assert.AreEqual(2, first.CallCount);
+    }
+
+    [TestMethod]
+    public async Task ContentFilter_AllModelsFiltered_Throws()
+    {
+        var first  = new FixedStub(ex: new Exception("HTTP 400 (: content_filter)"));
+        var second = new FixedStub(ex: new Exception("HTTP 400 (: content_filter)"));
+
+        var client = Build([("m1", first), ("m2", second)], maxRetries: 0);
+
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(
+            () => client.GetResponseAsync([]));
+    }
+
+    [TestMethod]
     public void GetService_DelegatesToActiveClient()
     {
         var metadata = new ChatClientMetadata("test-provider", null, "model-x");


### PR DESCRIPTION
## Summary
- Adds `ContentFilter` category to `FallbackChatClient` error classification
- When Azure's content filter blocks a request (HTTP 400 + "content_filter"), routes to the next model in the `BalancedModels` chain instead of throwing
- Azure model is **not degraded** — subsequent requests still try it first, so only filtered content hits the fallback provider

## Context
This is the third layer of defense for the Azure content filter issue:
1. **#207** — Reactive recovery: strip poisoned conversation history and retry
2. **#208** — Proactive prevention: directive telling the LLM not to adopt personas from casual remarks
3. **This PR** — Provider fallback: if Azure still filters a request, route to a non-Azure provider transparently

## Test plan
- [x] All 738 tests pass (0 failures)
- [x] 3 new tests:
  - Content filter falls back without degrading the primary model
  - Subsequent calls retry the primary (not permanently skipped)
  - All models filtered throws `InvalidOperationException`
- [x] Deployed to k8s

🤖 Generated with [Claude Code](https://claude.com/claude-code)