### PR TITLE
Add /clear command to reset conversation context

### DIFF
--- a/src/RockBot.Agent/ClearContextHandler.cs
+++ b/src/RockBot.Agent/ClearContextHandler.cs
@@ -1,0 +1,42 @@
+using Microsoft.Extensions.Logging;
+using RockBot.Host;
+using RockBot.Messaging;
+using RockBot.UserProxy;
+
+namespace RockBot.Agent;
+
+/// <summary>
+/// Handles <see cref="ClearContextRequest"/> by clearing conversation memory
+/// for the session. Long-term memory and conversation logs are preserved.
+/// </summary>
+internal sealed class ClearContextHandler(
+    IConversationMemory conversationMemory,
+    ISessionTracker sessionTracker,
+    IMessagePublisher publisher,
+    AgentIdentity agent,
+    ILogger<ClearContextHandler> logger) : IMessageHandler<ClearContextRequest>
+{
+    public async Task HandleAsync(ClearContextRequest message, MessageHandlerContext context)
+    {
+        var ct = context.CancellationToken;
+
+        // Cancel any in-flight work for this session
+        var handle = sessionTracker.BeginSession(message.SessionId, ct);
+        sessionTracker.EndSession(message.SessionId, handle.Generation);
+
+        // Clear conversation memory (ephemeral turns only — logs are preserved)
+        await conversationMemory.ClearAsync(message.SessionId, ct);
+
+        logger.LogInformation("Cleared conversation context for session {SessionId}", message.SessionId);
+
+        var reply = new AgentReply
+        {
+            Content = "Context cleared — starting fresh.",
+            SessionId = message.SessionId,
+            AgentName = agent.Name,
+            IsFinal = true
+        };
+        var envelope = reply.ToEnvelope<AgentReply>(source: agent.Name);
+        await publisher.PublishAsync(UserProxyTopics.UserResponse, envelope, ct);
+    }
+}

--- a/src/RockBot.Agent/Program.cs
+++ b/src/RockBot.Agent/Program.cs
@@ -227,6 +227,7 @@ builder.Services.AddRockBotHost(agent =>
     agent.HandleMessage<UserMessage, UserMessageHandler>();
     agent.HandleMessage<UserFeedback, UserFeedbackHandler>();
     agent.HandleMessage<CancelSessionRequest, CancelSessionHandler>();
+    agent.HandleMessage<ClearContextRequest, ClearContextHandler>();
     agent.HandleMessage<ConversationHistoryRequest, ConversationHistoryRequestHandler>();
     agent.HandleMessage<AgentInfoRequest, AgentInfoRequestHandler>();
     agent.WithSavedResponses();
@@ -237,6 +238,7 @@ builder.Services.AddRockBotHost(agent =>
     agent.SubscribeTo(UserProxyTopics.UserMessage);
     agent.SubscribeTo(UserProxyTopics.UserFeedback);
     agent.SubscribeTo(UserProxyTopics.CancelSession);
+    agent.SubscribeTo(UserProxyTopics.ClearContext);
     agent.SubscribeTo(UserProxyTopics.ConversationHistoryRequest);
     agent.SubscribeTo(UserProxyTopics.AgentInfoRequest);
     agent.SubscribeTo(UserProxyTopics.SaveResponseRequest);

--- a/src/RockBot.UserProxy.Abstractions/ClearContextRequest.cs
+++ b/src/RockBot.UserProxy.Abstractions/ClearContextRequest.cs
@@ -1,0 +1,10 @@
+namespace RockBot.UserProxy;
+
+/// <summary>
+/// Message sent from the user proxy to clear conversation context for a session.
+/// Long-term memory and conversation logs are preserved.
+/// </summary>
+public sealed record ClearContextRequest
+{
+    public required string SessionId { get; init; }
+}

--- a/src/RockBot.UserProxy.Abstractions/UserProxyTopics.cs
+++ b/src/RockBot.UserProxy.Abstractions/UserProxyTopics.cs
@@ -8,6 +8,7 @@ public static class UserProxyTopics
     public const string UserMessage = "user.message";
     public const string UserResponse = "user.response";
     public const string CancelSession = "user.cancel";
+    public const string ClearContext = "user.context.clear";
     public const string ConversationHistoryRequest = "user.history.request";
     public const string ConversationHistoryResponse = "user.history.response";
     public const string UserFeedback = "user.feedback";

--- a/src/RockBot.UserProxy.Blazor/Pages/Chat.razor
+++ b/src/RockBot.UserProxy.Blazor/Pages/Chat.razor
@@ -420,6 +420,21 @@
         currentMessage = string.Empty;
         await JSRuntime.InvokeVoidAsync("chatHelpers.addToHistory", messageInput, messageContent);
 
+        // Handle /clear command — pure plumbing, no LLM involved
+        if (messageContent.Equals("/clear", StringComparison.OrdinalIgnoreCase))
+        {
+            ChatState.ClearMessages();
+            try
+            {
+                await ProxyService.ClearContextAsync(SessionId);
+            }
+            catch (Exception ex)
+            {
+                ChatState.AddError($"Could not clear agent context: {ex.Message}");
+            }
+            return;
+        }
+
         ChatState.AddUserMessage(messageContent, UserId, SessionId);
         ChatState.SetProcessing(true);
 

--- a/src/RockBot.UserProxy.Blazor/Services/ChatStateService.cs
+++ b/src/RockBot.UserProxy.Blazor/Services/ChatStateService.cs
@@ -273,6 +273,20 @@ public sealed class ChatStateService
         NotifyStateChanged();
     }
 
+    // ── Clear context ───────────────────────────────────────────────────────
+
+    public void ClearMessages()
+    {
+        lock (_lock)
+        {
+            _messages.Clear();
+            _activeActivityLogs.Clear();
+        }
+        _currentThinkingMessage = null;
+        _isProcessing = false;
+        NotifyStateChanged();
+    }
+
     // ── Saved references ────────────────────────────────────────────────────
 
     public void AddSavedReference(string id, string label, string content, string agentName)

--- a/src/RockBot.UserProxy/UserProxyService.cs
+++ b/src/RockBot.UserProxy/UserProxyService.cs
@@ -333,6 +333,18 @@ public sealed class UserProxyService(
         logger.LogInformation("Published cancel request for session {SessionId}", sessionId);
     }
 
+    /// <summary>
+    /// Publishes a clear context request to reset conversation memory for the given session.
+    /// Long-term memory and conversation logs are preserved.
+    /// </summary>
+    public async Task ClearContextAsync(string sessionId, CancellationToken cancellationToken = default)
+    {
+        var request = new ClearContextRequest { SessionId = sessionId };
+        var envelope = request.ToEnvelope<ClearContextRequest>(source: options.ProxyId);
+        await publisher.PublishAsync(UserProxyTopics.ClearContext, envelope, cancellationToken);
+        logger.LogInformation("Published clear context request for session {SessionId}", sessionId);
+    }
+
     internal Task<MessageResult> HandleResponseAsync(MessageEnvelope envelope, CancellationToken ct)
     {
         AgentReply? reply;


### PR DESCRIPTION
## Summary
- `/clear` command in Blazor chat clears local UI and resets agent conversation memory
- Cancels any in-flight work for the session
- Long-term memory, conversation logs, and saved responses are preserved
- Pure plumbing — no LLM call involved

## New files
- `ClearContextRequest.cs` — message type
- `ClearContextHandler.cs` — agent handler that clears `IConversationMemory` and cancels session

## Test plan
- [x] Solution builds, all tests pass
- [x] Deployed and tested on cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)