### PR TITLE
Fix stale subagent indicators with completion flag and startup sync

### DIFF
--- a/src/RockBot.Agent/ActiveStatusRequestHandler.cs
+++ b/src/RockBot.Agent/ActiveStatusRequestHandler.cs
@@ -1,0 +1,55 @@
+using Microsoft.Extensions.Logging;
+using RockBot.Host;
+using RockBot.Messaging;
+using RockBot.Subagent;
+using RockBot.UserProxy;
+
+namespace RockBot.Agent;
+
+/// <summary>
+/// Handles <see cref="ActiveStatusRequest"/> by returning a snapshot of currently
+/// running subagents and processing state. Lightweight and deterministic — no LLM invocation.
+/// </summary>
+internal sealed class ActiveStatusRequestHandler(
+    ISubagentManager subagentManager,
+    ISessionTracker sessionTracker,
+    IMessagePublisher publisher,
+    ILogger<ActiveStatusRequestHandler> logger) : IMessageHandler<ActiveStatusRequest>
+{
+    public async Task HandleAsync(ActiveStatusRequest message, MessageHandlerContext context)
+    {
+        var replyTo = context.Envelope.ReplyTo;
+        var correlationId = context.Envelope.CorrelationId;
+        var ct = context.CancellationToken;
+
+        if (string.IsNullOrEmpty(replyTo))
+        {
+            logger.LogWarning("ActiveStatusRequest received with no replyTo — ignoring");
+            return;
+        }
+
+        var activeSubagents = subagentManager.ListActive();
+
+        var response = new ActiveStatusResponse
+        {
+            Subagents = activeSubagents
+                .Select(e => new ActiveSubagentInfo
+                {
+                    TaskId = e.TaskId,
+                    Description = e.Description,
+                    StartedAt = e.StartedAt
+                })
+                .ToList(),
+            IsProcessing = sessionTracker.HasActiveUserLoop("blazor-session")
+        };
+
+        var envelope = response.ToEnvelope<ActiveStatusResponse>(
+            source: context.Agent.Name,
+            correlationId: correlationId);
+
+        await publisher.PublishAsync(replyTo, envelope, ct);
+
+        logger.LogDebug("Published active status: {SubagentCount} subagents, isProcessing={IsProcessing}",
+            response.Subagents.Count, response.IsProcessing);
+    }
+}

