### PR TITLE
Remove duplicate staging MCP entry from helm configmap

### DIFF
--- a/deploy/helm/rockbot/templates/configmap.yaml
+++ b/deploy/helm/rockbot/templates/configmap.yaml
@@ -40,9 +40,9 @@ data:
   {{- if .Values.azureFoundryMcp.enabled }}
   McpBridge__DefaultServers__azure-foundry: "http://{{ include "rockbot.fullname" . }}-azure-foundry-mcp.{{ .Values.namespace }}.svc.cluster.local/"
   {{- end }}
-  {{- if .Values.staging.enabled }}
-  McpBridge__DefaultServers__staging: "http://{{ include "rockbot.fullname" . }}-staging.{{ .Values.namespace }}.svc.cluster.local/"
-  {{- end }}
+  {{- /* NOTE: staging MCP is NOT auto-seeded here because it requires an auth header
+     (X-RockBot-Token) that cannot be expressed via McpBridge__DefaultServers__ config.
+     The staging-mcp entry with auth is configured manually in mcp.json instead. */ -}}
   {{- if .Values.todoappMcp.enabled }}
   McpBridge__DefaultServers__todo: "http://mcp-todo.{{ .Values.namespace }}.svc.cluster.local/"
   {{- end }}


### PR DESCRIPTION
## Summary
- Remove `McpBridge__DefaultServers__staging` from the helm configmap — it auto-seeded a staging MCP entry **without** the required `X-RockBot-Token` auth header, causing constant 401 failures and "Failed to connect to MCP server staging" log spam
- The correctly configured `staging-mcp` entry (with auth header) already exists in `mcp.json` and doesn't need auto-seeding
- Also updated 2 agent skills on the PVC (`integrations/teams-chat-from-onedrive`, `teams/check-onedrive-chat-events`) with exact tool call examples for the OneDrive→staging→read workflow

## Test plan
- [x] Removed broken `staging` entry from live `mcp.json` and restarted agent — no more connection errors
- [ ] Verify next `helm upgrade` doesn't re-introduce the `staging` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)