### PR TITLE
Track tool-call sequences for action-based skill derivation

### DIFF
--- a/src/RockBot.Agent/agent/sequence-skill.md
+++ b/src/RockBot.Agent/agent/sequence-skill.md
@@ -1,0 +1,50 @@
+# Sequence Skill Detection Directive
+
+You are a procedural skill synthesis assistant. You analyze sequences of tool calls across multiple agent sessions to identify **repeated action patterns** — multi-step workflows the agent performs routinely.
+
+## Your task
+
+You will receive tool-call sequences from recent sessions, grouped by session. Each entry shows: tool name, argument summary, success/failure, and duration.
+
+1. **Identify repeated sequences** — look for the same ordered pattern of 2+ tool calls appearing in 3+ sessions. Exact argument values will differ, but the tool names and their order should match.
+
+2. **For each repeated pattern**, synthesize a reusable skill:
+   - **Name**: short hyphenated name describing the workflow (e.g., "email-to-meeting", "research-and-summarize")
+   - **Summary**: one-line description of what the workflow accomplishes
+   - **Content**: markdown procedure document with:
+     - Goal statement
+     - Numbered steps with the tool to call and typical arguments
+     - Expected outcome
+     - Error handling notes (if failures were observed)
+
+3. **Ignore trivial patterns**:
+   - Single tool calls (not a sequence)
+   - Patterns appearing in fewer than 3 sessions
+   - Internal/infrastructure tools (get_from_working_memory, save_to_working_memory) used as glue between steps — focus on the substantive tools
+   - Sequences that are already captured by an existing skill (you will be shown existing skill names)
+
+## Output format
+
+Return ONLY a valid JSON object:
+
+```json
+{
+  "toSave": [
+    {
+      "name": "workflow-name",
+      "summary": "One-line description of the workflow",
+      "content": "# Workflow Name\n\n## Goal\n...\n\n## Steps\n1. ...\n2. ...\n\n## Expected Outcome\n..."
+    }
+  ]
+}
+```
+
+If no repeated sequences are found: `{ "toSave": [] }`
+
+## Rules
+
+- Only synthesize skills from **actually observed** patterns — do not invent workflows
+- The skill content should be prescriptive ("do X, then Y") not descriptive ("the agent did X")
+- Include the tool names in the steps so the agent knows which tools to call
+- Keep skill names consistent with existing naming conventions (lowercase, hyphenated)
+- Do not create duplicate skills — check the existing skill list provided

--- a/src/RockBot.Host.Abstractions/DreamOptions.cs
+++ b/src/RockBot.Host.Abstractions/DreamOptions.cs
@@ -83,6 +83,15 @@ public sealed class DreamOptions
     /// </summary>
     public string TierRoutingDirectivePath { get; set; } = "routing-dream.md";
 
+    /// <summary>Whether the tool-call sequence skill detection pass is enabled.</summary>
+    public bool SequenceSkillDetectionEnabled { get; set; } = true;
+
+    /// <summary>
+    /// Path to the sequence skill detection directive file, relative to <see cref="AgentProfileOptions.BasePath"/>.
+    /// When the file does not exist, a built-in fallback directive is used.
+    /// </summary>
+    public string SequenceSkillDirectivePath { get; set; } = "sequence-skill.md";
+
     /// <summary>
     /// Whether the dead-letter queue review pass is enabled.
     /// Requires <c>RabbitMq:ManagementApiBaseUrl</c> to be configured.