--- a/src/RockBot.Agent/Program.cs
+++ b/src/RockBot.Agent/Program.cs
@@ -230,6 +230,7 @@ builder.Services.AddRockBotHost(agent =>
     agent.HandleMessage<ClearContextRequest, ClearContextHandler>();
     agent.HandleMessage<ConversationHistoryRequest, ConversationHistoryRequestHandler>();
     agent.HandleMessage<AgentInfoRequest, AgentInfoRequestHandler>();
+    agent.HandleMessage<ActiveStatusRequest, ActiveStatusRequestHandler>();
     agent.WithSavedResponses();
     agent.HandleMessage<SaveResponseRequest, SaveResponseRequestHandler>();
     agent.HandleMessage<ListSavedResponsesRequest, ListSavedResponsesRequestHandler>();
@@ -241,6 +242,7 @@ builder.Services.AddRockBotHost(agent =>
     agent.SubscribeTo(UserProxyTopics.ClearContext);
     agent.SubscribeTo(UserProxyTopics.ConversationHistoryRequest);
     agent.SubscribeTo(UserProxyTopics.AgentInfoRequest);
+    agent.SubscribeTo(UserProxyTopics.ActiveStatusRequest);
     agent.SubscribeTo(UserProxyTopics.SaveResponseRequest);
     agent.SubscribeTo(UserProxyTopics.ListSavedResponsesRequest);
     agent.SubscribeTo(UserProxyTopics.GetSavedResponseRequest);

--- a/src/RockBot.Subagent/SubagentResultHandler.cs
+++ b/src/RockBot.Subagent/SubagentResultHandler.cs
@@ -75,7 +75,8 @@ internal sealed class SubagentResultHandler(
                 Content = completionContent,
                 SessionId = rawSessionId,
                 AgentName = $"subagent-{message.TaskId}",
-                IsFinal = false
+                IsFinal = false,
+                IsCompletion = true
             };
             var completionEnvelope = completionReply.ToEnvelope<AgentReply>(
                 source: $"subagent-{message.TaskId}");

--- a/src/RockBot.UserProxy.Abstractions/ActiveStatusRequest.cs
+++ b/src/RockBot.UserProxy.Abstractions/ActiveStatusRequest.cs
@@ -1,0 +1,8 @@
+namespace RockBot.UserProxy;
+
+/// <summary>
+/// Requests a snapshot of currently active background work (subagents, etc.)
+/// so the UI can reconcile its indicators on startup or reconnect.
+/// Lightweight request — no LLM invocation, deterministic response.
+/// </summary>
+public sealed record ActiveStatusRequest;

--- a/src/RockBot.UserProxy.Abstractions/ActiveStatusResponse.cs
+++ b/src/RockBot.UserProxy.Abstractions/ActiveStatusResponse.cs
@@ -1,0 +1,22 @@
+namespace RockBot.UserProxy;
+
+/// <summary>
+/// Snapshot of currently active background work returned in response to
+/// <see cref="ActiveStatusRequest"/>. The UI uses this to reconcile stale
+/// indicators (spinners, header badges) on startup or reconnect.
+/// </summary>
+public sealed record ActiveStatusResponse
+{
+    public required IReadOnlyList<ActiveSubagentInfo> Subagents { get; init; }
+    public required bool IsProcessing { get; init; }
+}
+
+/// <summary>
+/// Describes a currently running subagent.
+/// </summary>
+public sealed record ActiveSubagentInfo
+{
+    public required string TaskId { get; init; }
+    public required string Description { get; init; }
+    public required DateTimeOffset StartedAt { get; init; }
+}

--- a/src/RockBot.UserProxy.Abstractions/AgentReply.cs
+++ b/src/RockBot.UserProxy.Abstractions/AgentReply.cs
@@ -9,6 +9,14 @@ public sealed record AgentReply
     public required string SessionId { get; init; }
     public required string AgentName { get; init; }
     public bool IsFinal { get; init; } = true;
+
+    /// <summary>
+    /// When true on a non-final reply, signals that the source has finished producing
+    /// output and its activity log should be closed (spinner removed, header indicator
+    /// cleared). Used by SubagentResultHandler to mark the Phase 1 completion bubble.
+    /// </summary>
+    public bool IsCompletion { get; init; }
+
     public string? StructuredData { get; init; }
     public string? ContentType { get; init; }
 }

--- a/src/RockBot.UserProxy.Abstractions/UserProxyTopics.cs
+++ b/src/RockBot.UserProxy.Abstractions/UserProxyTopics.cs
@@ -14,6 +14,8 @@ public static class UserProxyTopics
     public const string UserFeedback = "user.feedback";
     public const string AgentInfoRequest = "agent.info.request";
     public const string AgentInfoResponse = "agent.info.response";
+    public const string ActiveStatusRequest = "agent.status.request";
+    public const string ActiveStatusResponse = "agent.status.response";
 
     // Saved responses
     public const string SaveResponseRequest = "user.saved.save.request";

--- a/src/RockBot.UserProxy.Blazor/Pages/Chat.razor
+++ b/src/RockBot.UserProxy.Blazor/Pages/Chat.razor
@@ -385,6 +385,18 @@
             {
                 ChatState.AddError($"Could not load conversation history: {ex.Message}");
             }
+
+            // Reconcile active status indicators against the agent's ground truth.
+            // This clears stale subagent spinners/header badges that persist in the
+            // singleton ChatStateService across page reloads, and seeds indicators
+            // for subagents that started before this UI connected.
+            try
+            {
+                var status = await ProxyService.GetActiveStatusAsync(timeout: TimeSpan.FromSeconds(5));
+                if (status is not null)
+                    ChatState.ReconcileActiveStatus(status);
+            }
+            catch { /* non-fatal — stale indicators clear on next user message */ }
         }
 
         // Only scroll when a new message has been added — not on every re-render

