### PR TITLE
Add wisp executor documentation

### DIFF
--- a/docs/dream-service.md
+++ b/docs/dream-service.md
@@ -160,6 +160,24 @@ failure, to prevent unbounded growth.
 **Directive file:** `pref-dream.md`. Built-in fallback if not present. Requires
 `IConversationLog`. Enabled/disabled by `DreamOptions.PreferenceInferenceEnabled`.
 
+### Wisp failure analysis
+
+**Input:** last 14 days of wisp execution records from `IWispExecutionLog`, grouped by
+description to surface recurring patterns.
+
+**What the LLM does:**
+- Identifies recurring failure patterns (frequency ≥ 3) with classification and affected steps
+- Proposes skill annotations — appends negative examples or corrected patterns to existing
+  skills that generated broken wisp definitions
+- Flags consistent success patterns (frequency ≥ 5, >80% success rate) as promotion candidates
+  for stored wisp skills
+
+**Directive file:** `wisp-failure-dream.md`. Built-in fallback if not present. Requires
+`IWispExecutionLog` and `ISkillStore`. Enabled/disabled by
+`DreamOptions.WispFailureAnalysisEnabled`.
+
+See [Wisps — Dream-time learning](wisps.md#dream-time-learning-phase-5) for details.
+
 ---
 
 ## Directive files

--- a/docs/subagents.md
+++ b/docs/subagents.md
@@ -23,6 +23,11 @@ Subagents solve both problems:
 - **Background** — the user can continue talking while the subagent works
 - **Conversational** — progress and results arrive as messages in the active session
 
+> **See also: [Wisps](wisps.md)** — for procedural multi-step tasks with known
+> parameters, wisps provide a lighter-weight alternative that costs 80-95% fewer
+> tokens. Use subagents when the task requires discovery or multi-turn reasoning;
+> use wisps when you can write out the exact steps in advance.
+
 ---
 
 ## Architecture

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -664,6 +664,7 @@ services.AddRockBotHost(agent =>
     agent.AddWebTools(opts => ...);     // web_search + web_browse
     agent.AddSchedulingTools();         // schedule_task + list/cancel
     agent.AddSubagents();               // spawn_subagent + cancel/list + whiteboard
+    agent.AddWisps(opts => ...);        // spawn_wisp (lightweight procedural pipelines)
     agent.AddRemoteScriptRunner();      // execute_python_script (Kubernetes)
     // OR:
     agent.AddLocalScriptRunner();       // execute_python_script (local dev)

--- a/docs/wisps.md
+++ b/docs/wisps.md
@@ -1,0 +1,292 @@
+# Wisps
+
+Wisps are a **lightweight execution tier** for procedural, multi-step tasks that don't
+require full agent context. Where subagents receive the complete `AgentContextBuilder`
+pipeline (soul, directives, memory recall, skill index, knowledge graph) on every LLM
+round-trip, wisps are harness-supervised pipelines that execute steps with minimal (or
+zero) LLM involvement.
+
+**Token savings:** A 5-step subagent task consumes ~60-80K input tokens. The same
+workflow as a wisp costs ~2-12K tokens or less, because direct steps bypass the LLM
+entirely and LLM steps receive only a tightly-scoped prompt.
+
+---
+
+## When to use wisps vs. subagents
+
+| Wisps | Subagents |
+|-------|-----------|
+| Steps are known in advance | Task requires discovery/improvisation |
+| Mostly tool calls with known parameters | Heavy judgment or multi-turn reasoning |
+| Data pipelines: fetch → transform → output | Open-ended research or analysis |
+| 2-12K tokens total | 60-80K tokens acceptable |
+
+**Rule of thumb:** If you can write out the exact steps and parameters in advance,
+use a wisp. If the task requires exploration or adaptation, use a subagent.
+
+---
+
+## Architecture
+
+```
+Calling agent (primary or subagent)
+┌─────────────────────────────────────────────────────────┐
+│                                                         │
+│  LLM calls spawn_wisp(definition: { ... })              │
+│     │                                                   │
+│     ▼                                                   │
+│  SpawnWispExecutor.ExecuteAsync()                       │
+│     │  Parses WispDefinition from JSON                  │
+│     │  Generates wisp ID                                │
+│     │                                                   │
+│     ▼                                                   │
+│  WispExecutor.ExecuteAsync()                            │
+│     │  For each step:                                   │
+│     │    ├── Direct: GatewayRouter → IToolExecutor      │
+│     │    │   (zero LLM tokens)                          │
+│     │    └── Llm: AgentLoopRunner.RunAsync()            │
+│     │        (minimal context, Low tier)                │
+│     │                                                   │
+│     ▼                                                   │
+│  Returns WispExecutionResult (synchronous)              │
+│     │  Per-step success/failure + content                │
+│     │  Failure classification (structural/external/…)    │
+│     │  Working memory namespace for detailed output      │
+│                                                         │
+│  [calling agent receives structured result immediately]  │
+└─────────────────────────────────────────────────────────┘
+```
+
+Unlike subagents (which are asynchronous — they return a task ID and deliver results
+later via messaging), wisps are **synchronous**. The calling agent blocks until all
+steps complete and receives the full result in the tool response.
+
+---
+
+## Step modes
+
+### Direct mode
+
+The harness invokes a tool with the exact parameters provided in the step definition.
+No LLM is involved — zero token cost. Use for all deterministic operations where you
+know the tool name, server, and parameters in advance.
+
+### LLM mode
+
+A lightweight LLM receives a tightly-scoped prompt (wisp directives + step instruction
++ data from prior steps) and makes tool calls. The wisp LLM has **no agent context** —
+no soul, no memory, no conversation history, no skill index, no directives. It receives
+only:
+
+- ~200-token wisp directives (execute steps, call only listed tools, stop on error)
+- The step prompt (provided by the calling agent)
+- Data from `input_from` (injected into the prompt or chunked into working memory)
+- Current date/time and timezone (injected by `AgentLoopRunner`)
+- A scoped tool set (see Tool scoping below)
+
+The LLM step always runs at `ModelTier.Low` with no follow-up pass and no completion
+evaluator.
+
+---
+
+## Gateways
+
+Direct mode steps route through one of four gateway types, each mapping to a specific
+registered tool:
+
+| Gateway | Registered tool | Required fields |
+|---------|----------------|-----------------|
+| `Mcp` | `mcp_invoke_tool` | `server`, `tool`, `params` |
+| `A2A` | `invoke_agent` | `agent`, `skill`, `message` |
+| `Script` | `execute_{language}_script` | `params.script` |
+| `Web` | `web_search` or `web_browse` | `tool`, `params` |
+
+The `GatewayRouter` builds the correct `ToolInvokeRequest` arguments for each gateway
+type. For example, an MCP step with `server: "ms365"` and `tool: "search_emails"` is
+translated to `mcp_invoke_tool({ server_name: "ms365", tool_name: "search_emails",
+arguments: { ... } })`.
+
+---
+
+## Tool scoping
+
+LLM steps can only call tools that are explicitly in scope. The tool set is built from:
+
+1. All tools implied by **direct steps'** gateway declarations (e.g., if any direct
+   step uses the MCP gateway, `mcp_invoke_tool` is in scope)
+2. Tools listed in the top-level **`tools`** array (for tools only LLM steps need)
+3. **Working memory tools** (`GetFromWorkingMemory`, `SearchWorkingMemory`, etc.) —
+   always available
+
+This prevents the LLM from calling tools the wisp definition didn't anticipate.
+
+---
+
+## Data flow
+
+### `output_to`
+
+When present on any step (direct or LLM), the harness writes the step's result to a
+file on the shared volume after the step completes:
+
+- **Direct steps:** Tool response content is written to the file path
+- **LLM steps:** LLM output text is written to the file path
+
+The result is also stored in working memory at `wisp/{wispId}/{stepId}/output` for
+fast inter-step access without re-reading from disk.
+
+### `input_from`
+
+When present on a step, the harness resolves input data before the step executes:
+
+- **Direct steps:** Template substitution in params (e.g., file path reference)
+- **LLM steps:** The harness reads the file from the shared volume. Small content
+  (≤8K chars) is injected directly into the prompt. Large content is chunked via
+  `ContentChunker` into the wisp's working memory namespace, and the LLM receives
+  an index table with chunk keys to retrieve via `GetFromWorkingMemory`.
+
+### Template substitution
+
+Step parameters and prompts support template references to prior step outputs:
+
+- `{{steps.<id>.result}}` — Replaced with the step's output content
+- `{{steps.<id>.output_to}}` — Replaced with the step's `output_to` file path
+
+### Transition patterns
+
+| Transition | Data path |
+|-----------|-----------|
+| Direct → Direct | Shared volume files (scripts read/write directly) |
+| Direct → LLM | Harness reads file, chunks into working memory if large |
+| LLM → Direct | Harness writes LLM output to shared volume |
+| LLM → LLM | Working memory (no file round-trip) |
+
+---
+
+## Error handling
+
+### On-failure branching
+
+Direct steps support `on_failure` with two actions:
+
+- `{ "action": "abort" }` — Stop the pipeline and return the error (default)
+- `{ "action": "skip_to", "skip_to": "step_id" }` — Skip intermediate steps and
+  resume at the named step
+
+### Failure classification
+
+Every failure is automatically classified by the harness:
+
+| Category | Examples | Learnable? |
+|----------|----------|-----------|
+| **Structural** | Wrong tool name, missing params, bad gateway config | Yes — skill bug |
+| **External** | Timeout, service unavailable, rate limit | No — transient |
+| **Judgment** | LLM picked wrong result, missed key data | Partially — prompt quality |
+| **Data** | Unexpected format, empty results, schema mismatch | Yes — assumption bug |
+
+### Working memory cleanup
+
+On success, the wisp's working memory namespace (`wisp/{wispId}`) is cleared. On
+failure, it is preserved for debugging — the calling agent can read the namespace to
+inspect intermediate results.
+
+---
+
+## Failure tracking (Phase 4)
+
+Every wisp execution (success or failure) produces a persistent `WispExecutionRecord`
+written to `IWispExecutionLog` (JSONL-backed via `FileWispExecutionLog`). Records include:
+
+- Wisp ID, description, and a SHA-256 definition hash
+- Success/failure status with step-level detail
+- Failure classification and error message
+- Session ID for correlation
+- `RetryOf` link when the wisp is detected as a successful retry of a prior failure
+
+### Correction pair capture
+
+When a wisp succeeds and a prior failure with the same definition hash exists in the
+same session, `SpawnWispExecutor` links them as a correction pair and emits a
+`WispCorrection` feedback signal via `IFeedbackStore`. The signal includes the prior
+failure's category, error message, and failed step — giving the dream system structured
+evidence of what went wrong and how it was fixed.
+
+---
+
+## Dream-time learning (Phase 5)
+
+The `DreamService` includes a `RunWispFailureAnalysisPassAsync()` pass that:
+
+1. Queries the last 14 days of wisp execution records
+2. Groups by description to identify recurring patterns
+3. Sends a summary to the LLM with a structured analysis directive
+4. The LLM returns:
+   - **Failure patterns** — recurring failures with category, frequency, and
+     recommendations
+   - **Skill updates** — annotations to append to existing skills (negative examples,
+     corrected patterns)
+   - **Promotion candidates** — consistently successful wisp patterns that could become
+     stored wisp skills (Phase 6, deferred)
+
+Configuration: `DreamOptions.WispFailureAnalysisEnabled` (default `true`) and
+`DreamOptions.WispFailureDirectivePath` (default `wisp-failure-dream.md`).
+
+---
+
+## DI registration
+
+```csharp
+agent.AddWisps(opts =>
+    opts.SharedVolumePath = "/rockbot/shared");
+```
+
+This registers:
+- `WispExecutor` — core pipeline execution engine
+- `FileWispExecutionLog` as `IWispExecutionLog` — persistent execution records
+- `WispToolRegistrar` — registers `spawn_wisp` in the tool registry
+- `WispToolSkillProvider` — provides `get_tool_guide("wisp")` documentation
+
+The `spawn_wisp` tool is available to both the primary agent and subagents (source
+`"wisp"` passes the subagent tool filter).
+
+---
+
+## Project structure
+
+```
+src/RockBot.Wisp/
+├── WispDefinition.cs          # Top-level pipeline definition
+├── WispStep.cs                # Single step (id, mode, gateway, params, etc.)
+├── StepMode.cs                # Direct / Llm enum
+├── GatewayType.cs             # Mcp / A2A / Script / Web enum
+├── OnFailureAction.cs         # abort / skip_to
+├── FailureCategory.cs         # Structural / External / Judgment / Data
+├── WispExecutor.cs            # Core pipeline executor
+├── WispExecutionResult.cs     # Overall result with per-step detail
+├── WispStepResult.cs          # Single step result
+├── WispStepError.cs           # Error with classification
+├── GatewayRouter.cs           # Maps steps to tool invocations + template resolution
+├── WispRegistryToolFunction.cs # AIFunction wrapper for scoped LLM step tools
+├── SpawnWispExecutor.cs       # IToolExecutor for spawn_wisp tool
+├── WispToolRegistrar.cs       # IHostedService tool registration
+├── WispToolSkillProvider.cs   # IToolSkillProvider usage guide
+├── WispOptions.cs             # Configuration (SharedVolumePath)
+├── WispServiceCollectionExtensions.cs # AddWisps() DI extension
+├── FileWispExecutionLog.cs    # JSONL-backed execution log
+│
+src/RockBot.Host.Abstractions/
+├── IWispExecutionLog.cs       # Execution log interface
+├── WispExecutionRecord.cs     # Persistent execution record
+│
+tests/RockBot.Wisp.Tests/      # 68 unit tests
+```
+
+---
+
+## Configuration
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `WispOptions.SharedVolumePath` | `/rockbot/shared` | Root directory for shared volume file I/O |
+| `DreamOptions.WispFailureAnalysisEnabled` | `true` | Enable wisp failure analysis dream pass |
+| `DreamOptions.WispFailureDirectivePath` | `wisp-failure-dream.md` | Custom directive for the dream pass |


### PR DESCRIPTION
## Summary

- New `docs/wisps.md` covering architecture, step modes, gateways, tool scoping, data flow, error handling, failure tracking, dream-time learning, DI registration, and configuration
- Cross-reference in `docs/subagents.md` (see-also box pointing to wisps for procedural tasks)
- Wisp failure analysis pass added to `docs/dream-service.md`
- `AddWisps()` registration added to `docs/tools.md`

## Test plan

- [x] Documentation only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)