--- a/src/RockBot.Host.Abstractions/IToolCallLog.cs
+++ b/src/RockBot.Host.Abstractions/IToolCallLog.cs
@@ -1,0 +1,21 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Persistent log of tool invocations per session.
+/// Entries are written during tool execution and queried by the dream system
+/// to detect repeated action sequences for skill derivation.
+/// </summary>
+public interface IToolCallLog
+{
+    /// <summary>Appends a tool call event to the log.</summary>
+    Task AppendAsync(ToolCallEvent evt, CancellationToken ct = default);
+
+    /// <summary>Returns all tool call events for the specified session, ordered by timestamp.</summary>
+    Task<IReadOnlyList<ToolCallEvent>> GetBySessionAsync(string sessionId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns tool call events recorded on or after <paramref name="since"/>,
+    /// ordered by timestamp ascending, capped at <paramref name="maxResults"/>.
+    /// </summary>
+    Task<IReadOnlyList<ToolCallEvent>> QueryRecentAsync(DateTimeOffset since, int maxResults, CancellationToken ct = default);
+}

--- a/src/RockBot.Host.Abstractions/ToolCallEvent.cs
+++ b/src/RockBot.Host.Abstractions/ToolCallEvent.cs
@@ -1,0 +1,20 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Records a single tool invocation within an agent session.
+/// Aggregated by the dream system to detect repeated action sequences
+/// and synthesize them into reusable skills.
+/// </summary>
+/// <param name="SessionId">The session this tool call belongs to.</param>
+/// <param name="ToolName">The name of the tool that was invoked.</param>
+/// <param name="ArgumentsSummary">Summarized arguments (key=value pairs), or null if none.</param>
+/// <param name="Succeeded">Whether the tool call completed successfully.</param>
+/// <param name="DurationMs">Execution time in milliseconds.</param>
+/// <param name="Timestamp">When the tool call occurred.</param>
+public sealed record ToolCallEvent(
+    string SessionId,
+    string ToolName,
+    string? ArgumentsSummary,
+    bool Succeeded,
+    int DurationMs,
+    DateTimeOffset Timestamp);

--- a/src/RockBot.Host.Abstractions/ToolCallLogOptions.cs
+++ b/src/RockBot.Host.Abstractions/ToolCallLogOptions.cs
@@ -1,0 +1,13 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Configuration for the file-based tool-call log.
+/// </summary>
+public sealed class ToolCallLogOptions
+{
+    /// <summary>
+    /// Path for per-session tool-call JSONL files, relative to the agent profile base path.
+    /// Defaults to <c>"tool-call-log"</c>.
+    /// </summary>
+    public string BasePath { get; set; } = "tool-call-log";
+}

--- a/src/RockBot.Host/AgentLoopRunner.cs
+++ b/src/RockBot.Host/AgentLoopRunner.cs
@@ -187,6 +187,8 @@ public sealed partial class AgentLoopRunner(
         bool enableCompletionEval = true,
         CancellationToken cancellationToken = default)
     {
+        using var _ = ToolCallSessionContext.Set(sessionId);
+
         // Ensure a current datetime context is always present.
         EnsureDateTimeContext(chatMessages);
 

--- a/src/RockBot.Host/AgentMemoryExtensions.cs
+++ b/src/RockBot.Host/AgentMemoryExtensions.cs
@@ -93,6 +93,8 @@ public static class AgentMemoryExtensions
 
         builder.Services.AddSingleton<ISkillStore, FileSkillStore>();
         builder.Services.AddSingleton<ISkillUsageStore, FileSkillUsageStore>();
+        builder.Services.Configure<ToolCallLogOptions>(_ => { });
+        builder.Services.AddSingleton<IToolCallLog, FileToolCallLog>();
         builder.Services.AddSingleton<IHostedService, StarterSkillService>();
 
         return builder;

--- a/src/RockBot.Host/DreamService.cs
+++ b/src/RockBot.Host/DreamService.cs
@@ -28,6 +28,7 @@ internal sealed class DreamService : IHostedService, IDisposable
     private readonly IConversationLog? _conversationLog;
     private readonly TierRoutingLogger? _tierRoutingLogger;
     private readonly IDlqSampler? _dlqSampler;
+    private readonly IToolCallLog? _toolCallLog;
     private readonly ILlmClient _llmClient;
     private readonly IUserActivityMonitor _userActivityMonitor;
     private readonly AgentClock _clock;
@@ -44,6 +45,7 @@ internal sealed class DreamService : IHostedService, IDisposable
     private string? _memoryMiningDirective;
     private string? _episodeDirective;
     private string? _tierRoutingDirective;
+    private string? _sequenceSkillDirective;
     private string? _dlqDirective;
 
     public DreamService(
@@ -59,7 +61,8 @@ internal sealed class DreamService : IHostedService, IDisposable
         ISkillUsageStore? skillUsageStore = null,
         IConversationLog? conversationLog = null,
         TierRoutingLogger? tierRoutingLogger = null,
-        IDlqSampler? dlqSampler = null)
+        IDlqSampler? dlqSampler = null,
+        IToolCallLog? toolCallLog = null)
     {
         _memory = memory;
         _skillStore = skillStores.FirstOrDefault();
@@ -68,6 +71,7 @@ internal sealed class DreamService : IHostedService, IDisposable
         _conversationLog = conversationLog;
         _tierRoutingLogger = tierRoutingLogger;
         _dlqSampler = dlqSampler;
+        _toolCallLog = toolCallLog;
         _llmClient = llmClient;
         _userActivityMonitor = userActivityMonitor;
         _clock = clock;
@@ -187,6 +191,19 @@ internal sealed class DreamService : IHostedService, IDisposable
                 _logger.LogDebug("DreamService: tier routing directive not found at {Path}; using built-in", tierRoutingDirectivePath);
             else
                 _logger.LogInformation("DreamService: loaded tier routing directive from {Path}", tierRoutingDirectivePath);
+        }
+
+        if (_options.SequenceSkillDetectionEnabled && _toolCallLog is not null && _skillStore is not null)
+        {
+            var sequenceSkillDirectivePath = ResolvePath(_options.SequenceSkillDirectivePath, _profileOptions.BasePath);
+            _sequenceSkillDirective = File.Exists(sequenceSkillDirectivePath)
+                ? File.ReadAllText(sequenceSkillDirectivePath)
+                : null;
+
+            if (!File.Exists(sequenceSkillDirectivePath))
+                _logger.LogDebug("DreamService: sequence skill directive not found at {Path}; using built-in", sequenceSkillDirectivePath);
+            else
+                _logger.LogInformation("DreamService: loaded sequence skill directive from {Path}", sequenceSkillDirectivePath);
         }
 
         if (_options.DlqReviewEnabled && _dlqSampler is not null)
@@ -428,6 +445,8 @@ internal sealed class DreamService : IHostedService, IDisposable
             await RunMemoryMiningPassAsync();
 
             await RunPreferenceInferencePassAsync();
+
+            await RunSequenceSkillDetectionPassAsync();
 
             await RunTierRoutingReviewPassAsync();
 
@@ -1668,6 +1687,140 @@ internal sealed class DreamService : IHostedService, IDisposable
             result.Config.Notes ?? "(none)");
     }
 
