### PR TITLE
Optimize hybrid search: shared embedding, batching, concurrent reads

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-    <Version>0.4.$(BuildNumber)</Version>
+    <Version>0.5.$(BuildNumber)</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.Host.Abstractions/ISkillStore.cs
+++ b/src/RockBot.Host.Abstractions/ISkillStore.cs
@@ -23,5 +23,12 @@ public interface ISkillStore
     /// Skills with no matching terms are excluded.
     /// Returns at most <paramref name="maxResults"/> entries.
     /// </summary>
-    Task<IReadOnlyList<Skill>> SearchAsync(string query, int maxResults, CancellationToken cancellationToken = default);
+    /// <param name="query">The search query text.</param>
+    /// <param name="maxResults">Maximum number of results to return.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <param name="queryEmbedding">
+    /// Pre-computed query embedding vector. When provided, the store skips generating
+    /// its own query embedding — avoiding redundant embedding endpoint calls.
+    /// </param>
+    Task<IReadOnlyList<Skill>> SearchAsync(string query, int maxResults, CancellationToken cancellationToken = default, float[]? queryEmbedding = null);
 }

--- a/src/RockBot.Host.Abstractions/MemorySearchCriteria.cs
+++ b/src/RockBot.Host.Abstractions/MemorySearchCriteria.cs
@@ -10,10 +10,16 @@ namespace RockBot.Host;
 /// <param name="CreatedAfter">Only include entries created after this time.</param>
 /// <param name="CreatedBefore">Only include entries created before this time.</param>
 /// <param name="MaxResults">Maximum number of results to return. Defaults to 20.</param>
+/// <param name="QueryEmbedding">
+/// Pre-computed query embedding vector. When provided, stores skip generating their own
+/// query embedding — avoiding redundant calls to the embedding endpoint when multiple
+/// searches share the same query text (e.g. during context building).
+/// </param>
 public sealed record MemorySearchCriteria(
     string? Query = null,
     string? Category = null,
     IReadOnlyList<string>? Tags = null,
     DateTimeOffset? CreatedAfter = null,
     DateTimeOffset? CreatedBefore = null,
-    int MaxResults = 20);
+    int MaxResults = 20,
+    float[]? QueryEmbedding = null);

--- a/src/RockBot.Host/AgentContextBuilder.cs
+++ b/src/RockBot.Host/AgentContextBuilder.cs
@@ -29,12 +29,14 @@ public sealed class AgentContextBuilder(
     IEnumerable<IServiceSearchIndex> serviceSearchIndexProviders,
     IEnumerable<IKnowledgeGraph> knowledgeGraphProviders,
     IOptions<KnowledgeGraphOptions> knowledgeGraphOptions,
+    IEnumerable<IEmbeddingGenerator<string, Embedding<float>>> embeddingGenerators,
     ILogger<AgentContextBuilder> logger)
 {
     private const int MaxLlmContextTurns = 20;
     private readonly IServiceSearchIndex? _serviceSearchIndex = serviceSearchIndexProviders.FirstOrDefault();
     private readonly IKnowledgeGraph? _knowledgeGraph = knowledgeGraphProviders.FirstOrDefault();
     private readonly KnowledgeGraphOptions _graphOptions = knowledgeGraphOptions.Value;
+    private readonly IEmbeddingGenerator<string, Embedding<float>>? _embeddingGenerator = embeddingGenerators.FirstOrDefault();
 
     /// <summary>
     /// Builds the full chat message list for one LLM call: system prompt, rules, history,
@@ -93,9 +95,30 @@ public sealed class AgentContextBuilder(
             logger.LogInformation("No AdditionalSystemPrompt configured for this model");
         }
 
+        // ── Wave 0: generate the query embedding once, shared across all searches ──
+        // Avoids redundant calls to the embedding endpoint — each store would otherwise
+        // generate its own query embedding for the same user message text.
+
+        float[]? sharedQueryEmbedding = null;
+        if (_embeddingGenerator is not null && !string.IsNullOrWhiteSpace(currentUserContent))
+        {
+            try
+            {
+                var result = await _embeddingGenerator.GenerateAsync(currentUserContent, cancellationToken: ct);
+                sharedQueryEmbedding = result.Vector.ToArray();
+                logger.LogInformation("Shared query embedding generated ({Dimensions} dimensions)", sharedQueryEmbedding.Length);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Failed to generate shared query embedding — stores will fall back to BM25-only");
+            }
+        }
+
         // ── Wave 1: fire all independent lookups concurrently ─────────────────
         // Each store is a separate singleton with its own locking, so cross-store
         // parallelism reduces wall-clock time from sum(all) to max(slowest store).
+        // The pre-computed query embedding is passed to all searches so they skip
+        // generating their own.
 
         var wmNamespace = workingMemoryNamespace ?? $"session/{sessionId}";
         var isUserSession = wmNamespace.StartsWith("session/", StringComparison.OrdinalIgnoreCase);
@@ -105,15 +128,15 @@ public sealed class AgentContextBuilder(
 
         var historyTask = conversationMemory.GetTurnsAsync(sessionId, ct);
         var ltmTask = longTermMemory.SearchAsync(
-            new MemorySearchCriteria(Query: currentUserContent, MaxResults: 8));
+            new MemorySearchCriteria(Query: currentUserContent, MaxResults: 8, QueryEmbedding: sharedQueryEmbedding));
         var episodicTask = longTermMemory.SearchAsync(
-            new MemorySearchCriteria(Query: currentUserContent, Category: "episodic", MaxResults: 5));
+            new MemorySearchCriteria(Query: currentUserContent, Category: "episodic", MaxResults: 5, QueryEmbedding: sharedQueryEmbedding));
         var identityTask = longTermMemory.SearchAsync(
             new MemorySearchCriteria(Category: AgentIdentityCategories.Prefix, MaxResults: 20));
         var skillListTask = shouldInjectSkillIndex
             ? skillStore.ListAsync()
             : Task.FromResult<IReadOnlyList<Skill>>([]);
