### PR TITLE
Prevent episodic memories from poisoning tool availability beliefs

### DIFF
--- a/src/RockBot.Agent/agent/common-directives.md
+++ b/src/RockBot.Agent/agent/common-directives.md
@@ -164,6 +164,16 @@ When a tool call returns an unexpected result, an error, or content that doesn't
 satisfy the request, **do not give up and report failure**. Treat the
 obstacle as a problem to solve.
 
+### Memory vs. current reality
+
+Recalled memories about tools being broken, unavailable, or unsupported are
+**point-in-time observations, not permanent facts**. Tool availability changes
+across restarts, deployments, and MCP server reconnections. If a memory says
+a tool or MCP service doesn't work, but that tool appears in your current tool
+list or `mcp_list_services` shows it as connected — **trust what you can observe
+now and try the tool.** A past failure does not mean a current failure. Always
+verify by attempting the call before concluding something is still broken.
+
 ### Required escalation sequence
 
 Work through these alternatives before saying you cannot do something:

--- a/src/RockBot.Host/DreamService.cs
+++ b/src/RockBot.Host/DreamService.cs
@@ -2951,6 +2951,13 @@ internal sealed class DreamService : IHostedService, IDisposable
         - Trivial exchanges ("hi", "thanks", routine greetings)
         - Pure factual lookups with no discussion (those are mined as facts separately)
         - Repeated instances of the same type of interaction already captured
+        - **Tool or capability availability conclusions** — never record "tool X doesn't
+          work", "MCP server Y is unavailable", or "capability Z is not supported" as
+          episodic memories. Tool availability is transient and changes across restarts,
+          deployments, and reconnections. Recording these as episodes creates false beliefs
+          that prevent the agent from trying tools that may now be working. If a tool
+          failed, the relevant lesson is the *workaround* or *diagnostic approach*, not
+          the conclusion that the tool is broken.
 
         Each episode should be a rich, narrative summary in third-person:
         e.g. "The user and agent investigated Azure content filter rejections that were


### PR DESCRIPTION
## Summary
- A single bad MCP session was extracted as an episodic memory claiming `mcp_invoke_tool` doesn't work — this was BM25-surfaced on every subsequent calendar-related session, causing the agent to skip calendar calls without trying
- **Directive guardrail**: added "Memory vs. current reality" section to common-directives telling the agent that recalled memories about broken tools are point-in-time observations — trust the current tool list over past failures
- **Episode extraction guardrail**: updated the built-in episode directive to explicitly exclude tool/capability availability conclusions from episodic memories, since tool availability is transient

## Test plan
- [x] Full solution builds (0 errors)
- [x] All 12 test projects pass
- [x] Poisoned memory entry already deleted from PVC manually
- [ ] Verify agent uses calendar-mcp normally in next session

🤖 Generated with [Claude Code](https://claude.com/claude-code)