### PR TITLE
Make follow-up pass failures non-fatal

### DIFF
--- a/src/RockBot.Host/AgentLoopRunner.cs
+++ b/src/RockBot.Host/AgentLoopRunner.cs
@@ -255,12 +255,21 @@ public sealed partial class AgentLoopRunner(
                     return result.Response;
                 }
 
-                var followUpResult = await RunFollowUpPassAsync(
-                    chatMessages, chatOptions, sessionId, result.Response,
-                    originalUserRequest, tier,
-                    onPreToolCall, onProgress, onToolTimeout, cancellationToken);
+                try
+                {
+                    var followUpResult = await RunFollowUpPassAsync(
+                        chatMessages, chatOptions, sessionId, result.Response,
+                        originalUserRequest, tier,
+                        onPreToolCall, onProgress, onToolTimeout, cancellationToken);
 
-                return followUpResult ?? result.Response;
+                    return followUpResult ?? result.Response;
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    logger.LogWarning(ex,
+                        "Follow-up pass failed; returning completed response instead of propagating error");
+                    return result.Response;
+                }
             }
 
             // Not complete — inject continuation and re-enter the loop.


### PR DESCRIPTION
## Summary
- Wraps the proactive follow-up pass in `RunAsync` with a try/catch so failures don't discard the already-completed response
- On failure, logs the error and returns `result.Response` — the user gets their answer instead of an error message

## Problem
The follow-up pass runs after the main request is complete to look for proactive next steps. If it timed out or hit a content filter, the exception propagated all the way up to `UserMessageHandler`, which showed the user an error — even though their actual question had already been fully answered.

## Test plan
- [x] All 738 tests pass (0 failures)
- [x] Deployed to k8s

🤖 Generated with [Claude Code](https://claude.com/claude-code)