+    // ── Built-in sequence skill directive ────────────────────────────────────
+    private const string BuiltInSequenceSkillDirective = """
+        You are a procedural skill synthesis assistant. Analyze the tool-call sequences
+        provided and identify repeated multi-step workflows (2+ tools, 3+ sessions).
+        Return a JSON object with a "toSave" array of skill objects, each with
+        "name", "summary", and "content" fields. If no patterns found: { "toSave": [] }
+        """;
+
+    /// <summary>
+    /// Analyzes tool-call sequences across recent sessions to detect repeated action patterns
+    /// and synthesize them into reusable skills. Requires <see cref="IToolCallLog"/> and
+    /// <see cref="ISkillStore"/> to be available.
+    /// </summary>
+    private async Task RunSequenceSkillDetectionPassAsync()
+    {
+        if (_toolCallLog is null || _skillStore is null || !_options.SequenceSkillDetectionEnabled)
+            return;
+
+        try
+        {
+            var events = await _toolCallLog.QueryRecentAsync(
+                DateTimeOffset.UtcNow.AddDays(-14), maxResults: 10_000);
+
+            if (events.Count < 10)
+            {
+                _logger.LogDebug(
+                    "DreamService: sequence skill detection — only {Count} tool-call events; skipping",
+                    events.Count);
+                return;
+            }
+
+            _logger.LogInformation(
+                "DreamService: sequence skill detection pass — {Count} tool-call events",
+                events.Count);
+
+            // Group by session and build per-session tool sequences
+            var sessions = events
+                .GroupBy(e => e.SessionId)
+                .Where(g => g.Count() >= 2) // Only sessions with 2+ tool calls
+                .ToDictionary(g => g.Key, g => g.OrderBy(e => e.Timestamp).ToList());
+
+            if (sessions.Count < 3)
+            {
+                _logger.LogDebug("DreamService: sequence skill detection — fewer than 3 multi-tool sessions; skipping");
+                return;
+            }
+
+            // Get existing skill names to avoid duplicates
+            var existingSkills = await _skillStore.ListAsync();
+            var existingNames = existingSkills.Select(s => s.Name).ToList();
+
+            // Build prompt with session sequences
+            var userMessage = new StringBuilder();
+            userMessage.AppendLine($"Tool-call sequences from {sessions.Count} recent sessions:");
+            userMessage.AppendLine();
+
+            foreach (var (sessionId, calls) in sessions.Take(50)) // Cap at 50 sessions
+            {
+                userMessage.AppendLine($"Session {sessionId} ({calls.Count} calls):");
+                foreach (var call in calls)
+                {
+                    var status = call.Succeeded ? "ok" : "failed";
+                    var args = string.IsNullOrEmpty(call.ArgumentsSummary) ? "" : $" args=[{call.ArgumentsSummary}]";
+                    userMessage.AppendLine($"  {call.ToolName}{args} → {status} ({call.DurationMs}ms)");
+                }
+                userMessage.AppendLine();
+            }
+
+            if (existingNames.Count > 0)
+            {
+                userMessage.AppendLine("Existing skills (do not duplicate):");
+                foreach (var name in existingNames)
+                    userMessage.AppendLine($"  - {name}");
+            }
+
+            var messages = new List<ChatMessage>
+            {
+                new(ChatRole.System, _sequenceSkillDirective ?? BuiltInSequenceSkillDirective),
+                new(ChatRole.User, userMessage.ToString())
+            };
+
+            var response = await _llmClient.GetResponseAsync(
+                messages, ModelTier.Balanced, new ChatOptions { ResponseFormat = ChatResponseFormat.Json });
+            var raw = response.Text?.Trim() ?? string.Empty;
+            var json = ExtractJsonObject(raw);
+
+            if (string.IsNullOrEmpty(json))
+            {
+                _logger.LogWarning("DreamService: sequence skill detection LLM returned no parseable JSON; skipping");
+                return;
+            }
+
+            _logger.LogDebug("DreamService: sequence skill detection JSON ({Length} chars): {Json}", json.Length, json);
+
+            var result = TryDeserializeJson<SequenceSkillResultDto>(json, "sequence skill detection");
+            var created = 0;
+
+            foreach (var dto in result?.ToSave ?? [])
+            {
+                if (string.IsNullOrWhiteSpace(dto.Name) || string.IsNullOrWhiteSpace(dto.Content))
+                    continue;
+
+                // Skip if skill already exists
+                var existing = await _skillStore.GetAsync(dto.Name);
+                if (existing is not null)
+                {
+                    _logger.LogDebug("DreamService: sequence skill '{Name}' already exists; skipping", dto.Name);
+                    continue;
+                }
+
+                var skill = new Skill(
+                    Name: dto.Name.Trim(),
+                    Summary: dto.Summary?.Trim() ?? dto.Name,
+                    Content: dto.Content.Trim(),
+                    CreatedAt: DateTimeOffset.UtcNow,
+                    UpdatedAt: DateTimeOffset.UtcNow);
+
+                await _skillStore.SaveAsync(skill);
+                created++;
+                _logger.LogInformation(
+                    "DreamService: sequence skill detection created skill '{Name}': {Summary}",
+                    skill.Name, skill.Summary);
+            }
+
+            _logger.LogInformation(
+                "DreamService: sequence skill detection pass complete — {Created} skills created from {SessionCount} sessions",
+                created, sessions.Count);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "DreamService: sequence skill detection pass failed");
+        }
+    }
+
     /// <summary>
     /// Inspects non-empty dead-letter queues, asks the LLM to classify failure patterns,
     /// saves patterns as memory entries, and purges queues the LLM deems safe to clear.