-        var skillSearchTask = skillStore.SearchAsync(currentUserContent, maxResults: 5, ct);
+        var skillSearchTask = skillStore.SearchAsync(currentUserContent, maxResults: 5, ct, queryEmbedding: sharedQueryEmbedding);
         var wmTask = workingMemory.ListAsync(wmNamespace);
         var graphTask = _knowledgeGraph?.FindEntitiesByNameAsync(currentUserContent);
         var patrolTask = isUserSession

--- a/src/RockBot.Host/EmbeddingCache.cs
+++ b/src/RockBot.Host/EmbeddingCache.cs
@@ -74,6 +74,93 @@ internal sealed class EmbeddingCache
     }
 
     /// <summary>
+    /// Returns cached embeddings for the given IDs, generating and caching any that are missing
+    /// in a single batched call to the embedding endpoint. Much faster than sequential
+    /// <see cref="GetOrCreateAsync"/> calls when multiple candidates have cache misses.
+    /// </summary>
+    public async Task<Dictionary<string, float[]?>> GetOrCreateBatchAsync(
+        IReadOnlyList<(string Id, string Text)> items,
+        CancellationToken ct = default)
+    {
+        var result = new Dictionary<string, float[]?>(items.Count, StringComparer.OrdinalIgnoreCase);
+        var misses = new List<(string Id, string Text)>();
+
+        // Fast path: read all cached embeddings without locking
+        foreach (var (id, text) in items)
+        {
+            var cached = await TryReadAsync(GetFilePath(id));
+            if (cached is not null)
+                result[id] = cached;
+            else
+                misses.Add((id, text));
+        }
+
+        if (misses.Count == 0)
+            return result;
+
+        await _semaphore.WaitAsync(ct);
+        try
+        {
+            // Double-check after acquiring lock — another thread may have generated some
+            var stillMissing = new List<(string Id, string Text)>();
+            foreach (var (id, text) in misses)
+            {
+                var cached = await TryReadAsync(GetFilePath(id));
+                if (cached is not null)
+                    result[id] = cached;
+                else
+                    stillMissing.Add((id, text));
+            }
+
+            if (stillMissing.Count == 0)
+                return result;
+
+            // Batch-generate all missing embeddings in one call
+            var sw = Stopwatch.StartNew();
+            try
+            {
+                HostDiagnostics.EmbeddingCalls.Add(1);
+
+                var texts = stillMissing.Select(m =>
+                    m.Text.Length > _maxInputChars ? m.Text[.._maxInputChars] : m.Text).ToList();
+                var generated = await _generator.GenerateAsync(texts, cancellationToken: ct);
+
+                sw.Stop();
+                HostDiagnostics.EmbeddingDuration.Record(sw.Elapsed.TotalMilliseconds);
+                _logger.LogInformation(
+                    "Batch embedding generated {Count} vectors in {Duration:F0}ms ({Dimensions} dimensions)",
+                    stillMissing.Count, sw.Elapsed.TotalMilliseconds,
+                    generated.Count > 0 ? generated[0].Vector.Length : 0);
+
+                for (var i = 0; i < stillMissing.Count && i < generated.Count; i++)
+                {
+                    var embedding = generated[i].Vector.ToArray();
+                    result[stillMissing[i].Id] = embedding;
+                    await WriteAsync(GetFilePath(stillMissing[i].Id), embedding);
+                }
+            }
+            catch (Exception ex)
+            {
+                sw.Stop();
+                HostDiagnostics.EmbeddingFailures.Add(1);
+                HostDiagnostics.EmbeddingDuration.Record(sw.Elapsed.TotalMilliseconds);
+                _logger.LogWarning(ex,
+                    "Batch embedding generation failed for {Count} items in {Duration:F0}ms — returning nulls",
+                    stillMissing.Count, sw.Elapsed.TotalMilliseconds);
+
+                foreach (var (id, _) in stillMissing)
+                    result.TryAdd(id, null);
+            }
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+
+        return result;
+    }
+
+    /// <summary>
     /// Generates and caches an embedding for a document, replacing any existing cached value.
     /// Called on save/update to keep the cache warm. Skips the write if the ID was deleted
     /// while generation was in flight (prevents orphaned .bin files).

--- a/src/RockBot.Host/FileMemoryStore.cs
+++ b/src/RockBot.Host/FileMemoryStore.cs
@@ -88,71 +88,75 @@ internal sealed partial class FileMemoryStore : ILongTermMemory
 
     public async Task<IReadOnlyList<MemoryEntry>> SearchAsync(MemorySearchCriteria criteria, CancellationToken cancellationToken = default)
     {
+        // Only hold the semaphore long enough to snapshot the index — search and embedding
+        // generation happen outside the lock so concurrent searches don't serialize.
+        List<MemoryEntry> candidates;
         await _semaphore.WaitAsync(cancellationToken);
         try
         {
             var index = await EnsureIndexAsync(cancellationToken);
-
-            // Apply hard filters: category prefix, tags, date range
-            var candidates = index.Values
+            candidates = index.Values
                 .Where(e => PassesStructuralFilters(e, criteria))
-                .ToList();
-
-            // No query: return most-recently updated entries up to MaxResults
-            if (criteria.Query is null)
-            {
-                return candidates
-                    .OrderByDescending(e => e.UpdatedAt ?? e.CreatedAt)
-                    .Take(criteria.MaxResults)
-                    .ToList();
-            }
-
-            // With query: use hybrid ranking if embeddings available, else BM25-only.
-            if (_embeddingCache is not null)
-            {
-                using var hybridActivity = HostDiagnostics.Source.StartActivity("rockbot.search.hybrid.memory");
-                var sw = Stopwatch.StartNew();
-
-                var queryEmbedding = await _embeddingCache.GenerateQueryEmbeddingAsync(criteria.Query, cancellationToken);
-                if (queryEmbedding is not null)
-                {
-                    // Pre-load all candidate embeddings asynchronously (avoids sync-over-async per candidate)
-                    var embeddingMap = new Dictionary<string, float[]?>(StringComparer.OrdinalIgnoreCase);
-                    foreach (var c in candidates)
-                        embeddingMap[c.Id] = await _embeddingCache.GetOrCreateAsync(c.Id, GetDocumentText(c), cancellationToken);
-
-                    var results = HybridRanker.RankWithScores(
-                            candidates, GetDocumentText,
-                            static e => e.Id,
-                            e => embeddingMap.GetValueOrDefault(e.Id),
-                            queryEmbedding, criteria.Query,
-                            _minSimilarity)
-                        .Select(r => (r.Item, Score: r.Score * ImportanceBoost(r.Item.ImportanceScore)))
-                        .OrderByDescending(r => r.Score)
-                        .Select(r => r.Item)
-                        .Take(criteria.MaxResults)
-                        .ToList();
-
-                    sw.Stop();
-                    HostDiagnostics.HybridSearchDuration.Record(sw.Elapsed.TotalMilliseconds);
-                    _logger.LogInformation("Hybrid memory search completed in {Duration:F0}ms ({Candidates} candidates, {Results} results)",
-                        sw.Elapsed.TotalMilliseconds, candidates.Count, results.Count);
-                    return results;
-                }
-            }
-
-            // Fallback: BM25-only ranking with importance boost.
-            return Bm25Ranker.RankWithScores(candidates, GetDocumentText, criteria.Query)
-                .Select(r => (r.Item, Score: r.Score * ImportanceBoost(r.Item.ImportanceScore)))
-                .OrderByDescending(r => r.Score)
-                .Select(r => r.Item)
-                .Take(criteria.MaxResults)
                 .ToList();
         }
         finally
         {
             _semaphore.Release();
         }
+
+        // No query: return most-recently updated entries up to MaxResults
+        if (criteria.Query is null)
+        {
+            return candidates
+                .OrderByDescending(e => e.UpdatedAt ?? e.CreatedAt)
+                .Take(criteria.MaxResults)
+                .ToList();
+        }
+
+        // With query: use hybrid ranking if embeddings available, else BM25-only.
+        if (_embeddingCache is not null)
+        {
+            using var hybridActivity = HostDiagnostics.Source.StartActivity("rockbot.search.hybrid.memory");
+            var sw = Stopwatch.StartNew();
+
+            // Use pre-computed query embedding if provided, otherwise generate one
+            var queryEmbedding = criteria.QueryEmbedding
+                ?? await _embeddingCache.GenerateQueryEmbeddingAsync(criteria.Query, cancellationToken);
+            if (queryEmbedding is not null)
+            {
+                // Batch-load all candidate embeddings (single endpoint call for cache misses)
+                var batchItems = candidates
+                    .Select(c => (c.Id, Text: GetDocumentText(c)))
+                    .ToList();
+                var embeddingMap = await _embeddingCache.GetOrCreateBatchAsync(batchItems, cancellationToken);
+
+                var results = HybridRanker.RankWithScores(
+                        candidates, GetDocumentText,
+                        static e => e.Id,
+                        e => embeddingMap.GetValueOrDefault(e.Id),
+                        queryEmbedding, criteria.Query,
+                        _minSimilarity)
+                    .Select(r => (r.Item, Score: r.Score * ImportanceBoost(r.Item.ImportanceScore)))
+                    .OrderByDescending(r => r.Score)
+                    .Select(r => r.Item)
+                    .Take(criteria.MaxResults)
+                    .ToList();
+
+                sw.Stop();
+                HostDiagnostics.HybridSearchDuration.Record(sw.Elapsed.TotalMilliseconds);
+                _logger.LogInformation("Hybrid memory search completed in {Duration:F0}ms ({Candidates} candidates, {Results} results)",
+                    sw.Elapsed.TotalMilliseconds, candidates.Count, results.Count);
+                return results;
+            }
+        }
+
+        // Fallback: BM25-only ranking with importance boost.
+        return Bm25Ranker.RankWithScores(candidates, GetDocumentText, criteria.Query)
+            .Select(r => (r.Item, Score: r.Score * ImportanceBoost(r.Item.ImportanceScore)))
+            .OrderByDescending(r => r.Score)
+            .Select(r => r.Item)
+            .Take(criteria.MaxResults)
+            .ToList();
     }
 
     public async Task<MemoryEntry?> GetAsync(string id, CancellationToken cancellationToken = default)

--- a/src/RockBot.Host/FileSkillStore.cs
+++ b/src/RockBot.Host/FileSkillStore.cs
@@ -133,52 +133,56 @@ internal sealed partial class FileSkillStore : ISkillStore
         }
     }
 
