### PR TITLE
Add A2A gateway streaming, ListTasks, push notifications, and extended agent card

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Each agent is an isolated process that reacts to messages, invokes tools, calls 
 | `RockBot.Scripts.Local` | Local Python script runner for development (no Kubernetes needed) |
 | `RockBot.Subagent` | In-process subagent spawning — isolated LLM loops, progress reporting, and long-term memory data handoff |
 | `RockBot.A2A` | Agent-to-agent task delegation over the message bus |
+| `RockBot.A2A.Gateway` | A2A v1 HTTP gateway — bridges external JSON-RPC clients to the RabbitMQ agent bus with API key auth, SSE streaming, and push notifications |
 | `RockBot.ServiceSearch` | Unified BM25 keyword search across A2A agents and MCP servers (`search_known_services`) |
 | `RockBot.UserProxy.Blazor` | Blazor Server chat UI with markdown rendering, conversation replay, and feedback signals |
 | `RockBot.UserProxy.Cli` | Console chat interface using Spectre.Console |

--- a/deploy/docker-compose/docker-compose.a2a-test.yml
+++ b/deploy/docker-compose/docker-compose.a2a-test.yml
@@ -104,6 +104,8 @@ services:
       RabbitMq__Password: rockbot
       ApiKeys__test-key-001__AgentId: a2a-test-harness
       ApiKeys__test-key-001__DisplayName: A2A Test Harness
+    volumes:
+      - gateway-data:/app/data
 
   a2a-test-harness:
     build:
@@ -130,3 +132,4 @@ services:
 volumes:
   agent-data:
   shared:
+  gateway-data:

--- a/docs/a2a.md
+++ b/docs/a2a.md
@@ -172,6 +172,91 @@ See `RockBot.SampleAgent.Http` for a complete working example.
 
 ---
 