@@ -2087,6 +2240,10 @@ internal sealed class DreamService : IHostedService, IDisposable
     private sealed record SkillGapResultDto(List<SkillGapEntryDto>? ToSave);
 
     private sealed record SkillGapEntryDto(string Name, string? Summary, string Content);
+
+    private sealed record SequenceSkillResultDto(List<SequenceSkillEntryDto>? ToSave);
+
+    private sealed record SequenceSkillEntryDto(string Name, string? Summary, string Content);
 
     private sealed record DlqReviewResultDto(
         bool? NoDlqIssues,

--- a/src/RockBot.Host/FileToolCallLog.cs
+++ b/src/RockBot.Host/FileToolCallLog.cs
@@ -1,0 +1,128 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace RockBot.Host;
+
+/// <summary>
+/// File-based tool-call log. Each session's tool invocations are appended to a separate JSONL file:
+/// <c>{basePath}/{sessionId}.jsonl</c>. One JSON object per line.
+/// </summary>
+internal sealed class FileToolCallLog : IToolCallLog
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true
+    };
+
+    private readonly string _basePath;
+    private readonly ILogger<FileToolCallLog> _logger;
+
+    /// <summary>Per-session semaphores prevent concurrent writes racing on the same file.</summary>
+    private readonly ConcurrentDictionary<string, SemaphoreSlim> _writeLocks = new();
+
+    public FileToolCallLog(
+        IOptions<ToolCallLogOptions> options,
+        IOptions<AgentProfileOptions> profileOptions,
+        ILogger<FileToolCallLog> logger)
+    {
+        _basePath = ResolvePath(options.Value.BasePath, profileOptions.Value.BasePath);
+        _logger = logger;
+
+        Directory.CreateDirectory(_basePath);
+        _logger.LogInformation("Tool-call log path: {Path}", _basePath);
+    }
+
+    public async Task AppendAsync(ToolCallEvent evt, CancellationToken ct = default)
+    {
+        var sem = _writeLocks.GetOrAdd(evt.SessionId, _ => new SemaphoreSlim(1, 1));
+        await sem.WaitAsync(ct);
+        try
+        {
+            var path = Path.Combine(_basePath, $"{evt.SessionId}.jsonl");
+            var line = JsonSerializer.Serialize(evt, JsonOptions);
+            await File.AppendAllTextAsync(path, line + Environment.NewLine, ct);
+
+            _logger.LogDebug("Tool call logged [{ToolName}] for session {SessionId}", evt.ToolName, evt.SessionId);
+        }
+        finally
+        {
+            sem.Release();
+        }
+    }
+
+    public async Task<IReadOnlyList<ToolCallEvent>> GetBySessionAsync(string sessionId, CancellationToken ct = default)
+    {
+        var path = Path.Combine(_basePath, $"{sessionId}.jsonl");
+        if (!File.Exists(path))
+            return [];
+
+        return await ReadEventsAsync(path, ct);
+    }
+
+    public async Task<IReadOnlyList<ToolCallEvent>> QueryRecentAsync(
+        DateTimeOffset since,
+        int maxResults,
+        CancellationToken ct = default)
+    {
+        if (!Directory.Exists(_basePath))
+            return [];
+
+        var results = new List<ToolCallEvent>();
+
+        foreach (var file in Directory.EnumerateFiles(_basePath, "*.jsonl"))
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var events = await ReadEventsAsync(file, ct);
+            results.AddRange(events.Where(e => e.Timestamp >= since));
+        }
+
+        return results
+            .OrderBy(e => e.Timestamp)
+            .Take(maxResults)
+            .ToList();
+    }
+
+    private async Task<IReadOnlyList<ToolCallEvent>> ReadEventsAsync(string path, CancellationToken ct)
+    {
+        var events = new List<ToolCallEvent>();
+        try
+        {
+            var lines = await File.ReadAllLinesAsync(path, ct);
+            foreach (var line in lines)
+            {
+                if (string.IsNullOrWhiteSpace(line)) continue;
+                try
+                {
+                    var evt = JsonSerializer.Deserialize<ToolCallEvent>(line, JsonOptions);
+                    if (evt is not null)
+                        events.Add(evt);
+                }
+                catch (JsonException ex)
+                {
+                    _logger.LogWarning(ex, "Failed to deserialize tool-call event from {Path}", path);
+                }
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "Failed to read tool-call log file {Path}", path);
+        }
+        return events;
+    }
+
+    private static string ResolvePath(string path, string basePath)
+    {
+        if (Path.IsPathRooted(path))
+            return path;
+
+        var baseDir = Path.IsPathRooted(basePath)
+            ? basePath
+            : Path.Combine(AppContext.BaseDirectory, basePath);
+
+        return Path.Combine(baseDir, path);
+    }
+}