-    public async Task<IReadOnlyList<Skill>> SearchAsync(string query, int maxResults, CancellationToken cancellationToken = default)
+    public async Task<IReadOnlyList<Skill>> SearchAsync(string query, int maxResults, CancellationToken cancellationToken = default, float[]? queryEmbedding = null)
     {
+        // Only hold the semaphore long enough to snapshot the index
+        List<Skill> candidates;
         await _semaphore.WaitAsync(cancellationToken);
         try
         {
             var index = await EnsureIndexAsync();
-            var candidates = index.Values.ToList();
-
-            if (_embeddingCache is not null)
-            {
-                using var hybridActivity = HostDiagnostics.Source.StartActivity("rockbot.search.hybrid.skills");
-                var sw = Stopwatch.StartNew();
-
-                var queryEmbedding = await _embeddingCache.GenerateQueryEmbeddingAsync(query, cancellationToken);
-                if (queryEmbedding is not null)
-                {
-                    // Pre-load all candidate embeddings asynchronously (avoids sync-over-async per candidate)
-                    var embeddingMap = new Dictionary<string, float[]?>(StringComparer.OrdinalIgnoreCase);
-                    foreach (var s in candidates)
-                        embeddingMap[s.Name] = await _embeddingCache.GetOrCreateAsync(s.Name, GetDocumentText(s), cancellationToken);
-
-                    var results = HybridRanker.Rank(
-                            candidates, GetDocumentText,
-                            static s => s.Name,
-                            s => embeddingMap.GetValueOrDefault(s.Name),
-                            queryEmbedding, query,
-                            _minSimilarity)
-                        .Take(maxResults)
-                        .ToList();
-
-                    sw.Stop();
-                    HostDiagnostics.HybridSearchDuration.Record(sw.Elapsed.TotalMilliseconds);
-                    _logger.LogInformation("Hybrid skill search completed in {Duration:F0}ms ({Candidates} candidates, {Results} results)",
-                        sw.Elapsed.TotalMilliseconds, candidates.Count, results.Count);
-                    return results;
-                }
-            }
-
-            return Bm25Ranker.Rank(candidates, GetDocumentText, query)
-                .Take(maxResults)
-                .ToList();
+            candidates = index.Values.ToList();
         }
         finally
         {
             _semaphore.Release();
         }
+
+        if (_embeddingCache is not null)
+        {
+            using var hybridActivity = HostDiagnostics.Source.StartActivity("rockbot.search.hybrid.skills");
+            var sw = Stopwatch.StartNew();
+
+            // Use pre-computed query embedding if provided, otherwise generate one
+            queryEmbedding ??= await _embeddingCache.GenerateQueryEmbeddingAsync(query, cancellationToken);
+            if (queryEmbedding is not null)
+            {
+                // Batch-load all candidate embeddings (single endpoint call for cache misses)
+                var batchItems = candidates
+                    .Select(s => (s.Name, Text: GetDocumentText(s)))
+                    .ToList();
+                var embeddingMap = await _embeddingCache.GetOrCreateBatchAsync(batchItems, cancellationToken);
+
+                var results = HybridRanker.Rank(
+                        candidates, GetDocumentText,
+                        static s => s.Name,
+                        s => embeddingMap.GetValueOrDefault(s.Name),
+                        queryEmbedding, query,
+                        _minSimilarity)
+                    .Take(maxResults)
+                    .ToList();
+
+                sw.Stop();
+                HostDiagnostics.HybridSearchDuration.Record(sw.Elapsed.TotalMilliseconds);
+                _logger.LogInformation("Hybrid skill search completed in {Duration:F0}ms ({Candidates} candidates, {Results} results)",
+                    sw.Elapsed.TotalMilliseconds, candidates.Count, results.Count);
+                return results;
+            }
+        }
+
+        return Bm25Ranker.Rank(candidates, GetDocumentText, query)
+            .Take(maxResults)
+            .ToList();
     }
 
     /// <summary>

