### PR TITLE
Prevent topic keyword pollution in tier routing

### DIFF
--- a/src/RockBot.Agent/agent/routing-dream.md
+++ b/src/RockBot.Agent/agent/routing-dream.md
@@ -31,6 +31,26 @@ Recurring prompt shapes consistently routed to the wrong tier. Identify keywords
 that should be added to `highSignalKeywords` or `lowSignalKeywords`. These learned associations
 replace static keyword guesses with evidence-backed routing rules.
 
+**CRITICAL — keyword quality rules:**
+Keywords must indicate *cognitive complexity*, NOT topic or domain. The tier selector asks
+"how hard is this to think about?", not "what is this about?".
+
+Good high-signal keywords describe **reasoning difficulty**: "analyze", "architect", "trade-off",
+"compare and contrast", "step by step", "threat model", "prove", "optimize".
+
+Bad high-signal keywords describe **topics or tools**: "calendar", "email", "todo", "mcp server",
+"working memory", "retrieve", "schedule", "flight", "health report", "skill". These words appear
+in both trivial and complex prompts — they tell you the *domain*, not the *difficulty*. A prompt
+like "check my calendar" is trivially simple despite containing "calendar".
+
+Before adding a keyword, apply this test: "Would a prompt containing ONLY this word and a simple
+verb be complex?" If "check my [keyword]" or "list the [keyword]" would be simple, the word is a
+topic indicator and MUST NOT be added to highSignalKeywords.
+
+When a topic-heavy prompt was misrouted, the correct fix is to adjust **thresholds**, not to add
+topic words as high-signal keywords. Topic keyword pollution is the #1 cause of over-routing to
+High tier.
+
 ### 4. Cost-Aware Correction
 If a class of prompts routed Low produces many tool calls and high token usage, routing them to
 Balanced upfront is more efficient. Calculate: (Low tier token cost × retries) vs. (Balanced tier

--- a/src/RockBot.Llm/KeywordTierSelector.cs
+++ b/src/RockBot.Llm/KeywordTierSelector.cs
@@ -245,12 +245,37 @@ public sealed class KeywordTierSelector : ILlmTierSelector
     private const int MinKeywordLength = 3;
 
     /// <summary>
+    /// Topic/domain words that must never appear as high-signal complexity keywords.
+    /// These indicate *what* a prompt is about, not *how hard* it is to reason about.
+    /// The dream routing review LLM is instructed to avoid these, but this serves as
+    /// a code-level guardrail in case the directive is ignored.
+    /// </summary>
+    private static readonly HashSet<string> TopicBlocklist = new(StringComparer.OrdinalIgnoreCase)
+    {
+        // Communication / PIM
+        "email", "emails", "inbox", "calendar", "calendar event", "calendar events",
+        "schedule", "scheduled", "todo", "todo list", "task list", "flight",
+        // Tools / infrastructure
+        "mcp server", "mcp servers", "mcp service", "mcp services", "server",
+        "working memory", "long term memory", "retrieve", "skill", "tool guide",
+        // Health / personal
+        "health report", "heart rhythm", "afib", "medical episode",
+        // Generic actions
+        "create", "remove", "mark complete", "mark as complete", "check",
+        "paid bill", "bill payment",
+    };
+
+    /// <summary>
     /// Filters out keywords that are too short to be useful routing signals.
+    /// For high-signal lists, also strips topic/domain words that indicate subject
+    /// matter rather than cognitive complexity.
     /// Returns null when the input list is null (caller falls back to defaults).
     /// </summary>
     private string[]? SanitizeKeywords(List<string>? keywords, string listName)
     {
         if (keywords is null) return null;
+
+        var isHighSignal = listName.Contains("high", StringComparison.OrdinalIgnoreCase);
 
         var filtered = keywords
             .Where(k => !string.IsNullOrWhiteSpace(k) && k.Trim().Length >= MinKeywordLength)
@@ -258,16 +283,39 @@ public sealed class KeywordTierSelector : ILlmTierSelector
             .Distinct()
             .ToArray();
 
-        var removed = keywords.Count - filtered.Length;
-        if (removed > 0)
+        // For high-signal keywords, strip topic/domain words
+        string[] afterBlocklist;
+        if (isHighSignal)
         {
-            var rejected = keywords.Where(k => string.IsNullOrWhiteSpace(k) || k.Trim().Length < MinKeywordLength);
-            _logger?.LogWarning(
-                "KeywordTierSelector: dropped {Count} keyword(s) from {List} (too short or blank): [{Keywords}]",
-                removed, listName, string.Join(", ", rejected.Select(k => $"\"{k}\"")));
+            afterBlocklist = filtered
+                .Where(k => !TopicBlocklist.Contains(k))
+                .ToArray();
+
+            var blocked = filtered.Length - afterBlocklist.Length;
+            if (blocked > 0)
+            {
+                var blockedWords = filtered.Where(k => TopicBlocklist.Contains(k));
+                _logger?.LogWarning(
+                    "KeywordTierSelector: stripped {Count} topic word(s) from {List} (domain indicators, not complexity signals): [{Keywords}]",
+                    blocked, listName, string.Join(", ", blockedWords.Select(k => $"\"{k}\"")));
+            }
+        }
+        else
+        {
+            afterBlocklist = filtered;
         }
 
-        return filtered.Length > 0 ? filtered : null;
+        var removed = keywords.Count - afterBlocklist.Length;
+        if (removed > 0)
+        {
+            var tooShort = keywords.Where(k => string.IsNullOrWhiteSpace(k) || k.Trim().Length < MinKeywordLength);
+            if (tooShort.Any())
+                _logger?.LogWarning(
+                    "KeywordTierSelector: dropped {Count} keyword(s) from {List} (too short or blank): [{Keywords}]",
+                    tooShort.Count(), listName, string.Join(", ", tooShort.Select(k => $"\"{k}\"")));
+        }
+
+        return afterBlocklist.Length > 0 ? afterBlocklist : null;
     }
 
     // ── Word-boundary matching ─────────────────────────────────────────────────

--- a/tests/RockBot.Llm.Tests/KeywordTierSelectorTests.cs
+++ b/tests/RockBot.Llm.Tests/KeywordTierSelectorTests.cs
@@ -308,4 +308,74 @@ public class KeywordTierSelectorTests
             Directory.Delete(tempDir, recursive: true);
         }
     }