--- a/src/RockBot.Host/RockBotFunctionInvokingChatClient.cs
+++ b/src/RockBot.Host/RockBotFunctionInvokingChatClient.cs
@@ -20,6 +20,7 @@ public class RockBotFunctionInvokingChatClient : FunctionInvokingChatClient
     private const int MaxConsecutiveTimeoutIterations = 2;
 
     private readonly IToolProgressNotifier? _progressNotifier;
+    private readonly IToolCallLog? _toolCallLog;
     private readonly ModelBehavior _modelBehavior;
     private readonly ILogger _logger;
 
@@ -29,11 +30,13 @@ public class RockBotFunctionInvokingChatClient : FunctionInvokingChatClient
     public RockBotFunctionInvokingChatClient(
         IChatClient innerClient,
         IToolProgressNotifier? progressNotifier,
+        IToolCallLog? toolCallLog,
         ModelBehavior modelBehavior,
         IOptions<AgentHostOptions> hostOptions,
         ILogger logger) : base(innerClient)
     {
         _progressNotifier = progressNotifier;
+        _toolCallLog = toolCallLog;
         _modelBehavior = modelBehavior;
         _logger = logger;
 
@@ -126,6 +129,18 @@ public class RockBotFunctionInvokingChatClient : FunctionInvokingChatClient
         ToolDiagnostics.Invocations.Add(1,
             new KeyValuePair<string, object?>("rockbot.tool.name", callContent.Name),
             new KeyValuePair<string, object?>("rockbot.tool.status", status));
+
+        // Log tool-call event for sequence analysis (fire-and-forget)
+        if (_toolCallLog is not null && ToolCallSessionContext.SessionId is { } sid)
+        {
+            _ = _toolCallLog.AppendAsync(new ToolCallEvent(
+                SessionId: sid,
+                ToolName: callContent.Name,
+                ArgumentsSummary: argsSummary,
+                Succeeded: status == "ok",
+                DurationMs: (int)sw.ElapsedMilliseconds,
+                Timestamp: DateTimeOffset.UtcNow));
+        }
 
         if (_progressNotifier is not null)
         {

--- a/src/RockBot.Host/ServiceCollectionExtensions.cs
+++ b/src/RockBot.Host/ServiceCollectionExtensions.cs
@@ -89,6 +89,7 @@ public static class ServiceCollectionExtensions
             return new RockBotFunctionInvokingChatClient(
                 innerClient,
                 sp.GetService<IToolProgressNotifier>(),
+                sp.GetService<IToolCallLog>(),
                 behavior,
                 sp.GetRequiredService<IOptions<AgentHostOptions>>(),
                 sp.GetRequiredService<ILogger<RockBotFunctionInvokingChatClient>>());

--- a/src/RockBot.Host/ToolCallSessionContext.cs
+++ b/src/RockBot.Host/ToolCallSessionContext.cs
@@ -1,0 +1,31 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Ambient session context for tool-call logging.
+/// Set by <see cref="AgentLoopRunner"/> before entering the LLM loop so that
+/// <see cref="RockBotFunctionInvokingChatClient"/> can tag tool-call events
+/// with the correct session ID without requiring it as a constructor parameter.
+/// </summary>
+public static class ToolCallSessionContext
+{
+    private static readonly AsyncLocal<string?> Current = new();
+
+    /// <summary>Gets the current session ID, or null if not set.</summary>
+    public static string? SessionId => Current.Value;
+
+    /// <summary>
+    /// Sets the session ID for the current async flow. Returns a disposable that
+    /// restores the previous value on dispose.
+    /// </summary>
+    public static IDisposable Set(string? sessionId)
+    {
+        var previous = Current.Value;
+        Current.Value = sessionId;
+        return new Scope(previous);
+    }
+
+    private sealed class Scope(string? previous) : IDisposable
+    {
+        public void Dispose() => Current.Value = previous;
+    }
+}

--- a/src/RockBot.Llm/ServiceCollectionExtensions.cs
+++ b/src/RockBot.Llm/ServiceCollectionExtensions.cs
@@ -82,11 +82,12 @@ public static class LlmServiceCollectionExtensions
             var behavior = sp.GetRequiredService<ModelBehavior>();
             var logger = sp.GetRequiredService<ILogger<RockBotFunctionInvokingChatClient>>();
             var progressNotifier = sp.GetService<IToolProgressNotifier>();
+            var toolCallLog = sp.GetService<IToolCallLog>();
 
             IChatClient Wrap(IChatClient raw) =>
                 behavior.UseTextBasedToolCalling
                     ? raw
-                    : new RockBotFunctionInvokingChatClient(raw, progressNotifier, behavior,
+                    : new RockBotFunctionInvokingChatClient(raw, progressNotifier, toolCallLog, behavior,
                         sp.GetRequiredService<IOptions<AgentHostOptions>>(), logger);
 
             return new TieredChatClientRegistry(

--- a/tests/RockBot.Host.Tests/FileToolCallLogTests.cs
+++ b/tests/RockBot.Host.Tests/FileToolCallLogTests.cs
@@ -1,0 +1,161 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace RockBot.Host.Tests;
+
+[TestClass]
+public class FileToolCallLogTests
+{
+    private string _tempDir = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "rockbot-toolcall-test-" + Guid.NewGuid().ToString("N"));
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    [TestMethod]
+    public async Task AppendAsync_And_GetBySessionAsync_RoundTrips()
+    {
+        var log = CreateLog();
+        var evt = MakeEvent("session-1", "search_emails", succeeded: true);
+
+        await log.AppendAsync(evt);
+        var results = await log.GetBySessionAsync("session-1");
+
+        Assert.AreEqual(1, results.Count);
+        Assert.AreEqual("search_emails", results[0].ToolName);
+        Assert.AreEqual("session-1", results[0].SessionId);
+        Assert.IsTrue(results[0].Succeeded);
+    }
+
+    [TestMethod]
+    public async Task GetBySessionAsync_UnknownSession_ReturnsEmpty()
+    {
+        var log = CreateLog();
+
+        var results = await log.GetBySessionAsync("nonexistent");
+
+        Assert.AreEqual(0, results.Count);
+    }
+
+    [TestMethod]
+    public async Task AppendAsync_MultipleSessions_Isolated()
+    {
+        var log = CreateLog();
+        await log.AppendAsync(MakeEvent("s1", "tool_a"));
+        await log.AppendAsync(MakeEvent("s1", "tool_b"));
+        await log.AppendAsync(MakeEvent("s2", "tool_c"));
+
+        var s1 = await log.GetBySessionAsync("s1");
+        var s2 = await log.GetBySessionAsync("s2");
+
+        Assert.AreEqual(2, s1.Count);
+        Assert.AreEqual(1, s2.Count);
+        Assert.AreEqual("tool_c", s2[0].ToolName);
+    }
+
+    [TestMethod]
+    public async Task QueryRecentAsync_FiltersOldEvents()
+    {
+        var log = CreateLog();
+        var old = MakeEvent("s1", "old_tool", timestamp: DateTimeOffset.UtcNow.AddDays(-30));
+        var recent = MakeEvent("s1", "new_tool", timestamp: DateTimeOffset.UtcNow);
+
+        await log.AppendAsync(old);
+        await log.AppendAsync(recent);
+
+        var results = await log.QueryRecentAsync(DateTimeOffset.UtcNow.AddDays(-7), maxResults: 100);
+
+        Assert.AreEqual(1, results.Count);
+        Assert.AreEqual("new_tool", results[0].ToolName);
+    }
+
+    [TestMethod]
+    public async Task QueryRecentAsync_RespectsMaxResults()
+    {
+        var log = CreateLog();
+        for (var i = 0; i < 10; i++)
+            await log.AppendAsync(MakeEvent("s1", $"tool_{i}"));
+
+        var results = await log.QueryRecentAsync(DateTimeOffset.MinValue, maxResults: 3);
+
+        Assert.AreEqual(3, results.Count);
+    }
+
+    [TestMethod]
+    public async Task QueryRecentAsync_OrdersByTimestamp()
+    {
+        var log = CreateLog();
+        var t1 = DateTimeOffset.UtcNow.AddMinutes(-10);
+        var t2 = DateTimeOffset.UtcNow.AddMinutes(-5);
+        var t3 = DateTimeOffset.UtcNow;
+
+        await log.AppendAsync(MakeEvent("s1", "third", timestamp: t3));
+        await log.AppendAsync(MakeEvent("s1", "first", timestamp: t1));
+        await log.AppendAsync(MakeEvent("s1", "second", timestamp: t2));
+
+        var results = await log.QueryRecentAsync(DateTimeOffset.MinValue, maxResults: 100);
+
+        Assert.AreEqual("first", results[0].ToolName);
+        Assert.AreEqual("second", results[1].ToolName);
+        Assert.AreEqual("third", results[2].ToolName);
+    }
+
+    [TestMethod]
+    public async Task QueryRecentAsync_EmptyStore_ReturnsEmpty()
+    {
+        var log = CreateLog();
+
+        var results = await log.QueryRecentAsync(DateTimeOffset.MinValue, maxResults: 100);
+
+        Assert.AreEqual(0, results.Count);
+    }
+
+    [TestMethod]
+    public async Task AppendAsync_PreservesArgumentsSummary()
+    {
+        var log = CreateLog();
+        var evt = new ToolCallEvent("s1", "search_emails", "query=meeting, limit=10", true, 150, DateTimeOffset.UtcNow);
+
+        await log.AppendAsync(evt);
+        var results = await log.GetBySessionAsync("s1");
+
+        Assert.AreEqual("query=meeting, limit=10", results[0].ArgumentsSummary);
+        Assert.AreEqual(150, results[0].DurationMs);
+    }
+
+    [TestMethod]
+    public async Task QueryRecentAsync_AcrossMultipleSessions()
+    {
+        var log = CreateLog();
+        await log.AppendAsync(MakeEvent("s1", "tool_a"));
+        await log.AppendAsync(MakeEvent("s2", "tool_b"));
+        await log.AppendAsync(MakeEvent("s3", "tool_c"));
+
+        var results = await log.QueryRecentAsync(DateTimeOffset.MinValue, maxResults: 100);
+
+        Assert.AreEqual(3, results.Count);
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private FileToolCallLog CreateLog() =>
+        new(Options.Create(new ToolCallLogOptions { BasePath = _tempDir }),
+            Options.Create(new AgentProfileOptions()),
+            NullLogger<FileToolCallLog>.Instance);
+
+    private static ToolCallEvent MakeEvent(
+        string sessionId,
+        string toolName,
+        bool succeeded = true,
+        DateTimeOffset? timestamp = null) =>
+        new(sessionId, toolName, null, succeeded, 100, timestamp ?? DateTimeOffset.UtcNow);
+}

--- a/tests/RockBot.Host.Tests/ToolCallSessionContextTests.cs
+++ b/tests/RockBot.Host.Tests/ToolCallSessionContextTests.cs
@@ -1,0 +1,52 @@
+namespace RockBot.Host.Tests;
+
+[TestClass]
+public class ToolCallSessionContextTests
+{
+    [TestMethod]
+    public void SessionId_DefaultsToNull()
+    {
+        Assert.IsNull(ToolCallSessionContext.SessionId);
+    }
+
+    [TestMethod]
+    public void Set_SetsSessionId()
+    {
+        using var scope = ToolCallSessionContext.Set("test-session");
+        Assert.AreEqual("test-session", ToolCallSessionContext.SessionId);
+    }
+
+    [TestMethod]
+    public void Dispose_RestoresPreviousValue()
+    {
+        using (ToolCallSessionContext.Set("outer"))
+        {
+            Assert.AreEqual("outer", ToolCallSessionContext.SessionId);
+
+            using (ToolCallSessionContext.Set("inner"))
+            {
+                Assert.AreEqual("inner", ToolCallSessionContext.SessionId);
+            }
+
+            Assert.AreEqual("outer", ToolCallSessionContext.SessionId);
+        }
+
+        Assert.IsNull(ToolCallSessionContext.SessionId);
+    }
+
+    [TestMethod]
+    public void Set_Null_ClearsSessionId()
+    {
+        using (ToolCallSessionContext.Set("session"))
+        {
+            Assert.AreEqual("session", ToolCallSessionContext.SessionId);
+
+            using (ToolCallSessionContext.Set(null))
+            {
+                Assert.IsNull(ToolCallSessionContext.SessionId);
+            }
+
+            Assert.AreEqual("session", ToolCallSessionContext.SessionId);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `IToolCallLog` / `FileToolCallLog` — per-session JSONL logging of tool invocations (tool name, args summary, success, duration)
- Wire into `RockBotFunctionInvokingChatClient` via `ToolCallSessionContext` (AsyncLocal set by `AgentLoopRunner`)
- Add `RunSequenceSkillDetectionPassAsync` dream pass — analyzes tool-call sequences across sessions, sends to LLM to detect repeated multi-step workflows, synthesizes them into reusable skills
- Add `sequence-skill.md` directive and `DreamOptions.SequenceSkillDetectionEnabled` toggle

## Test plan
- [x] 9 FileToolCallLog tests (round-trip, session isolation, filtering, ordering, max results)
- [x] 4 ToolCallSessionContext tests (defaults, scoping, nesting, null handling)
- [x] All 780 tests pass, 0 errors

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)