### PR TITLE
Fix LLM timeout bypassing FallbackChatClient model fallback

### DIFF
--- a/src/RockBot.Agent/Program.cs
+++ b/src/RockBot.Agent/Program.cs
@@ -98,7 +98,13 @@ if (tierOptions.Balanced.IsConfigured || tierOptions.BalancedModels.Count > 0)
             .Select(cfg => (cfg.ModelId!, BuildClient(cfg)))
             .ToList();
 
-        balancedInner = new FallbackChatClient(entries, fallbackLogger);
+        // Read the per-call timeout so FallbackChatClient can apply it per-attempt,
+        // giving each model in the chain its own timeout window for fallback to work.
+        var agentHostOpts = new AgentHostOptions();
+        builder.Configuration.GetSection("AgentHost").Bind(agentHostOpts);
+
+        balancedInner = new FallbackChatClient(entries, fallbackLogger,
+            perAttemptTimeout: agentHostOpts.LlmCallTimeout);
     }
     else if (tierOptions.BalancedModels.Count == 1)
     {

--- a/src/RockBot.Host/LlmClient.cs
+++ b/src/RockBot.Host/LlmClient.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 namespace RockBot.Host;
 
@@ -15,10 +14,8 @@ namespace RockBot.Host;
 /// </summary>
 internal sealed class LlmClient(
     TieredChatClientRegistry registry,
-    IOptions<AgentHostOptions> hostOptions,
     ILogger<LlmClient> logger) : ILlmClient
 {
-    private readonly TimeSpan _callTimeout = hostOptions.Value.LlmCallTimeout;
     /// <summary>Calls the LLM using the Balanced tier.</summary>
     public Task<ChatResponse> GetResponseAsync(
         IEnumerable<ChatMessage> messages,
@@ -63,67 +60,41 @@ internal sealed class LlmClient(
         var status = "ok";
         try
         {
-            // Apply per-call timeout: if the LLM provider stalls, abort before the
-            // 5-minute HTTP NetworkTimeout and surface as TimeoutException so evaluators
-            // can fail-open instead of hanging.
-            CancellationToken effectiveCt;
-            CancellationTokenSource? timeoutCts = null;
-            if (_callTimeout > TimeSpan.Zero)
-            {
-                timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                timeoutCts.CancelAfter(_callTimeout);
-                effectiveCt = timeoutCts.Token;
-            }
-            else
-            {
-                effectiveCt = cancellationToken;
-            }
+            // Per-call timeout is handled inside FallbackChatClient as a per-attempt
+            // timeout — each model in the fallback chain gets its own timeout window.
+            // This ensures a stalled primary model doesn't prevent fallback to the
+            // next model. The original cancellation token is passed through so
+            // FallbackChatClient can correctly distinguish user cancellation from
+            // provider timeouts.
+            var response = await InvokeWithNullArgRetryAsync(client, messages, options, cancellationToken);
 
-            try
+            if (response.Usage is { } usage)
             {
-                var response = await InvokeWithNullArgRetryAsync(client, messages, options, effectiveCt);
+                var inputTokens = usage.InputTokenCount ?? 0;
+                var outputTokens = usage.OutputTokenCount ?? 0;
 
-                if (response.Usage is { } usage)
+                var tierTag = new KeyValuePair<string, object?>("rockbot.llm.tier", tier.ToString());
+                var modelTag = new KeyValuePair<string, object?>("rockbot.llm.model", modelId);
+
+                if (usage.InputTokenCount.HasValue)
+                    HostDiagnostics.LlmTokenInput.Add(inputTokens, tierTag, modelTag);
+                if (usage.OutputTokenCount.HasValue)
+                    HostDiagnostics.LlmTokenOutput.Add(outputTokens, tierTag, modelTag);
+
+                var costUsd = LlmCostEstimator.EstimateCost(modelId, inputTokens, outputTokens);
+                if (costUsd > 0)
                 {
-                    var inputTokens = usage.InputTokenCount ?? 0;
-                    var outputTokens = usage.OutputTokenCount ?? 0;
-
-                    var tierTag = new KeyValuePair<string, object?>("rockbot.llm.tier", tier.ToString());
-                    var modelTag = new KeyValuePair<string, object?>("rockbot.llm.model", modelId);
-
-                    if (usage.InputTokenCount.HasValue)
-                        HostDiagnostics.LlmTokenInput.Add(inputTokens, tierTag, modelTag);
-                    if (usage.OutputTokenCount.HasValue)
-                        HostDiagnostics.LlmTokenOutput.Add(outputTokens, tierTag, modelTag);
-
-                    var costUsd = LlmCostEstimator.EstimateCost(modelId, inputTokens, outputTokens);
-                    if (costUsd > 0)
-                    {
-                        HostDiagnostics.LlmCostUsd.Add(costUsd, tierTag, modelTag);
-                        HostDiagnostics.LlmCostPerRequest.Record(costUsd, tierTag, modelTag);
-                    }
-
-                    activity?.SetTag("rockbot.llm.tokens.input", inputTokens);
-                    activity?.SetTag("rockbot.llm.tokens.output", outputTokens);
-                    activity?.SetTag("rockbot.llm.cost.usd", costUsd);
+                    HostDiagnostics.LlmCostUsd.Add(costUsd, tierTag, modelTag);
+                    HostDiagnostics.LlmCostPerRequest.Record(costUsd, tierTag, modelTag);
                 }
 
-                activity?.SetStatus(ActivityStatusCode.Ok);
-                return response;
+                activity?.SetTag("rockbot.llm.tokens.input", inputTokens);
+                activity?.SetTag("rockbot.llm.tokens.output", outputTokens);
+                activity?.SetTag("rockbot.llm.cost.usd", costUsd);
             }
-            catch (OperationCanceledException) when (timeoutCts is not null && timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
-            {
-                // Per-call timeout fired (not the caller's token) — convert to TimeoutException
-                // so evaluators' catch-all (ex is not OperationCanceledException) can fail-open.
-                logger.LogWarning("LLM call timed out after {Timeout} on {Tier} tier ({Model})",
-                    _callTimeout, tier, modelId);
-                throw new TimeoutException(
-                    $"LLM call to {modelId} ({tier}) timed out after {_callTimeout.TotalSeconds:F0}s");
-            }
-            finally
-            {
-                timeoutCts?.Dispose();
-            }
+
+            activity?.SetStatus(ActivityStatusCode.Ok);
+            return response;
         }
         catch (Exception) when (status == "ok")
         {

--- a/src/RockBot.Llm/FallbackChatClient.cs
+++ b/src/RockBot.Llm/FallbackChatClient.cs
@@ -20,6 +20,7 @@ public sealed class FallbackChatClient : IChatClient
     private readonly DateTimeOffset[] _degradedAt;
     private readonly TimeSpan _retryDelay;
     private readonly TimeSpan _cooldownPeriod;
+    private readonly TimeSpan _perAttemptTimeout;
     private readonly int _maxRetries;
     private volatile int _activeIndex;
 
@@ -28,7 +29,8 @@ public sealed class FallbackChatClient : IChatClient
         ILogger logger,
         TimeSpan? retryDelay = null,
         int maxRetries = 1,
-        TimeSpan? cooldownPeriod = null)
+        TimeSpan? cooldownPeriod = null,
+        TimeSpan? perAttemptTimeout = null)
     {
         if (entries.Count == 0)
             throw new ArgumentException("At least one entry is required.", nameof(entries));
@@ -38,6 +40,7 @@ public sealed class FallbackChatClient : IChatClient
         _degradedAt = new DateTimeOffset[entries.Count];
         _retryDelay = retryDelay ?? TimeSpan.FromSeconds(1);
         _cooldownPeriod = cooldownPeriod ?? TimeSpan.FromMinutes(5);
+        _perAttemptTimeout = perAttemptTimeout ?? TimeSpan.Zero;
         _maxRetries = maxRetries;
     }
 
@@ -64,13 +67,38 @@ public sealed class FallbackChatClient : IChatClient
                 if (attempt > 0 && _retryDelay > TimeSpan.Zero)
                     await Task.Delay(_retryDelay, cancellationToken);
 
+                // Per-attempt timeout: each model attempt gets its own timeout window
+                // so a stalled model doesn't consume the budget for fallback models.
+                // The per-attempt CTS is linked to the caller's token so user
+                // cancellation still propagates immediately.
+                CancellationTokenSource? attemptCts = null;
+                CancellationToken attemptCt = cancellationToken;
+                if (_perAttemptTimeout > TimeSpan.Zero)
+                {
+                    attemptCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                    attemptCts.CancelAfter(_perAttemptTimeout);
+                    attemptCt = attemptCts.Token;
+                }
+
                 try
                 {
-                    return await client.GetResponseAsync(messages, options, cancellationToken);
+                    return await client.GetResponseAsync(messages, options, attemptCt);
                 }
                 catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
                     throw; // User cancellation — do not retry or switch
+                }
+                catch (OperationCanceledException) when (attemptCts is not null && attemptCts.IsCancellationRequested)
+                {
+                    // Per-attempt timeout fired (not user cancellation) — treat as transient
+                    _logger.LogWarning(
+                        "FallbackChatClient: model {ModelId} timed out after {Timeout} (attempt {Attempt}/{MaxRetries})",
+                        modelId, _perAttemptTimeout, attempt + 1, _maxRetries + 1);
+
+                    if (attempt < _maxRetries)
+                        continue; // Retry same model
+
+                    break; // Fall through to next model
                 }
                 catch (Exception ex)
                 {
@@ -107,6 +135,10 @@ public sealed class FallbackChatClient : IChatClient
                     }
 
                     break; // Fall through to next model
+                }
+                finally
+                {
+                    attemptCts?.Dispose();
                 }
             }
 

--- a/tests/RockBot.Llm.Tests/FallbackChatClientTests.cs
+++ b/tests/RockBot.Llm.Tests/FallbackChatClientTests.cs
@@ -281,6 +281,75 @@ public class FallbackChatClientTests
     }
 
     [TestMethod]
