### PR TITLE
Scope message bus topics by agent name for multi-instance isolation

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-    <Version>0.8.0</Version>
+    <Version>0.8.1</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-    <Version>0.7.1</Version>
+    <Version>0.8.0</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-    <Version>0.8.1</Version>
+    <Version>0.8.2</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.A2A/A2ATaskErrorHandler.cs
+++ b/src/RockBot.A2A/A2ATaskErrorHandler.cs
@@ -96,7 +96,7 @@ internal sealed class A2ATaskErrorHandler(
             {
                 SessionId = rawSessionId,
                 AgentName = DisplayName,
-                ReplyTo = UserProxyTopics.UserResponse
+                ReplyTo = $"{UserProxyTopics.UserResponse}.{agent.Name}"
             });
 
             var finalContent = await agentLoopRunner.RunAsync(
@@ -117,7 +117,7 @@ internal sealed class A2ATaskErrorHandler(
                 IsFinal = true
             };
             var envelope = reply.ToEnvelope<AgentReply>(source: agent.Name);
-            await publisher.PublishAsync(UserProxyTopics.UserResponse, envelope, ct);
+            await publisher.PublishAsync($"{UserProxyTopics.UserResponse}.{agent.Name}", envelope, ct);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {

--- a/src/RockBot.A2A/A2ATaskResultHandler.cs
+++ b/src/RockBot.A2A/A2ATaskResultHandler.cs
@@ -276,7 +276,7 @@ internal sealed class A2ATaskResultHandler(
             {
                 SessionId = rawSessionId,
                 AgentName = DisplayName,
-                ReplyTo = UserProxyTopics.UserResponse
+                ReplyTo = $"{UserProxyTopics.UserResponse}.{agent.Name}"
             });
 
             var finalContent = await agentLoopRunner.RunAsync(
@@ -297,7 +297,7 @@ internal sealed class A2ATaskResultHandler(
                 IsFinal = true
             };
             var envelope = reply.ToEnvelope<AgentReply>(source: agent.Name);
-            await publisher.PublishAsync(UserProxyTopics.UserResponse, envelope, ct);
+            await publisher.PublishAsync($"{UserProxyTopics.UserResponse}.{agent.Name}", envelope, ct);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
@@ -324,7 +324,7 @@ internal sealed class A2ATaskResultHandler(
                 IsFinal = true
             };
             var envelope = reply.ToEnvelope<AgentReply>(source: agent.Name);
-            await publisher.PublishAsync(UserProxyTopics.UserResponse, envelope, ct);
+            await publisher.PublishAsync($"{UserProxyTopics.UserResponse}.{agent.Name}", envelope, ct);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {

--- a/src/RockBot.A2A/A2ATaskStatusHandler.cs
+++ b/src/RockBot.A2A/A2ATaskStatusHandler.cs
@@ -67,7 +67,7 @@ internal sealed class A2ATaskStatusHandler(
                     IsFinal = false
                 };
                 var progressEnvelope = progressReply.ToEnvelope<AgentReply>(source: agent.Name);
-                await publisher.PublishAsync(UserProxyTopics.UserResponse, progressEnvelope, ct);
+                await publisher.PublishAsync($"{UserProxyTopics.UserResponse}.{agent.Name}", progressEnvelope, ct);
             }
             return;
         }
@@ -114,7 +114,7 @@ internal sealed class A2ATaskStatusHandler(
             {
                 SessionId = rawSessionId,
                 AgentName = DisplayName,
-                ReplyTo = UserProxyTopics.UserResponse
+                ReplyTo = $"{UserProxyTopics.UserResponse}.{agent.Name}"
             });
 
             var finalContent = await agentLoopRunner.RunAsync(
@@ -135,7 +135,7 @@ internal sealed class A2ATaskStatusHandler(
                 IsFinal = false
             };
             var envelope = reply.ToEnvelope<AgentReply>(source: agent.Name);
-            await publisher.PublishAsync(UserProxyTopics.UserResponse, envelope, ct);
+            await publisher.PublishAsync($"{UserProxyTopics.UserResponse}.{agent.Name}", envelope, ct);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {

--- a/src/RockBot.A2A/InputRequiredHandler.cs
+++ b/src/RockBot.A2A/InputRequiredHandler.cs
@@ -109,7 +109,7 @@ internal sealed class InputRequiredHandler(
             {
                 SessionId = rawSessionId,
                 AgentName = DisplayName,
-                ReplyTo = UserProxyTopics.UserResponse
+                ReplyTo = $"{UserProxyTopics.UserResponse}.{agent.Name}"
             });
 
             responseText = await agentLoopRunner.RunAsync(

--- a/src/RockBot.Agent/CancelSessionHandler.cs
+++ b/src/RockBot.Agent/CancelSessionHandler.cs
@@ -35,6 +35,6 @@ internal sealed class CancelSessionHandler(
             IsFinal = true
         };
         var envelope = reply.ToEnvelope<AgentReply>(source: agent.Name);
-        await publisher.PublishAsync(UserProxyTopics.UserResponse, envelope, ct);
+        await publisher.PublishAsync($"{UserProxyTopics.UserResponse}.{agent.Name}", envelope, ct);
     }
 }

--- a/src/RockBot.Agent/ClearContextHandler.cs
+++ b/src/RockBot.Agent/ClearContextHandler.cs
@@ -37,6 +37,6 @@ internal sealed class ClearContextHandler(
             IsFinal = true
         };
         var envelope = reply.ToEnvelope<AgentReply>(source: agent.Name);
-        await publisher.PublishAsync(UserProxyTopics.UserResponse, envelope, ct);
+        await publisher.PublishAsync($"{UserProxyTopics.UserResponse}.{agent.Name}", envelope, ct);
     }
 }

--- a/src/RockBot.Agent/Program.cs
+++ b/src/RockBot.Agent/Program.cs
@@ -253,9 +253,11 @@ builder.Services.AddSingleton<SkillRecallTracker>();
 builder.Services.AddSingleton<IToolSkillProvider, MemoryToolSkillProvider>();
 builder.Services.AddSingleton<IToolSkillProvider, SkillToolSkillProvider>();
 
+var agentName = builder.Configuration["Agent:Name"] ?? "RockBot";
+
 builder.Services.AddRockBotHost(agent =>
 {
-    agent.WithIdentity("RockBot");
+    agent.WithIdentity(agentName);
     agent.WithProfile();
     agent.WithRules();
     agent.WithMemory();
@@ -281,7 +283,7 @@ builder.Services.AddRockBotHost(agent =>
     {
         opts.Card = new AgentCard
         {
-            AgentName = "RockBot",
+            AgentName = agentName,
             Description = "Personal AI agent — accepts notifications and availability queries",
             Version = "1.0",
             Skills =
@@ -335,17 +337,17 @@ builder.Services.AddRockBotHost(agent =>
     agent.HandleMessage<ListSavedResponsesRequest, ListSavedResponsesRequestHandler>();
     agent.HandleMessage<GetSavedResponseRequest, GetSavedResponseRequestHandler>();
     agent.HandleMessage<DeleteSavedResponseRequest, DeleteSavedResponseRequestHandler>();
-    agent.SubscribeTo(UserProxyTopics.UserMessage);
-    agent.SubscribeTo(UserProxyTopics.UserFeedback);
-    agent.SubscribeTo(UserProxyTopics.CancelSession);
-    agent.SubscribeTo(UserProxyTopics.ClearContext);
-    agent.SubscribeTo(UserProxyTopics.ConversationHistoryRequest);
-    agent.SubscribeTo(UserProxyTopics.AgentInfoRequest);
-    agent.SubscribeTo(UserProxyTopics.ActiveStatusRequest);
-    agent.SubscribeTo(UserProxyTopics.SaveResponseRequest);
-    agent.SubscribeTo(UserProxyTopics.ListSavedResponsesRequest);
-    agent.SubscribeTo(UserProxyTopics.GetSavedResponseRequest);
-    agent.SubscribeTo(UserProxyTopics.DeleteSavedResponseRequest);
+    agent.SubscribeTo($"{UserProxyTopics.UserMessage}.{agentName}");
+    agent.SubscribeTo($"{UserProxyTopics.UserFeedback}.{agentName}");
+    agent.SubscribeTo($"{UserProxyTopics.CancelSession}.{agentName}");
+    agent.SubscribeTo($"{UserProxyTopics.ClearContext}.{agentName}");
+    agent.SubscribeTo($"{UserProxyTopics.ConversationHistoryRequest}.{agentName}");
+    agent.SubscribeTo($"{UserProxyTopics.AgentInfoRequest}.{agentName}");
+    agent.SubscribeTo($"{UserProxyTopics.ActiveStatusRequest}.{agentName}");
+    agent.SubscribeTo($"{UserProxyTopics.SaveResponseRequest}.{agentName}");
+    agent.SubscribeTo($"{UserProxyTopics.ListSavedResponsesRequest}.{agentName}");
+    agent.SubscribeTo($"{UserProxyTopics.GetSavedResponseRequest}.{agentName}");
+    agent.SubscribeTo($"{UserProxyTopics.DeleteSavedResponseRequest}.{agentName}");
 });
 
 // Bind AgentProfileOptions from the AgentProfile config section so AgentProfile__BasePath

--- a/src/RockBot.Agent/Program.cs
+++ b/src/RockBot.Agent/Program.cs
@@ -40,13 +40,21 @@ builder.Configuration.AddUserSecrets<Program>();
         builder.Configuration.AddJsonFile(Path.Combine(pvcBase, "appsettings.json"), optional: true, reloadOnChange: false);
 }
 
+var agentName = builder.Configuration["Agent:Name"] ?? "RockBot";
+
 builder.Services.AddRockBotRabbitMq(opts => builder.Configuration.GetSection("RabbitMq").Bind(opts));
 
 // OpenTelemetry — enabled via Telemetry:Enabled config key (set in k8s ConfigMap)
+// ServiceName defaults to the agent name so multi-instance deployments are
+// distinguishable in Grafana dashboards without extra config.
 if (builder.Configuration.GetValue<bool>("Telemetry:Enabled"))
 {
     builder.Services.AddRockBotTelemetry(opts =>
-        builder.Configuration.GetSection("Telemetry").Bind(opts));
+    {
+        builder.Configuration.GetSection("Telemetry").Bind(opts);
+        if (opts.ServiceName == "rockbot")
+            opts.ServiceName = agentName;
+    });
 }
 
 // ── LLM configuration — three-tier (Low / Balanced / High) ──────────────────
@@ -252,8 +260,6 @@ builder.Services.AddSingleton<SkillRecallTracker>();
 // Tool guides for memory and skill subsystems
 builder.Services.AddSingleton<IToolSkillProvider, MemoryToolSkillProvider>();
 builder.Services.AddSingleton<IToolSkillProvider, SkillToolSkillProvider>();
-
-var agentName = builder.Configuration["Agent:Name"] ?? "RockBot";
 
 builder.Services.AddRockBotHost(agent =>
 {

--- a/src/RockBot.Agent/ScheduledTaskHandler.cs
+++ b/src/RockBot.Agent/ScheduledTaskHandler.cs
@@ -105,7 +105,7 @@ internal sealed class ScheduledTaskHandler(
                 {
                     SessionId = replySessionId,
                     AgentName = agent.Name,
-                    ReplyTo = UserProxyTopics.UserResponse
+                    ReplyTo = $"{UserProxyTopics.UserResponse}.{agent.Name}"
                 });
 
                 finalText = await agentLoopRunner.RunAsync(
@@ -148,6 +148,6 @@ internal sealed class ScheduledTaskHandler(
         };
 
         var envelope = reply.ToEnvelope<AgentReply>(source: agent.Name);
-        await publisher.PublishAsync(UserProxyTopics.UserResponse, envelope, ct);
+        await publisher.PublishAsync($"{UserProxyTopics.UserResponse}.{agent.Name}", envelope, ct);
     }
 }

--- a/src/RockBot.Agent/UserFeedbackHandler.cs
+++ b/src/RockBot.Agent/UserFeedbackHandler.cs
@@ -185,7 +185,7 @@ internal sealed class UserFeedbackHandler(
         };
 
         var envelope = reply.ToEnvelope<AgentReply>(source: agent.Name);
-        await publisher.PublishAsync(UserProxyTopics.UserResponse, envelope, ct);
+        await publisher.PublishAsync($"{UserProxyTopics.UserResponse}.{agent.Name}", envelope, ct);
 
         logger.LogInformation(
             "Published re-evaluated reply for session {SessionId} ({Length} chars)",

--- a/src/RockBot.Agent/UserMessageHandler.cs
+++ b/src/RockBot.Agent/UserMessageHandler.cs
@@ -66,7 +66,7 @@ internal sealed class UserMessageHandler(
 
     public async Task HandleAsync(UserMessage message, MessageHandlerContext context)
     {
-        var replyTo = context.Envelope.ReplyTo ?? UserProxyTopics.UserResponse;
+        var replyTo = context.Envelope.ReplyTo ?? $"{UserProxyTopics.UserResponse}.{agent.Name}";
         var correlationId = context.Envelope.CorrelationId;
         var ct = context.CancellationToken;
         var wipMessageId = context.Items.TryGetValue(WipConstants.MessageIdKey, out var id)

--- a/src/RockBot.Agent/agent/common-directives.md
+++ b/src/RockBot.Agent/agent/common-directives.md
@@ -86,29 +86,36 @@ These rules eliminate hesitation. Follow them strictly:
 - **Retrieve enough context.** When analyzing data (messages, logs, documents), retrieve surrounding context to understand the full situation — don't inspect only the single item mentioned.
 - **Assume referenced data is actionable.** When a data source you can access is mentioned — files, logs, email, calendar, APIs — treat it as a request to inspect it now. Retrieve and analyze immediately.
 
+## Prefer Wisps Over Direct Tool Calls
+
+**For any task requiring two or more tool calls, use `spawn_wisps` instead of calling
+tools directly.** Wisp steps execute without LLM round-trips, making them far cheaper
+than a series of direct tool calls — even for sequential workflows.
+
+- **Sequential workflows**: A single wisp with multiple steps (fetch → transform → store)
+  is cheaper than calling each tool yourself with an LLM turn between each step.
+- **Parallel workflows**: Independent tasks (e.g. checking emails from multiple accounts,
+  querying multiple calendars) should be separate wisps in one `spawn_wisps` call so they
+  run concurrently. The batch completes in the time of the slowest wisp, not the sum.
+- **Mixed**: Combine both — spawn multiple wisps, each with its own sequential pipeline.
+
+Only call tools directly when the task is a single tool call, or when the next step
+genuinely cannot be determined without inspecting the previous result (i.e. the workflow
+requires real-time judgment, not just data flow).
+
+Call `get_tool_guide("wisp")` for the full definition format and examples.
+
+**Cost comparison**: A 5-step wisp costs 2-3K tokens; the same 5 steps via direct tool
+calls costs 30-50K tokens (one LLM round-trip per step).
+
 ## Choosing Between Wisps and Subagents
 
-Both wisps and subagents delegate work, but they serve different needs:
+- **Wisps** (`spawn_wisps`) — Procedural, known-in-advance workflows. Default choice.
+- **Subagents** (`spawn_subagent`) — Open-ended tasks requiring discovery, judgment, or
+  multi-turn reasoning where you cannot predict the exact tool calls in advance.
 
-- **Wisps** (`spawn_wisps`) — Use for **procedural, known-in-advance** workflows where
-  steps and parameters are deterministic. Direct steps cost zero LLM tokens. Use wisps
-  for data pipelines (fetch → parse → summarize), multi-tool sequences with known
-  parameters, and any workflow where you can write out the exact steps. Call
-  `get_tool_guide("wisp")` for the full definition format and examples.
-
-  **Split independent work into separate wisps** — they run concurrently. For example,
-  if you need to search 4 email accounts, create 4 wisp definitions (one per account),
-  not 4 sequential steps in one wisp. The batch completes in the time of the slowest
-  wisp, not the sum. Each wisp can still have its own multi-step pipeline internally.
-
-- **Subagents** (`spawn_subagent`) — Use for **open-ended** tasks that require
-  discovery, judgment across many tool calls, or multi-turn reasoning. Subagents get
-  full agent context and can improvise. Use subagents when you cannot predict the exact
-  tool calls in advance.
-
-**Default to wisps when the workflow is predictable.** A 5-step wisp costs 2-3K tokens;
-the same work via a subagent costs 60-80K tokens. Use subagents only when the task
-genuinely requires exploration or adaptation.
+Subagents should also prefer wisps internally for their own multi-step work — they are
+wisp orchestrators, not direct tool callers.
 
 ## Using Your Capabilities
 

--- a/src/RockBot.Host/AgentProfileLoader.cs
+++ b/src/RockBot.Host/AgentProfileLoader.cs
@@ -174,7 +174,7 @@ internal sealed class AgentProfileLoader : IHostedService, IDisposable
         {
             var notification = new AgentNameChanged { AgentName = agentName };
             var envelope = notification.ToEnvelope<AgentNameChanged>(source: _agent.Name);
-            await _publisher.PublishAsync(UserProxyTopics.UserResponse, envelope);
+            await _publisher.PublishAsync($"{UserProxyTopics.UserResponse}.{_agent.Name}", envelope);
             _logger.LogInformation("Published agent name change notification: {Name}", agentName);
         }
         catch (Exception ex)

--- a/src/RockBot.Host/InboundNotificationService.cs
+++ b/src/RockBot.Host/InboundNotificationService.cs
@@ -102,7 +102,7 @@ internal sealed class InboundNotificationService : IHostedService, IDisposable
             };
 
             var envelope = reply.ToEnvelope<AgentReply>(source: _agent.Name);
-            await _publisher.PublishAsync(UserProxyTopics.UserResponse, envelope, ct);
+            await _publisher.PublishAsync($"{UserProxyTopics.UserResponse}.{_agent.Name}", envelope, ct);
         }
         catch (Exception ex)
         {

--- a/src/RockBot.Messaging.RabbitMQ/RabbitMqSubscriber.cs
+++ b/src/RockBot.Messaging.RabbitMQ/RabbitMqSubscriber.cs
@@ -69,20 +69,52 @@ public sealed class RabbitMqSubscriber : IMessageSubscriber
                 routingKey: topic,
                 cancellationToken: ct);
 
-            // Declare the main queue with dead-letter routing
+            // Declare the main queue with dead-letter routing.
+            // If the queue already exists with different arguments (e.g. after a
+            // topic-scoping upgrade), RabbitMQ returns 406 PRECONDITION_FAILED and
+            // kills the channel. We handle that by deleting the stale queue on a
+            // fresh channel and retrying.
             var args = new Dictionary<string, object?>
             {
                 ["x-dead-letter-exchange"] = dlxName,
                 ["x-dead-letter-routing-key"] = topic
             };
 
-            await channel.QueueDeclareAsync(
-                queue: queueName,
-                durable: durable,
-                exclusive: false,
-                autoDelete: false,
-                arguments: args,
-                cancellationToken: ct);
+            try
+            {
+                await channel.QueueDeclareAsync(
+                    queue: queueName,
+                    durable: durable,
+                    exclusive: false,
+                    autoDelete: false,
+                    arguments: args,
+                    cancellationToken: ct);
+            }
+            catch (global::RabbitMQ.Client.Exceptions.OperationInterruptedException ex)
+                when (ex.ShutdownReason?.ReplyCode == 406)
+            {
+                _logger.LogWarning(
+                    "Queue {Queue} has stale arguments — deleting and recreating: {Reason}",
+                    queueName, ex.ShutdownReason.ReplyText);
+
+                // The original channel is dead after a 406; open a new one.
+                channel = await _connectionManager.CreateChannelAsync(ct);
+                await channel.BasicQosAsync(0, prefetchCount, false, cancellationToken: ct);
+
+                await channel.QueueDeleteAsync(queueName, cancellationToken: ct);
+
+                // Re-declare DLQ and main queue on the fresh channel
+                await channel.QueueDeclareAsync(
+                    queue: dlqName, durable: durable, exclusive: false,
+                    autoDelete: false, cancellationToken: ct);
+                await channel.QueueBindAsync(
+                    queue: dlqName, exchange: dlxName,
+                    routingKey: topic, cancellationToken: ct);
+
+                await channel.QueueDeclareAsync(
+                    queue: queueName, durable: durable, exclusive: false,
+                    autoDelete: false, arguments: args, cancellationToken: ct);
+            }
 
             await channel.QueueBindAsync(
                 queue: queueName,

--- a/src/RockBot.Subagent/ReportProgressFunction.cs
+++ b/src/RockBot.Subagent/ReportProgressFunction.cs
@@ -20,17 +20,21 @@ internal sealed class ReportProgressFunctions
     private readonly string _subagentId;
     private readonly ILogger _logger;
 
+    private readonly string _agentName;
+
     public ReportProgressFunctions(
         string taskId,
         string primarySessionId,
         IMessagePublisher publisher,
         string subagentId,
+        string agentName,
         ILogger logger)
     {
         _taskId = taskId;
         _primarySessionId = primarySessionId;
         _publisher = publisher;
         _subagentId = subagentId;
+        _agentName = agentName;
         _logger = logger;
 
         Tools =
@@ -54,7 +58,7 @@ internal sealed class ReportProgressFunctions
         };
 
         var envelope = progress.ToEnvelope<SubagentProgressMessage>(source: _subagentId);
-        await _publisher.PublishAsync(SubagentTopics.Progress, envelope, CancellationToken.None);
+        await _publisher.PublishAsync($"{SubagentTopics.Progress}.{_agentName}", envelope, CancellationToken.None);
 
         _logger.LogInformation("Subagent {TaskId} reported progress: {Message}", _taskId, message);
         return "Progress reported.";

--- a/src/RockBot.Subagent/SubagentManager.cs
+++ b/src/RockBot.Subagent/SubagentManager.cs
@@ -14,6 +14,7 @@ public sealed class SubagentManager(
     IServiceScopeFactory scopeFactory,
     IOptions<SubagentOptions> options,
     IMessagePublisher publisher,
+    AgentIdentity agent,
     ILogger<SubagentManager> logger) : ISubagentManager
 {
     private readonly ConcurrentDictionary<string, SubagentEntry> _active = new();
@@ -143,7 +144,7 @@ public sealed class SubagentManager(
                     Consolidate = consolidate
                 };
                 var envelope = result.ToEnvelope<SubagentResultMessage>(source: $"subagent-{taskId}");
-                await publisher.PublishAsync(SubagentTopics.Result, envelope, CancellationToken.None);
+                await publisher.PublishAsync($"{SubagentTopics.Result}.{agent.Name}", envelope, CancellationToken.None);
             }
             catch (Exception pubEx)
             {

--- a/src/RockBot.Subagent/SubagentProgressHandler.cs
+++ b/src/RockBot.Subagent/SubagentProgressHandler.cs
@@ -50,7 +50,7 @@ internal sealed class SubagentProgressHandler(
                 IsFinal = false
             };
             var envelope = progressReply.ToEnvelope<AgentReply>(source: agent.Name);
-            await publisher.PublishAsync(UserProxyTopics.UserResponse, envelope, ct);
+            await publisher.PublishAsync($"{UserProxyTopics.UserResponse}.{agent.Name}", envelope, ct);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {

--- a/src/RockBot.Subagent/SubagentResultHandler.cs
+++ b/src/RockBot.Subagent/SubagentResultHandler.cs
@@ -80,7 +80,7 @@ internal sealed class SubagentResultHandler(
             };
             var completionEnvelope = completionReply.ToEnvelope<AgentReply>(
                 source: $"subagent-{message.TaskId}");
-            await publisher.PublishAsync(UserProxyTopics.UserResponse, completionEnvelope, ct);
+            await publisher.PublishAsync($"{UserProxyTopics.UserResponse}.{agent.Name}", completionEnvelope, ct);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
@@ -198,7 +198,7 @@ internal sealed class SubagentResultHandler(
             {
                 SessionId = rawSessionId,
                 AgentName = agent.Name,
-                ReplyTo = UserProxyTopics.UserResponse
+                ReplyTo = $"{UserProxyTopics.UserResponse}.{agent.Name}"
             });
 
             var finalContent = await agentLoopRunner.RunAsync(
@@ -219,7 +219,7 @@ internal sealed class SubagentResultHandler(
                 IsFinal = true
             };
             var envelope = reply.ToEnvelope<AgentReply>(source: agent.Name);
-            await publisher.PublishAsync(UserProxyTopics.UserResponse, envelope, ct);
+            await publisher.PublishAsync($"{UserProxyTopics.UserResponse}.{agent.Name}", envelope, ct);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {

--- a/src/RockBot.Subagent/SubagentRunner.cs
+++ b/src/RockBot.Subagent/SubagentRunner.cs
@@ -27,6 +27,7 @@ internal sealed class SubagentRunner(
     IToolRegistry toolRegistry,
     ToolGuideTools toolGuideTools,
     IMessagePublisher publisher,
+    AgentIdentity agent,
     TierRoutingLogger tierRoutingLogger,
     AgentProfile agentProfile,
     ILogger<SubagentRunner> logger)
@@ -125,7 +126,7 @@ internal sealed class SubagentRunner(
         // report_progress tool — baked with taskId and primarySessionId
         var subagentId = $"subagent-{taskId}";
         var reportProgressFunctions = new ReportProgressFunctions(
-            taskId, primarySessionId, publisher, subagentId, logger);
+            taskId, primarySessionId, publisher, subagentId, agent.Name, logger);
 
         var chatOptions = new ChatOptions
         {
@@ -160,7 +161,7 @@ internal sealed class SubagentRunner(
             {
                 SessionId = primarySessionId,
                 AgentName = $"subagent-{taskId}",
-                ReplyTo = UserProxy.UserProxyTopics.UserResponse
+                ReplyTo = $"{UserProxy.UserProxyTopics.UserResponse}.{agent.Name}"
             });
 
             finalOutput = await agentLoopRunner.RunAsync(
@@ -226,7 +227,7 @@ internal sealed class SubagentRunner(
         };
 
         var envelope = result.ToEnvelope<SubagentResultMessage>(source: subagentId);
-        await publisher.PublishAsync(SubagentTopics.Result, envelope, CancellationToken.None);
+        await publisher.PublishAsync($"{SubagentTopics.Result}.{agent.Name}", envelope, CancellationToken.None);
 
         logger.LogInformation("Subagent {TaskId} published result (success={Success})", taskId, isSuccess);
     }

--- a/src/RockBot.Subagent/SubagentServiceCollectionExtensions.cs
+++ b/src/RockBot.Subagent/SubagentServiceCollectionExtensions.cs
@@ -29,8 +29,9 @@ public static class SubagentServiceCollectionExtensions
         // Message handlers for primary agent side
         builder.HandleMessage<SubagentProgressMessage, SubagentProgressHandler>();
         builder.HandleMessage<SubagentResultMessage, SubagentResultHandler>();
-        builder.SubscribeTo(SubagentTopics.Progress);
-        builder.SubscribeTo(SubagentTopics.Result);
+        var agentName = builder.Identity.Name;
+        builder.SubscribeTo($"{SubagentTopics.Progress}.{agentName}");
+        builder.SubscribeTo($"{SubagentTopics.Result}.{agentName}");
 
         // Tool registrar (registers spawn_subagent, cancel_subagent, list_subagents)
         builder.Services.AddHostedService<SubagentToolRegistrar>();

--- a/src/RockBot.UserProxy.Blazor/Program.cs
+++ b/src/RockBot.UserProxy.Blazor/Program.cs
@@ -12,7 +12,10 @@ builder.Services.AddRazorComponents()
 
 // Add RockBot services
 builder.Services.AddRockBotRabbitMq(opts => builder.Configuration.GetSection("RabbitMq").Bind(opts));
-builder.Services.AddUserProxy();
+builder.Services.AddUserProxy(opts =>
+{
+    opts.AgentName = builder.Configuration["Agent:Name"] ?? "RockBot";
+});
 builder.Services.AddSingleton<IUserFrontend, BlazorUserFrontend>();
 builder.Services.AddSingleton<ChatStateService>();
 

--- a/src/RockBot.UserProxy.Cli/Program.cs
+++ b/src/RockBot.UserProxy.Cli/Program.cs
@@ -7,7 +7,10 @@ using RockBot.UserProxy.Cli;
 var builder = Host.CreateApplicationBuilder(args);
 
 builder.Services.AddRockBotRabbitMq();
-builder.Services.AddUserProxy();
+builder.Services.AddUserProxy(opts =>
+{
+    opts.AgentName = builder.Configuration["Agent:Name"] ?? "RockBot";
+});
 builder.Services.AddSingleton<IUserFrontend, SpectreConsoleFrontend>();
 builder.Services.AddHostedService<ChatLoopService>();
 

--- a/src/RockBot.UserProxy/UserProxyOptions.cs
+++ b/src/RockBot.UserProxy/UserProxyOptions.cs
@@ -6,6 +6,12 @@ namespace RockBot.UserProxy;
 public sealed class UserProxyOptions
 {
     public string ProxyId { get; set; } = "user-proxy";
+
+    /// <summary>
+    /// Name of the agent this proxy communicates with.
+    /// Used to scope message bus topics so multiple agent instances can share the same broker.
+    /// </summary>
+    public string AgentName { get; set; } = "RockBot";
     public TimeSpan DefaultReplyTimeout { get; set; } = TimeSpan.FromMinutes(3);
 
     /// <summary>

--- a/src/RockBot.UserProxy/UserProxyService.cs
+++ b/src/RockBot.UserProxy/UserProxyService.cs
@@ -59,7 +59,7 @@ public sealed class UserProxyService(
         try
         {
             _subscription = await subscriber.SubscribeAsync(
-                UserProxyTopics.UserResponse,
+                $"{UserProxyTopics.UserResponse}.{options.AgentName}",
                 $"user-proxy.{options.ProxyId}",
                 HandleResponseAsync,
                 cancellationToken);
@@ -67,14 +67,14 @@ public sealed class UserProxyService(
             IsConnected = true;
             OnConnectionChanged?.Invoke();
             logger.LogInformation("User proxy {ProxyId} subscribed to {Topic}",
-                options.ProxyId, UserProxyTopics.UserResponse);
+                options.ProxyId, $"{UserProxyTopics.UserResponse}.{options.AgentName}");
         }
         catch (Exception ex)
         {
             IsConnected = false;
             OnConnectionChanged?.Invoke();
             logger.LogError(ex, "User proxy {ProxyId} failed to subscribe to {Topic}",
-                options.ProxyId, UserProxyTopics.UserResponse);
+                options.ProxyId, $"{UserProxyTopics.UserResponse}.{options.AgentName}");
 
             if (options.MaxSubscribeRetries > 0)
             {
@@ -107,7 +107,7 @@ public sealed class UserProxyService(
             try
             {
                 _subscription = await subscriber.SubscribeAsync(
-                    UserProxyTopics.UserResponse,
+                    $"{UserProxyTopics.UserResponse}.{options.AgentName}",
                     $"user-proxy.{options.ProxyId}",
                     HandleResponseAsync,
                     ct);
@@ -116,7 +116,7 @@ public sealed class UserProxyService(
                 OnConnectionChanged?.Invoke();
                 logger.LogInformation(
                     "User proxy {ProxyId} subscribed to {Topic} on retry attempt {Attempt}",
-                    options.ProxyId, UserProxyTopics.UserResponse, attempt);
+                    options.ProxyId, $"{UserProxyTopics.UserResponse}.{options.AgentName}", attempt);
                 return;
             }
             catch (OperationCanceledException)
@@ -127,7 +127,7 @@ public sealed class UserProxyService(
             {
                 logger.LogWarning(ex,
                     "User proxy {ProxyId} retry attempt {Attempt} failed for {Topic}",
-                    options.ProxyId, attempt, UserProxyTopics.UserResponse);
+                    options.ProxyId, attempt, $"{UserProxyTopics.UserResponse}.{options.AgentName}");
 
                 // Exponential backoff capped at MaxSubscribeRetryDelay
                 delay = TimeSpan.FromTicks(Math.Min(
@@ -138,7 +138,7 @@ public sealed class UserProxyService(
 
         logger.LogError(
             "User proxy {ProxyId} exhausted all {MaxRetries} retry attempts for {Topic}",
-            options.ProxyId, options.MaxSubscribeRetries, UserProxyTopics.UserResponse);
+            options.ProxyId, options.MaxSubscribeRetries, $"{UserProxyTopics.UserResponse}.{options.AgentName}");
     }
 
     public async Task StopAsync(CancellationToken cancellationToken)
@@ -260,14 +260,14 @@ public sealed class UserProxyService(
             var envelope = message.ToEnvelope<UserMessage>(
                 source: options.ProxyId,
                 correlationId: correlationId,
-                replyTo: UserProxyTopics.UserResponse,
+                replyTo: $"{UserProxyTopics.UserResponse}.{options.AgentName}",
                 destination: message.TargetAgent);
 
-            await publisher.PublishAsync(UserProxyTopics.UserMessage, envelope, cancellationToken);
+            await publisher.PublishAsync($"{UserProxyTopics.UserMessage}.{options.AgentName}", envelope, cancellationToken);
             UserProxyDiagnostics.MessagesSent.Add(1);
 
             logger.LogDebug("Published user message {CorrelationId} to {Topic}",
-                correlationId, UserProxyTopics.UserMessage);
+                correlationId, $"{UserProxyTopics.UserMessage}.{options.AgentName}");
 
             using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             timeoutCts.CancelAfter(effectiveTimeout);
@@ -306,7 +306,7 @@ public sealed class UserProxyService(
             source: options.ProxyId,
             destination: feedback.AgentName);
 
-        await publisher.PublishAsync(UserProxyTopics.UserFeedback, envelope, cancellationToken);
+        await publisher.PublishAsync($"{UserProxyTopics.UserFeedback}.{options.AgentName}", envelope, cancellationToken);
 
         logger.LogDebug("Published {FeedbackType} feedback for message {MessageId} to {Agent}",
             feedback.IsPositive ? "positive" : "negative",
@@ -326,10 +326,10 @@ public sealed class UserProxyService(
         var envelope = message.ToEnvelope<UserMessage>(
             source: options.ProxyId,
             correlationId: correlationId,
-            replyTo: UserProxyTopics.UserResponse,
+            replyTo: $"{UserProxyTopics.UserResponse}.{options.AgentName}",
             destination: message.TargetAgent);
 
-        await publisher.PublishAsync(UserProxyTopics.UserMessage, envelope, cancellationToken);
+        await publisher.PublishAsync($"{UserProxyTopics.UserMessage}.{options.AgentName}", envelope, cancellationToken);
         UserProxyDiagnostics.MessagesSent.Add(1);
 
         logger.LogDebug("Published fire-and-forget user message {CorrelationId}", correlationId);
@@ -342,7 +342,7 @@ public sealed class UserProxyService(
     {
         var request = new CancelSessionRequest { SessionId = sessionId };
         var envelope = request.ToEnvelope<CancelSessionRequest>(source: options.ProxyId);
-        await publisher.PublishAsync(UserProxyTopics.CancelSession, envelope, cancellationToken);
+        await publisher.PublishAsync($"{UserProxyTopics.CancelSession}.{options.AgentName}", envelope, cancellationToken);
         logger.LogInformation("Published cancel request for session {SessionId}", sessionId);
     }
 
@@ -354,7 +354,7 @@ public sealed class UserProxyService(
     {
         var request = new ClearContextRequest { SessionId = sessionId };
         var envelope = request.ToEnvelope<ClearContextRequest>(source: options.ProxyId);
-        await publisher.PublishAsync(UserProxyTopics.ClearContext, envelope, cancellationToken);
+        await publisher.PublishAsync($"{UserProxyTopics.ClearContext}.{options.AgentName}", envelope, cancellationToken);
         logger.LogInformation("Published clear context request for session {SessionId}", sessionId);
     }
 
@@ -452,7 +452,7 @@ public sealed class UserProxyService(
                 correlationId: correlationId,
                 replyTo: HistoryResponseTopic);
 
-            await publisher.PublishAsync(UserProxyTopics.ConversationHistoryRequest, envelope, cancellationToken);
+            await publisher.PublishAsync($"{UserProxyTopics.ConversationHistoryRequest}.{options.AgentName}", envelope, cancellationToken);
 
             logger.LogDebug("Published ConversationHistoryRequest {CorrelationId} for session {SessionId}",
                 correlationId, sessionId);
@@ -526,7 +526,7 @@ public sealed class UserProxyService(
                 correlationId: correlationId,
                 replyTo: AgentInfoResponseTopic);
 
-            await publisher.PublishAsync(UserProxyTopics.AgentInfoRequest, envelope, cancellationToken);
+            await publisher.PublishAsync($"{UserProxyTopics.AgentInfoRequest}.{options.AgentName}", envelope, cancellationToken);
 
             logger.LogDebug("Published AgentInfoRequest {CorrelationId}", correlationId);
 
@@ -638,7 +638,7 @@ public sealed class UserProxyService(
                 correlationId: correlationId,
                 replyTo: ActiveStatusResponseTopic);
 
-            await publisher.PublishAsync(UserProxyTopics.ActiveStatusRequest, envelope, cancellationToken);
+            await publisher.PublishAsync($"{UserProxyTopics.ActiveStatusRequest}.{options.AgentName}", envelope, cancellationToken);
 
             logger.LogDebug("Published ActiveStatusRequest {CorrelationId}", correlationId);
 
@@ -749,7 +749,7 @@ public sealed class UserProxyService(
                 correlationId: correlationId,
                 replyTo: SaveResponseAckTopic);
 
-            await publisher.PublishAsync(UserProxyTopics.SaveResponseRequest, envelope, cancellationToken);
+            await publisher.PublishAsync($"{UserProxyTopics.SaveResponseRequest}.{options.AgentName}", envelope, cancellationToken);
 
             logger.LogDebug("Published SaveResponseRequest {CorrelationId}", correlationId);
 
@@ -796,7 +796,7 @@ public sealed class UserProxyService(
                 correlationId: correlationId,
                 replyTo: ListSavedResponsesTopic);
 
-            await publisher.PublishAsync(UserProxyTopics.ListSavedResponsesRequest, envelope, cancellationToken);
+            await publisher.PublishAsync($"{UserProxyTopics.ListSavedResponsesRequest}.{options.AgentName}", envelope, cancellationToken);
 
             logger.LogDebug("Published ListSavedResponsesRequest {CorrelationId}", correlationId);
 
@@ -844,7 +844,7 @@ public sealed class UserProxyService(
                 correlationId: correlationId,
                 replyTo: GetSavedResponseTopic);
 
-            await publisher.PublishAsync(UserProxyTopics.GetSavedResponseRequest, envelope, cancellationToken);
+            await publisher.PublishAsync($"{UserProxyTopics.GetSavedResponseRequest}.{options.AgentName}", envelope, cancellationToken);
 
             logger.LogDebug("Published GetSavedResponseRequest {CorrelationId} for {Id}", correlationId, id);
 
@@ -892,7 +892,7 @@ public sealed class UserProxyService(
                 correlationId: correlationId,
                 replyTo: DeleteSavedAckTopic);
 
-            await publisher.PublishAsync(UserProxyTopics.DeleteSavedResponseRequest, envelope, cancellationToken);
+            await publisher.PublishAsync($"{UserProxyTopics.DeleteSavedResponseRequest}.{options.AgentName}", envelope, cancellationToken);
 
             logger.LogDebug("Published DeleteSavedResponseRequest {CorrelationId} for {Id}", correlationId, id);
 

--- a/tests/RockBot.Agent.Tests/UserFeedbackHandlerTests.cs
+++ b/tests/RockBot.Agent.Tests/UserFeedbackHandlerTests.cs
@@ -164,7 +164,7 @@ public class UserFeedbackHandlerTests
         Assert.AreEqual(1, _publisher.Published.Count);
 
         var (topic, envelope) = _publisher.Published[0];
-        Assert.AreEqual(UserProxyTopics.UserResponse, topic);
+        Assert.AreEqual($"{UserProxyTopics.UserResponse}.{AgentName}", topic);
 
         var reply = envelope.GetPayload<AgentReply>();
         Assert.IsNotNull(reply);

--- a/tests/RockBot.Host.Tests/InboundNotificationServiceTests.cs
+++ b/tests/RockBot.Host.Tests/InboundNotificationServiceTests.cs
@@ -89,7 +89,7 @@ public class InboundNotificationServiceTests
         await _publisher.WaitForPublish();
 
         Assert.AreEqual(1, _publisher.Published.Count);
-        Assert.AreEqual(UserProxyTopics.UserResponse, _publisher.Published[0].Topic);
+        Assert.AreEqual($"{UserProxyTopics.UserResponse}.RockBot", _publisher.Published[0].Topic);
 
         var reply = _publisher.Published[0].Envelope.GetPayload<AgentReply>();
         Assert.IsNotNull(reply);

--- a/tests/RockBot.Messaging.Tests/MultiInstanceIsolationTests.cs
+++ b/tests/RockBot.Messaging.Tests/MultiInstanceIsolationTests.cs
@@ -1,0 +1,312 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using RockBot.Messaging;
+using RockBot.Messaging.InProcess;
+using RockBot.Messaging.RabbitMQ;
+using RockBot.UserProxy;
+
+namespace RockBot.Messaging.Tests;
+
+/// <summary>
+/// Proves that two RockBot agent instances with different names can share the
+/// same message broker without cross-contamination. Each agent's proxy publishes
+/// and subscribes to agent-name-scoped topics; messages must never leak across.
+/// </summary>
+[TestClass]
+public class MultiInstanceIsolationTests
+{
+    // ── InProcess tests (always run) ─────────────────────────────────────────
+
+    [TestMethod]
+    public async Task InProcess_TwoAgents_MessagesDoNotCrossContaminate()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging(b => b.SetMinimumLevel(LogLevel.Warning));
+        services.AddRockBotInProcessMessaging();
+        await using var provider = services.BuildServiceProvider();
+
+        var publisher = provider.GetRequiredService<IMessagePublisher>();
+        var subscriber = provider.GetRequiredService<IMessageSubscriber>();
+
+        await RunIsolationTest(publisher, subscriber);
+    }
+
+    [TestMethod]
+    public async Task InProcess_SubagentTopics_DoNotCrossContaminate()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging(b => b.SetMinimumLevel(LogLevel.Warning));
+        services.AddRockBotInProcessMessaging();
+        await using var provider = services.BuildServiceProvider();
+
+        var publisher = provider.GetRequiredService<IMessagePublisher>();
+        var subscriber = provider.GetRequiredService<IMessageSubscriber>();
+
+        await RunSubagentIsolationTest(publisher, subscriber);
+    }
+
+    // ── RabbitMQ tests (gated by env var) ────────────────────────────────────
+
+    [TestMethod]
+    public async Task RabbitMq_TwoAgents_MessagesDoNotCrossContaminate()
+    {
+        var host = Environment.GetEnvironmentVariable("ROCKBOT_RABBITMQ_HOST");
+        if (string.IsNullOrEmpty(host))
+        {
+            Assert.Inconclusive("RabbitMQ not available (set ROCKBOT_RABBITMQ_HOST)");
+            return;
+        }
+
+        var services = new ServiceCollection();
+        services.AddLogging(b => b.SetMinimumLevel(LogLevel.Warning));
+        services.AddRockBotRabbitMq(opts =>
+        {
+            opts.HostName = host;
+            opts.ExchangeName = $"rockbot-isolation-{Guid.NewGuid():N}";
+            opts.DeadLetterExchangeName = $"rockbot-isolation-dlx-{Guid.NewGuid():N}";
+        });
+        await using var provider = services.BuildServiceProvider();
+
+        var publisher = provider.GetRequiredService<IMessagePublisher>();
+        var subscriber = provider.GetRequiredService<IMessageSubscriber>();
+
+        await RunIsolationTest(publisher, subscriber);
+    }
+
+    [TestMethod]
+    public async Task RabbitMq_SubagentTopics_DoNotCrossContaminate()
+    {
+        var host = Environment.GetEnvironmentVariable("ROCKBOT_RABBITMQ_HOST");
+        if (string.IsNullOrEmpty(host))
+        {
+            Assert.Inconclusive("RabbitMQ not available (set ROCKBOT_RABBITMQ_HOST)");
+            return;
+        }
+
+        var services = new ServiceCollection();
+        services.AddLogging(b => b.SetMinimumLevel(LogLevel.Warning));
+        services.AddRockBotRabbitMq(opts =>
+        {
+            opts.HostName = host;
+            opts.ExchangeName = $"rockbot-isolation-{Guid.NewGuid():N}";
+            opts.DeadLetterExchangeName = $"rockbot-isolation-dlx-{Guid.NewGuid():N}";
+        });
+        await using var provider = services.BuildServiceProvider();
+
+        var publisher = provider.GetRequiredService<IMessagePublisher>();
+        var subscriber = provider.GetRequiredService<IMessageSubscriber>();
+
+        await RunSubagentIsolationTest(publisher, subscriber);
+    }
+
+    // ── Core test logic ──────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Two UserProxyService instances (Alpha and Beta) each send a message through
+    /// a shared bus. Simulated agent handlers echo replies. We verify each proxy
+    /// receives only its own agent's reply, and each agent handler receives only
+    /// its own proxy's message.
+    /// </summary>
+    private static async Task RunIsolationTest(
+        IMessagePublisher publisher, IMessageSubscriber subscriber)
+    {
+        const string alphaName = "AgentAlpha";
+        const string betaName = "AgentBeta";
+
+        // Track which agent handlers were invoked and by whom
+        var alphaReceived = new List<string>();
+        var betaReceived = new List<string>();
+
+        // Simulate Agent Alpha: subscribe to user.message.AgentAlpha, reply on envelope.ReplyTo
+        await using var alphaAgent = await SimulateAgent(
+            subscriber, publisher, alphaName, alphaReceived);
+
+        // Simulate Agent Beta: subscribe to user.message.AgentBeta, reply on envelope.ReplyTo
+        await using var betaAgent = await SimulateAgent(
+            subscriber, publisher, betaName, betaReceived);
+
+        // Create two proxies sharing the same bus
+        var proxyAlpha = CreateProxy(publisher, subscriber, alphaName, "proxy-alpha");
+        var proxyBeta = CreateProxy(publisher, subscriber, betaName, "proxy-beta");
+
+        await proxyAlpha.StartAsync(CancellationToken.None);
+        await proxyBeta.StartAsync(CancellationToken.None);
+
+        try
+        {
+            // Send through each proxy concurrently
+            var alphaTask = proxyAlpha.SendAsync(
+                new UserMessage { Content = "Hello from Alpha", SessionId = "s-alpha", UserId = "u1" },
+                timeout: TimeSpan.FromSeconds(5));
+            var betaTask = proxyBeta.SendAsync(
+                new UserMessage { Content = "Hello from Beta", SessionId = "s-beta", UserId = "u2" },
+                timeout: TimeSpan.FromSeconds(5));
+
+            var alphaReply = await alphaTask;
+            var betaReply = await betaTask;
+
+            // Each proxy got a reply
+            Assert.IsNotNull(alphaReply, "Proxy Alpha should receive a reply");
+            Assert.IsNotNull(betaReply, "Proxy Beta should receive a reply");
+
+            // Each reply came from the correct agent
+            Assert.AreEqual(alphaName, alphaReply.AgentName,
+                "Alpha's reply should come from AgentAlpha");
+            Assert.AreEqual(betaName, betaReply.AgentName,
+                "Beta's reply should come from AgentBeta");
+
+            // Each reply echoes the correct content
+            Assert.IsTrue(alphaReply.Content.Contains("Hello from Alpha"),
+                "Alpha's reply should echo Alpha's message");
+            Assert.IsTrue(betaReply.Content.Contains("Hello from Beta"),
+                "Beta's reply should echo Beta's message");
+
+            // No cross-contamination: each agent handler was invoked exactly once
+            Assert.AreEqual(1, alphaReceived.Count,
+                "AgentAlpha handler should receive exactly 1 message");
+            Assert.AreEqual(1, betaReceived.Count,
+                "AgentBeta handler should receive exactly 1 message");
+
+            // Verify the correct message reached each handler
+            Assert.AreEqual("Hello from Alpha", alphaReceived[0]);
+            Assert.AreEqual("Hello from Beta", betaReceived[0]);
+        }
+        finally
+        {
+            await proxyAlpha.StopAsync(CancellationToken.None);
+            await proxyBeta.StopAsync(CancellationToken.None);
+        }
+    }
+
+    /// <summary>
+    /// Verifies subagent topics are also isolated: subagent.progress.{agentName}
+    /// and subagent.result.{agentName} don't cross between agent instances.
+    /// </summary>
+    private static async Task RunSubagentIsolationTest(
+        IMessagePublisher publisher, IMessageSubscriber subscriber)
+    {
+        const string alphaName = "AgentAlpha";
+        const string betaName = "AgentBeta";
+
+        var alphaProgress = new List<string>();
+        var betaProgress = new List<string>();
+        var alphaResults = new List<string>();
+        var betaResults = new List<string>();
+
+        // Subscribe to scoped subagent topics for each agent
+        await using var alphaProgressSub = await subscriber.SubscribeAsync(
+            $"subagent.progress.{alphaName}", $"progress-{alphaName}",
+            (env, _) => { lock (alphaProgress) alphaProgress.Add(env.Source); return Task.FromResult(MessageResult.Ack); });
+
+        await using var betaProgressSub = await subscriber.SubscribeAsync(
+            $"subagent.progress.{betaName}", $"progress-{betaName}",
+            (env, _) => { lock (betaProgress) betaProgress.Add(env.Source); return Task.FromResult(MessageResult.Ack); });
+
+        await using var alphaResultSub = await subscriber.SubscribeAsync(
+            $"subagent.result.{alphaName}", $"result-{alphaName}",
+            (env, _) => { lock (alphaResults) alphaResults.Add(env.Source); return Task.FromResult(MessageResult.Ack); });
+
+        await using var betaResultSub = await subscriber.SubscribeAsync(
+            $"subagent.result.{betaName}", $"result-{betaName}",
+            (env, _) => { lock (betaResults) betaResults.Add(env.Source); return Task.FromResult(MessageResult.Ack); });
+
+        // Publish subagent messages for each agent
+        var alphaProgressMsg = MessageEnvelope.Create("SubagentProgressMessage",
+            Array.Empty<byte>(), "subagent-alpha-1");
+        await publisher.PublishAsync($"subagent.progress.{alphaName}", alphaProgressMsg);
+
+        var betaProgressMsg = MessageEnvelope.Create("SubagentProgressMessage",
+            Array.Empty<byte>(), "subagent-beta-1");
+        await publisher.PublishAsync($"subagent.progress.{betaName}", betaProgressMsg);
+
+        var alphaResultMsg = MessageEnvelope.Create("SubagentResultMessage",
+            Array.Empty<byte>(), "subagent-alpha-1");
+        await publisher.PublishAsync($"subagent.result.{alphaName}", alphaResultMsg);
+
+        var betaResultMsg = MessageEnvelope.Create("SubagentResultMessage",
+            Array.Empty<byte>(), "subagent-beta-1");
+        await publisher.PublishAsync($"subagent.result.{betaName}", betaResultMsg);
+
+        // Wait for delivery
+        await Task.Delay(500);
+
+        // Each agent's subscribers received exactly their own messages
+        Assert.AreEqual(1, alphaProgress.Count, "Alpha should get 1 progress message");
+        Assert.AreEqual("subagent-alpha-1", alphaProgress[0]);
+
+        Assert.AreEqual(1, betaProgress.Count, "Beta should get 1 progress message");
+        Assert.AreEqual("subagent-beta-1", betaProgress[0]);
+
+        Assert.AreEqual(1, alphaResults.Count, "Alpha should get 1 result message");
+        Assert.AreEqual("subagent-alpha-1", alphaResults[0]);
+
+        Assert.AreEqual(1, betaResults.Count, "Beta should get 1 result message");
+        Assert.AreEqual("subagent-beta-1", betaResults[0]);
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static UserProxyService CreateProxy(
+        IMessagePublisher publisher,
+        IMessageSubscriber subscriber,
+        string agentName,
+        string proxyId)
+    {
+        var options = new UserProxyOptions { ProxyId = proxyId, AgentName = agentName };
+        var frontend = new NoOpFrontend();
+        return new UserProxyService(
+            publisher, subscriber, frontend, options,
+            NullLogger<UserProxyService>.Instance);
+    }
+
+    /// <summary>
+    /// Simulates an agent: subscribes to <c>user.message.{agentName}</c> and publishes
+    /// an <see cref="AgentReply"/> back to the envelope's <c>ReplyTo</c> topic.
+    /// Records received message content for cross-contamination assertions.
+    /// </summary>
+    private static async Task<ISubscription> SimulateAgent(
+        IMessageSubscriber subscriber,
+        IMessagePublisher publisher,
+        string agentName,
+        List<string> receivedMessages)
+    {
+        return await subscriber.SubscribeAsync(
+            $"{UserProxyTopics.UserMessage}.{agentName}",
+            $"agent-handler-{agentName}",
+            async (envelope, ct) =>
+            {
+                var message = envelope.GetPayload<UserMessage>();
+                if (message is null) return MessageResult.DeadLetter;
+
+                lock (receivedMessages)
+                    receivedMessages.Add(message.Content);
+
+                var reply = new AgentReply
+                {
+                    Content = $"Echo: {message.Content}",
+                    SessionId = message.SessionId,
+                    AgentName = agentName,
+                    IsFinal = true
+                };
+
+                var replyTopic = envelope.ReplyTo;
+                if (string.IsNullOrEmpty(replyTopic)) return MessageResult.Ack;
+
+                var replyEnvelope = reply.ToEnvelope<AgentReply>(
+                    source: agentName,
+                    correlationId: envelope.CorrelationId);
+
+                await publisher.PublishAsync(replyTopic, replyEnvelope, ct);
+                return MessageResult.Ack;
+            });
+    }
+
+    private sealed class NoOpFrontend : IUserFrontend
+    {
+        public Task DisplayReplyAsync(AgentReply reply, CancellationToken ct = default) =>
+            Task.CompletedTask;
+        public Task DisplayErrorAsync(string message, CancellationToken ct = default) =>
+            Task.CompletedTask;
+    }
+}

--- a/tests/RockBot.Messaging.Tests/RockBot.Messaging.Tests.csproj
+++ b/tests/RockBot.Messaging.Tests/RockBot.Messaging.Tests.csproj
@@ -22,6 +22,7 @@
     <ProjectReference Include="..\..\src\RockBot.Messaging.Abstractions\RockBot.Messaging.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\RockBot.Messaging.RabbitMQ\RockBot.Messaging.RabbitMQ.csproj" />
     <ProjectReference Include="..\..\src\RockBot.Messaging.InProcess\RockBot.Messaging.InProcess.csproj" />
+    <ProjectReference Include="..\..\src\RockBot.UserProxy\RockBot.UserProxy.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/RockBot.Subagent.Tests/SubagentManagerTests.cs
+++ b/tests/RockBot.Subagent.Tests/SubagentManagerTests.cs
@@ -88,6 +88,7 @@ public class SubagentManagerTests
             provider.GetRequiredService<IServiceScopeFactory>(),
             opts,
             provider.GetRequiredService<IMessagePublisher>(),
+            new AgentIdentity("TestBot"),
             NullLogger<SubagentManager>.Instance);
     }
 
@@ -111,6 +112,7 @@ public class SubagentManagerTests
             provider.GetRequiredService<IServiceScopeFactory>(),
             opts,
             provider.GetRequiredService<IMessagePublisher>(),
+            new AgentIdentity("TestBot"),
             NullLogger<SubagentManager>.Instance);
 
         return (manager, tcs);

--- a/tests/RockBot.UserProxy.Tests/UserProxyServiceTests.cs
+++ b/tests/RockBot.UserProxy.Tests/UserProxyServiceTests.cs
@@ -38,7 +38,7 @@ public sealed class UserProxyServiceTests
     [TestMethod]
     public void StartAsync_SubscribesToUserResponseTopic()
     {
-        Assert.AreEqual(UserProxyTopics.UserResponse, _subscriber.CapturedTopic);
+        Assert.AreEqual($"{UserProxyTopics.UserResponse}.{_options.AgentName}", _subscriber.CapturedTopic);
         Assert.AreEqual("user-proxy.test-proxy", _subscriber.CapturedSubscriptionName);
     }
 
@@ -53,7 +53,7 @@ public sealed class UserProxyServiceTests
         // Verify publish happened
         await Task.Delay(10);
         Assert.AreEqual(1, _publisher.Published.Count);
-        Assert.AreEqual(UserProxyTopics.UserMessage, _publisher.Published[0].Topic);
+        Assert.AreEqual($"{UserProxyTopics.UserMessage}.{_options.AgentName}", _publisher.Published[0].Topic);
 
         // Let it timeout
         var result = await sendTask;
@@ -70,7 +70,7 @@ public sealed class UserProxyServiceTests
 
         var envelope = _publisher.Published[0].Envelope;
         Assert.IsNotNull(envelope.CorrelationId);
-        Assert.AreEqual(UserProxyTopics.UserResponse, envelope.ReplyTo);
+        Assert.AreEqual($"{UserProxyTopics.UserResponse}.{_options.AgentName}", envelope.ReplyTo);
         Assert.AreEqual("test-proxy", envelope.Source);
 
         await sendTask;
@@ -189,7 +189,7 @@ public sealed class UserProxyServiceTests
         await _service.SendFireAndForgetAsync(message);
 
         Assert.AreEqual(1, _publisher.Published.Count);
-        Assert.AreEqual(UserProxyTopics.UserMessage, _publisher.Published[0].Topic);
+        Assert.AreEqual($"{UserProxyTopics.UserMessage}.{_options.AgentName}", _publisher.Published[0].Topic);
         Assert.IsNotNull(_publisher.Published[0].Envelope.CorrelationId);
     }
 
@@ -263,7 +263,7 @@ public sealed class UserProxyServiceTests
         await connected.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
         Assert.IsTrue(svc.IsConnected);
-        Assert.AreEqual(UserProxyTopics.UserResponse, failingSubscriber.CapturedTopic);
+        Assert.AreEqual($"{UserProxyTopics.UserResponse}.{retryOptions.AgentName}", failingSubscriber.CapturedTopic);
         // 1 initial failure + 1 retry failure + 1 retry success = 3 total calls
         Assert.AreEqual(3, failingSubscriber.CallCount);
 
@@ -348,7 +348,7 @@ public sealed class UserProxyServiceTests
         await Task.Delay(10);
 
         Assert.AreEqual(1, _publisher.Published.Count);
-        Assert.AreEqual(UserProxyTopics.ConversationHistoryRequest, _publisher.Published[0].Topic);
+        Assert.AreEqual($"{UserProxyTopics.ConversationHistoryRequest}.{_options.AgentName}", _publisher.Published[0].Topic);
 
         await historyTask; // let it timeout
     }


### PR DESCRIPTION
## Summary
- Append `.{agentName}` suffix to all user proxy and subagent topics so multiple RockBot instances can share the same RabbitMQ broker without message collisions
- Agent name configurable via `Agent:Name` config (defaults to `"RockBot"`)
- Follows the existing A2A topic scoping pattern (`agent.task.{agentName}`)

Closes #268

## Changes
- **22 source files** across Agent, Host, Subagent, A2A, and UserProxy projects — all publish/subscribe calls now use scoped topics
- **4 test files** updated with scoped topic assertions
- `UserProxyOptions.AgentName` added so Blazor/CLI proxies target the correct agent
- Intentionally global topics (`discovery.announce`, `agent.task.status`, per-proxy response topics) are unchanged

## Migration
- **Breaking wire-protocol change** — agent and proxy must be deployed together
- No config changes needed for single-instance deployments (default name is `"RockBot"`)
- To run a second instance, set `Agent__Name=RockBot-Bob` on both agent and proxy pods

## Test plan
- [x] `dotnet build RockBot.slnx` — 0 errors
- [x] `dotnet test RockBot.slnx` — all tests pass (0 failures)
- [x] Grep confirms no remaining unscoped topic references in source
- [ ] Deploy to staging and verify agent ↔ proxy communication
- [ ] Test two instances with distinct `Agent:Name` values on same RabbitMQ

🤖 Generated with [Claude Code](https://claude.com/claude-code)