--- a/src/RockBot.UserProxy.Blazor/Services/BlazorUserFrontend.cs
+++ b/src/RockBot.UserProxy.Blazor/Services/BlazorUserFrontend.cs
@@ -29,8 +29,11 @@ public sealed class BlazorUserFrontend(ChatStateService chatState) : IUserFronte
         else
         {
             // Non-final progress — append to the source's activity log bubble
-            // instead of creating a separate bubble per message
-            chatState.AppendActivityLogEntry(reply.Content, category, reply.AgentName);
+            // instead of creating a separate bubble per message.
+            // IsCompletion signals the source has finished (e.g. subagent result Phase 1) —
+            // close the activity log so the spinner and header indicator disappear.
+            chatState.AppendActivityLogEntry(reply.Content, category, reply.AgentName,
+                close: reply.IsCompletion);
         }
         return Task.CompletedTask;
     }

--- a/src/RockBot.UserProxy.Blazor/Services/ChatStateService.cs
+++ b/src/RockBot.UserProxy.Blazor/Services/ChatStateService.cs
@@ -1,3 +1,5 @@
+using RockBot.UserProxy;
+
 namespace RockBot.UserProxy.Blazor.Services;
 
 public enum MessageCategory
@@ -168,7 +170,8 @@ public sealed class ChatStateService
     public void AppendActivityLogEntry(
         string content,
         MessageCategory category = MessageCategory.PrimaryProgress,
-        string? agentName = null)
+        string? agentName = null,
+        bool close = false)
     {
         lock (_lock)
         {
@@ -196,6 +199,9 @@ public sealed class ChatStateService
 
             logBubble.ActivityLogEntries.Add(new ActivityLogEntry(content, DateTime.UtcNow));
             logBubble.Content = content; // summary line = latest entry
+
+            if (close)
+                _activeActivityLogs.Remove(key);
         }
         NotifyStateChanged();
     }
@@ -341,6 +347,58 @@ public sealed class ChatStateService
             }
             return indicators;
         }
+    }
+
+    /// <summary>
+    /// Reconciles local activity-log state against the authoritative snapshot from
+    /// the agent. Removes stale entries for subagents that are no longer running and
+    /// seeds entries for subagents that are active but unknown to the UI (e.g. after
+    /// a page reload while subagents were in flight).
+    /// </summary>
+    public void ReconcileActiveStatus(ActiveStatusResponse status)
+    {
+        lock (_lock)
+        {
+            var activeAgentNames = status.Subagents
+                .Select(s => $"subagent-{s.TaskId}")
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            // Remove stale subagent activity logs for subagents that are no longer running
+            var subagentPrefix = $"{MessageCategory.SubagentActivity}:";
+            var keysToRemove = _activeActivityLogs.Keys
+                .Where(k => k.StartsWith(subagentPrefix, StringComparison.Ordinal) &&
+                            !activeAgentNames.Contains(k[subagentPrefix.Length..]))
+                .ToList();
+
+            foreach (var key in keysToRemove)
+                _activeActivityLogs.Remove(key);
+
+            // Seed activity log entries for subagents that are running but have no UI state
+            foreach (var sub in status.Subagents)
+            {
+                var agentName = $"subagent-{sub.TaskId}";
+                var key = ActivityLogKey(MessageCategory.SubagentActivity, agentName);
+
+                if (!_activeActivityLogs.ContainsKey(key))
+                {
+                    var bubble = new ChatMessage
+                    {
+                        Content = $"Running: {sub.Description}",
+                        IsFromUser = false,
+                        Timestamp = sub.StartedAt.UtcDateTime,
+                        AgentName = agentName,
+                        Category = MessageCategory.SubagentActivity,
+                        IsActivityLog = true,
+                        IsExpanded = false
+                    };
+                    bubble.ActivityLogEntries.Add(new ActivityLogEntry(
+                        $"Running: {sub.Description}", sub.StartedAt.UtcDateTime));
+                    _messages.Add(bubble);
+                    _activeActivityLogs[key] = bubble.MessageId;
+                }
+            }
+        }
+        NotifyStateChanged();
     }
 
     private static string ActivityLogKey(MessageCategory category, string? agentName)

