### PR TITLE
Add dynamic narrative identity that evolves from experience

### DIFF
--- a/design/agent-identity.md
+++ b/design/agent-identity.md
@@ -155,6 +155,45 @@ builder.Services.AddRockBotHost(agent =>
 });
 ```
 
+## Narrative Identity (Dynamic Self-Model)
+
+While `soul.md` and `directives.md` are static and deployment-controlled, the agent also maintains a **mutable narrative identity** — a set of long-term memory entries under `agent-identity/` that evolve as the agent accumulates experience.
+
+### Categories
+
+| Category | Purpose |
+|----------|---------|
+| `agent-identity/mission` | How the agent interprets its purpose given experience |
+| `agent-identity/goals` | Long-term goals derived from user patterns and feedback |
+| `agent-identity/projects` | Active projects and their status |
+| `agent-identity/capabilities` | Self-assessed strengths and limitations |
+| `agent-identity/self-model` | Overall narrative description of who the agent has become |
+
+### How It Works
+
+1. **Dream service** runs an identity reflection pass during each dream cycle. It reviews recent episodic memories, feedback signals, and user preferences, then updates identity entries when a meaningful shift has occurred.
+2. **AgentContextBuilder** injects identity entries into every LLM context. Primary agents see first-person framing ("Your evolving identity..."); subagents and patrol tasks see third-person framing ("Primary agent identity context...") that reinforces their subordinate role.
+3. **Users can review and edit** identity entries via the standard `search_memory` / `save_memory` tools using the `agent-identity` category.
+
+### Design Constraints
+
+- **soul.md is immutable** — identity entries complement the soul but can never override core values, boundaries, or personality.
+- **Conservative evolution** — the dream directive instructs the LLM to update only when there is a meaningful shift, not every cycle. Target is 1-2 entries per subcategory.
+- **Role-aware injection** — subagents see the primary agent's identity as context about the agent they serve, preventing them from assuming the primary's role.
+- **Constants** — `AgentIdentityCategories` in `RockBot.Host.Abstractions` defines the well-known category names.
+
+### Example
+
+After weeks of primarily managing email and calendar:
+
+```
+Category: agent-identity/self-model
+Content: "I have become primarily a communication and scheduling manager
+          with research capabilities. Most user interactions involve email
+          triage, calendar management, and meeting preparation."
+Importance: 0.8
+```
+
 ## Error Handling
 
 | Scenario | Behavior |

--- a/src/RockBot.Agent/agent/common-directives.md
+++ b/src/RockBot.Agent/agent/common-directives.md
@@ -119,6 +119,25 @@ Call `search_memory` explicitly only when you want to search with a specific
 query that differs from the raw message (e.g., after clarification, or when you
 want to narrow to a category).
 
+### Narrative identity
+
+Your evolving self-model is stored in long-term memory under `agent-identity/`
+categories (mission, goals, projects, capabilities, self-model). These entries
+are injected into every context automatically — you will see them labeled
+"Your evolving identity" and they reflect how your understanding of your role
+has developed through experience.
+
+**Your core identity (soul) is immutable** — identity entries complement it,
+they never override your values or boundaries. The dream service updates these
+entries periodically based on your accumulated experiences and feedback. You do
+not need to manually maintain them, but you can reference them to inform your
+behavior — e.g., if your self-model says you have become primarily a
+communication manager, lean into that strength.
+
+Subagents see these same entries framed as "Primary agent identity context" —
+they understand who you are so they can serve you effectively without trying
+to assume your role.
+
 ### Skill index and per-turn recall
 
 At the start of each session, a summary index of all your skills is injected

--- a/src/RockBot.Host.Abstractions/AgentIdentityCategories.cs
+++ b/src/RockBot.Host.Abstractions/AgentIdentityCategories.cs
@@ -1,0 +1,27 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Well-known long-term memory category names for the agent's mutable narrative identity.
+/// These entries are agent-written (via the dream service) and user-reviewable/editable
+/// via standard memory tools. They complement but never override the immutable soul.md.
+/// </summary>
+public static class AgentIdentityCategories
+{
+    /// <summary>Category prefix for all identity entries.</summary>
+    public const string Prefix = "agent-identity";
+
+    /// <summary>Current understanding of purpose — how the agent interprets its mission given experience.</summary>
+    public const string Mission = "agent-identity/mission";
+
+    /// <summary>Long-term goals derived from user patterns and feedback.</summary>
+    public const string Goals = "agent-identity/goals";
+
+    /// <summary>Active projects and their status.</summary>
+    public const string Projects = "agent-identity/projects";
+
+    /// <summary>Self-assessed strengths and limitations based on accumulated experience.</summary>
+    public const string Capabilities = "agent-identity/capabilities";
+
+    /// <summary>How the agent describes itself based on experience — the narrative self-model.</summary>
+    public const string SelfModel = "agent-identity/self-model";
+}

--- a/src/RockBot.Host.Abstractions/DreamOptions.cs
+++ b/src/RockBot.Host.Abstractions/DreamOptions.cs
@@ -110,6 +110,15 @@ public sealed class DreamOptions
     /// </summary>
     public string GraphConsolidationDirectivePath { get; set; } = "graph-consolidation-dream.md";
 
+    /// <summary>Whether the narrative identity reflection pass is enabled.</summary>
+    public bool IdentityReflectionEnabled { get; set; } = true;
+
+    /// <summary>
+    /// Path to the identity reflection directive file, relative to <see cref="AgentProfileOptions.BasePath"/>.
+    /// When the file does not exist, a built-in fallback directive is used.
+    /// </summary>
+    public string IdentityDirectivePath { get; set; } = "identity-dream.md";
+
     /// <summary>
     /// Whether the dead-letter queue review pass is enabled.
     /// Requires <c>RabbitMq:ManagementApiBaseUrl</c> to be configured.

--- a/src/RockBot.Host/AgentContextBuilder.cs
+++ b/src/RockBot.Host/AgentContextBuilder.cs
@@ -154,6 +154,43 @@ public sealed class AgentContextBuilder(
             }
         }
 
+        // Narrative identity injection — agent-identity/ entries that complement the static soul.
+        // Primary agent gets first-person framing; subagents/tasks get third-person framing
+        // that reinforces they support the primary agent but do not assume its role.
+        {
+            var identityEntries = await longTermMemory.SearchAsync(
+                new MemorySearchCriteria(Category: AgentIdentityCategories.Prefix, MaxResults: 20));
+
+            if (identityEntries.Count > 0)
+            {
+                var isPrimary = systemPromptOverride is null;
+                var lines = identityEntries.Select(e =>
+                    $"- ({e.Category ?? AgentIdentityCategories.SelfModel}): {e.Content}");
+
+                string identityContext;
+                if (isPrimary)
+                {
+                    identityContext =
+                        "Your evolving identity (complements your core soul — these reflect how your understanding " +
+                        "of your role has developed through experience):\n" +
+                        string.Join("\n", lines);
+                }
+                else
+                {
+                    identityContext =
+                        "Primary agent identity context (you are a subordinate agent supporting the primary agent — " +
+                        "do not assume its role, speak to users on its behalf, or act as the primary orchestrator. " +
+                        "This context helps you understand the agent you serve):\n" +
+                        string.Join("\n", lines);
+                }
+
+                chatMessages.Add(new ChatMessage(ChatRole.System, identityContext));
+                logger.LogInformation(
+                    "Injected {Count} identity entries for session {SessionId} (primary={IsPrimary})",
+                    identityEntries.Count, sessionId, isPrimary);
+            }
+        }
+
         // Knowledge graph expansion — detect entities in the query, traverse relationships
         if (_knowledgeGraph is not null)
         {

--- a/src/RockBot.Host/DreamService.cs
+++ b/src/RockBot.Host/DreamService.cs
@@ -50,6 +50,7 @@ internal sealed class DreamService : IHostedService, IDisposable
     private string? _entityExtractionDirective;
     private string? _graphConsolidationDirective;
     private string? _dlqDirective;
+    private string? _identityDirective;
 
     public DreamService(
         ILongTermMemory memory,
@@ -245,6 +246,19 @@ internal sealed class DreamService : IHostedService, IDisposable
                 _logger.LogDebug("DreamService: DLQ directive not found at {Path}; using built-in", dlqDirectivePath);
             else
                 _logger.LogInformation("DreamService: loaded DLQ directive from {Path}", dlqDirectivePath);
+        }
+
+        if (_options.IdentityReflectionEnabled)
+        {
+            var identityDirectivePath = ResolvePath(_options.IdentityDirectivePath, _profileOptions.BasePath);
+            _identityDirective = File.Exists(identityDirectivePath)
+                ? File.ReadAllText(identityDirectivePath)
+                : null; // null → BuiltInIdentityDirective used in RunIdentityReflectionPassAsync
+
+            if (!File.Exists(identityDirectivePath))
+                _logger.LogDebug("DreamService: identity directive not found at {Path}; using built-in", identityDirectivePath);
+            else
+                _logger.LogInformation("DreamService: loaded identity directive from {Path}", identityDirectivePath);
         }
 
         try
@@ -483,6 +497,8 @@ internal sealed class DreamService : IHostedService, IDisposable
             await RunTierRoutingReviewPassAsync();
 
             await RunDlqReviewPassAsync();
+
+            await RunIdentityReflectionPassAsync();
 
             sw.Stop();
             _logger.LogInformation(
@@ -2241,6 +2257,173 @@ internal sealed class DreamService : IHostedService, IDisposable
     }
 
     /// <summary>
+    /// Reflects on accumulated experience and updates the agent's narrative identity entries
+    /// under the <c>agent-identity/</c> memory category. These entries complement the immutable
+    /// soul.md — the pass cannot override core values or boundaries.
+    /// </summary>
+    private async Task RunIdentityReflectionPassAsync()
+    {
+        if (!_options.IdentityReflectionEnabled)
+            return;
+
+        _logger.LogInformation("DreamService: identity reflection pass — starting");
+
+        try
+        {
+            // Fetch current identity entries
+            var identityEntries = await _memory.SearchAsync(
+                new MemorySearchCriteria(Category: AgentIdentityCategories.Prefix, MaxResults: 50));
+
+            // Fetch recent episodic memories for experiential context
+            var recentEpisodes = await _memory.SearchAsync(
+                new MemorySearchCriteria(Category: "episodic", MaxResults: 20,
+                    CreatedAfter: DateTimeOffset.UtcNow.AddDays(-14)));
+
+            // Fetch recent feedback signals for quality context
+            IReadOnlyList<FeedbackEntry> recentFeedback = [];
+            if (_feedbackStore is not null)
+            {
+                recentFeedback = await _feedbackStore.QueryRecentAsync(
+                    since: DateTimeOffset.UtcNow.AddDays(-14),
+                    maxResults: 50);
+            }
+
+            // Fetch recent user preferences for behavioral context
+            var recentPrefs = await _memory.SearchAsync(
+                new MemorySearchCriteria(Category: "user-preferences", MaxResults: 20));
+
+            // Build user message
+            var userMessage = new StringBuilder();
+            userMessage.AppendLine("Review the agent's accumulated experience and update its narrative identity.");
+            userMessage.AppendLine();
+
+            if (identityEntries.Count > 0)
+            {
+                userMessage.AppendLine("## Current Identity Entries");
+                for (var i = 0; i < identityEntries.Count; i++)
+                {
+                    var e = identityEntries[i];
+                    userMessage.AppendLine($"{i + 1}. [ID:{e.Id}] category={e.Category ?? "uncategorized"} importance={e.ImportanceScore:F2}");
+                    userMessage.AppendLine($"   {e.Content}");
+                }
+                userMessage.AppendLine();
+            }
+            else
+            {
+                userMessage.AppendLine("## Current Identity Entries");
+                userMessage.AppendLine("(none — this is the first identity reflection)");
+                userMessage.AppendLine();
+            }
+
+            if (recentEpisodes.Count > 0)
+            {
+                userMessage.AppendLine("## Recent Experiences (last 14 days)");
+                foreach (var e in recentEpisodes)
+                    userMessage.AppendLine($"- {e.Content}");
+                userMessage.AppendLine();
+            }
+
+            if (recentFeedback.Count > 0)
+            {
+                userMessage.AppendLine("## Recent Feedback Signals (last 14 days)");
+                foreach (var fb in recentFeedback)
+                {
+                    var detail = string.IsNullOrWhiteSpace(fb.Detail) ? string.Empty : $" (\"{fb.Detail}\")";
+                    userMessage.AppendLine($"- [{fb.SignalType}] session {fb.SessionId}: {fb.Summary}{detail}");
+                }
+                userMessage.AppendLine();
+            }
+
+            if (recentPrefs.Count > 0)
+            {
+                userMessage.AppendLine("## Known User Preferences");
+                foreach (var p in recentPrefs)
+                    userMessage.AppendLine($"- {p.Content}");
+                userMessage.AppendLine();
+            }
+
+            var messages = new List<ChatMessage>
+            {
+                new(ChatRole.System, _identityDirective ?? BuiltInIdentityDirective),
+                new(ChatRole.User, userMessage.ToString())
+            };
+
+            var response = await _llmClient.GetResponseAsync(messages, ModelTier.Balanced,
+                new ChatOptions { ResponseFormat = ChatResponseFormat.Json });
+            var raw = response.Text?.Trim() ?? string.Empty;
+            var json = ExtractJsonObject(raw);
+
+            if (string.IsNullOrEmpty(json))
+            {
+                _logger.LogWarning("DreamService: identity reflection LLM returned no parseable JSON; skipping");
+                return;
+            }
+
+            _logger.LogDebug("DreamService: identity reflection JSON ({Length} chars): {Json}", json.Length, json);
+
+            var result = TryDeserializeJson<IdentityReflectionResultDto>(json, "identity reflection");
+            if (result is null) return;
+
+            if (result.NoChange == true)
+            {
+                _logger.LogInformation("DreamService: identity reflection — no meaningful shifts detected");
+                return;
+            }
+
+            // Delete entries the LLM wants to replace
+            var deleted = 0;
+            foreach (var id in result.ToDelete ?? [])
+            {
+                await _memory.DeleteAsync(id);
+                deleted++;
+                _logger.LogDebug("DreamService: identity reflection deleted entry {Id}", id);
+            }
+
+            // Save new/updated identity entries
+            var saved = 0;
+            foreach (var dto in result.ToSave ?? [])
+            {
+                if (string.IsNullOrWhiteSpace(dto.Content))
+                    continue;
+
+                // Ensure category is under agent-identity/
+                var category = string.IsNullOrWhiteSpace(dto.Category)
+                    ? AgentIdentityCategories.SelfModel
+                    : dto.Category.Trim();
+
+                if (!category.StartsWith(AgentIdentityCategories.Prefix, StringComparison.OrdinalIgnoreCase))
+                    category = $"{AgentIdentityCategories.Prefix}/{category}";
+
+                var tags = new List<string>(dto.Tags ?? []);
+                if (!tags.Contains("identity", StringComparer.OrdinalIgnoreCase))
+                    tags.Insert(0, "identity");
+
+                var entry = new MemoryEntry(
+                    Id: Guid.NewGuid().ToString("N")[..12],
+                    Content: dto.Content.Trim(),
+                    Category: category,
+                    Tags: tags,
+                    CreatedAt: DateTimeOffset.UtcNow,
+                    UpdatedAt: DateTimeOffset.UtcNow,
+                    ImportanceScore: Math.Clamp(dto.Importance ?? 0.7f, 0f, 1f));
+
+                await _memory.SaveAsync(entry);
+                saved++;
+                _logger.LogDebug("DreamService: identity reflection saved {Id} ({Category}): {Content}",
+                    entry.Id, entry.Category, entry.Content);
+            }
+
+            _logger.LogInformation(
+                "DreamService: identity reflection pass complete — {Deleted} deleted, {Saved} saved",
+                deleted, saved);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "DreamService: identity reflection pass failed");
+        }
+    }
+
+    /// <summary>
     /// Extracts the outermost JSON object from <paramref name="text"/>, tolerating
     /// DeepSeek-style thinking blocks and prose preamble.
     /// </summary>
@@ -2521,6 +2704,17 @@ internal sealed class DreamService : IHostedService, IDisposable
         List<string>? Purge);
 
     private sealed record DlqPatternDto(string Content, string? Detail, IReadOnlyList<string>? Queues);
+
+    private sealed record IdentityReflectionResultDto(
+        bool? NoChange,
+        List<string>? ToDelete,
+        List<IdentityEntryDto>? ToSave);
+
+    private sealed record IdentityEntryDto(
+        string Content,
+        string? Category,
+        IReadOnlyList<string>? Tags,
+        float? Importance);
 
     private sealed record MemoryMiningResultDto(List<MemoryMiningEntryDto>? ToSave);
 
@@ -2841,5 +3035,52 @@ internal sealed class DreamService : IHostedService, IDisposable
         - purge: only include queues whose messages are clearly unrecoverable (DeathCount ≥ 5 and older than 7 days, or all messages are malformed/unknown)
         - Be conservative on purge — when in doubt, omit the queue
         - If no issues: {"noDlqIssues": true, "patterns": [], "purge": []}
+        """;
+
+    private const string BuiltInIdentityDirective = """
+        You are a narrative identity reflection assistant. Your job is to maintain the agent's
+        evolving self-model — how it understands its own role, capabilities, and relationship
+        with the user based on accumulated experience.
+
+        CRITICAL CONSTRAINT: The agent's core identity (soul.md) is IMMUTABLE. You cannot
+        override, contradict, or weaken the agent's core values, boundaries, or personality.
+        Identity entries complement the soul — they capture how the agent's operational
+        understanding has evolved through experience.
+
+        Review the current identity entries, recent experiences, feedback signals, and user
+        preferences. Determine whether the agent's self-model should be updated.
+
+        Valid categories (use exactly these):
+        - agent-identity/mission: How the agent currently interprets its purpose given experience
+        - agent-identity/goals: Long-term goals derived from user patterns and feedback
+        - agent-identity/projects: Active projects and their status
+        - agent-identity/capabilities: Self-assessed strengths and limitations
+        - agent-identity/self-model: Overall narrative description of who the agent has become
+
+        Guidelines:
+        - Only update when there is a MEANINGFUL shift — not every cycle needs changes
+        - Each entry should be a concise, first-person statement (e.g., "I have become primarily
+          a communication and scheduling manager with research capabilities")
+        - Prefer updating existing entries over creating new ones for the same subcategory
+        - When updating, include the ID of the entry being replaced in toDelete
+        - Importance should reflect how central the insight is to the agent's operation (0.6-0.9)
+        - Never create entries that contradict the soul or claim capabilities the agent doesn't have
+        - Keep the total number of identity entries small (aim for 1-2 per subcategory)
+
+        Return ONLY a JSON object:
+        {
+          "noChange": false,
+          "toDelete": ["id1", "id2"],
+          "toSave": [
+            {
+              "content": "First-person identity statement",
+              "category": "agent-identity/self-model",
+              "tags": ["identity"],
+              "importance": 0.7
+            }
+          ]
+        }
+
+        If no meaningful shifts are evident: {"noChange": true, "toDelete": [], "toSave": []}
         """;
 }

--- a/tests/RockBot.Host.Tests/AgentIdentityTests.cs
+++ b/tests/RockBot.Host.Tests/AgentIdentityTests.cs
@@ -1,0 +1,321 @@
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using RockBot.Host;
+using RockBot.Llm;
+using RockBot.Memory;
+using RockBot.Skills;
+
+namespace RockBot.Host.Tests;
+
+[TestClass]
+public class AgentIdentityTests
+{
+    // ── AgentIdentityCategories constants ────────────────────────────────────
+
+    [TestMethod]
+    public void Prefix_IsAgentIdentity()
+    {
+        Assert.AreEqual("agent-identity", AgentIdentityCategories.Prefix);
+    }
+
+    [TestMethod]
+    public void AllCategories_StartWithPrefix()
+    {
+        var categories = new[]
+        {
+            AgentIdentityCategories.Mission,
+            AgentIdentityCategories.Goals,
+            AgentIdentityCategories.Projects,
+            AgentIdentityCategories.Capabilities,
+            AgentIdentityCategories.SelfModel
+        };
+
+        foreach (var cat in categories)
+            Assert.IsTrue(cat.StartsWith(AgentIdentityCategories.Prefix + "/"),
+                $"Category '{cat}' should start with '{AgentIdentityCategories.Prefix}/'");
+    }
+
+    [TestMethod]
+    public void SubCategories_HaveExpectedValues()
+    {
+        Assert.AreEqual("agent-identity/mission", AgentIdentityCategories.Mission);
+        Assert.AreEqual("agent-identity/goals", AgentIdentityCategories.Goals);
+        Assert.AreEqual("agent-identity/projects", AgentIdentityCategories.Projects);
+        Assert.AreEqual("agent-identity/capabilities", AgentIdentityCategories.Capabilities);
+        Assert.AreEqual("agent-identity/self-model", AgentIdentityCategories.SelfModel);
+    }
+
+    // ── DreamOptions identity defaults ──────────────────────────────────────
+
+    [TestMethod]
+    public void DreamOptions_IdentityReflectionEnabled_DefaultsToTrue()
+    {
+        var options = new DreamOptions();
+        Assert.IsTrue(options.IdentityReflectionEnabled);
+    }
+
+    [TestMethod]
+    public void DreamOptions_IdentityDirectivePath_DefaultsToIdentityDreamMd()
+    {
+        var options = new DreamOptions();
+        Assert.AreEqual("identity-dream.md", options.IdentityDirectivePath);
+    }
+
+    // ── Identity DTO serialization ──────────────────────────────────────────
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true
+    };
+
+    [TestMethod]
+    public void IdentityReflectionResult_Deserializes_WithEntries()
+    {
+        var json = """
+        {
+          "noChange": false,
+          "toDelete": ["abc123"],
+          "toSave": [
+            {
+              "content": "I have become primarily a communication manager.",
+              "category": "agent-identity/self-model",
+              "tags": ["identity"],
+              "importance": 0.8
+            }
+          ]
+        }
+        """;
+
+        var result = JsonSerializer.Deserialize<IdentityReflectionResultDto>(json, JsonOptions);
+
+        Assert.IsNotNull(result);
+        Assert.IsFalse(result.NoChange);
+        Assert.AreEqual(1, result.ToDelete?.Count);
+        Assert.AreEqual("abc123", result.ToDelete![0]);
+        Assert.AreEqual(1, result.ToSave?.Count);
+
+        var entry = result.ToSave![0];
+        Assert.AreEqual("I have become primarily a communication manager.", entry.Content);
+        Assert.AreEqual("agent-identity/self-model", entry.Category);
+        Assert.AreEqual(0.8f, entry.Importance);
+    }
+
+    [TestMethod]
+    public void IdentityReflectionResult_Deserializes_NoChange()
+    {
+        var json = """{"noChange": true, "toDelete": [], "toSave": []}""";
+
+        var result = JsonSerializer.Deserialize<IdentityReflectionResultDto>(json, JsonOptions);
+
+        Assert.IsNotNull(result);
+        Assert.IsTrue(result.NoChange);
+        Assert.AreEqual(0, result.ToSave?.Count);
+        Assert.AreEqual(0, result.ToDelete?.Count);
+    }
+
+    // ── AgentContextBuilder: identity injection ─────────────────────────────
+
+    [TestMethod]
+    public async Task BuildAsync_InjectsIdentityEntries_WithFirstPersonFraming_ForPrimaryAgent()
+    {
+        var identityEntry = new MemoryEntry(
+            Id: "id001",
+            Content: "I primarily manage schedules and communications.",
+            Category: AgentIdentityCategories.SelfModel,
+            Tags: ["identity"],
+            CreatedAt: DateTimeOffset.UtcNow);
+
+        var memory = new FakeLongTermMemory(identityEntry);
+        var builder = CreateContextBuilder(memory);
+
+        var messages = await builder.BuildAsync("test-session", "hello", CancellationToken.None);
+
+        var identityMessage = messages.FirstOrDefault(m =>
+            m.Role == ChatRole.System &&
+            m.Text?.Contains("Your evolving identity") == true);
+
+        Assert.IsNotNull(identityMessage, "Should contain identity context for primary agent");
+        Assert.IsTrue(identityMessage.Text!.Contains("I primarily manage schedules"),
+            "Should contain the identity entry content");
+        Assert.IsFalse(identityMessage.Text!.Contains("subordinate agent"),
+            "Primary agent should not see subordinate framing");
+    }
+
+    [TestMethod]
+    public async Task BuildAsync_InjectsIdentityEntries_WithThirdPersonFraming_ForSubagent()
+    {
+        var identityEntry = new MemoryEntry(
+            Id: "id002",
+            Content: "I primarily manage schedules and communications.",
+            Category: AgentIdentityCategories.SelfModel,
+            Tags: ["identity"],
+            CreatedAt: DateTimeOffset.UtcNow);
+
+        var memory = new FakeLongTermMemory(identityEntry);
+        var builder = CreateContextBuilder(memory);
+
+        // systemPromptOverride non-null signals subagent/patrol context
+        var messages = await builder.BuildAsync(
+            "subagent/task-123", "do research", CancellationToken.None,
+            workingMemoryNamespace: "subagent/task-123",
+            systemPromptOverride: "You are a subagent.");
+
+        var identityMessage = messages.FirstOrDefault(m =>
+            m.Role == ChatRole.System &&
+            m.Text?.Contains("Primary agent identity context") == true);
+
+        Assert.IsNotNull(identityMessage, "Should contain identity context for subagent");
+        Assert.IsTrue(identityMessage.Text!.Contains("subordinate agent"),
+            "Subagent should see subordinate framing");
+        Assert.IsTrue(identityMessage.Text!.Contains("I primarily manage schedules"),
+            "Should contain the identity entry content");
+    }
+
+    [TestMethod]
+    public async Task BuildAsync_SkipsIdentityInjection_WhenNoEntries()
+    {
+        var memory = new FakeLongTermMemory(); // no identity entries
+        var builder = CreateContextBuilder(memory);
+
+        var messages = await builder.BuildAsync("test-session", "hello", CancellationToken.None);
+
+        var identityMessage = messages.FirstOrDefault(m =>
+            m.Role == ChatRole.System &&
+            (m.Text?.Contains("evolving identity") == true ||
+             m.Text?.Contains("Primary agent identity") == true));
+
+        Assert.IsNull(identityMessage, "Should not inject identity block when no entries exist");
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static AgentContextBuilder CreateContextBuilder(ILongTermMemory memory)
+    {
+        var soul = new AgentProfileDocument("soul", null, [], "Soul content.");
+        var directives = new AgentProfileDocument("directives", null, [], "Directive content.");
+        var profile = new AgentProfile(soul, directives);
+        var holder = new ProfileHolder();
+        holder.Update(profile);
+
+        return new AgentContextBuilder(
+            profileHolder: holder,
+            agent: new AgentIdentity("test-agent"),
+            promptBuilder: new FakeSystemPromptBuilder(),
+            rulesStore: new FakeRulesStore(),
+            modelBehavior: ModelBehavior.Default,
+            conversationMemory: new FakeConversationMemory(),
+            longTermMemory: memory,
+            injectedMemoryTracker: new InjectedMemoryTracker(),
+            workingMemory: new FakeWorkingMemory(),
+            skillStore: new FakeSkillStore(),
+            skillIndexTracker: new SkillIndexTracker(),
+            skillRecallTracker: new SkillRecallTracker(),
+            clock: new AgentClock(
+                new ConfigurationBuilder().Build(),
+                Options.Create(new AgentProfileOptions()),
+                NullLogger<AgentClock>.Instance),
+            serviceSearchIndexProviders: [],
+            knowledgeGraphProviders: [],
+            knowledgeGraphOptions: Options.Create(new KnowledgeGraphOptions()),
+            logger: NullLogger<AgentContextBuilder>.Instance);
+    }
+
+    // ── Fakes ────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Fake long-term memory that returns identity entries when queried with the
+    /// agent-identity category prefix, and empty results otherwise.
+    /// </summary>
+    private sealed class FakeLongTermMemory(params MemoryEntry[] identityEntries) : ILongTermMemory
+    {
+        public Task SaveAsync(MemoryEntry entry, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task<IReadOnlyList<MemoryEntry>> SearchAsync(MemorySearchCriteria criteria, CancellationToken cancellationToken = default)
+        {
+            if (criteria.Category is not null &&
+                criteria.Category.StartsWith(AgentIdentityCategories.Prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return Task.FromResult<IReadOnlyList<MemoryEntry>>(identityEntries.ToList());
+            }
+            return Task.FromResult<IReadOnlyList<MemoryEntry>>([]);
+        }
+
+        public Task<MemoryEntry?> GetAsync(string id, CancellationToken cancellationToken = default)
+            => Task.FromResult<MemoryEntry?>(null);
+
+        public Task DeleteAsync(string id, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task<IReadOnlyList<string>> ListTagsAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<string>>([]);
+
+        public Task<IReadOnlyList<string>> ListCategoriesAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<string>>([]);
+    }
+
+    private sealed class FakeSystemPromptBuilder : ISystemPromptBuilder
+    {
+        public string Build(AgentProfile profile, AgentIdentity identity) => "System prompt.";
+    }
+
+    private sealed class FakeRulesStore : IRulesStore
+    {
+        public IReadOnlyList<string> Rules => [];
+        public Task<IReadOnlyList<string>> ListAsync() => Task.FromResult<IReadOnlyList<string>>([]);
+        public Task AddAsync(string rule) => Task.CompletedTask;
+        public Task RemoveAsync(string rule) => Task.CompletedTask;
+    }
+
+    private sealed class FakeConversationMemory : IConversationMemory
+    {
+        public Task AddTurnAsync(string sessionId, ConversationTurn turn, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+        public Task<IReadOnlyList<ConversationTurn>> GetTurnsAsync(string sessionId, CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<ConversationTurn>>([]);
+        public Task ClearAsync(string sessionId, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+        public Task<IReadOnlyList<string>> ListSessionsAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<string>>([]);
+    }
+
+    private sealed class FakeWorkingMemory : IWorkingMemory
+    {
+        public Task SetAsync(string key, string value, TimeSpan? ttl = null,
+            string? category = null, IReadOnlyList<string>? tags = null) => Task.CompletedTask;
+        public Task<string?> GetAsync(string key) => Task.FromResult<string?>(null);
+        public Task<IReadOnlyList<WorkingMemoryEntry>> ListAsync(string? prefix = null)
+            => Task.FromResult<IReadOnlyList<WorkingMemoryEntry>>([]);
+        public Task DeleteAsync(string key) => Task.CompletedTask;
+        public Task ClearAsync(string? prefix = null) => Task.CompletedTask;
+        public Task<IReadOnlyList<WorkingMemoryEntry>> SearchAsync(MemorySearchCriteria criteria, string? prefix = null)
+            => Task.FromResult<IReadOnlyList<WorkingMemoryEntry>>([]);
+    }
+
+    private sealed class FakeSkillStore : ISkillStore
+    {
+        public Task SaveAsync(Skill skill) => Task.CompletedTask;
+        public Task<Skill?> GetAsync(string name) => Task.FromResult<Skill?>(null);
+        public Task<IReadOnlyList<Skill>> ListAsync() => Task.FromResult<IReadOnlyList<Skill>>([]);
+        public Task DeleteAsync(string name) => Task.CompletedTask;
+        public Task<IReadOnlyList<Skill>> SearchAsync(string query, int maxResults, CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<Skill>>([]);
+    }
+
+    // ── DTOs (mirrors DreamService private records for deserialization testing) ──
+
+    internal sealed record IdentityReflectionResultDto(
+        bool? NoChange,
+        List<string>? ToDelete,
+        List<IdentityEntryDto>? ToSave);
+
+    internal sealed record IdentityEntryDto(
+        string Content,
+        string? Category,
+        IReadOnlyList<string>? Tags,
+        float? Importance);
+}


### PR DESCRIPTION
## Summary
- Adds `agent-identity/` long-term memory category with subcategories (mission, goals, projects, capabilities, self-model) for the agent's mutable narrative identity
- Dream service runs an identity reflection pass each cycle — reviews episodic memories, feedback, and preferences to evolve identity entries when meaningful shifts occur
- `AgentContextBuilder` injects identity entries into every context with role-aware framing: first-person for primary agent, third-person for subagents/tasks (reinforcing they don't assume the primary's role)
- soul.md remains immutable — identity entries complement but never override core values
- Updated `common-directives.md` so the agent knows about the capability, and `design/agent-identity.md` with architecture docs

Closes #215

## Test plan
- [x] 10 unit tests: category constants, DreamOptions defaults, DTO serialization, context builder injection (primary vs subagent framing, empty entries)
- [x] Full solution build passes (0 errors)
- [x] All 12 test projects pass
- [x] Deployed to k8s — dream cycle ran identity reflection pass successfully (2 deleted, 2 saved)
- [x] Verified identity entries on PVC in `agent-identity/capabilities` and `agent-identity/self-model`

🤖 Generated with [Claude Code](https://claude.com/claude-code)