+## A2A HTTP Gateway (inbound)
+
+`RockBot.A2A.Gateway` is an ASP.NET Core HTTP gateway that accepts inbound A2A v1
+JSON-RPC requests from external clients and bridges them to the RockBot agent over
+RabbitMQ. This is the reverse of `invoke_agent` — instead of RockBot calling out,
+external agents call **in**.
+
+### Endpoints
+
+| Endpoint | Auth | Description |
+|---|---|---|
+| `GET /.well-known/agent-card.json` | None | A2A discovery — returns the agent card with capabilities and security schemes |
+| `POST /` | Required | JSON-RPC 2.0 dispatch for all A2A methods |
+
+### Supported JSON-RPC methods
+
+| Method | Response | Description |
+|---|---|---|
+| `SendMessage` / `message/send` | JSON | Send a message and wait for the agent's response |
+| `SendStreamingMessage` / `message/sendStream` | SSE | Send a message and stream status updates + final response as Server-Sent Events |
+| `GetTask` | JSON | Retrieve the current state of a task by ID |
+| `ListTasks` | JSON | List tasks with optional status filter and pagination |
+| `CancelTask` | JSON | Request cancellation of an in-flight task |
+| `SubscribeToTask` | SSE | Attach to an existing task and receive future events as SSE |
+| `CreateTaskPushNotificationConfig` | JSON | Register a webhook URL to receive task status changes |
+| `GetTaskPushNotificationConfig` | JSON | Get a push notification config by ID |
+| `ListTaskPushNotificationConfig` | JSON | List push configs for a task |
+| `DeleteTaskPushNotificationConfig` | JSON | Remove a push notification config |
+| `GetExtendedAgentCard` | JSON | Return the agent card with full capabilities (authenticated) |
+
+### Authentication
+
+The gateway currently supports **X-Api-Key** header authentication. Each API key maps
+to an agent identity (agent ID + display name) configured in the `ApiKeys` section of
+`appsettings.json`. JWT/Bearer authentication is planned (#264).
+
+### SSE streaming
+
+Streaming methods (`SendStreamingMessage`, `SubscribeToTask`) return
+`Content-Type: text/event-stream`. Each SSE event is a JSON-RPC 2.0 result wrapping a
+`StreamResponse` (which contains either a `TaskStatusUpdateEvent`, `TaskArtifactUpdateEvent`,
+or final `Message`):
+
+```
+data: {"jsonrpc":"2.0","id":1,"result":{"statusUpdate":{"taskId":"abc","status":{"state":"working"}}}}
+
+data: {"jsonrpc":"2.0","id":1,"result":{"message":{"role":"agent","parts":[{"text":"Done."}]}}}
+
+```
+
+Under the hood, the gateway subscribes to the RabbitMQ `agent.task.status` topic and
+the per-caller reply topic, forwarding events to the SSE stream as they arrive.
+
+### Task persistence
+
+Tasks are stored in a file-backed task store (`tasks.json` on the PVC) so they survive
+pod restarts. `ListTasks` supports filtering by status, context ID, timestamp, and
+cursor-based pagination. Tasks are scoped per authenticated caller.
+
+### Push notifications
+
+When a push notification config is registered for a task, the gateway sends an HTTP
+POST to the configured webhook URL on every task status change. The webhook body is
+the same `StreamResponse` JSON used in SSE streaming. Configs are persisted to
+`push-configs.json` on the PVC.
+
+### Example request
+
+```bash
+curl -X POST http://localhost:5200/ \
+  -H "Content-Type: application/json" \
+  -H "X-Api-Key: my-key" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "SendMessage",
+    "params": {
+      "message": { "role": "user", "parts": [{ "text": "What is the weather?" }] },
+      "metadata": { "skill": "notify-user" }
+    }
+  }'
+```
+
+---
+
 ## KEDA ephemeral pattern
 
 `ResearchAgent` uses the ephemeral one-shot pattern:

--- a/src/RockBot.A2A.Gateway/FilePushNotificationConfigStore.cs
+++ b/src/RockBot.A2A.Gateway/FilePushNotificationConfigStore.cs
@@ -1,0 +1,153 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using A2A;
+
+namespace RockBot.A2A.Gateway;
+
+/// <summary>
+/// File-backed store for <see cref="TaskPushNotificationConfig"/> records.
+/// Thread-safe via <see cref="ConcurrentDictionary{TKey,TValue}"/> with serialized file writes.
+/// Configs are scoped by caller (tenant) and task ID.
+/// </summary>
+internal sealed class FilePushNotificationConfigStore
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = true
+    };
+
+    private readonly ConcurrentDictionary<string, TaskPushNotificationConfig> _configs = new(StringComparer.OrdinalIgnoreCase);
+    private readonly string? _filePath;
+    private readonly SemaphoreSlim _writeLock = new(1, 1);
+    private volatile bool _loaded;
+
+    public FilePushNotificationConfigStore(string? filePath)
+    {
+        _filePath = string.IsNullOrWhiteSpace(filePath) ? null : filePath;
+    }
+
+    public async Task<TaskPushNotificationConfig> CreateAsync(
+        string taskId, string configId, string tenant, PushNotificationConfig config, CancellationToken ct)
+    {
+        await EnsureLoadedAsync(ct);
+
+        var entry = new TaskPushNotificationConfig
+        {
+            Id = configId,
+            TaskId = taskId,
+            Tenant = tenant,
+            PushNotificationConfig = config
+        };
+        _configs[configId] = entry;
+        await PersistAsync(ct);
+        return entry;
+    }
+
+    public async Task<TaskPushNotificationConfig?> GetAsync(string configId, CancellationToken ct)
+    {
+        await EnsureLoadedAsync(ct);
+        return _configs.TryGetValue(configId, out var entry) ? entry : null;
+    }
+
+    public async Task<(List<TaskPushNotificationConfig> Configs, string NextPageToken)> ListAsync(
+        string taskId, int? pageSize, string? pageToken, CancellationToken ct)
+    {
+        await EnsureLoadedAsync(ct);
+
+        var matching = _configs.Values
+            .Where(c => string.Equals(c.TaskId, taskId, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(c => c.Id)
+            .ToList();
+
+        if (!string.IsNullOrEmpty(pageToken))
+        {
+            var idx = matching.FindIndex(c => string.Equals(c.Id, pageToken, StringComparison.OrdinalIgnoreCase));
+            if (idx >= 0)
+                matching = matching.Skip(idx + 1).ToList();
+        }
+
+        var size = pageSize ?? 20;
+        var page = matching.Take(size).ToList();
+        var nextToken = page.Count == size && matching.Count > size ? page[^1].Id : string.Empty;
+
+        return (page, nextToken);
+    }
+
+    public async Task<bool> DeleteAsync(string configId, CancellationToken ct)
+    {
+        await EnsureLoadedAsync(ct);
+
+        if (_configs.TryRemove(configId, out _))
+        {
+            await PersistAsync(ct);
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Returns all push notification configs for a given task, regardless of tenant.
+    /// Used by <see cref="PushNotificationSender"/> to fire webhooks on status changes.
+    /// </summary>
+    public async Task<List<TaskPushNotificationConfig>> GetConfigsForTaskAsync(string taskId, CancellationToken ct)
+    {
+        await EnsureLoadedAsync(ct);
+
+        return _configs.Values
+            .Where(c => string.Equals(c.TaskId, taskId, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+    }
+
+    private async Task EnsureLoadedAsync(CancellationToken ct)
+    {
+        if (_loaded) return;
+
+        await _writeLock.WaitAsync(ct);
+        try
+        {
+            if (_loaded) return;
+
+            if (_filePath is not null && File.Exists(_filePath))
+            {
+                var json = await File.ReadAllTextAsync(_filePath, ct);
+                var entries = JsonSerializer.Deserialize<List<TaskPushNotificationConfig>>(json, JsonOptions);
+                if (entries is not null)
+                {
+                    foreach (var entry in entries)
+                    {
+                        if (entry.Id is not null)
+                            _configs.TryAdd(entry.Id, entry);
+                    }
+                }
+            }
+
+            _loaded = true;
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
+    }
+
+    private async Task PersistAsync(CancellationToken ct)
+    {
+        if (_filePath is null) return;
+
+        await _writeLock.WaitAsync(ct);
+        try
+        {
+            var entries = _configs.Values.ToList();
+            var json = JsonSerializer.Serialize(entries, JsonOptions);
+            var dir = Path.GetDirectoryName(_filePath);
+            if (!string.IsNullOrEmpty(dir))
+                Directory.CreateDirectory(dir);
+            await File.WriteAllTextAsync(_filePath, json, ct);
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
+    }
+}

--- a/src/RockBot.A2A.Gateway/FileTaskStore.cs
+++ b/src/RockBot.A2A.Gateway/FileTaskStore.cs
@@ -1,0 +1,200 @@
+using System.Collections.Concurrent;
+using System.Security.Claims;
+using System.Text.Json;
+using A2A;
+
+namespace RockBot.A2A.Gateway;
+
+/// <summary>
+/// File-backed <see cref="ITaskStore"/> that persists <see cref="AgentTask"/> records as JSON.
+/// Each task is wrapped with caller identity and creation time for caller-scoped queries.
+/// Thread-safe via <see cref="ConcurrentDictionary{TKey,TValue}"/> with serialized file writes.
+/// </summary>
+internal sealed class FileTaskStore : ITaskStore
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = true
+    };
+
+    private readonly ConcurrentDictionary<string, StoredTask> _tasks = new(StringComparer.OrdinalIgnoreCase);
+    private readonly string? _filePath;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly SemaphoreSlim _writeLock = new(1, 1);
+    private volatile bool _loaded;
+
+    public FileTaskStore(IHttpContextAccessor httpContextAccessor, string? filePath)
+    {
+        _httpContextAccessor = httpContextAccessor;
+        _filePath = string.IsNullOrWhiteSpace(filePath) ? null : filePath;
+    }
+
+    public async Task<AgentTask?> GetTaskAsync(string taskId, CancellationToken cancellationToken)
+    {
+        await EnsureLoadedAsync(cancellationToken);
+
+        return _tasks.TryGetValue(taskId, out var stored) ? stored.Task : null;
+    }
+
+    public async Task SaveTaskAsync(string taskId, AgentTask task, CancellationToken cancellationToken)
+    {
+        await EnsureLoadedAsync(cancellationToken);
+
+        var callerId = _httpContextAccessor.HttpContext?.User.FindFirst(ClaimTypes.NameIdentifier)?.Value
+                       ?? "system";
+
+        _tasks.AddOrUpdate(
+            taskId,
+            _ => new StoredTask(callerId, task, DateTimeOffset.UtcNow),
+            (_, existing) => existing with { Task = task });
+
+        await PersistAsync(cancellationToken);
+    }
+
+    public async Task DeleteTaskAsync(string taskId, CancellationToken cancellationToken)
+    {
+        await EnsureLoadedAsync(cancellationToken);
+
+        if (_tasks.TryRemove(taskId, out _))
+            await PersistAsync(cancellationToken);
+    }
+
+    public async Task<ListTasksResponse> ListTasksAsync(ListTasksRequest request, CancellationToken cancellationToken)
+    {
+        await EnsureLoadedAsync(cancellationToken);
+
+        IEnumerable<StoredTask> query = _tasks.Values;
+
+        // Caller scoping via Tenant
+        if (!string.IsNullOrWhiteSpace(request.Tenant))
+            query = query.Where(s => string.Equals(s.CallerId, request.Tenant, StringComparison.OrdinalIgnoreCase));
+
+        // Filter by context ID
+        if (!string.IsNullOrWhiteSpace(request.ContextId))
+            query = query.Where(s => s.Task.ContextId == request.ContextId);
+
+        // Filter by status
+        if (request.Status.HasValue)
+            query = query.Where(s => s.Task.Status?.State == request.Status.Value);
+
+        // Filter by timestamp
+        if (request.StatusTimestampAfter.HasValue)
+            query = query.Where(s => s.Task.Status?.Timestamp > request.StatusTimestampAfter.Value);
+
+        // Order by creation time
+        var ordered = query.OrderByDescending(s => s.CreatedAt).ToList();
+        var totalSize = ordered.Count;
+
+        // Cursor-based pagination (page token = task ID)
+        if (!string.IsNullOrWhiteSpace(request.PageToken))
+        {
+            var idx = ordered.FindIndex(s => string.Equals(s.Task.Id, request.PageToken, StringComparison.OrdinalIgnoreCase));
+            if (idx >= 0)
+                ordered = ordered.Skip(idx + 1).ToList();
+        }
+
+        var pageSize = request.PageSize ?? 20;
+        var page = ordered.Take(pageSize).ToList();
+        var nextPageToken = page.Count == pageSize && ordered.Count > pageSize
+            ? page[^1].Task.Id ?? string.Empty
+            : string.Empty;
+
+        // Apply history truncation and artifact filtering
+        var tasks = page.Select(s =>
+        {
+            var task = s.Task;
+            if (request.HistoryLength.HasValue && task.History is { Count: > 0 })
+            {
+                var maxHistory = request.HistoryLength.Value;
+                if (task.History.Count > maxHistory)
+                {
+                    task = new AgentTask
+                    {
+                        Id = task.Id,
+                        ContextId = task.ContextId,
+                        Status = task.Status,
+                        History = task.History.TakeLast(maxHistory).ToList(),
+                        Artifacts = (request.IncludeArtifacts != false) ? task.Artifacts : null,
+                        Metadata = task.Metadata
+                    };
+                }
+            }
+            else if (request.IncludeArtifacts == false && task.Artifacts is { Count: > 0 })
+            {
+                task = new AgentTask
+                {
+                    Id = task.Id,
+                    ContextId = task.ContextId,
+                    Status = task.Status,
+                    History = task.History,
+                    Artifacts = null,
+                    Metadata = task.Metadata
+                };
+            }
+            return task;
+        }).ToList();
+
+        return new ListTasksResponse
+        {
+            Tasks = tasks,
+            NextPageToken = nextPageToken,
+            PageSize = pageSize,
+            TotalSize = totalSize
+        };
+    }
+
+    private async Task EnsureLoadedAsync(CancellationToken ct)
+    {
+        if (_loaded) return;
+
+        await _writeLock.WaitAsync(ct);
+        try
+        {
+            if (_loaded) return;
+
+            if (_filePath is not null && File.Exists(_filePath))
+            {
+                var json = await File.ReadAllTextAsync(_filePath, ct);
+                var entries = JsonSerializer.Deserialize<List<StoredTask>>(json, JsonOptions);
+                if (entries is not null)
+                {
+                    foreach (var entry in entries)
+                    {
+                        if (entry.Task?.Id is not null)
+                            _tasks.TryAdd(entry.Task.Id, entry);
+                    }
+                }
+            }
+
+            _loaded = true;
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
+    }
+
+    private async Task PersistAsync(CancellationToken ct)
+    {
+        if (_filePath is null) return;
+
+        await _writeLock.WaitAsync(ct);
+        try
+        {
+            var entries = _tasks.Values.ToList();
+            var json = JsonSerializer.Serialize(entries, JsonOptions);
+            var dir = Path.GetDirectoryName(_filePath);
+            if (!string.IsNullOrEmpty(dir))
+                Directory.CreateDirectory(dir);
+            await File.WriteAllTextAsync(_filePath, json, ct);
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
+    }
+
+    internal sealed record StoredTask(string CallerId, AgentTask Task, DateTimeOffset CreatedAt);
+}

--- a/src/RockBot.A2A.Gateway/GatewayOptions.cs
+++ b/src/RockBot.A2A.Gateway/GatewayOptions.cs
@@ -10,6 +10,15 @@ public sealed class GatewayOptions
     public string? Description { get; set; }
     public string? Version { get; set; }
     public List<GatewaySkillConfig> Skills { get; set; } = [];
+
+    /// <summary>File path for durable task storage (relative to AppContext.BaseDirectory). Null disables persistence.</summary>
+    public string? TaskStorePath { get; set; } = "tasks.json";
+
+    /// <summary>File path for push notification config storage (relative to AppContext.BaseDirectory). Null disables persistence.</summary>
+    public string? PushNotificationConfigStorePath { get; set; } = "push-configs.json";
+
+    /// <summary>Maximum seconds to wait for the agent to respond to a task (streaming or non-streaming).</summary>
+    public int TaskTimeoutSeconds { get; set; } = 120;
 }
 
 public sealed class GatewaySkillConfig

--- a/src/RockBot.A2A.Gateway/JsonRpcRouter.cs
+++ b/src/RockBot.A2A.Gateway/JsonRpcRouter.cs
@@ -5,6 +5,8 @@ namespace RockBot.A2A.Gateway;
 
 /// <summary>
 /// Routes A2A v1 JSON-RPC requests to the appropriate <see cref="A2AServer"/> method.
+/// Streaming methods (<c>SendStreamingMessage</c>, <c>SubscribeToTask</c>) write SSE
+/// directly to the response and return <c>null</c>; non-streaming methods return <see cref="IResult"/>.
 /// </summary>
 internal static class JsonRpcRouter
 {
@@ -15,8 +17,14 @@ internal static class JsonRpcRouter
         DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
     };
 
-    public static async Task<IResult> HandleAsync(
+    /// <summary>
+    /// Parses the JSON-RPC request, dispatches to the matching <see cref="A2AServer"/> method,
+    /// and returns an <see cref="IResult"/> for synchronous methods or <c>null</c> when the
+    /// response was already written as SSE.
+    /// </summary>
+    public static async Task<IResult?> HandleAsync(
         HttpRequest request,
+        HttpResponse response,
         A2AServer server,
         ILoggerFactory loggerFactory,
         CancellationToken ct)
@@ -55,14 +63,42 @@ internal static class JsonRpcRouter
         {
             return method switch
             {
+                // ── Core message methods ────────────────────────────────────
                 "message/send" or A2AMethods.SendMessage =>
                     await HandleSendMessageAsync(server, paramsJson, idRaw, ct),
 
+                "message/sendStream" or A2AMethods.SendStreamingMessage =>
+                    await HandleSendStreamingMessageAsync(response, server, paramsJson, idRaw, logger, ct),
+
+                // ── Task methods ────────────────────────────────────────────
                 A2AMethods.GetTask =>
                     await HandleGetTaskAsync(server, paramsJson, idRaw, ct),
 
+                A2AMethods.ListTasks =>
+                    await HandleListTasksAsync(server, paramsJson, idRaw, ct),
+
                 A2AMethods.CancelTask =>
                     await HandleCancelTaskAsync(server, paramsJson, idRaw, ct),
+
+                A2AMethods.SubscribeToTask =>
+                    await HandleSubscribeToTaskAsync(response, server, paramsJson, idRaw, logger, ct),
+
+                // ── Push notification config CRUD ───────────────────────────
+                A2AMethods.CreateTaskPushNotificationConfig =>
+                    await HandleCreatePushNotificationConfigAsync(server, paramsJson, idRaw, ct),
+
+                A2AMethods.GetTaskPushNotificationConfig =>
+                    await HandleGetPushNotificationConfigAsync(server, paramsJson, idRaw, ct),
+
+                A2AMethods.ListTaskPushNotificationConfig =>
+                    await HandleListPushNotificationConfigAsync(server, paramsJson, idRaw, ct),
+
+                A2AMethods.DeleteTaskPushNotificationConfig =>
+                    await HandleDeletePushNotificationConfigAsync(server, paramsJson, idRaw, ct),
+
+                // ── Agent card ──────────────────────────────────────────────
+                A2AMethods.GetExtendedAgentCard =>
+                    await HandleGetExtendedAgentCardAsync(server, paramsJson, idRaw, ct),
 
                 _ => JsonRpcError(idRaw, -32601, $"Method not found: {method}")
             };
@@ -78,6 +114,8 @@ internal static class JsonRpcRouter
         }
     }
 
+    // ── Core message handlers ───────────────────────────────────────────────
+
     private static async Task<IResult> HandleSendMessageAsync(
         A2AServer server, string paramsJson, string idRaw, CancellationToken ct)
     {
@@ -88,6 +126,21 @@ internal static class JsonRpcRouter
         var response = await server.SendMessageAsync(sendRequest, ct);
         return JsonRpcResult(idRaw, response);
     }
+
+    private static async Task<IResult?> HandleSendStreamingMessageAsync(
+        HttpResponse httpResponse, A2AServer server, string paramsJson, string idRaw,
+        ILogger logger, CancellationToken ct)
+    {
+        var sendRequest = JsonSerializer.Deserialize<SendMessageRequest>(paramsJson, JsonOptions);
+        if (sendRequest is null)
+            return JsonRpcError(idRaw, -32600, "Invalid SendStreamingMessage params");
+
+        var events = server.SendStreamingMessageAsync(sendRequest, ct);
+        await SseWriter.WriteStreamAsync(httpResponse, idRaw, events, logger, ct);
+        return null; // Response already written as SSE
+    }
+
+    // ── Task handlers ───────────────────────────────────────────────────────
 
     private static async Task<IResult> HandleGetTaskAsync(
         A2AServer server, string paramsJson, string idRaw, CancellationToken ct)
@@ -100,6 +153,17 @@ internal static class JsonRpcRouter
         return JsonRpcResult(idRaw, task);
     }
 
+    private static async Task<IResult> HandleListTasksAsync(
+        A2AServer server, string paramsJson, string idRaw, CancellationToken ct)
+    {
+        var listRequest = JsonSerializer.Deserialize<ListTasksRequest>(paramsJson, JsonOptions);
+        if (listRequest is null)
+            return JsonRpcError(idRaw, -32600, "Invalid ListTasks params");
+
+        var response = await server.ListTasksAsync(listRequest, ct);
+        return JsonRpcResult(idRaw, response);
+    }
+
     private static async Task<IResult> HandleCancelTaskAsync(
         A2AServer server, string paramsJson, string idRaw, CancellationToken ct)
     {
@@ -110,6 +174,80 @@ internal static class JsonRpcRouter
         var task = await server.CancelTaskAsync(cancelRequest, ct);
         return JsonRpcResult(idRaw, task);
     }
+
+    private static async Task<IResult?> HandleSubscribeToTaskAsync(
+        HttpResponse httpResponse, A2AServer server, string paramsJson, string idRaw,
+        ILogger logger, CancellationToken ct)
+    {
+        var subRequest = JsonSerializer.Deserialize<SubscribeToTaskRequest>(paramsJson, JsonOptions);
+        if (subRequest is null)
+            return JsonRpcError(idRaw, -32600, "Invalid SubscribeToTask params");
+
+        var events = server.SubscribeToTaskAsync(subRequest, ct);
+        await SseWriter.WriteStreamAsync(httpResponse, idRaw, events, logger, ct);
+        return null; // Response already written as SSE
+    }
+
+    // ── Push notification config CRUD ───────────────────────────────────────
+
+    private static async Task<IResult> HandleCreatePushNotificationConfigAsync(
+        A2AServer server, string paramsJson, string idRaw, CancellationToken ct)
+    {
+        var createRequest = JsonSerializer.Deserialize<CreateTaskPushNotificationConfigRequest>(paramsJson, JsonOptions);
+        if (createRequest is null)
+            return JsonRpcError(idRaw, -32600, "Invalid CreateTaskPushNotificationConfig params");
+
+        var config = await server.CreateTaskPushNotificationConfigAsync(createRequest, ct);
+        return JsonRpcResult(idRaw, config);
+    }
+
+    private static async Task<IResult> HandleGetPushNotificationConfigAsync(
+        A2AServer server, string paramsJson, string idRaw, CancellationToken ct)
+    {
+        var getRequest = JsonSerializer.Deserialize<GetTaskPushNotificationConfigRequest>(paramsJson, JsonOptions);
+        if (getRequest is null)
+            return JsonRpcError(idRaw, -32600, "Invalid GetTaskPushNotificationConfig params");
+
+        var config = await server.GetTaskPushNotificationConfigAsync(getRequest, ct);
+        return JsonRpcResult(idRaw, config);
+    }
+
+    private static async Task<IResult> HandleListPushNotificationConfigAsync(
+        A2AServer server, string paramsJson, string idRaw, CancellationToken ct)
+    {
+        var listRequest = JsonSerializer.Deserialize<ListTaskPushNotificationConfigRequest>(paramsJson, JsonOptions);
+        if (listRequest is null)
+            return JsonRpcError(idRaw, -32600, "Invalid ListTaskPushNotificationConfig params");
+
+        var response = await server.ListTaskPushNotificationConfigAsync(listRequest, ct);
+        return JsonRpcResult(idRaw, response);
+    }
+
+    private static async Task<IResult> HandleDeletePushNotificationConfigAsync(
+        A2AServer server, string paramsJson, string idRaw, CancellationToken ct)
+    {
+        var deleteRequest = JsonSerializer.Deserialize<DeleteTaskPushNotificationConfigRequest>(paramsJson, JsonOptions);
+        if (deleteRequest is null)
+            return JsonRpcError(idRaw, -32600, "Invalid DeleteTaskPushNotificationConfig params");
+
+        await server.DeleteTaskPushNotificationConfigAsync(deleteRequest, ct);
+        return JsonRpcResult(idRaw, new { }); // Void operation — return empty result
+    }
+
+    // ── Agent card ──────────────────────────────────────────────────────────
+
+    private static async Task<IResult> HandleGetExtendedAgentCardAsync(
+        A2AServer server, string paramsJson, string idRaw, CancellationToken ct)
+    {
+        var cardRequest = JsonSerializer.Deserialize<GetExtendedAgentCardRequest>(paramsJson, JsonOptions);
+        if (cardRequest is null)
+            return JsonRpcError(idRaw, -32600, "Invalid GetExtendedAgentCard params");
+
+        var card = await server.GetExtendedAgentCardAsync(cardRequest, ct);
+        return JsonRpcResult(idRaw, card);
+    }
+
+    // ── JSON-RPC response helpers ───────────────────────────────────────────
 
     private static IResult JsonRpcResult(string idRaw, object result)
     {

--- a/src/RockBot.A2A.Gateway/JsonRpcRouter.cs
+++ b/src/RockBot.A2A.Gateway/JsonRpcRouter.cs
@@ -1,5 +1,9 @@
 using System.Text.Json;
 using A2A;
+using Microsoft.Extensions.Options;
+
+using A2AAgentCard = A2A.AgentCard;
+using A2AAgentSkill = A2A.AgentSkill;
 
 namespace RockBot.A2A.Gateway;
 
@@ -7,6 +11,8 @@ namespace RockBot.A2A.Gateway;
 /// Routes A2A v1 JSON-RPC requests to the appropriate <see cref="A2AServer"/> method.
 /// Streaming methods (<c>SendStreamingMessage</c>, <c>SubscribeToTask</c>) write SSE
 /// directly to the response and return <c>null</c>; non-streaming methods return <see cref="IResult"/>.
+/// Push notification CRUD and extended agent card are handled directly (the SDK's
+/// <see cref="A2AServer"/> does not support these out of the box).
 /// </summary>
 internal static class JsonRpcRouter
 {
@@ -26,6 +32,8 @@ internal static class JsonRpcRouter
         HttpRequest request,
         HttpResponse response,
         A2AServer server,
+        IOptions<GatewayOptions> gatewayOptions,
+        FilePushNotificationConfigStore pushConfigStore,
         ILoggerFactory loggerFactory,
         CancellationToken ct)
     {
@@ -85,20 +93,20 @@ internal static class JsonRpcRouter
 
                 // ── Push notification config CRUD ───────────────────────────
                 A2AMethods.CreateTaskPushNotificationConfig =>
-                    await HandleCreatePushNotificationConfigAsync(server, paramsJson, idRaw, ct),
+                    await HandleCreatePushNotificationConfigAsync(pushConfigStore, paramsJson, idRaw, ct),
 
                 A2AMethods.GetTaskPushNotificationConfig =>
-                    await HandleGetPushNotificationConfigAsync(server, paramsJson, idRaw, ct),
+                    await HandleGetPushNotificationConfigAsync(pushConfigStore, paramsJson, idRaw, ct),
 
                 A2AMethods.ListTaskPushNotificationConfig =>
-                    await HandleListPushNotificationConfigAsync(server, paramsJson, idRaw, ct),
+                    await HandleListPushNotificationConfigAsync(pushConfigStore, paramsJson, idRaw, ct),
 
                 A2AMethods.DeleteTaskPushNotificationConfig =>
-                    await HandleDeletePushNotificationConfigAsync(server, paramsJson, idRaw, ct),
+                    await HandleDeletePushNotificationConfigAsync(pushConfigStore, paramsJson, idRaw, ct),
 
                 // ── Agent card ──────────────────────────────────────────────
                 A2AMethods.GetExtendedAgentCard =>
-                    await HandleGetExtendedAgentCardAsync(server, paramsJson, idRaw, ct),
+                    HandleGetExtendedAgentCard(gatewayOptions.Value, idRaw),
 
                 _ => JsonRpcError(idRaw, -32601, $"Method not found: {method}")
             };
@@ -189,61 +197,84 @@ internal static class JsonRpcRouter
     }
 
     // ── Push notification config CRUD ───────────────────────────────────────
+    // Handled directly via FilePushNotificationConfigStore — the SDK's A2AServer
+    // does not have a push notification store wired up.
 
     private static async Task<IResult> HandleCreatePushNotificationConfigAsync(
-        A2AServer server, string paramsJson, string idRaw, CancellationToken ct)
+        FilePushNotificationConfigStore store, string paramsJson, string idRaw, CancellationToken ct)
     {
-        var createRequest = JsonSerializer.Deserialize<CreateTaskPushNotificationConfigRequest>(paramsJson, JsonOptions);
-        if (createRequest is null)
+        var req = JsonSerializer.Deserialize<CreateTaskPushNotificationConfigRequest>(paramsJson, JsonOptions);
+        if (req is null)
             return JsonRpcError(idRaw, -32600, "Invalid CreateTaskPushNotificationConfig params");
 
-        var config = await server.CreateTaskPushNotificationConfigAsync(createRequest, ct);
+        var configId = req.ConfigId ?? Guid.NewGuid().ToString("N");
+        var config = await store.CreateAsync(req.TaskId, configId, req.Tenant ?? string.Empty, req.Config, ct);
         return JsonRpcResult(idRaw, config);
     }
 
     private static async Task<IResult> HandleGetPushNotificationConfigAsync(
-        A2AServer server, string paramsJson, string idRaw, CancellationToken ct)
+        FilePushNotificationConfigStore store, string paramsJson, string idRaw, CancellationToken ct)
     {
-        var getRequest = JsonSerializer.Deserialize<GetTaskPushNotificationConfigRequest>(paramsJson, JsonOptions);
-        if (getRequest is null)
+        var req = JsonSerializer.Deserialize<GetTaskPushNotificationConfigRequest>(paramsJson, JsonOptions);
+        if (req is null)
             return JsonRpcError(idRaw, -32600, "Invalid GetTaskPushNotificationConfig params");
 
-        var config = await server.GetTaskPushNotificationConfigAsync(getRequest, ct);
+        var config = await store.GetAsync(req.Id, ct);
+        if (config is null)
+            return JsonRpcError(idRaw, -32001, $"Push notification config '{req.Id}' not found");
         return JsonRpcResult(idRaw, config);
     }
 
     private static async Task<IResult> HandleListPushNotificationConfigAsync(
-        A2AServer server, string paramsJson, string idRaw, CancellationToken ct)
+        FilePushNotificationConfigStore store, string paramsJson, string idRaw, CancellationToken ct)
     {
-        var listRequest = JsonSerializer.Deserialize<ListTaskPushNotificationConfigRequest>(paramsJson, JsonOptions);
-        if (listRequest is null)
+        var req = JsonSerializer.Deserialize<ListTaskPushNotificationConfigRequest>(paramsJson, JsonOptions);
+        if (req is null)
             return JsonRpcError(idRaw, -32600, "Invalid ListTaskPushNotificationConfig params");
 
-        var response = await server.ListTaskPushNotificationConfigAsync(listRequest, ct);
-        return JsonRpcResult(idRaw, response);
+        var (configs, nextPageToken) = await store.ListAsync(req.TaskId, req.PageSize, req.PageToken, ct);
+        return JsonRpcResult(idRaw, new ListTaskPushNotificationConfigResponse
+        {
+            Configs = configs,
+            NextPageToken = nextPageToken
+        });
     }
 
     private static async Task<IResult> HandleDeletePushNotificationConfigAsync(
-        A2AServer server, string paramsJson, string idRaw, CancellationToken ct)
+        FilePushNotificationConfigStore store, string paramsJson, string idRaw, CancellationToken ct)
     {
-        var deleteRequest = JsonSerializer.Deserialize<DeleteTaskPushNotificationConfigRequest>(paramsJson, JsonOptions);
-        if (deleteRequest is null)
+        var req = JsonSerializer.Deserialize<DeleteTaskPushNotificationConfigRequest>(paramsJson, JsonOptions);
+        if (req is null)
             return JsonRpcError(idRaw, -32600, "Invalid DeleteTaskPushNotificationConfig params");
 
-        await server.DeleteTaskPushNotificationConfigAsync(deleteRequest, ct);
-        return JsonRpcResult(idRaw, new { }); // Void operation — return empty result
+        await store.DeleteAsync(req.Id, ct);
+        return JsonRpcResult(idRaw, new { });
     }
 
     // ── Agent card ──────────────────────────────────────────────────────────
+    // Handled directly from GatewayOptions — the SDK's A2AServer does not
+    // support extended agent cards out of the box.
 
-    private static async Task<IResult> HandleGetExtendedAgentCardAsync(
-        A2AServer server, string paramsJson, string idRaw, CancellationToken ct)
+    private static IResult HandleGetExtendedAgentCard(GatewayOptions config, string idRaw)
     {
-        var cardRequest = JsonSerializer.Deserialize<GetExtendedAgentCardRequest>(paramsJson, JsonOptions);
-        if (cardRequest is null)
-            return JsonRpcError(idRaw, -32600, "Invalid GetExtendedAgentCard params");
-
-        var card = await server.GetExtendedAgentCardAsync(cardRequest, ct);
+        var card = new A2AAgentCard
+        {
+            Name = config.AgentName,
+            Description = config.Description ?? string.Empty,
+            Version = config.Version ?? "1.0",
+            Capabilities = new AgentCapabilities
+            {
+                Streaming = true,
+                PushNotifications = true,
+                ExtendedAgentCard = true
+            },
+            Skills = config.Skills.Select(s => new A2AAgentSkill
+            {
+                Id = s.Id,
+                Name = s.Name,
+                Description = s.Description ?? string.Empty
+            }).ToList()
+        };
         return JsonRpcResult(idRaw, card);
     }
 

--- a/src/RockBot.A2A.Gateway/Program.cs
+++ b/src/RockBot.A2A.Gateway/Program.cs
@@ -36,6 +36,15 @@ builder.Services.AddSingleton<ITaskStore>(sp =>
     return new FileTaskStore(sp.GetRequiredService<IHttpContextAccessor>(), path);
 });
 builder.Services.AddSingleton<ChannelEventNotifier>();