+    public async Task PerAttemptTimeout_FallsBackToNextModel()
+    {
+        // First model stalls forever; second responds immediately.
+        var first  = new SlowStub(delay: TimeSpan.FromSeconds(30));
+        var second = new FixedStub(response: OkResponse("from-fallback"));
+
+        var client = new FallbackChatClient(
+            [("slow-model", first), ("fast-model", second)],
+            NullLogger.Instance,
+            retryDelay: TimeSpan.Zero,
+            maxRetries: 0,
+            perAttemptTimeout: TimeSpan.FromMilliseconds(100));
+
+        var response = await client.GetResponseAsync([]);
+
+        Assert.AreEqual("from-fallback", response.Messages[^1].Text);
+        Assert.AreEqual(1, first.CallCount, "Slow model should have been called once");
+        Assert.AreEqual(1, second.CallCount, "Fast model should have been called as fallback");
+    }
+
+    [TestMethod]
+    public async Task PerAttemptTimeout_UserCancellation_PropagatesImmediately()
+    {
+        var slow = new SlowStub(delay: TimeSpan.FromSeconds(30));
+        var fallback = new FixedStub(response: OkResponse("should-not-reach"));
+
+        var client = new FallbackChatClient(
+            [("slow", slow), ("fallback", fallback)],
+            NullLogger.Instance,
+            retryDelay: TimeSpan.Zero,
+            maxRetries: 0,
+            perAttemptTimeout: TimeSpan.FromSeconds(5));
+
+        using var userCts = new CancellationTokenSource();
+        userCts.Cancel(); // User cancelled immediately
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => client.GetResponseAsync([], cancellationToken: userCts.Token));
+
+        Assert.AreEqual(0, fallback.CallCount, "Should not fall back on user cancellation");
+    }
+
+    // ── additional stubs ────────────────────────────────────────────────────
+
+    /// <summary>Delays for a configurable period before responding (simulates a stalled model).</summary>
+    private sealed class SlowStub(TimeSpan delay) : IChatClient
+    {
+        public int CallCount { get; private set; }
+
+        public async Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> chatMessages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            CallCount++;
+            await Task.Delay(delay, cancellationToken);
+            return new ChatResponse(new ChatMessage(ChatRole.Assistant, "slow-response"));
+        }
+
+        public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> chatMessages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+        public void Dispose() { }
+    }
+
+    [TestMethod]
     public void GetService_DelegatesToActiveClient()
     {
         var metadata = new ChatClientMetadata("test-provider", null, "model-x");


### PR DESCRIPTION
## Summary
- `LlmClient` created a linked CTS (user token + timeout) and passed it to `FallbackChatClient`, which treated the timeout cancellation as user cancellation — throwing immediately without trying the fallback model
- Moved per-call timeout into `FallbackChatClient` as a **per-attempt timeout**: each model in the fallback chain gets its own timeout window with a fresh linked CTS
- `FallbackChatClient` now correctly distinguishes user cancellation (original token cancelled → propagate) from attempt timeout (per-attempt CTS cancelled → treat as transient → fall back to next model)
- Removed timeout logic from `LlmClient` — it just passes the original cancellation token through

## Test plan
- [x] New test: `PerAttemptTimeout_FallsBackToNextModel` — slow model times out, fast fallback model succeeds
- [x] New test: `PerAttemptTimeout_UserCancellation_PropagatesImmediately` — user cancellation still throws without fallback
- [x] All 13 FallbackChatClient tests pass
- [x] Full solution: all 12 test projects pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)