--- a/tests/RockBot.Agent.Tests/SkillToolsTests.cs
+++ b/tests/RockBot.Agent.Tests/SkillToolsTests.cs
@@ -221,7 +221,7 @@ public class SkillToolsTests
         public Task<IReadOnlyList<Skill>> ListAsync() =>
             Task.FromResult<IReadOnlyList<Skill>>(_skills.Values.OrderBy(s => s.Name).ToList());
         public Task DeleteAsync(string name) { _skills.Remove(name); return Task.CompletedTask; }
-        public Task<IReadOnlyList<Skill>> SearchAsync(string query, int maxResults, CancellationToken cancellationToken = default) =>
+        public Task<IReadOnlyList<Skill>> SearchAsync(string query, int maxResults, CancellationToken cancellationToken = default, float[]? queryEmbedding = null) =>
             Task.FromResult<IReadOnlyList<Skill>>([]);
     }
 

--- a/tests/RockBot.Agent.Tests/UserFeedbackHandlerTests.cs
+++ b/tests/RockBot.Agent.Tests/UserFeedbackHandlerTests.cs
@@ -80,6 +80,7 @@ public class UserFeedbackHandlerTests
             [],
             Enumerable.Empty<IKnowledgeGraph>(),
             Options.Create(new KnowledgeGraphOptions()),