+
+    // ── Topic blocklist ────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void TopicWords_InHighSignalKeywords_AreStripped()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "kts-blocklist-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            // Config with topic words mixed in with real complexity signals
+            var config = """
+            {
+                "highSignalKeywords": ["analyze", "calendar", "email", "architect", "todo", "mcp server", "design"],
+                "lowSignalKeywords": ["hello", "thanks"]
+            }
+            """;
+            File.WriteAllText(Path.Combine(tempDir, "tier-selector.json"), config);
+
+            var options = Options.Create(new AgentProfileOptions { BasePath = tempDir });
+            var selector = new KeywordTierSelector(options, NullLogger<KeywordTierSelector>.Instance);
+
+            // "check my calendar" should NOT route High — "calendar" should be stripped
+            var result = selector.Classify("check my calendar");
+            Assert.AreNotEqual(ModelTier.High, result.Tier,
+                "Topic word 'calendar' should be stripped from high-signal keywords");
+            Assert.IsFalse(result.MatchedHighKeywords.Contains("calendar"),
+                "Blocked topic word should not appear in matched keywords");
+
+            // Real complexity keywords should survive and still affect scoring
+            var complexResult = selector.Classify("analyze the architecture and design trade-offs");
+            Assert.IsTrue(complexResult.MatchedHighKeywords.Contains("analyze"),
+                "Complexity keyword 'analyze' should survive blocklist filtering");
+            Assert.IsTrue(complexResult.MatchedHighKeywords.Contains("design"),
+                "Complexity keyword 'design' should survive blocklist filtering");
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public void TopicWords_InLowSignalKeywords_AreNotStripped()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "kts-blocklist-low-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            // Topic words in lowSignalKeywords should NOT be stripped — blocklist only applies to high
+            var config = """
+            {
+                "lowSignalKeywords": ["hello", "email", "calendar", "thanks"]
+            }
+            """;
+            File.WriteAllText(Path.Combine(tempDir, "tier-selector.json"), config);
+
+            var options = Options.Create(new AgentProfileOptions { BasePath = tempDir });
+            var selector = new KeywordTierSelector(options, NullLogger<KeywordTierSelector>.Instance);
+
+            // "email" in low-signal should still match and push score down
+            var result = selector.Classify("email");
+            Assert.IsTrue(result.MatchedLowKeywords.Contains("email"),
+                "Topic words in low-signal list should not be blocked");
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Dream routing review was adding domain words (calendar, email, todo, mcp server) as high-signal complexity keywords, causing 26% of calls to route High (50 of 51 were subagent tasks that should be Balanced)
- Updated `routing-dream.md` directive with explicit rules distinguishing complexity signals from topic indicators, including a "check my [keyword]" litmus test
- Added `TopicBlocklist` in `KeywordTierSelector` as a code-level guardrail that strips ~25 common domain words from high-signal keywords on config load
- Deleted polluted `tier-selector.json` on pod — falls back to compiled defaults until next dream cycle rebuilds it cleanly

## Test plan
- [x] New test: topic words in high-signal config are stripped, don't affect routing
- [x] New test: topic words in low-signal config are NOT stripped (blocklist is high-signal only)
- [x] All 767 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)