+builder.Services.AddSingleton(sp =>
+{
+    var path = gatewayConfig.PushNotificationConfigStorePath is not null
+        ? Path.Combine(AppContext.BaseDirectory, gatewayConfig.PushNotificationConfigStorePath)
+        : null;
+    return new FilePushNotificationConfigStore(path);
+});
+builder.Services.AddHttpClient();
+builder.Services.AddSingleton<PushNotificationSender>();
 builder.Services.AddSingleton<IAgentHandler, RockBotBridgeHandler>();
 builder.Services.AddSingleton(sp => new A2AServer(
     sp.GetRequiredService<IAgentHandler>(),
@@ -96,10 +105,12 @@ app.MapGet("/.well-known/agent-card.json", (IOptions<GatewayOptions> opts) =>
 
 // ── JSON-RPC endpoint (authenticated) ────────────────────────────────────────
 
-app.MapPost("/", async (HttpContext ctx, A2AServer server, ILoggerFactory loggerFactory) =>
+app.MapPost("/", async (HttpContext ctx, A2AServer server,
+    IOptions<GatewayOptions> opts, FilePushNotificationConfigStore pushConfigStore,
+    ILoggerFactory loggerFactory) =>
 {
     var result = await JsonRpcRouter.HandleAsync(
-        ctx.Request, ctx.Response, server, loggerFactory, ctx.RequestAborted);
+        ctx.Request, ctx.Response, server, opts, pushConfigStore, loggerFactory, ctx.RequestAborted);
     if (result is not null)
         await result.ExecuteAsync(ctx);
 }).RequireAuthorization();

--- a/src/RockBot.A2A.Gateway/Program.cs
+++ b/src/RockBot.A2A.Gateway/Program.cs
@@ -27,7 +27,14 @@ builder.Services.AddHttpContextAccessor();
 
 // ── A2A v1 server components ─────────────────────────────────────────────────
 
-builder.Services.AddSingleton<ITaskStore, InMemoryTaskStore>();
+var gatewayConfig = builder.Configuration.GetSection("Gateway").Get<GatewayOptions>() ?? new GatewayOptions();
+builder.Services.AddSingleton<ITaskStore>(sp =>
+{
+    var path = gatewayConfig.TaskStorePath is not null
+        ? Path.Combine(AppContext.BaseDirectory, gatewayConfig.TaskStorePath)
+        : null;
+    return new FileTaskStore(sp.GetRequiredService<IHttpContextAccessor>(), path);
+});
 builder.Services.AddSingleton<ChannelEventNotifier>();
 builder.Services.AddSingleton<IAgentHandler, RockBotBridgeHandler>();
 builder.Services.AddSingleton(sp => new A2AServer(
@@ -52,6 +59,12 @@ app.MapGet("/.well-known/agent-card.json", (IOptions<GatewayOptions> opts) =>
         Name = config.AgentName,
         Description = config.Description ?? string.Empty,
         Version = config.Version ?? "1.0",
+        Capabilities = new AgentCapabilities
+        {
+            Streaming = true,
+            PushNotifications = true,
+            ExtendedAgentCard = true
+        },
         Skills = config.Skills.Select(s => new AgentSkill
         {
             Id = s.Id,
@@ -83,9 +96,13 @@ app.MapGet("/.well-known/agent-card.json", (IOptions<GatewayOptions> opts) =>
 
 // ── JSON-RPC endpoint (authenticated) ────────────────────────────────────────
 
-app.MapPost("/", (HttpRequest request, A2AServer server, ILoggerFactory loggerFactory) =>
-    JsonRpcRouter.HandleAsync(request, server, loggerFactory, request.HttpContext.RequestAborted))
-    .RequireAuthorization();
+app.MapPost("/", async (HttpContext ctx, A2AServer server, ILoggerFactory loggerFactory) =>
+{
+    var result = await JsonRpcRouter.HandleAsync(
+        ctx.Request, ctx.Response, server, loggerFactory, ctx.RequestAborted);
+    if (result is not null)
+        await result.ExecuteAsync(ctx);
+}).RequireAuthorization();
 
 // ── Startup ──────────────────────────────────────────────────────────────────
 

--- a/src/RockBot.A2A.Gateway/PushNotificationSender.cs
+++ b/src/RockBot.A2A.Gateway/PushNotificationSender.cs
@@ -1,0 +1,97 @@
+using System.Text.Json;
+using A2A;
+
+namespace RockBot.A2A.Gateway;
+
+/// <summary>
+/// Sends HTTP POST webhooks to push notification config URLs when task status changes.
+/// Fire-and-forget with logging — webhook failures do not block the caller.
+/// </summary>
+internal sealed class PushNotificationSender(
+    FilePushNotificationConfigStore configStore,
+    IHttpClientFactory httpClientFactory,
+    ILogger<PushNotificationSender> logger)
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
+    };
+
+    private static readonly TimeSpan WebhookTimeout = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Sends the given <see cref="TaskStatusUpdateEvent"/> to all push notification configs
+    /// registered for the task. Non-blocking — failures are logged but do not propagate.
+    /// </summary>
+    public async Task TrySendStatusUpdateAsync(string taskId, TaskStatusUpdateEvent statusUpdate, CancellationToken ct)
+    {
+        var configs = await configStore.GetConfigsForTaskAsync(taskId, ct);
+        if (configs.Count == 0) return;
+
+        var payload = JsonSerializer.Serialize(new StreamResponse { StatusUpdate = statusUpdate }, JsonOptions);
+        await SendToAllAsync(configs, payload, taskId, ct);
+    }
+
+    /// <summary>
+    /// Sends a completed task notification to all push notification configs.
+    /// </summary>
+    public async Task TrySendTaskCompletedAsync(string taskId, AgentTask task, CancellationToken ct)
+    {
+        var configs = await configStore.GetConfigsForTaskAsync(taskId, ct);
+        if (configs.Count == 0) return;
+
+        var payload = JsonSerializer.Serialize(new StreamResponse { Task = task }, JsonOptions);
+        await SendToAllAsync(configs, payload, taskId, ct);
+    }
+
+    private async Task SendToAllAsync(
+        List<TaskPushNotificationConfig> configs, string payload, string taskId, CancellationToken ct)
+    {
+        foreach (var config in configs)
+        {
+            _ = Task.Run(() => SendWebhookAsync(config, payload, taskId), ct);
+        }
+        await Task.CompletedTask;
+    }
+
+    private async Task SendWebhookAsync(TaskPushNotificationConfig config, string payload, string taskId)
+    {
+        var url = config.PushNotificationConfig?.Url;
+        if (string.IsNullOrEmpty(url)) return;
+
+        try
+        {
+            using var cts = new CancellationTokenSource(WebhookTimeout);
+            var httpClient = httpClientFactory.CreateClient();
+
+            // Attach authentication if configured
+            if (config.PushNotificationConfig.Authentication is { } auth &&
+                !string.IsNullOrEmpty(auth.Scheme) && !string.IsNullOrEmpty(auth.Credentials))
+            {
+                httpClient.DefaultRequestHeaders.Authorization =
+                    new System.Net.Http.Headers.AuthenticationHeaderValue(auth.Scheme, auth.Credentials);
+            }
+
+            // Attach token as bearer if configured (shorthand)
+            if (!string.IsNullOrEmpty(config.PushNotificationConfig.Token))
+            {
+                httpClient.DefaultRequestHeaders.Authorization =
+                    new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", config.PushNotificationConfig.Token);
+            }
+
+            var content = new StringContent(payload, System.Text.Encoding.UTF8, "application/json");
+            var response = await httpClient.PostAsync(url, content, cts.Token);
+
+            logger.LogDebug(
+                "Push notification for task {TaskId} to {Url}: {StatusCode}",
+                taskId, url, response.StatusCode);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or OperationCanceledException)
+        {
+            logger.LogWarning(
+                "Push notification failed for task {TaskId} to {Url}: {Error}",
+                taskId, url, ex.Message);
+        }
+    }
+}

--- a/src/RockBot.A2A.Gateway/RockBot.A2A.Gateway.csproj
+++ b/src/RockBot.A2A.Gateway/RockBot.A2A.Gateway.csproj
@@ -11,6 +11,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="RockBot.A2A.Gateway.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="A2A" Version="1.0.0-preview" />
   </ItemGroup>
 

--- a/src/RockBot.A2A.Gateway/RockBotBridgeHandler.cs
+++ b/src/RockBot.A2A.Gateway/RockBotBridgeHandler.cs
@@ -1,5 +1,8 @@
 using System.Security.Claims;
 using A2A;
+using Microsoft.Extensions.Options;
+
+using A2ATaskStatus = A2A.TaskStatus;
 using RockBot.Messaging;
 
 using RbAgentTaskRequest = RockBot.A2A.AgentTaskRequest;
@@ -7,6 +10,7 @@ using RbAgentTaskResult = RockBot.A2A.AgentTaskResult;
 using RbAgentTaskCancelRequest = RockBot.A2A.AgentTaskCancelRequest;
 using RbAgentMessage = RockBot.A2A.AgentMessage;
 using RbAgentMessagePart = RockBot.A2A.AgentMessagePart;
+using RbAgentTaskStatusUpdate = RockBot.A2A.AgentTaskStatusUpdate;
 
 namespace RockBot.A2A.Gateway;
 
@@ -20,6 +24,8 @@ internal sealed class RockBotBridgeHandler(
     IMessagePublisher publisher,
     IMessageSubscriber subscriber,
     IHttpContextAccessor httpContextAccessor,
+    IOptions<GatewayOptions> gatewayOptions,
+    ITaskStore taskStore,
     ILogger<RockBotBridgeHandler> logger) : IAgentHandler
 {
     private string GetCallerId() =>
@@ -39,15 +45,16 @@ internal sealed class RockBotBridgeHandler(
             skill = skillEl.GetString() ?? "general";
 
         var messageText = context.UserText ?? "(empty)";
+        var timeout = TimeSpan.FromSeconds(gatewayOptions.Value.TaskTimeoutSeconds);
 
         logger.LogInformation(
-            "Bridging A2A task {TaskId} skill={Skill} caller={CallerId} to RockBot via RabbitMQ",
-            taskId, skill, callerId);
+            "Bridging A2A task {TaskId} skill={Skill} caller={CallerId} streaming={Streaming} to RockBot via RabbitMQ",
+            taskId, skill, callerId, context.StreamingResponse);
 
         // Subscribe for the response BEFORE publishing
         var resultTcs = new TaskCompletionSource<RbAgentTaskResult>();
         var subName = $"a2a-gw-{Guid.NewGuid():N}";
-        await using var sub = await subscriber.SubscribeAsync(
+        await using var replySub = await subscriber.SubscribeAsync(
             replyTopic,
             subName,
             (envelope, _) =>
@@ -63,44 +70,118 @@ internal sealed class RockBotBridgeHandler(
             },
             cancellationToken);
 
-        // Brief delay for subscription to bind
-        await Task.Delay(300, cancellationToken);
-
-        // Publish task to RockBot
-        var request = new RbAgentTaskRequest
+        // Subscribe to status updates for intermediate streaming events
+        IAsyncDisposable? statusSub = null;
+        if (context.StreamingResponse)
         {
-            TaskId = taskId,
-            Skill = skill,
-            Message = new RbAgentMessage
+            var statusSubName = $"a2a-gw-status-{Guid.NewGuid():N}";
+            statusSub = await subscriber.SubscribeAsync(
+                "agent.task.status",
+                statusSubName,
+                async (envelope, _) =>
+                {
+                    try
+                    {
+                        var update = envelope.GetPayload<RbAgentTaskStatusUpdate>();
+                        if (update is not null && envelope.CorrelationId == taskId)
+                        {
+                            var statusText = update.Message?.Parts
+                                .Where(p => p.Kind == "text")
+                                .Select(p => p.Text)
+                                .FirstOrDefault();
+
+                            await eventQueue.EnqueueStatusUpdateAsync(new TaskStatusUpdateEvent
+                            {
+                                TaskId = taskId,
+                                ContextId = context.ContextId,
+                                Status = new A2ATaskStatus
+                                {
+                                    State = MapTaskState(update.State),
+                                    Message = statusText is not null
+                                        ? new Message { Role = Role.Agent, Parts = [new Part { Text = statusText }] }
+                                        : null,
+                                    Timestamp = DateTimeOffset.UtcNow
+                                }
+                            }, cancellationToken);
+                        }
+                    }
+                    catch { /* ignore deserialization errors */ }
+                    return MessageResult.Ack;
+                },
+                cancellationToken);
+        }
+
+        try
+        {
+            // Brief delay for subscriptions to bind
+            await Task.Delay(300, cancellationToken);
+
+            // Publish task to RockBot
+            var request = new RbAgentTaskRequest
             {
-                Role = "user",
-                Parts = [new RbAgentMessagePart { Kind = "text", Text = messageText }]
-            }
-        };
+                TaskId = taskId,
+                Skill = skill,
+                Message = new RbAgentMessage
+                {
+                    Role = "user",
+                    Parts = [new RbAgentMessagePart { Kind = "text", Text = messageText }]
+                }
+            };
 
-        var envelope = request.ToEnvelope<RbAgentTaskRequest>(
-            source: callerId,
-            correlationId: taskId,
-            replyTo: replyTopic);
+            var envelope = request.ToEnvelope<RbAgentTaskRequest>(
+                source: callerId,
+                correlationId: taskId,
+                replyTo: replyTopic);
 
-        await publisher.PublishAsync("agent.task.RockBot", envelope, cancellationToken);
+            await publisher.PublishAsync("agent.task.RockBot", envelope, cancellationToken);
 
-        // Wait for RockBot's response
-        var result = await resultTcs.Task.WaitAsync(TimeSpan.FromSeconds(60), cancellationToken);
+            // Wait for RockBot's response
+            var result = await resultTcs.Task.WaitAsync(timeout, cancellationToken);
 
-        logger.LogInformation("Got response for task {TaskId}: state={State}", taskId, result.State);
+            logger.LogInformation("Got response for task {TaskId}: state={State}", taskId, result.State);
 
-        // Map RockBot result back to A2A v1 Message
-        var responseText = result.Message?.Parts
-            .Where(p => p.Kind == "text")
-            .Select(p => p.Text)
-            .FirstOrDefault() ?? "(no response)";
+            // Map RockBot result back to A2A v1 Message
+            var responseText = result.Message?.Parts
+                .Where(p => p.Kind == "text")
+                .Select(p => p.Text)
+                .FirstOrDefault() ?? "(no response)";
 
-        await eventQueue.EnqueueMessageAsync(new Message
+            var responseMessage = new Message
+            {
+                Role = Role.Agent,
+                Parts = [new Part { Text = responseText }]
+            };
+
+            // Persist the completed task so ListTasks can return it.
+            // The SDK's A2AServer manages task state in memory for synchronous
+            // SendMessage flows without calling SaveTaskAsync, so we save directly.
+            await taskStore.SaveTaskAsync(taskId, new AgentTask
+            {
+                Id = taskId,
+                ContextId = context.ContextId,
+                Status = new A2ATaskStatus
+                {
+                    State = MapTaskState(result.State),
+                    Message = responseMessage,
+                    Timestamp = DateTimeOffset.UtcNow
+                },
+                History = [
+                    new Message
+                    {
+                        Role = Role.User,
+                        Parts = [new Part { Text = messageText }]
+                    },
+                    responseMessage
+                ]
+            }, cancellationToken);
+
+            await eventQueue.EnqueueMessageAsync(responseMessage, cancellationToken);
+        }
+        finally
         {
-            Role = Role.Agent,
-            Parts = [new Part { Text = responseText }]
-        }, cancellationToken);
+            if (statusSub is not null)
+                await statusSub.DisposeAsync();
+        }
     }
 
     public async Task CancelAsync(RequestContext context, AgentEventQueue eventQueue, CancellationToken cancellationToken)
@@ -120,4 +201,15 @@ internal sealed class RockBotBridgeHandler(
 
         await publisher.PublishAsync("agent.task.cancel.RockBot", envelope, cancellationToken);
     }
+
+    private static TaskState MapTaskState(AgentTaskState state) => state switch
+    {
+        AgentTaskState.Submitted => TaskState.Submitted,
+        AgentTaskState.Working => TaskState.Working,
+        AgentTaskState.InputRequired => TaskState.InputRequired,
+        AgentTaskState.Completed => TaskState.Completed,
+        AgentTaskState.Failed => TaskState.Failed,
+        AgentTaskState.Canceled => TaskState.Canceled,
+        _ => TaskState.Working
+    };
 }

--- a/src/RockBot.A2A.Gateway/RockBotBridgeHandler.cs
+++ b/src/RockBot.A2A.Gateway/RockBotBridgeHandler.cs
@@ -26,6 +26,7 @@ internal sealed class RockBotBridgeHandler(
     IHttpContextAccessor httpContextAccessor,
     IOptions<GatewayOptions> gatewayOptions,
     ITaskStore taskStore,
+    PushNotificationSender pushSender,
     ILogger<RockBotBridgeHandler> logger) : IAgentHandler
 {
     private string GetCallerId() =>
@@ -90,7 +91,7 @@ internal sealed class RockBotBridgeHandler(
                                 .Select(p => p.Text)
                                 .FirstOrDefault();
 
-                            await eventQueue.EnqueueStatusUpdateAsync(new TaskStatusUpdateEvent
+                            var statusEvent = new TaskStatusUpdateEvent
                             {
                                 TaskId = taskId,
                                 ContextId = context.ContextId,
@@ -102,7 +103,10 @@ internal sealed class RockBotBridgeHandler(
                                         : null,
                                     Timestamp = DateTimeOffset.UtcNow
                                 }
-                            }, cancellationToken);
+                            };
+                            await eventQueue.EnqueueStatusUpdateAsync(statusEvent, cancellationToken);
+                            // Fire-and-forget push notification
+                            var __ = pushSender.TrySendStatusUpdateAsync(taskId, statusEvent, cancellationToken);
                         }
                     }
                     catch { /* ignore deserialization errors */ }
@@ -155,7 +159,7 @@ internal sealed class RockBotBridgeHandler(
             // Persist the completed task so ListTasks can return it.
             // The SDK's A2AServer manages task state in memory for synchronous
             // SendMessage flows without calling SaveTaskAsync, so we save directly.
-            await taskStore.SaveTaskAsync(taskId, new AgentTask
+            var completedTask = new AgentTask
             {
                 Id = taskId,
                 ContextId = context.ContextId,
@@ -173,7 +177,9 @@ internal sealed class RockBotBridgeHandler(
                     },
                     responseMessage
                 ]
-            }, cancellationToken);
+            };
+            await taskStore.SaveTaskAsync(taskId, completedTask, cancellationToken);
+            _ = pushSender.TrySendTaskCompletedAsync(taskId, completedTask, cancellationToken);
 
             await eventQueue.EnqueueMessageAsync(responseMessage, cancellationToken);
         }

--- a/src/RockBot.A2A.Gateway/SseWriter.cs
+++ b/src/RockBot.A2A.Gateway/SseWriter.cs
@@ -1,0 +1,62 @@
+using System.Text.Json;
+using A2A;
+
+namespace RockBot.A2A.Gateway;
+
+/// <summary>
+/// Writes <see cref="StreamResponse"/> events to an HTTP response as Server-Sent Events (SSE).
+/// Each event is a JSON-RPC 2.0 result wrapping the <see cref="StreamResponse"/> payload.
+/// </summary>
+internal static class SseWriter
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
+    };
+
+    /// <summary>
+    /// Streams <see cref="StreamResponse"/> events as SSE to the given <see cref="HttpResponse"/>.
+    /// Sets appropriate headers before writing. Each event is formatted as
+    /// <c>data: {"jsonrpc":"2.0","id":...,"result":...}\n\n</c>.
+    /// </summary>
+    public static async Task WriteStreamAsync(
+        HttpResponse response,
+        string idRaw,
+        IAsyncEnumerable<StreamResponse> events,
+        ILogger logger,
+        CancellationToken ct)
+    {
+        response.ContentType = "text/event-stream";
+        response.Headers.CacheControl = "no-cache";
+        response.Headers.Connection = "keep-alive";
+
+        try
+        {
+            await foreach (var evt in events.WithCancellation(ct))
+            {
+                var resultJson = JsonSerializer.Serialize(evt, JsonOptions);
+                var line = $"data: {{\"jsonrpc\":\"2.0\",\"id\":{idRaw},\"result\":{resultJson}}}\n\n";
+                await response.WriteAsync(line, ct);
+                await response.Body.FlushAsync(ct);
+            }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // Client disconnected — expected for SSE
+            logger.LogDebug("SSE stream cancelled (client disconnected)");
+        }
+        catch (A2AException ex)
+        {
+            logger.LogWarning(ex, "A2A error during SSE stream");
+            var escapedMessage = JsonSerializer.Serialize(ex.Message);
+            var errorLine = $"data: {{\"jsonrpc\":\"2.0\",\"id\":{idRaw},\"error\":{{\"code\":{(int)ex.ErrorCode},\"message\":{escapedMessage}}}}}\n\n";
+            try
+            {
+                await response.WriteAsync(errorLine, ct);
+                await response.Body.FlushAsync(ct);
+            }
+            catch { /* response may already be closed */ }
+        }
+    }
+}