+            Enumerable.Empty<IEmbeddingGenerator<string, Embedding<float>>>(),
             NullLogger<AgentContextBuilder>.Instance);
 
         var rulesTools = new RulesTools(
@@ -393,6 +394,6 @@ internal sealed class StubSkillStore : ISkillStore
     public Task<Skill?> GetAsync(string name) => Task.FromResult<Skill?>(null);
     public Task<IReadOnlyList<Skill>> ListAsync() => Task.FromResult<IReadOnlyList<Skill>>([]);
     public Task DeleteAsync(string name) => Task.CompletedTask;
-    public Task<IReadOnlyList<Skill>> SearchAsync(string query, int maxResults = 5, CancellationToken ct = default) =>
+    public Task<IReadOnlyList<Skill>> SearchAsync(string query, int maxResults = 5, CancellationToken ct = default, float[]? queryEmbedding = null) =>
         Task.FromResult<IReadOnlyList<Skill>>([]);
 }

--- a/tests/RockBot.Host.Tests/AgentIdentityTests.cs
+++ b/tests/RockBot.Host.Tests/AgentIdentityTests.cs
@@ -221,6 +221,7 @@ public class AgentIdentityTests
             serviceSearchIndexProviders: [],
             knowledgeGraphProviders: [],
             knowledgeGraphOptions: Options.Create(new KnowledgeGraphOptions()),
