### PR TITLE
Add view modal for saved responses

### DIFF
--- a/src/RockBot.UserProxy.Blazor/Pages/Chat.razor
+++ b/src/RockBot.UserProxy.Blazor/Pages/Chat.razor
@@ -231,29 +231,49 @@
     {
         <div class="modal-overlay" @onclick="ToggleSavedModal">
             <div class="saved-modal" @onclick:stopPropagation="true">
-                <h5>Saved Responses</h5>
-                @if (_savedItems is null)
+                @if (_viewingItem is not null)
                 {
-                    <p>Loading...</p>
-                }
-                else if (_savedItems.Count == 0)
-                {
-                    <p class="text-muted">No saved responses yet.</p>
+                    <div class="saved-view-header">
+                        <h5>@_viewingItem.Label</h5>
+                        <small class="saved-item-meta">@_viewingItem.AgentName — @TimeZoneInfo.ConvertTime(_viewingItem.SavedAt, _displayZone).ToString("MMM d, yyyy h:mm tt")</small>
+                    </div>
+                    <div class="saved-view-content">
+                        @((MarkupString)Markdig.Markdown.ToHtml(_viewingItem.Content, MarkdownPipeline))
+                    </div>
+                    <div class="d-flex gap-2 mt-2">
+                        <button class="btn btn-sm btn-secondary" @onclick="BackToSavedList">Back</button>
+                        <button class="btn btn-sm btn-primary" @onclick="() => InsertViewedItem()">Insert into chat</button>
+                    </div>
                 }
                 else
                 {
-                    @foreach (var item in _savedItems)
+                    <h5>Saved Responses</h5>
+                    @if (_savedItems is null)
                     {
-                        <div class="saved-item d-flex justify-content-between align-items-center p-2 mb-1 rounded">
-                            <div class="saved-item-info" @onclick="() => LoadSavedItem(item.Id)" style="cursor:pointer;">
-                                <strong>@item.Label</strong>
-                                <small class="saved-item-meta d-block">@item.AgentName — @TimeZoneInfo.ConvertTime(item.SavedAt, _displayZone).ToString("MMM d, yyyy h:mm tt")</small>
-                            </div>
-                            <button class="btn btn-sm btn-outline-danger" @onclick="() => DeleteSavedItem(item.Id)">🗑️</button>
-                        </div>
+                        <p>Loading...</p>
                     }
+                    else if (_savedItems.Count == 0)
+                    {
+                        <p class="text-muted">No saved responses yet.</p>
+                    }
+                    else
+                    {
+                        @foreach (var item in _savedItems)
+                        {
+                            <div class="saved-item d-flex justify-content-between align-items-center p-2 mb-1 rounded">
+                                <div class="saved-item-info" @onclick="() => LoadSavedItem(item.Id)" style="cursor:pointer;" title="Insert into chat">
+                                    <strong>@item.Label</strong>
+                                    <small class="saved-item-meta d-block">@item.AgentName — @TimeZoneInfo.ConvertTime(item.SavedAt, _displayZone).ToString("MMM d, yyyy h:mm tt")</small>
+                                </div>
+                                <div class="d-flex gap-1">
+                                    <button class="btn btn-sm btn-outline-secondary" @onclick="() => ViewSavedItem(item.Id)" title="View">👁️</button>
+                                    <button class="btn btn-sm btn-outline-danger" @onclick="() => DeleteSavedItem(item.Id)" title="Delete">🗑️</button>
+                                </div>
+                            </div>
+                        }
+                    }
+                    <button class="btn btn-sm btn-secondary mt-2" @onclick="ToggleSavedModal">Close</button>
                 }
-                <button class="btn btn-sm btn-secondary mt-2" @onclick="ToggleSavedModal">Close</button>
             </div>
         </div>
     }
@@ -311,6 +331,7 @@
     private string _saveLabel = string.Empty;
     private bool _showSavedModal;
     private IReadOnlyList<SavedResponseSummary>? _savedItems;
+    private GetSavedResponseResponse? _viewingItem;
 
     private static readonly MarkdownPipeline MarkdownPipeline = new MarkdownPipelineBuilder()
         .UseAdvancedExtensions()
@@ -583,6 +604,7 @@
     private async Task ToggleSavedModal()
     {
         _showSavedModal = !_showSavedModal;
+        _viewingItem = null;
         if (_showSavedModal)
         {
             _savedItems = null;
@@ -602,6 +624,7 @@
     private async Task LoadSavedItem(string id)
     {
         _showSavedModal = false;
+        _viewingItem = null;
         try
         {
             var response = await ProxyService.GetSavedResponseAsync(id);
@@ -612,6 +635,33 @@
         {
             ChatState.AddError($"Could not load saved response: {ex.Message}");
         }
+    }
+
+    private async Task ViewSavedItem(string id)
+    {
+        try
+        {
+            var response = await ProxyService.GetSavedResponseAsync(id);
+            if (response is not null && response.Found)
+                _viewingItem = response;
+        }
+        catch (Exception ex)
+        {
+            ChatState.AddError($"Could not load saved response: {ex.Message}");
+        }
+    }
+
+    private void BackToSavedList()
+    {
+        _viewingItem = null;
+    }
+
+    private void InsertViewedItem()
+    {
+        if (_viewingItem is null) return;
+        ChatState.AddSavedReference(_viewingItem.Id, _viewingItem.Label, _viewingItem.Content, _viewingItem.AgentName);
+        _viewingItem = null;
+        _showSavedModal = false;
     }
 
     private async Task DeleteSavedItem(string id)

--- a/src/RockBot.UserProxy.Blazor/wwwroot/css/app.css
+++ b/src/RockBot.UserProxy.Blazor/wwwroot/css/app.css
@@ -668,6 +668,27 @@ body.dark-mode .chevron-indicator {
     color: #6b7280;
 }
 
+.saved-view-header {
+    margin-bottom: 0.75rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid #e5e7eb;
+}
+
+.saved-view-header h5 {
+    margin-bottom: 0.25rem;
+}
+
+.saved-view-content {
+    max-height: 50vh;
+    overflow-y: auto;
+    padding: 0.75rem;
+    background: #f9fafb;
+    border-radius: 0.375rem;
+    border: 1px solid #e5e7eb;
+    font-size: 0.9rem;
+    line-height: 1.6;
+}
+
 /* ── Dark mode: saved reference ─────────────────────────────────────── */
 
 body.dark-mode .saved-reference-bubble {
@@ -695,6 +716,16 @@ body.dark-mode .saved-item:hover {
 
 body.dark-mode .saved-item-meta {
     color: #9ca3af;
+}
+
+body.dark-mode .saved-view-header {
+    border-bottom-color: #4b5563;
+}
+
+body.dark-mode .saved-view-content {
+    background: #1f2937;
+    border-color: #4b5563;
+    color: #e5e7eb;
 }
 
 body.dark-mode .save-label-input {


### PR DESCRIPTION
## Summary
- Added view button (👁️) to each saved response list item for previewing content without inserting into chat
- View modal renders full content as markdown in a scrollable panel with Back and Insert buttons
- Clicking item label still inserts directly into chat (unchanged behavior)
- Light and dark mode styles included

## Test plan
- [ ] Open saved responses list, verify view button appears alongside delete
- [ ] Click view button — verify content renders as markdown with label/agent/date header
- [ ] Click Back — verify return to list
- [ ] Click Insert into chat — verify item is inserted and modal closes
- [ ] Click item label directly — verify it still inserts without going through view
- [ ] Verify dark mode styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)