--- a/src/RockBot.A2A.Gateway/appsettings.json
+++ b/src/RockBot.A2A.Gateway/appsettings.json
@@ -3,6 +3,9 @@
     "AgentName": "RockBot",
     "Description": "Personal AI agent \u2014 accepts notifications and availability queries",
     "Version": "1.0",
+    "TaskStorePath": "tasks.json",
+    "PushNotificationConfigStorePath": "push-configs.json",
+    "TaskTimeoutSeconds": 120,
     "Skills": [
       {
         "Id": "notify-user",

--- a/tests/RockBot.A2A.Gateway.Tests/FileTaskStoreTests.cs
+++ b/tests/RockBot.A2A.Gateway.Tests/FileTaskStoreTests.cs
@@ -1,0 +1,194 @@
+using System.Security.Claims;
+using A2A;
+using Microsoft.AspNetCore.Http;
+
+using A2ATaskStatus = A2A.TaskStatus;
+
+namespace RockBot.A2A.Gateway.Tests;
+
+[TestClass]
+public class FileTaskStoreTests
+{
+    private static IHttpContextAccessor CreateAccessor(string callerId = "test-caller")
+    {
+        var context = new DefaultHttpContext();
+        context.User = new ClaimsPrincipal(new ClaimsIdentity(
+        [
+            new Claim(ClaimTypes.NameIdentifier, callerId)
+        ], "test"));
+        return new HttpContextAccessor { HttpContext = context };
+    }
+
+    private static AgentTask MakeTask(string id, TaskState state = TaskState.Completed) => new()
+    {
+        Id = id,
+        ContextId = $"ctx-{id}",
+        Status = new A2ATaskStatus
+        {
+            State = state,
+            Timestamp = DateTimeOffset.UtcNow
+        }
+    };
+
+    [TestMethod]
+    public async Task SaveAndRetrieve_RoundTrips()
+    {
+        var store = new FileTaskStore(CreateAccessor(), filePath: null);
+        var task = MakeTask("t1");
+
+        await store.SaveTaskAsync("t1", task, CancellationToken.None);
+        var retrieved = await store.GetTaskAsync("t1", CancellationToken.None);
+
+        Assert.IsNotNull(retrieved);
+        Assert.AreEqual("t1", retrieved!.Id);
+        Assert.AreEqual(TaskState.Completed, retrieved.Status?.State);
+    }
+
+    [TestMethod]
+    public async Task GetTask_NotFound_ReturnsNull()
+    {
+        var store = new FileTaskStore(CreateAccessor(), filePath: null);
+
+        var result = await store.GetTaskAsync("nonexistent", CancellationToken.None);
+        Assert.IsNull(result);
+    }
+
+    [TestMethod]
+    public async Task DeleteTask_RemovesEntry()
+    {
+        var store = new FileTaskStore(CreateAccessor(), filePath: null);
+        await store.SaveTaskAsync("t1", MakeTask("t1"), CancellationToken.None);
+
+        await store.DeleteTaskAsync("t1", CancellationToken.None);
+
+        var result = await store.GetTaskAsync("t1", CancellationToken.None);
+        Assert.IsNull(result);
+    }
+
+    [TestMethod]
+    public async Task ListTasks_ReturnsAllForCaller()
+    {
+        var store = new FileTaskStore(CreateAccessor("alice"), filePath: null);
+        await store.SaveTaskAsync("t1", MakeTask("t1"), CancellationToken.None);
+        await store.SaveTaskAsync("t2", MakeTask("t2"), CancellationToken.None);
+
+        var result = await store.ListTasksAsync(
+            new ListTasksRequest { Tenant = "alice" }, CancellationToken.None);
+
+        Assert.AreEqual(2, result.Tasks.Count);
+        Assert.AreEqual(2, result.TotalSize);
+    }
+
+    [TestMethod]
+    public async Task ListTasks_CallerScoping_FiltersOtherCallers()
+    {
+        // Alice saves a task
+        var aliceStore = new FileTaskStore(CreateAccessor("alice"), filePath: null);
+        await aliceStore.SaveTaskAsync("t1", MakeTask("t1"), CancellationToken.None);
+
+        // Bob saves a task (same store instance, different HTTP context)
+        var bobAccessor = CreateAccessor("bob");
+        // We need to share the same store but swap the accessor.
+        // Since the store captures IHttpContextAccessor at construction, we use a shared store.
+        // For this test, create a separate accessor-aware store by saving directly.
+        // Simpler: use two stores that share the same file.
+        var tempPath = Path.Combine(Path.GetTempPath(), $"task-test-{Guid.NewGuid():N}.json");
+        try
+        {
+            var store1 = new FileTaskStore(CreateAccessor("alice"), tempPath);
+            await store1.SaveTaskAsync("t-alice", MakeTask("t-alice"), CancellationToken.None);
+
+            var store2 = new FileTaskStore(CreateAccessor("bob"), tempPath);
+            await store2.SaveTaskAsync("t-bob", MakeTask("t-bob"), CancellationToken.None);
+
+            // Alice's list should only show her task
+            var aliceResult = await store2.ListTasksAsync(
+                new ListTasksRequest { Tenant = "alice" }, CancellationToken.None);
+            Assert.AreEqual(1, aliceResult.Tasks.Count);
+            Assert.AreEqual("t-alice", aliceResult.Tasks[0].Id);
+
+            // Bob's list should only show his task
+            var bobResult = await store2.ListTasksAsync(
+                new ListTasksRequest { Tenant = "bob" }, CancellationToken.None);
+            Assert.AreEqual(1, bobResult.Tasks.Count);
+            Assert.AreEqual("t-bob", bobResult.Tasks[0].Id);
+        }
+        finally
+        {
+            File.Delete(tempPath);
+        }
+    }
+
+    [TestMethod]
+    public async Task ListTasks_StatusFilter()
+    {
+        var store = new FileTaskStore(CreateAccessor("alice"), filePath: null);
+        await store.SaveTaskAsync("t1", MakeTask("t1", TaskState.Completed), CancellationToken.None);
+        await store.SaveTaskAsync("t2", MakeTask("t2", TaskState.Working), CancellationToken.None);
+        await store.SaveTaskAsync("t3", MakeTask("t3", TaskState.Failed), CancellationToken.None);
+
+        var result = await store.ListTasksAsync(
+            new ListTasksRequest { Tenant = "alice", Status = TaskState.Working },
+            CancellationToken.None);
+
+        Assert.AreEqual(1, result.Tasks.Count);
+        Assert.AreEqual("t2", result.Tasks[0].Id);
+    }
+
+    [TestMethod]
+    public async Task ListTasks_Pagination()
+    {
+        var store = new FileTaskStore(CreateAccessor("alice"), filePath: null);
+        for (int i = 1; i <= 5; i++)
+            await store.SaveTaskAsync($"t{i}", MakeTask($"t{i}"), CancellationToken.None);
+
+        var page1 = await store.ListTasksAsync(
+            new ListTasksRequest { Tenant = "alice", PageSize = 2 },
+            CancellationToken.None);
+
+        Assert.AreEqual(2, page1.Tasks.Count);
+        Assert.AreEqual(5, page1.TotalSize);
+        Assert.IsFalse(string.IsNullOrEmpty(page1.NextPageToken));
+
+        var page2 = await store.ListTasksAsync(
+            new ListTasksRequest { Tenant = "alice", PageSize = 2, PageToken = page1.NextPageToken },
+            CancellationToken.None);
+
+        Assert.AreEqual(2, page2.Tasks.Count);
+        // No overlap between pages
+        Assert.IsFalse(page1.Tasks.Select(t => t.Id).Intersect(page2.Tasks.Select(t => t.Id)).Any());
+    }
+
+    [TestMethod]
+    public async Task Persistence_SurvivesReload()
+    {
+        var tempPath = Path.Combine(Path.GetTempPath(), $"task-test-{Guid.NewGuid():N}.json");
+        try
+        {
+            // Save with one instance
+            var store1 = new FileTaskStore(CreateAccessor("alice"), tempPath);
+            await store1.SaveTaskAsync("t1", MakeTask("t1"), CancellationToken.None);
+
+            // Load with a new instance
+            var store2 = new FileTaskStore(CreateAccessor("alice"), tempPath);
+            var task = await store2.GetTaskAsync("t1", CancellationToken.None);
+
+            Assert.IsNotNull(task);
+            Assert.AreEqual("t1", task!.Id);
+        }
+        finally
+        {
+            File.Delete(tempPath);
+        }
+    }
+
+    [TestMethod]
+    public async Task InMemoryMode_WorksWithoutFile()
+    {
+        var store = new FileTaskStore(CreateAccessor(), filePath: null);
+        await store.SaveTaskAsync("t1", MakeTask("t1"), CancellationToken.None);
+
+        var task = await store.GetTaskAsync("t1", CancellationToken.None);
+        Assert.IsNotNull(task);
+    }
+}

--- a/tests/RockBot.A2A.Gateway.Tests/JsonRpcRouterTests.cs
+++ b/tests/RockBot.A2A.Gateway.Tests/JsonRpcRouterTests.cs
@@ -102,6 +102,44 @@ public class JsonRpcRouterTests
         Assert.IsTrue(body.Contains("-32600"), $"Expected invalid-request code, got: {body}");
     }
 
+    /// <summary>
+    /// Agent card should advertise capabilities (streaming, push notifications, extended card).
+    /// </summary>
+    [TestMethod]
+    public async Task GetAgentCard_IncludesCapabilities()
+    {
+        await using var factory = CreateFactory();
+        var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/.well-known/agent-card.json");
+
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.IsTrue(body.Contains("\"streaming\""), $"Expected streaming capability, got: {body}");
+        Assert.IsTrue(body.Contains("\"pushNotifications\""), $"Expected pushNotifications capability, got: {body}");
+        Assert.IsTrue(body.Contains("\"extendedAgentCard\""), $"Expected extendedAgentCard capability, got: {body}");
+    }
+
+    /// <summary>
+    /// POST / with ListTasks method and valid API key should return a JSON-RPC result
+    /// (not method-not-found).
+    /// </summary>
+    [TestMethod]
+    public async Task Post_ListTasks_ReturnsValidResponse()
+    {
+        await using var factory = CreateFactory();
+        var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Add("X-Api-Key", "test-key");
+
+        var payload = JsonRpcRequest("ListTasks", new { });
+        var response = await client.PostAsync("/", payload);
+
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.IsTrue(body.Contains("\"result\""), $"Expected result field, got: {body}");
+        Assert.IsFalse(body.Contains("-32601"), $"Got method-not-found error: {body}");
+    }
+
     private static WebApplicationFactory<Program> CreateFactory()
     {
         return new WebApplicationFactory<Program>()
@@ -109,11 +147,13 @@ public class JsonRpcRouterTests
             {
                 builder.ConfigureAppConfiguration((_, config) =>
                 {
-                    // Override with test API key and disable RabbitMQ connection
+                    // Override with test API key, use in-memory task store, disable RabbitMQ
                     config.AddInMemoryCollection(new Dictionary<string, string?>
                     {
                         ["ApiKeys:test-key:AgentId"] = "test-agent",
                         ["ApiKeys:test-key:DisplayName"] = "Test Agent",
+                        ["Gateway:TaskStorePath"] = null,
+                        ["Gateway:PushNotificationConfigStorePath"] = null,
                         ["RabbitMq:HostName"] = "localhost",
                         ["RabbitMq:Port"] = "5672",
                         ["RabbitMq:UserName"] = "guest",

--- a/tests/RockBot.A2A.Gateway.Tests/SseWriterTests.cs
+++ b/tests/RockBot.A2A.Gateway.Tests/SseWriterTests.cs
@@ -1,0 +1,166 @@
+using System.Text;
+using A2A;
+using Microsoft.AspNetCore.Http;
+
+using A2ATaskStatus = A2A.TaskStatus;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace RockBot.A2A.Gateway.Tests;
+
+[TestClass]
+public class SseWriterTests
+{
+    private static readonly ILogger TestLogger = NullLoggerFactory.Instance.CreateLogger("Test");
+
+    [TestMethod]
+    public async Task WriteStream_SetsCorrectHeaders()
+    {
+        var context = new DefaultHttpContext();
+        context.Response.Body = new MemoryStream();
+
+        await SseWriter.WriteStreamAsync(
+            context.Response,
+            "1",
+            EmptyStream(),
+            TestLogger,
+            CancellationToken.None);
+
+        Assert.AreEqual("text/event-stream", context.Response.ContentType);
+        Assert.AreEqual("no-cache", context.Response.Headers.CacheControl.ToString());
+    }
+
+    [TestMethod]
+    public async Task WriteStream_EmptyStream_WritesNothing()
+    {
+        var context = new DefaultHttpContext();
+        var body = new MemoryStream();
+        context.Response.Body = body;
+
+        await SseWriter.WriteStreamAsync(
+            context.Response,
+            "1",
+            EmptyStream(),
+            TestLogger,
+            CancellationToken.None);
+
+        Assert.AreEqual(0, body.Length);
+    }
+
+    [TestMethod]
+    public async Task WriteStream_SingleEvent_CorrectSseFormat()
+    {
+        var context = new DefaultHttpContext();
+        var body = new MemoryStream();
+        context.Response.Body = body;
+
+        var events = SingleEvent(new StreamResponse
+        {
+            StatusUpdate = new TaskStatusUpdateEvent
+            {
+                TaskId = "t1",
+                Status = new A2ATaskStatus { State = TaskState.Working }
+            }
+        });
+
+        await SseWriter.WriteStreamAsync(
+            context.Response,
+            "42",
+            events,
+            TestLogger,
+            CancellationToken.None);
+
+        body.Seek(0, SeekOrigin.Begin);
+        var output = await new StreamReader(body, Encoding.UTF8).ReadToEndAsync();
+
+        // Must start with "data: " and end with double newline
+        Assert.IsTrue(output.StartsWith("data: "), $"Expected SSE data prefix, got: {output}");
+        Assert.IsTrue(output.EndsWith("\n\n"), $"Expected double newline, got: {output}");
+
+        // Must contain JSON-RPC envelope with our ID
+        Assert.IsTrue(output.Contains("\"jsonrpc\":\"2.0\""), $"Missing jsonrpc field: {output}");
+        Assert.IsTrue(output.Contains("\"id\":42"), $"Missing id field: {output}");
+        Assert.IsTrue(output.Contains("\"result\":"), $"Missing result field: {output}");
+    }
+
+    [TestMethod]
+    public async Task WriteStream_MultipleEvents_EachOnSeparateLine()
+    {
+        var context = new DefaultHttpContext();
+        var body = new MemoryStream();
+        context.Response.Body = body;
+
+        var events = MultipleEvents(
+            new StreamResponse { Message = new Message { Role = Role.Agent, Parts = [new Part { Text = "one" }] } },
+            new StreamResponse { Message = new Message { Role = Role.Agent, Parts = [new Part { Text = "two" }] } }
+        );
+
+        await SseWriter.WriteStreamAsync(
+            context.Response,
+            "1",
+            events,
+            TestLogger,
+            CancellationToken.None);
+
+        body.Seek(0, SeekOrigin.Begin);
+        var output = await new StreamReader(body, Encoding.UTF8).ReadToEndAsync();
+
+        // Count SSE events (split by double newline)
+        var eventCount = output.Split("\n\n", StringSplitOptions.RemoveEmptyEntries).Length;
+        Assert.AreEqual(2, eventCount, $"Expected 2 events, got output: {output}");
+    }
+
+    [TestMethod]
+    public async Task WriteStream_Cancellation_HandledGracefully()
+    {
+        var context = new DefaultHttpContext();
+        context.Response.Body = new MemoryStream();
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel(); // Pre-cancel
+
+        // Should not throw
+        await SseWriter.WriteStreamAsync(
+            context.Response,
+            "1",
+            NeverEndingStream(),
+            TestLogger,
+            cts.Token);
+    }
+
+    private static async IAsyncEnumerable<StreamResponse> EmptyStream()
+    {
+        await Task.CompletedTask;
+        yield break;
+    }
+
+    private static async IAsyncEnumerable<StreamResponse> SingleEvent(StreamResponse evt)
+    {
+        await Task.CompletedTask;
+        yield return evt;
+    }
+
+    private static async IAsyncEnumerable<StreamResponse> MultipleEvents(params StreamResponse[] events)
+    {
+        await Task.CompletedTask;
+        foreach (var evt in events)
+            yield return evt;
+    }
+
+    private static async IAsyncEnumerable<StreamResponse> NeverEndingStream(
+        [System.Runtime.CompilerServices.EnumeratorCancellation] System.Threading.CancellationToken ct = default)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            yield return new StreamResponse
+            {
+                StatusUpdate = new TaskStatusUpdateEvent
+                {
+                    TaskId = "t1",
+                    Status = new A2ATaskStatus { State = TaskState.Working }
+                }
+            };
+            await Task.Delay(100, ct);
+        }
+    }
+}

--- a/tests/RockBot.A2A.IntegrationTests/Scenarios/HttpA2AScenarios.cs
+++ b/tests/RockBot.A2A.IntegrationTests/Scenarios/HttpA2AScenarios.cs
@@ -142,6 +142,272 @@ internal static class HttpA2AScenarios
         Assert(body.Contains("Authentication required"), $"Expected auth error message, got: {body}");
     }
 
+    /// <summary>
+    /// Scenario 4: Verify the agent card advertises streaming, push notification, and extended card capabilities.
+    /// </summary>
+    public static async Task AgentCardCapabilitiesAsync(string gatewayUrl, IServiceProvider services, CancellationToken ct)
+    {
+        var httpClientFactory = services.GetRequiredService<IHttpClientFactory>();
+        var httpClient = httpClientFactory.CreateClient();
+
+        HttpResponseMessage? response = null;
+        for (var attempt = 0; attempt < 30; attempt++)
+        {
+            try
+            {
+                response = await httpClient.GetAsync($"{gatewayUrl}/.well-known/agent-card.json", ct);
+                if (response.IsSuccessStatusCode) break;
+            }
+            catch (HttpRequestException) when (!ct.IsCancellationRequested) { }
+            await Task.Delay(1000, ct);
+        }
+        Assert(response is not null, "Could not connect to A2A gateway after retries");
+        response!.EnsureSuccessStatusCode();
+
+        var card = await response.Content.ReadFromJsonAsync<A2AV1.AgentCard>(JsonOptions, ct);
+        Assert(card is not null, "Agent card is null");
+        Assert(card!.Capabilities is not null, "Agent card Capabilities is null");
+        Assert(card.Capabilities!.Streaming == true, $"Expected Streaming=true, got {card.Capabilities.Streaming}");
+        Assert(card.Capabilities.PushNotifications == true, $"Expected PushNotifications=true, got {card.Capabilities.PushNotifications}");
+        Assert(card.Capabilities.ExtendedAgentCard == true, $"Expected ExtendedAgentCard=true, got {card.Capabilities.ExtendedAgentCard}");
+    }
+
+    /// <summary>
+    /// Scenario 5: Send a task, then verify it appears in ListTasks.
+    /// </summary>
+    public static async Task SendAndListTasksAsync(string gatewayUrl, string? apiKey, IServiceProvider services, CancellationToken ct)
+    {
+        var a2aClient = CreateA2AClient(gatewayUrl, apiKey, services);
+        await WaitForGateway(gatewayUrl, services, ct);
+
+        // Send a task first
+        var sendRequest = new A2AV1.SendMessageRequest
+        {
+            Message = new A2AV1.Message
+            {
+                Role = A2AV1.Role.User,
+                MessageId = Guid.NewGuid().ToString("N"),
+                Parts = [new A2AV1.Part { Text = "Integration test: ListTasks verification" }]
+            },
+            Metadata = new Dictionary<string, JsonElement>
+            {
+                ["skill"] = JsonSerializer.SerializeToElement("notify-user")
+            }
+        };
+        var sendResponse = await a2aClient.SendMessageAsync(sendRequest, ct);
+        Assert(sendResponse is not null, "SendMessage response is null");
+
+        // Now list tasks — should include the one we just sent
+        var listResponse = await a2aClient.ListTasksAsync(new A2AV1.ListTasksRequest(), ct);
+        Assert(listResponse is not null, "ListTasks response is null");
+        Assert(listResponse!.Tasks is not null, "ListTasks Tasks list is null");
+        Assert(listResponse.Tasks.Count >= 1, $"Expected at least 1 task, got {listResponse.Tasks.Count}");
+    }
+
+    /// <summary>
+    /// Scenario 6: Send a streaming message and consume SSE events.
+    /// The EchoChatClient agent will process the task and return a result;
+    /// we verify that at least one StreamResponse event arrives via SSE.
+    /// </summary>
+    public static async Task SendStreamingMessageAsync(string gatewayUrl, string? apiKey, IServiceProvider services, CancellationToken ct)
+    {
+        var a2aClient = CreateA2AClient(gatewayUrl, apiKey, services);
+        await WaitForGateway(gatewayUrl, services, ct);
+
+        var sendRequest = new A2AV1.SendMessageRequest
+        {
+            Message = new A2AV1.Message
+            {
+                Role = A2AV1.Role.User,
+                MessageId = Guid.NewGuid().ToString("N"),
+                Parts = [new A2AV1.Part { Text = "Integration test: streaming response" }]
+            },
+            Metadata = new Dictionary<string, JsonElement>
+            {
+                ["skill"] = JsonSerializer.SerializeToElement("notify-user")
+            }
+        };
+
+        var events = new List<A2AV1.StreamResponse>();
+        await foreach (var evt in a2aClient.SendStreamingMessageAsync(sendRequest, ct))
+        {
+            events.Add(evt);
+        }
+
+        Assert(events.Count >= 1, $"Expected at least 1 SSE event, got {events.Count}");
+
+        // The last event should contain either a message or a completed task
+        var last = events[^1];
+        var hasContent = last.PayloadCase switch
+        {
+            A2AV1.StreamResponseCase.Message when last.Message is { } msg =>
+                msg.Parts.Any(p => !string.IsNullOrEmpty(p.Text)),
+            A2AV1.StreamResponseCase.Task when last.Task is { } task =>
+                task.Status?.State is A2AV1.TaskState.Completed or A2AV1.TaskState.Working,
+            A2AV1.StreamResponseCase.StatusUpdate when last.StatusUpdate is { } su =>
+                su.Status is not null,
+            _ => false
+        };
+        Assert(hasContent, $"Expected content in final SSE event, got PayloadCase={last.PayloadCase}");
+    }
+
+    /// <summary>
+    /// Scenario 7: Exercise push notification config CRUD — create, get, list, delete.
+    /// If the SDK's A2AServer doesn't support push notifications (no store wired up),
+    /// the test catches the expected error and passes with a note.
+    /// </summary>
+    public static async Task PushNotificationConfigCrudAsync(string gatewayUrl, string? apiKey, IServiceProvider services, CancellationToken ct)
+    {
+        var a2aClient = CreateA2AClient(gatewayUrl, apiKey, services);
+        await WaitForGateway(gatewayUrl, services, ct);
+
+        // First, create a task so we have a valid task ID
+        var sendRequest = new A2AV1.SendMessageRequest
+        {
+            Message = new A2AV1.Message
+            {
+                Role = A2AV1.Role.User,
+                MessageId = Guid.NewGuid().ToString("N"),
+                Parts = [new A2AV1.Part { Text = "Integration test: push notification CRUD" }]
+            },
+            Metadata = new Dictionary<string, JsonElement>
+            {
+                ["skill"] = JsonSerializer.SerializeToElement("notify-user")
+            }
+        };
+        var sendResponse = await a2aClient.SendMessageAsync(sendRequest, ct);
+        Assert(sendResponse is not null, "SendMessage response is null");
+
+        // Extract task ID from the response
+        var taskId = sendResponse!.PayloadCase == A2AV1.SendMessageResponseCase.Task
+            ? sendResponse.Task?.Id
+            : null;
+
+        // If we got a Message (not a Task), get the task ID from ListTasks
+        if (taskId is null)
+        {
+            var list = await a2aClient.ListTasksAsync(new A2AV1.ListTasksRequest(), ct);
+            taskId = list?.Tasks?.FirstOrDefault()?.Id;
+        }
+        Assert(taskId is not null, "Could not obtain a task ID for push notification CRUD");
+
+        var configId = Guid.NewGuid().ToString("N");
+
+        try
+        {
+            // Create
+            var created = await a2aClient.CreateTaskPushNotificationConfigAsync(
+                new A2AV1.CreateTaskPushNotificationConfigRequest
+                {
+                    TaskId = taskId!,
+                    ConfigId = configId,
+                    Config = new A2AV1.PushNotificationConfig
+                    {
+                        Url = "https://example.com/webhook",
+                        Token = "test-token-123"
+                    }
+                }, ct);
+            Assert(created is not null, "CreateTaskPushNotificationConfig returned null");
+            Assert(created!.Id == configId, $"Expected config ID '{configId}', got '{created.Id}'");
+
+            // Get
+            var fetched = await a2aClient.GetTaskPushNotificationConfigAsync(
+                new A2AV1.GetTaskPushNotificationConfigRequest
+                {
+                    TaskId = taskId!,
+                    Id = configId
+                }, ct);
+            Assert(fetched is not null, "GetTaskPushNotificationConfig returned null");
+            Assert(fetched!.PushNotificationConfig?.Url == "https://example.com/webhook",
+                $"Expected URL 'https://example.com/webhook', got '{fetched.PushNotificationConfig?.Url}'");
+
+            // List
+            var listed = await a2aClient.ListTaskPushNotificationConfigAsync(
+                new A2AV1.ListTaskPushNotificationConfigRequest { TaskId = taskId! }, ct);
+            Assert(listed is not null, "ListTaskPushNotificationConfig returned null");
+            Assert(listed!.Configs.Any(c => c.Id == configId),
+                "Created config not found in list");
+
+            // Delete
+            await a2aClient.DeleteTaskPushNotificationConfigAsync(
+                new A2AV1.DeleteTaskPushNotificationConfigRequest
+                {
+                    TaskId = taskId!,
+                    Id = configId
+                }, ct);
+
+            // Verify deletion
+            var afterDelete = await a2aClient.ListTaskPushNotificationConfigAsync(
+                new A2AV1.ListTaskPushNotificationConfigRequest { TaskId = taskId! }, ct);
+            Assert(!afterDelete!.Configs.Any(c => c.Id == configId),
+                "Config still present after deletion");
+        }
+        catch (A2AV1.A2AException ex) when (ex.ErrorCode == A2AV1.A2AErrorCode.PushNotificationNotSupported)
+        {
+            // Expected if the SDK's A2AServer doesn't have a push notification store.
+            // This is a known limitation — pass with a note rather than fail.
+            throw new Exception(
+                $"Push notifications not supported by SDK's A2AServer (code={ex.ErrorCode}). " +
+                "A custom push notification store needs to be wired up. Treating as known limitation.");
+        }
+    }
+
+    /// <summary>
+    /// Scenario 8: Fetch the extended agent card.
+    /// If the SDK returns ExtendedAgentCardNotConfigured, the test catches it and notes the limitation.
+    /// </summary>
+    public static async Task GetExtendedAgentCardAsync(string gatewayUrl, string? apiKey, IServiceProvider services, CancellationToken ct)
+    {
+        var a2aClient = CreateA2AClient(gatewayUrl, apiKey, services);
+        await WaitForGateway(gatewayUrl, services, ct);
+
+        try
+        {
+            var card = await a2aClient.GetExtendedAgentCardAsync(
+                new A2AV1.GetExtendedAgentCardRequest(), ct);
+            Assert(card is not null, "Extended agent card is null");
+            Assert(card!.Name == "RockBot", $"Expected Name 'RockBot', got '{card.Name}'");
+        }
+        catch (A2AV1.A2AException ex) when (ex.ErrorCode == A2AV1.A2AErrorCode.ExtendedAgentCardNotConfigured)
+        {
+            // The SDK's A2AServer returns this when no extended card handler is configured.
+            // Our router delegates to A2AServer, which may not support it out of the box.
+            throw new Exception(
+                $"Extended agent card not configured in SDK's A2AServer (code={ex.ErrorCode}). " +
+                "Treating as known limitation.");
+        }
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private static A2AV1.A2AClient CreateA2AClient(string gatewayUrl, string? apiKey, IServiceProvider services)
+    {
+        var httpClientFactory = services.GetRequiredService<IHttpClientFactory>();
+        var httpClient = httpClientFactory.CreateClient();
+        if (apiKey is not null)
+            httpClient.DefaultRequestHeaders.Add("X-Api-Key", apiKey);
+
+        return new A2AV1.A2AClient(new Uri(gatewayUrl.TrimEnd('/')), httpClient);
+    }
+
+    private static async Task WaitForGateway(string gatewayUrl, IServiceProvider services, CancellationToken ct)
+    {
+        var httpClientFactory = services.GetRequiredService<IHttpClientFactory>();
+        var httpClient = httpClientFactory.CreateClient();
+
+        for (var attempt = 0; attempt < 15; attempt++)
+        {
+            try
+            {
+                var probe = await httpClient.GetAsync($"{gatewayUrl}/.well-known/agent-card.json", ct);
+                if (probe.IsSuccessStatusCode) return;
+            }
+            catch (HttpRequestException) when (!ct.IsCancellationRequested) { }
+            await Task.Delay(1000, ct);
+        }
+        throw new Exception("Gateway not ready after 15 retries");
+    }
+
     private static void Assert(bool condition, string message)
     {
         if (!condition) throw new Exception(message);

--- a/tests/RockBot.A2A.IntegrationTests/Scenarios/HttpA2AScenarios.cs
+++ b/tests/RockBot.A2A.IntegrationTests/Scenarios/HttpA2AScenarios.cs
@@ -293,89 +293,69 @@ internal static class HttpA2AScenarios
 
         var configId = Guid.NewGuid().ToString("N");
 
-        try
-        {
-            // Create
-            var created = await a2aClient.CreateTaskPushNotificationConfigAsync(
-                new A2AV1.CreateTaskPushNotificationConfigRequest
+        // Create
+        var created = await a2aClient.CreateTaskPushNotificationConfigAsync(
+            new A2AV1.CreateTaskPushNotificationConfigRequest
+            {
+                TaskId = taskId!,
+                ConfigId = configId,
+                Config = new A2AV1.PushNotificationConfig
                 {
-                    TaskId = taskId!,
-                    ConfigId = configId,
-                    Config = new A2AV1.PushNotificationConfig
-                    {
-                        Url = "https://example.com/webhook",
-                        Token = "test-token-123"
-                    }
-                }, ct);
-            Assert(created is not null, "CreateTaskPushNotificationConfig returned null");
-            Assert(created!.Id == configId, $"Expected config ID '{configId}', got '{created.Id}'");
+                    Url = "https://example.com/webhook",
+                    Token = "test-token-123"
+                }
+            }, ct);
+        Assert(created is not null, "CreateTaskPushNotificationConfig returned null");
+        Assert(created!.Id == configId, $"Expected config ID '{configId}', got '{created.Id}'");
 
-            // Get
-            var fetched = await a2aClient.GetTaskPushNotificationConfigAsync(
-                new A2AV1.GetTaskPushNotificationConfigRequest
-                {
-                    TaskId = taskId!,
-                    Id = configId
-                }, ct);
-            Assert(fetched is not null, "GetTaskPushNotificationConfig returned null");
-            Assert(fetched!.PushNotificationConfig?.Url == "https://example.com/webhook",
-                $"Expected URL 'https://example.com/webhook', got '{fetched.PushNotificationConfig?.Url}'");
+        // Get
+        var fetched = await a2aClient.GetTaskPushNotificationConfigAsync(
+            new A2AV1.GetTaskPushNotificationConfigRequest
+            {
+                TaskId = taskId!,
+                Id = configId
+            }, ct);
+        Assert(fetched is not null, "GetTaskPushNotificationConfig returned null");
+        Assert(fetched!.PushNotificationConfig?.Url == "https://example.com/webhook",
+            $"Expected URL 'https://example.com/webhook', got '{fetched.PushNotificationConfig?.Url}'");
 
-            // List
-            var listed = await a2aClient.ListTaskPushNotificationConfigAsync(
-                new A2AV1.ListTaskPushNotificationConfigRequest { TaskId = taskId! }, ct);
-            Assert(listed is not null, "ListTaskPushNotificationConfig returned null");
-            Assert(listed!.Configs.Any(c => c.Id == configId),
-                "Created config not found in list");
+        // List
+        var listed = await a2aClient.ListTaskPushNotificationConfigAsync(
+            new A2AV1.ListTaskPushNotificationConfigRequest { TaskId = taskId! }, ct);
+        Assert(listed is not null, "ListTaskPushNotificationConfig returned null");
+        Assert(listed!.Configs.Any(c => c.Id == configId),
+            "Created config not found in list");
 
-            // Delete
-            await a2aClient.DeleteTaskPushNotificationConfigAsync(
-                new A2AV1.DeleteTaskPushNotificationConfigRequest
-                {
-                    TaskId = taskId!,
-                    Id = configId
-                }, ct);
+        // Delete
+        await a2aClient.DeleteTaskPushNotificationConfigAsync(
+            new A2AV1.DeleteTaskPushNotificationConfigRequest
+            {
+                TaskId = taskId!,
+                Id = configId
+            }, ct);
 
-            // Verify deletion
-            var afterDelete = await a2aClient.ListTaskPushNotificationConfigAsync(
-                new A2AV1.ListTaskPushNotificationConfigRequest { TaskId = taskId! }, ct);
-            Assert(!afterDelete!.Configs.Any(c => c.Id == configId),
-                "Config still present after deletion");
-        }
-        catch (A2AV1.A2AException ex) when (ex.ErrorCode == A2AV1.A2AErrorCode.PushNotificationNotSupported)
-        {
-            // Expected if the SDK's A2AServer doesn't have a push notification store.
-            // This is a known limitation — pass with a note rather than fail.
-            throw new Exception(
-                $"Push notifications not supported by SDK's A2AServer (code={ex.ErrorCode}). " +
-                "A custom push notification store needs to be wired up. Treating as known limitation.");
-        }
+        // Verify deletion
+        var afterDelete = await a2aClient.ListTaskPushNotificationConfigAsync(
+            new A2AV1.ListTaskPushNotificationConfigRequest { TaskId = taskId! }, ct);
+        Assert(!afterDelete!.Configs.Any(c => c.Id == configId),
+            "Config still present after deletion");
     }
 
     /// <summary>
-    /// Scenario 8: Fetch the extended agent card.
-    /// If the SDK returns ExtendedAgentCardNotConfigured, the test catches it and notes the limitation.
+    /// Scenario 8: Fetch the extended agent card with capabilities.
     /// </summary>
     public static async Task GetExtendedAgentCardAsync(string gatewayUrl, string? apiKey, IServiceProvider services, CancellationToken ct)
     {
         var a2aClient = CreateA2AClient(gatewayUrl, apiKey, services);
         await WaitForGateway(gatewayUrl, services, ct);
 
-        try
-        {
-            var card = await a2aClient.GetExtendedAgentCardAsync(
-                new A2AV1.GetExtendedAgentCardRequest(), ct);
-            Assert(card is not null, "Extended agent card is null");
-            Assert(card!.Name == "RockBot", $"Expected Name 'RockBot', got '{card.Name}'");
-        }
-        catch (A2AV1.A2AException ex) when (ex.ErrorCode == A2AV1.A2AErrorCode.ExtendedAgentCardNotConfigured)
-        {
-            // The SDK's A2AServer returns this when no extended card handler is configured.
-            // Our router delegates to A2AServer, which may not support it out of the box.
-            throw new Exception(
-                $"Extended agent card not configured in SDK's A2AServer (code={ex.ErrorCode}). " +
-                "Treating as known limitation.");
-        }
+        var card = await a2aClient.GetExtendedAgentCardAsync(
+            new A2AV1.GetExtendedAgentCardRequest(), ct);
+        Assert(card is not null, "Extended agent card is null");
+        Assert(card!.Name == "RockBot", $"Expected Name 'RockBot', got '{card.Name}'");
+        Assert(card.Capabilities is not null, "Extended card should include capabilities");
+        Assert(card.Capabilities!.Streaming == true, "Extended card should advertise streaming");
+        Assert(card.Skills is { Count: >= 2 }, $"Expected at least 2 skills, got {card.Skills?.Count ?? 0}");
     }
 
     // ── Helpers ─────────────────────────────────────────────────────────────

--- a/tests/RockBot.A2A.IntegrationTests/TestRunner.cs
+++ b/tests/RockBot.A2A.IntegrationTests/TestRunner.cs
@@ -36,6 +36,31 @@ internal sealed class TestRunner(IServiceProvider services, TestConfig config)
             ct => Scenarios.HttpA2AScenarios.UnauthenticatedRequestRejectedAsync(config.GatewayUrl, services, ct),
             timeout: TimeSpan.FromSeconds(15)));
 
+        // Agent card capabilities (streaming, push notifications, extended card)
+        results.Add(await RunAsync("A2A: Agent Card Capabilities",
+            ct => Scenarios.HttpA2AScenarios.AgentCardCapabilitiesAsync(config.GatewayUrl, services, ct),
+            timeout: TimeSpan.FromSeconds(30)));
+
+        // ListTasks — send a task, then verify it appears in the list
+        results.Add(await RunAsync("A2A: Send + ListTasks",
+            ct => Scenarios.HttpA2AScenarios.SendAndListTasksAsync(config.GatewayUrl, config.GatewayApiKey, services, ct),
+            timeout: TimeSpan.FromSeconds(90)));
+
+        // SSE streaming — send a streaming request and consume events
+        results.Add(await RunAsync("A2A: SendStreamingMessage",
+            ct => Scenarios.HttpA2AScenarios.SendStreamingMessageAsync(config.GatewayUrl, config.GatewayApiKey, services, ct),
+            timeout: TimeSpan.FromSeconds(90)));
+
+        // Push notification config CRUD
+        results.Add(await RunAsync("A2A: Push Notification Config CRUD",
+            ct => Scenarios.HttpA2AScenarios.PushNotificationConfigCrudAsync(config.GatewayUrl, config.GatewayApiKey, services, ct),
+            timeout: TimeSpan.FromSeconds(60)));
+
+        // Extended agent card
+        results.Add(await RunAsync("A2A: GetExtendedAgentCard",
+            ct => Scenarios.HttpA2AScenarios.GetExtendedAgentCardAsync(config.GatewayUrl, config.GatewayApiKey, services, ct),
+            timeout: TimeSpan.FromSeconds(30)));
+
         // RabbitMQ discovery — RockBot may take a while to start
         results.Add(await RunAsync("Discovery: RockBot AgentCard",
             ct => Scenarios.DiscoveryScenario.VerifyAnnouncementAsync(services, ct),


### PR DESCRIPTION
## Summary

Closes #262. Adds the remaining A2A v1 protocol methods to the HTTP gateway:

- **SSE streaming** — `SendStreamingMessage` and `SubscribeToTask` via `SseWriter` (text/event-stream)
- **ListTasks** — file-backed `FileTaskStore` replacing `InMemoryTaskStore` for durable, caller-scoped task queries with filtering and pagination
- **Push notification config CRUD** — `CreateTaskPushNotificationConfig`, `GetTaskPushNotificationConfig`, `ListTaskPushNotificationConfig`, `DeleteTaskPushNotificationConfig` routed through `A2AServer`
- **GetExtendedAgentCard** — routed through `A2AServer`
- **Agent card capabilities** — advertises `streaming`, `pushNotifications`, `extendedAgentCard`
- **Documentation** — new "A2A HTTP Gateway (inbound)" section in `docs/a2a.md`, gateway added to `README.md` components table
- **Integration tests** — 5 new docker-compose scenarios: capabilities, Send+ListTasks, SSE streaming, push notification CRUD, extended agent card

### Known SDK limitations

Two methods return errors from the A2A SDK's `A2AServer` (not our code):
- Push notification CRUD → `PushNotificationNotSupported` (SDK has no push notification store)
- GetExtendedAgentCard → `ExtendedAgentCardNotConfigured` (SDK has no extended card handler)

These will need custom implementations bypassing `A2AServer` — tracked for follow-up.

### Related issues
- #264 — JWT/Bearer auth (split out from this issue)
- #265 — Outbound A2A long-running task support

## Test plan

- [x] `dotnet build RockBot.slnx` — clean build
- [x] `dotnet test RockBot.slnx` — all unit tests pass (28 gateway tests including new FileTaskStore and SseWriter tests)
- [x] `docker compose -f deploy/docker-compose/docker-compose.a2a-test.yml up --build` — 10/12 integration tests pass (2 are known SDK limitations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)