+            embeddingGenerators: [],
             logger: NullLogger<AgentContextBuilder>.Instance);
     }
 
@@ -302,7 +303,7 @@ public class AgentIdentityTests
         public Task<Skill?> GetAsync(string name) => Task.FromResult<Skill?>(null);
         public Task<IReadOnlyList<Skill>> ListAsync() => Task.FromResult<IReadOnlyList<Skill>>([]);
         public Task DeleteAsync(string name) => Task.CompletedTask;
-        public Task<IReadOnlyList<Skill>> SearchAsync(string query, int maxResults, CancellationToken cancellationToken = default)
+        public Task<IReadOnlyList<Skill>> SearchAsync(string query, int maxResults, CancellationToken cancellationToken = default, float[]? queryEmbedding = null)
             => Task.FromResult<IReadOnlyList<Skill>>([]);
     }
 

--- a/tests/RockBot.Subagent.Tests/SubagentManagerTests.cs
+++ b/tests/RockBot.Subagent.Tests/SubagentManagerTests.cs
@@ -345,7 +345,7 @@ public class SubagentManagerTests
         public Task<IReadOnlyList<Skill>> ListAsync() => Task.FromResult<IReadOnlyList<Skill>>([]);
         public Task DeleteAsync(string name) => Task.CompletedTask;
         public Task<IReadOnlyList<Skill>> SearchAsync(string query, int maxResults,
-            CancellationToken cancellationToken = default) =>
+            CancellationToken cancellationToken = default, float[]? queryEmbedding = null) =>
             Task.FromResult<IReadOnlyList<Skill>>([]);
     }
 


### PR DESCRIPTION
## Summary
- **Shared query embedding** — `AgentContextBuilder` generates a single query embedding and passes it to all 3 searches (LTM, episodic, skill), eliminating 2 redundant Ollama calls per turn
- **Batch candidate embeddings** — new `EmbeddingCache.GetOrCreateBatchAsync` collects cache misses and generates all missing embeddings in one `IEmbeddingGenerator` batch call instead of sequential per-candidate calls (138 serial → 1 batch)
- **Concurrent store reads** — `FileMemoryStore` and `FileSkillStore` now release the store semaphore after snapshotting the index, so search/embedding/ranking happens outside the lock. LTM and episodic searches execute truly concurrently

**Expected impact:** steady-state context build drops from ~1-4s to ~100-300ms. Cold-start cache-miss path drops from 138 sequential embedding calls to 1 batched call.

## Test plan
- [x] All 808 tests pass
- [ ] Deploy and verify hybrid search durations in Loki (`Hybrid.*search completed`)
- [ ] Confirm single shared query embedding log line per turn (`Shared query embedding generated`)
- [ ] Verify batch embedding log line on cache miss (`Batch embedding generated`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)