--- a/src/RockBot.UserProxy/UserProxyService.cs
+++ b/src/RockBot.UserProxy/UserProxyService.cs
@@ -24,9 +24,11 @@ public sealed class UserProxyService(
     private readonly ConcurrentDictionary<string, TaskCompletionSource<ListSavedResponsesResponse>> _pendingListSaved = new();
     private readonly ConcurrentDictionary<string, TaskCompletionSource<GetSavedResponseResponse>> _pendingGetSaved = new();
     private readonly ConcurrentDictionary<string, TaskCompletionSource<DeleteSavedResponseAck>> _pendingDeleteSaved = new();
+    private readonly ConcurrentDictionary<string, TaskCompletionSource<ActiveStatusResponse>> _pendingActiveStatus = new();
     private ISubscription? _subscription;
     private ISubscription? _historySubscription;
     private ISubscription? _agentInfoSubscription;
+    private ISubscription? _activeStatusSubscription;
     private ISubscription? _saveResponseSubscription;
     private ISubscription? _listSavedSubscription;
     private ISubscription? _getSavedSubscription;
@@ -37,8 +39,10 @@ public sealed class UserProxyService(
     private bool _listSavedInitialized;
     private bool _getSavedInitialized;
     private bool _deleteSavedInitialized;
+    private bool _activeStatusInitialized;
     private readonly SemaphoreSlim _historyInitLock = new(1, 1);
     private readonly SemaphoreSlim _agentInfoInitLock = new(1, 1);
+    private readonly SemaphoreSlim _activeStatusInitLock = new(1, 1);
     private readonly SemaphoreSlim _saveResponseInitLock = new(1, 1);
     private readonly SemaphoreSlim _listSavedInitLock = new(1, 1);
     private readonly SemaphoreSlim _getSavedInitLock = new(1, 1);
@@ -166,6 +170,12 @@ public sealed class UserProxyService(
                 tcs.TrySetCanceled();
         }
 
+        foreach (var kvp in _pendingActiveStatus)
+        {
+            if (_pendingActiveStatus.TryRemove(kvp.Key, out var tcs))
+                tcs.TrySetCanceled();
+        }
+
         foreach (var kvp in _pendingSaveResponse)
         {
             if (_pendingSaveResponse.TryRemove(kvp.Key, out var tcs))
@@ -198,6 +208,9 @@ public sealed class UserProxyService(
 
         if (_agentInfoSubscription is not null)
             await _agentInfoSubscription.DisposeAsync();
+
+        if (_activeStatusSubscription is not null)
+            await _activeStatusSubscription.DisposeAsync();
 
         if (_saveResponseSubscription is not null)
             await _saveResponseSubscription.DisposeAsync();
@@ -576,6 +589,118 @@ public sealed class UserProxyService(
 
         logger.LogDebug("Agent info response correlated for {CorrelationId}: {Name} v{Version}",
             envelope.CorrelationId, response.AgentName, response.AgentVersion);
+
+        return Task.FromResult(MessageResult.Ack);
+    }
+
+    // ── Active status ──────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Requests a snapshot of currently active background work (subagents, processing state)
+    /// from the agent. Returns null if the request times out or the agent is unavailable.
+    /// </summary>
+    public async Task<ActiveStatusResponse?> GetActiveStatusAsync(
+        TimeSpan? timeout = null,
+        CancellationToken cancellationToken = default)
+    {
+        var effectiveTimeout = timeout ?? options.DefaultReplyTimeout;
+        var correlationId = Guid.NewGuid().ToString("N");
+        var tcs = new TaskCompletionSource<ActiveStatusResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        _pendingActiveStatus[correlationId] = tcs;
+
+        try
+        {
+            await EnsureActiveStatusSubscribedAsync(cancellationToken);
+
+            var request = new ActiveStatusRequest();
+            var envelope = request.ToEnvelope<ActiveStatusRequest>(
+                source: options.ProxyId,
+                correlationId: correlationId,
+                replyTo: ActiveStatusResponseTopic);
+
+            await publisher.PublishAsync(UserProxyTopics.ActiveStatusRequest, envelope, cancellationToken);
+
+            logger.LogDebug("Published ActiveStatusRequest {CorrelationId}", correlationId);
+
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutCts.CancelAfter(effectiveTimeout);
+
+            try
+            {
+                return await tcs.Task.WaitAsync(timeoutCts.Token);
+            }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+                logger.LogWarning("Active status request timeout for correlation {CorrelationId} after {Timeout}",
+                    correlationId, effectiveTimeout);
+                return null;
+            }
+        }
+        finally
+        {
+            _pendingActiveStatus.TryRemove(correlationId, out _);
+        }
+    }
+
+    private string ActiveStatusResponseTopic => $"{UserProxyTopics.ActiveStatusResponse}.{options.ProxyId}";
+
+    private async Task EnsureActiveStatusSubscribedAsync(CancellationToken ct)
+    {
+        if (_activeStatusInitialized) return;
+
+        await _activeStatusInitLock.WaitAsync(ct);
+        try
+        {
+            if (_activeStatusInitialized) return;
+
+            _activeStatusSubscription = await subscriber.SubscribeAsync(
+                ActiveStatusResponseTopic,
+                $"user-proxy.{options.ProxyId}.active-status",
+                HandleActiveStatusResponseAsync,
+                ct);
+
+            _activeStatusInitialized = true;
+        }
+        finally
+        {
+            _activeStatusInitLock.Release();
+        }
+    }
+
+    internal Task<MessageResult> HandleActiveStatusResponseAsync(MessageEnvelope envelope, CancellationToken ct)
+    {
+        if (envelope.CorrelationId is null ||
+            !_pendingActiveStatus.TryGetValue(envelope.CorrelationId, out var tcs))
+        {
+            logger.LogWarning("Received active status response with unknown correlation ID: {CorrelationId}",
+                envelope.CorrelationId);
+            return Task.FromResult(MessageResult.Ack);
+        }
+
+        ActiveStatusResponse? response;
+        try
+        {
+            response = envelope.GetPayload<ActiveStatusResponse>();
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to deserialize ActiveStatusResponse");
+            tcs.TrySetException(ex);
+            return Task.FromResult(MessageResult.DeadLetter);
+        }
+
+        if (response is null)
+        {
+            logger.LogWarning("Received null ActiveStatusResponse");
+            return Task.FromResult(MessageResult.DeadLetter);
+        }
+
+        _pendingActiveStatus.TryRemove(envelope.CorrelationId, out _);
+        tcs.TrySetResult(response);
+
+        logger.LogDebug("Active status response correlated for {CorrelationId}: {SubagentCount} subagents, isProcessing={IsProcessing}",
+            envelope.CorrelationId, response.Subagents.Count, response.IsProcessing);
 
         return Task.FromResult(MessageResult.Ack);
     }


### PR DESCRIPTION
## Summary
- **Fix ongoing cleanup bug**: Added `IsCompletion` flag to `AgentReply` so subagent completion bubbles immediately close their activity log entries (spinner + header badge). Previously, the Phase 2 synthesis reply was `PrimaryFinal` which only cleared the primary progress key, leaving subagent indicators stuck until the next user message.
- **Add startup reconciliation**: New `ActiveStatusRequest`/`ActiveStatusResponse` message pair lets the Blazor UI query the agent for actually-running subagents on startup, clearing stale `_activeActivityLogs` entries that survive in the singleton `ChatStateService` across page reloads, and seeding indicators for subagents that started before the UI connected.

## Test plan
- [ ] Spawn multiple subagents → verify header 🤖 indicators disappear when each completes (not on next user message)
- [ ] Refresh the page while subagents are running → verify running subagents show indicators, completed ones do not
- [ ] Refresh the page with no subagents running → verify no stale indicators appear
- [ ] Verify activity log bubbles stop showing spinners once their subagent completes
- [ ] Run `dotnet test RockBot.slnx` — all 833 tests pass (0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)