### PR TITLE
Outbound A2A: consume streaming responses via SendStreamingMessageAsync

### DIFF
--- a/src/RockBot.A2A.Abstractions/AgentCard.cs
+++ b/src/RockBot.A2A.Abstractions/AgentCard.cs
@@ -40,6 +40,14 @@ public sealed record AgentCard
     public string? ProtocolVersion { get; init; }
 
     /// <summary>
+    /// Whether the remote agent advertises streaming support (<c>capabilities.streaming: true</c>).
+    /// When true and protocol version is v1, <c>InvokeAgentExecutor</c> uses
+    /// <c>SendStreamingMessageAsync</c> instead of polling.
+    /// Populated automatically by <c>RegisterAgentExecutor</c> during protocol detection.
+    /// </summary>
+    public bool? SupportsStreaming { get; init; }
+
+    /// <summary>
     /// When true, the agent is shutting down and should be removed from the directory.
     /// Published by <c>AgentDiscoveryService.StopAsync</c> on graceful shutdown.
     /// </summary>

--- a/src/RockBot.A2A.Gateway/PushNotificationSender.cs
+++ b/src/RockBot.A2A.Gateway/PushNotificationSender.cs
@@ -66,7 +66,7 @@ internal sealed class PushNotificationSender(
             var httpClient = httpClientFactory.CreateClient();
 
             // Attach authentication if configured
-            if (config.PushNotificationConfig.Authentication is { } auth &&
+            if (config.PushNotificationConfig?.Authentication is { } auth &&
                 !string.IsNullOrEmpty(auth.Scheme) && !string.IsNullOrEmpty(auth.Credentials))
             {
                 httpClient.DefaultRequestHeaders.Authorization =
@@ -74,10 +74,10 @@ internal sealed class PushNotificationSender(
             }
 
             // Attach token as bearer if configured (shorthand)
-            if (!string.IsNullOrEmpty(config.PushNotificationConfig.Token))
+            if (!string.IsNullOrEmpty(config.PushNotificationConfig?.Token))
             {
                 httpClient.DefaultRequestHeaders.Authorization =
-                    new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", config.PushNotificationConfig.Token);
+                    new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", config.PushNotificationConfig!.Token!);
             }
 
             var content = new StringContent(payload, System.Text.Encoding.UTF8, "application/json");

--- a/src/RockBot.A2A/A2ADiagnostics.cs
+++ b/src/RockBot.A2A/A2ADiagnostics.cs
@@ -56,4 +56,11 @@ internal static class A2ADiagnostics
             "rockbot.a2a.polling_attempts",
             unit: "{attempt}",
             description: "A2A GetTask polling attempts for long-running tasks");
+
+    /// <summary>Number of streaming events received during outbound A2A streaming dispatch.</summary>
+    public static readonly Counter<long> StreamingEvents =
+        Meter.CreateCounter<long>(
+            "rockbot.a2a.streaming_events",
+            unit: "{event}",
+            description: "Streaming events received during outbound A2A dispatch");
 }

--- a/src/RockBot.A2A/GetAgentDetailsExecutor.cs
+++ b/src/RockBot.A2A/GetAgentDetailsExecutor.cs
@@ -62,6 +62,7 @@ internal sealed class GetAgentDetailsExecutor(IAgentDirectory directory) : ITool
             version = entry.Card.Version,
             url = entry.Card.Url,
             hasAuth = !string.IsNullOrEmpty(entry.Card.AuthHeaderName),
+            supportsStreaming = entry.Card.SupportsStreaming,
             isWellKnown = entry.IsWellKnown,
             lastSeen,
             skills = entry.Card.Skills?.Select(s => new

--- a/src/RockBot.A2A/InputRequiredHandler.cs
+++ b/src/RockBot.A2A/InputRequiredHandler.cs
@@ -23,7 +23,6 @@ internal sealed class InputRequiredHandler(
     AgentLoopRunner agentLoopRunner,
     AgentContextBuilder agentContextBuilder,
     ILlmClient llmClient,
-    IMessagePublisher publisher,
     AgentIdentity agent,
     IWorkingMemory workingMemory,
     MemoryTools memoryTools,

--- a/src/RockBot.A2A/InvokeAgentExecutor.cs
+++ b/src/RockBot.A2A/InvokeAgentExecutor.cs
@@ -206,9 +206,38 @@ internal sealed class InvokeAgentExecutor(
 
             AgentTaskResult? result;
             if (useV1)
-                result = await DispatchV1Async(httpClient, endpoint, taskRequest, taskId, messageText, pending, ct);
+            {
+                var a2aClient = new A2AV1.A2AClient(endpoint, httpClient);
+
+                if (agentCard.SupportsStreaming == true)
+                {
+                    httpActivity?.SetTag("rockbot.a2a.transport", "streaming");
+                    try
+                    {
+                        result = await DispatchV1StreamingAsync(
+                            a2aClient, taskRequest, taskId, messageText, pending, ct);
+                    }
+                    catch (Exception ex) when (ex is not OperationCanceledException)
+                    {
+                        logger.LogWarning(ex,
+                            "Streaming dispatch failed for task {TaskId} to '{AgentName}', falling back to polling",
+                            taskId, agentName);
+                        httpActivity?.SetTag("rockbot.a2a.transport", "streaming-fallback");
+                        result = await DispatchV1Async(
+                            a2aClient, taskRequest, taskId, messageText, pending, ct);
+                    }
+                }
+                else
+                {
+                    httpActivity?.SetTag("rockbot.a2a.transport", "polling");
+                    result = await DispatchV1Async(
+                        a2aClient, taskRequest, taskId, messageText, pending, ct);
+                }
+            }
             else
+            {
                 result = await DispatchV03Async(httpClient, endpoint, taskRequest, taskId, messageText, pending, ct);
+            }
 
             httpSw.Stop();
             var latencyGrade = httpSw.Elapsed.TotalSeconds > 5 ? "slow" : "fast";
@@ -534,15 +563,13 @@ internal sealed class InvokeAgentExecutor(
     // ── V1 dispatch ──────────────────────────────────────────────────────────────
 
     private async Task<AgentTaskResult?> DispatchV1Async(
-        HttpClient httpClient,
-        Uri endpoint,
+        A2AV1.A2AClient a2aClient,
         AgentTaskRequest taskRequest,
         string taskId,
         string messageText,
         PendingA2ATask pending,
         CancellationToken ct)
     {
-        var a2aClient = new A2AV1.A2AClient(endpoint, httpClient);
         string? contextId = null;
         var repetitionDetector = new InputRequiredRepetitionDetector(options.InputRequiredRepetitionThreshold);
 
@@ -626,6 +653,185 @@ internal sealed class InvokeAgentExecutor(
         }
 
         return result;
+    }
+
+    // ── V1 streaming dispatch ───────────────────────────────────────────────────
+
+    /// <summary>
+    /// Dispatches a v1 A2A task using streaming (<c>SendStreamingMessageAsync</c>).
+    /// Consumes SSE events in real time, forwarding intermediate status updates to the
+    /// internal bus. Falls through to the caller's fallback on exception.
+    /// </summary>
+    private async Task<AgentTaskResult?> DispatchV1StreamingAsync(
+        A2AV1.A2AClient a2aClient,
+        AgentTaskRequest taskRequest,
+        string taskId,
+        string messageText,
+        PendingA2ATask pending,
+        CancellationToken ct)
+    {
+        using var streamActivity = A2ADiagnostics.Source.StartActivity("rockbot.a2a.streaming_dispatch");
+        streamActivity?.SetTag("rockbot.a2a.task_id", taskId);
+        streamActivity?.SetTag("rockbot.a2a.target_agent", pending.TargetAgent);
+        streamActivity?.SetTag("rockbot.a2a.session_id", pending.PrimarySessionId);
+
+        string? contextId = null;
+        var repetitionDetector = new InputRequiredRepetitionDetector(options.InputRequiredRepetitionThreshold);
+        var sendRequest = BuildV1SendRequest(taskId, messageText, contextId, taskRequest.Skill);
+
+        while (!ct.IsCancellationRequested)
+        {
+            AgentTaskResult? lastResult = null;
+            bool inputRequired = false;
+
+            await foreach (var evt in a2aClient.SendStreamingMessageAsync(sendRequest, ct))
+            {
+                A2ADiagnostics.StreamingEvents.Add(1,
+                    new KeyValuePair<string, object?>("rockbot.a2a.target_agent", pending.TargetAgent),
+                    new KeyValuePair<string, object?>("rockbot.a2a.event_type", evt.PayloadCase.ToString()));
+
+                switch (evt.PayloadCase)
+                {
+                    case A2AV1.StreamResponseCase.StatusUpdate when evt.StatusUpdate is { } su:
+                        lastResult = MapV1StatusUpdateEvent(su, taskId);
+                        contextId ??= su.ContextId;
+                        pending.ContextId ??= contextId;
+
+                        if (lastResult.State is AgentTaskState.Completed or AgentTaskState.Failed or AgentTaskState.Canceled)
+                            return lastResult;
+
+                        if (lastResult.State is AgentTaskState.Working or AgentTaskState.Submitted)
+                            await PublishStatusUpdateAsync(lastResult, pending.TargetAgent, taskId, ct);
+
+                        if (lastResult.State == AgentTaskState.InputRequired)
+                        {
+                            inputRequired = true;
+                            goto EndStream; // break out of await foreach
+                        }
+                        break;
+
+                    case A2AV1.StreamResponseCase.Task when evt.Task is { } task:
+                        lastResult = MapV1TaskResponse(task, taskId);
+                        contextId ??= task.ContextId;
+                        pending.ContextId ??= contextId;
+
+                        if (lastResult is null) break;
+
+                        if (lastResult.State is AgentTaskState.Completed or AgentTaskState.Failed or AgentTaskState.Canceled)
+                            return lastResult;
+
+                        if (lastResult.State is AgentTaskState.Working or AgentTaskState.Submitted)
+                            await PublishStatusUpdateAsync(lastResult, pending.TargetAgent, taskId, ct);
+
+                        if (lastResult.State == AgentTaskState.InputRequired)
+                        {
+                            inputRequired = true;
+                            goto EndStream;
+                        }
+                        break;
+
+                    case A2AV1.StreamResponseCase.Message when evt.Message is { } msg:
+                        return new AgentTaskResult
+                        {
+                            TaskId = taskId,
+                            ContextId = contextId,
+                            State = AgentTaskState.Completed,
+                            Message = MapV1Message(msg)
+                        };
+
+                    default:
+                        logger.LogDebug("Ignoring streaming event with PayloadCase={PayloadCase} for task {TaskId}",
+                            evt.PayloadCase, taskId);
+                        break;
+                }
+            }
+
+            EndStream:
+
+            // InputRequired follow-up — same logic as the polling path
+            if (inputRequired && lastResult is not null)
+            {
+                pending.InputRequiredRound++;
+                if (pending.InputRequiredRound > options.MaxInputRequiredRounds)
+                {
+                    logger.LogWarning(
+                        "A2A streaming task {TaskId} exceeded max InputRequired rounds ({Max})",
+                        taskId, options.MaxInputRequiredRounds);
+                    A2ADiagnostics.InputRequiredBreaks.Add(1,
+                        new KeyValuePair<string, object?>("rockbot.a2a.target_agent", pending.TargetAgent),
+                        new KeyValuePair<string, object?>("rockbot.a2a.reason", "max_rounds"));
+                    return MakeLoopExceededResult(taskId, contextId, "max rounds exceeded");
+                }
+
+                var questionText = ExtractResultText(lastResult);
+                logger.LogInformation(
+                    "A2A streaming task {TaskId} from '{AgentName}' requires input (round {Round})",
+                    taskId, pending.TargetAgent, pending.InputRequiredRound);
+
+                var followUp = await inputRequiredHandler.HandleAsync(
+                    new InputRequiredContext
+                    {
+                        TaskId = taskId,
+                        ContextId = contextId,
+                        TargetAgent = pending.TargetAgent,
+                        Skill = pending.Skill,
+                        QuestionText = questionText,
+                        PrimarySessionId = pending.PrimarySessionId,
+                        Round = pending.InputRequiredRound
+                    }, ct);
+
+                if (repetitionDetector.Track(questionText, followUp.ResponseText))
+                {
+                    logger.LogWarning(
+                        "A2A streaming task {TaskId} InputRequired loop stuck (repeated {Threshold}x)",
+                        taskId, options.InputRequiredRepetitionThreshold);
+                    A2ADiagnostics.InputRequiredBreaks.Add(1,
+                        new KeyValuePair<string, object?>("rockbot.a2a.target_agent", pending.TargetAgent),
+                        new KeyValuePair<string, object?>("rockbot.a2a.reason", "repetition"));
+                    return MakeLoopExceededResult(taskId, contextId, "conversation stuck in a loop");
+                }
+
+                logger.LogInformation(
+                    "A2A streaming InputRequired follow-up sent for task {TaskId} round {Round} (autonomous={Autonomous})",
+                    taskId, pending.InputRequiredRound, followUp.WasAutonomous);
+
+                // Send follow-up with contextId — continue streaming
+                sendRequest = BuildV1SendRequest(taskId, followUp.ResponseText, contextId, taskRequest.Skill);
+                continue;
+            }
+
+            // Stream ended without a terminal event
+            return lastResult;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Maps a streaming <see cref="A2AV1.TaskStatusUpdateEvent"/> to an <see cref="AgentTaskResult"/>.
+    /// </summary>
+    internal static AgentTaskResult MapV1StatusUpdateEvent(A2AV1.TaskStatusUpdateEvent statusUpdate, string taskId)
+    {
+        var state = statusUpdate.Status.State switch
+        {
+            A2AV1.TaskState.Completed => AgentTaskState.Completed,
+            A2AV1.TaskState.Failed => AgentTaskState.Failed,
+            A2AV1.TaskState.Canceled => AgentTaskState.Canceled,
+            A2AV1.TaskState.Working => AgentTaskState.Working,
+            A2AV1.TaskState.InputRequired => AgentTaskState.InputRequired,
+            A2AV1.TaskState.Submitted => AgentTaskState.Submitted,
+            A2AV1.TaskState.Rejected => AgentTaskState.Failed,
+            A2AV1.TaskState.AuthRequired => AgentTaskState.InputRequired,
+            _ => AgentTaskState.Completed
+        };
+
+        return new AgentTaskResult
+        {
+            TaskId = taskId,
+            ContextId = statusUpdate.ContextId,
+            State = state,
+            Message = statusUpdate.Status.Message is { } msg ? MapV1Message(msg) : null
+        };
     }
 
     private static A2AV1.SendMessageRequest BuildV1SendRequest(

--- a/src/RockBot.A2A/RegisterAgentExecutor.cs
+++ b/src/RockBot.A2A/RegisterAgentExecutor.cs
@@ -15,6 +15,8 @@ internal sealed class RegisterAgentExecutor(
     IHttpClientFactory httpClientFactory,
     ILogger<RegisterAgentExecutor> logger) : IToolExecutor
 {
+    private sealed record DetectedProtocol(string? Version, bool SupportsStreaming);
+
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
@@ -78,15 +80,15 @@ internal sealed class RegisterAgentExecutor(
 
         // Auto-detect protocol version from the remote agent's well-known card
         // unless the caller explicitly specified one.
-        string? detectedVersion = null;
+        DetectedProtocol? detected = null;
         if (string.IsNullOrEmpty(explicitProtocolVersion))
         {
-            detectedVersion = await DetectProtocolVersionAsync(url, authHeaderName, authHeaderValueBase64, ct);
+            detected = await DetectProtocolVersionAsync(url, authHeaderName, authHeaderValueBase64, ct);
         }
 
         var protocolVersion = !string.IsNullOrEmpty(explicitProtocolVersion)
             ? explicitProtocolVersion
-            : detectedVersion;
+            : detected?.Version;
 
         // When updating an existing agent, preserve fields that weren't provided in this call
         // (e.g. auth config, description, skills) so a simple URL update doesn't wipe them.
@@ -100,7 +102,8 @@ internal sealed class RegisterAgentExecutor(
             Skills = skills ?? existing?.Skills,
             AuthHeaderName = string.IsNullOrEmpty(authHeaderName) ? existing?.AuthHeaderName : authHeaderName,
             AuthHeaderValueBase64 = string.IsNullOrEmpty(authHeaderValueBase64) ? existing?.AuthHeaderValueBase64 : authHeaderValueBase64,
-            ProtocolVersion = protocolVersion ?? existing?.ProtocolVersion
+            ProtocolVersion = protocolVersion ?? existing?.ProtocolVersion,
+            SupportsStreaming = detected?.SupportsStreaming ?? existing?.SupportsStreaming
         };
 
         directory.AddOrUpdate(card);
@@ -121,11 +124,12 @@ internal sealed class RegisterAgentExecutor(
     }
 
     /// <summary>
-    /// Probes the remote agent's well-known card endpoints to detect the A2A protocol version.
-    /// Tries v1 (<c>/.well-known/a2a/agent-card</c>) first, then v0.3 (<c>/.well-known/agent-card.json</c>).
+    /// Probes the remote agent's well-known card endpoints to detect the A2A protocol version
+    /// and streaming capability. Tries v1 (<c>/.well-known/a2a/agent-card</c>) first,
+    /// then v0.3 (<c>/.well-known/agent-card.json</c>).
     /// Returns null if detection fails (caller falls back to existing behavior).
     /// </summary>
-    internal async Task<string?> DetectProtocolVersionAsync(
+    private async Task<DetectedProtocol?> DetectProtocolVersionAsync(
         string baseUrl,
         string? authHeaderName,
         string? authHeaderValueBase64,
@@ -147,14 +151,14 @@ internal sealed class RegisterAgentExecutor(
             var trimmedUrl = baseUrl.TrimEnd('/');
 
             // Try v1 well-known endpoint first
-            var v1Version = await TryDetectV1Async(httpClient, trimmedUrl, ct);
-            if (v1Version is not null)
-                return v1Version;
+            var v1Result = await TryDetectV1Async(httpClient, trimmedUrl, ct);
+            if (v1Result is not null)
+                return v1Result;
 
             // Try v0.3 well-known endpoint
-            var v03Version = await TryDetectV03Async(httpClient, trimmedUrl, ct);
-            if (v03Version is not null)
-                return v03Version;
+            var v03Result = await TryDetectV03Async(httpClient, trimmedUrl, ct);
+            if (v03Result is not null)
+                return v03Result;
         }
         catch (Exception ex)
         {
@@ -164,7 +168,7 @@ internal sealed class RegisterAgentExecutor(
         return null;
     }
 
-    private async Task<string?> TryDetectV1Async(HttpClient httpClient, string trimmedUrl, CancellationToken ct)
+    private async Task<DetectedProtocol?> TryDetectV1Async(HttpClient httpClient, string trimmedUrl, CancellationToken ct)
     {
         try
         {
@@ -180,6 +184,11 @@ internal sealed class RegisterAgentExecutor(
             if (root.TryGetProperty("supportedInterfaces", out var interfaces) &&
                 interfaces.ValueKind == JsonValueKind.Array)
             {
+                // Check capabilities.streaming
+                bool streaming = root.TryGetProperty("capabilities", out var caps) &&
+                    caps.TryGetProperty("streaming", out var streamProp) &&
+                    streamProp.ValueKind == JsonValueKind.True;
+
                 // Extract the protocol version from the first interface if available
                 foreach (var iface in interfaces.EnumerateArray())
                 {
@@ -190,17 +199,18 @@ internal sealed class RegisterAgentExecutor(
                         if (!string.IsNullOrEmpty(version))
                         {
                             logger.LogInformation(
-                                "Detected A2A protocol version '{Version}' from v1 agent card at {Url}",
-                                version, trimmedUrl);
-                            return version;
+                                "Detected A2A protocol version '{Version}' from v1 agent card at {Url} (streaming={Streaming})",
+                                version, trimmedUrl, streaming);
+                            return new DetectedProtocol(version, streaming);
                         }
                     }
                 }
 
                 // Has supportedInterfaces but no explicit protocolVersion — assume 1.0
                 logger.LogInformation(
-                    "Detected A2A v1 agent card (supportedInterfaces present) at {Url}", trimmedUrl);
-                return "1.0";
+                    "Detected A2A v1 agent card (supportedInterfaces present) at {Url} (streaming={Streaming})",
+                    trimmedUrl, streaming);
+                return new DetectedProtocol("1.0", streaming);
             }
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
@@ -211,7 +221,7 @@ internal sealed class RegisterAgentExecutor(
         return null;
     }
 
-    private async Task<string?> TryDetectV03Async(HttpClient httpClient, string trimmedUrl, CancellationToken ct)
+    private async Task<DetectedProtocol?> TryDetectV03Async(HttpClient httpClient, string trimmedUrl, CancellationToken ct)
     {
         try
         {
@@ -233,13 +243,13 @@ internal sealed class RegisterAgentExecutor(
                     logger.LogInformation(
                         "Detected A2A protocol version '{Version}' from v0.3 agent card at {Url}",
                         version, trimmedUrl);
-                    return version;
+                    return new DetectedProtocol(version, SupportsStreaming: false);
                 }
             }
 
             // Card exists at v0.3 endpoint but no explicit version — assume 0.3
             logger.LogInformation("Detected A2A v0.3 agent card at {Url}", trimmedUrl);
-            return "0.3";
+            return new DetectedProtocol("0.3", SupportsStreaming: false);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {

--- a/tests/RockBot.A2A.IntegrationTests/Scenarios/HttpA2AScenarios.cs
+++ b/tests/RockBot.A2A.IntegrationTests/Scenarios/HttpA2AScenarios.cs
@@ -252,6 +252,105 @@ internal static class HttpA2AScenarios
     }
 
     /// <summary>
+    /// Scenario 6b: Verify outbound streaming consumption — exercises the same event
+    /// processing that <c>InvokeAgentExecutor.DispatchV1StreamingAsync</c> performs.
+    /// Fetches the agent card to confirm streaming capability, then sends a streaming
+    /// request and verifies the event sequence: intermediate StatusUpdate events with
+    /// consistent contextId, followed by a terminal event.
+    /// </summary>
+    public static async Task OutboundStreamingConsumptionAsync(string gatewayUrl, string? apiKey, IServiceProvider services, CancellationToken ct)
+    {
+        // Step 1: Verify the agent card advertises streaming — this is what
+        // RegisterAgentExecutor.TryDetectV1Async parses to set SupportsStreaming
+        var httpClientFactory = services.GetRequiredService<IHttpClientFactory>();
+        var httpClient = httpClientFactory.CreateClient();
+        await WaitForGateway(gatewayUrl, services, ct);
+
+        var cardResponse = await httpClient.GetAsync($"{gatewayUrl}/.well-known/agent-card.json", ct);
+        cardResponse.EnsureSuccessStatusCode();
+        var cardJson = await cardResponse.Content.ReadAsStringAsync(ct);
+        using var doc = JsonDocument.Parse(cardJson);
+        var root = doc.RootElement;
+
+        Assert(root.TryGetProperty("capabilities", out var caps),
+            "Agent card missing 'capabilities' — RegisterAgentExecutor would not detect streaming");
+        Assert(caps.TryGetProperty("streaming", out var streamProp) && streamProp.GetBoolean(),
+            "Agent card capabilities.streaming is not true — DispatchV1StreamingAsync would not be chosen");
+
+        // Step 2: Consume streaming events the same way DispatchV1StreamingAsync does
+        var a2aClient = CreateA2AClient(gatewayUrl, apiKey, services);
+        var sendRequest = new A2AV1.SendMessageRequest
+        {
+            Message = new A2AV1.Message
+            {
+                Role = A2AV1.Role.User,
+                MessageId = Guid.NewGuid().ToString("N"),
+                Parts = [new A2AV1.Part { Text = "Integration test: outbound streaming consumption" }]
+            },
+            Metadata = new Dictionary<string, JsonElement>
+            {
+                ["skill"] = JsonSerializer.SerializeToElement("notify-user")
+            }
+        };
+
+        var statusUpdates = new List<A2AV1.TaskStatusUpdateEvent>();
+        A2AV1.AgentTask? terminalTask = null;
+        A2AV1.Message? terminalMessage = null;
+        string? contextId = null;
+
+        await foreach (var evt in a2aClient.SendStreamingMessageAsync(sendRequest, ct))
+        {
+            switch (evt.PayloadCase)
+            {
+                case A2AV1.StreamResponseCase.StatusUpdate when evt.StatusUpdate is { } su:
+                    statusUpdates.Add(su);
+                    contextId ??= su.ContextId;
+                    // Verify contextId consistency across events
+                    if (contextId is not null && su.ContextId is not null)
+                        Assert(su.ContextId == contextId,
+                            $"ContextId changed mid-stream: expected '{contextId}', got '{su.ContextId}'");
+                    break;
+
+                case A2AV1.StreamResponseCase.Task when evt.Task is { } task:
+                    contextId ??= task.ContextId;
+                    if (task.Status.State is A2AV1.TaskState.Completed or A2AV1.TaskState.Failed or A2AV1.TaskState.Canceled)
+                        terminalTask = task;
+                    break;
+
+                case A2AV1.StreamResponseCase.Message when evt.Message is { } msg:
+                    terminalMessage = msg;
+                    break;
+            }
+        }
+
+        // Step 3: Verify streaming event sequence
+        var totalEvents = statusUpdates.Count + (terminalTask is not null ? 1 : 0) + (terminalMessage is not null ? 1 : 0);
+        Assert(totalEvents >= 1, $"Expected at least 1 streaming event, got {totalEvents}");
+
+        // Must have a terminal event (Message or Completed Task)
+        var hasTerminal = terminalMessage is not null ||
+            (terminalTask?.Status.State is A2AV1.TaskState.Completed);
+        Assert(hasTerminal, "Stream ended without a terminal Completed event — " +
+            $"got {statusUpdates.Count} status updates, terminalTask state={terminalTask?.Status.State}");
+
+        // Terminal event should contain text content
+        var terminalText = terminalMessage?.Parts.FirstOrDefault(p => !string.IsNullOrEmpty(p.Text))?.Text
+            ?? terminalTask?.Status.Message?.Parts.FirstOrDefault(p => !string.IsNullOrEmpty(p.Text))?.Text;
+        Assert(!string.IsNullOrEmpty(terminalText),
+            "Terminal streaming event has no text content — DispatchV1StreamingAsync would return a result with no message");
+
+        // If we got StatusUpdate events, verify they have valid states
+        foreach (var su in statusUpdates)
+        {
+            Assert(su.Status is not null, "StatusUpdate event has null Status");
+            var validStates = new[] { A2AV1.TaskState.Working, A2AV1.TaskState.Submitted,
+                A2AV1.TaskState.Completed, A2AV1.TaskState.InputRequired };
+            Assert(validStates.Contains(su.Status.State),
+                $"Unexpected StatusUpdate state: {su.Status.State}");
+        }
+    }
+
+    /// <summary>
     /// Scenario 7: Exercise push notification config CRUD — create, get, list, delete.
     /// If the SDK's A2AServer doesn't support push notifications (no store wired up),
     /// the test catches the expected error and passes with a note.

--- a/tests/RockBot.A2A.IntegrationTests/Scenarios/HttpA2AScenarios.cs
+++ b/tests/RockBot.A2A.IntegrationTests/Scenarios/HttpA2AScenarios.cs
@@ -97,12 +97,12 @@ internal static class HttpA2AScenarios
 
         // The response should be a Message (immediate reply) since the gateway
         // waits for RockBot's result before responding.
-        var hasContent = response.PayloadCase switch
+        var hasContent = response!.PayloadCase switch
         {
             A2AV1.SendMessageResponseCase.Message when response.Message is { } msg =>
                 msg.Parts.Any(p => !string.IsNullOrEmpty(p.Text)),
             A2AV1.SendMessageResponseCase.Task when response.Task is { } task =>
-                task.Status.Message?.Parts.Any(p => !string.IsNullOrEmpty(p.Text)) ?? false,
+                task.Status?.Message?.Parts.Any(p => !string.IsNullOrEmpty(p.Text)) ?? false,
             _ => false
         };
 
@@ -201,7 +201,7 @@ internal static class HttpA2AScenarios
         var listResponse = await a2aClient.ListTasksAsync(new A2AV1.ListTasksRequest(), ct);
         Assert(listResponse is not null, "ListTasks response is null");
         Assert(listResponse!.Tasks is not null, "ListTasks Tasks list is null");
-        Assert(listResponse.Tasks.Count >= 1, $"Expected at least 1 task, got {listResponse.Tasks.Count}");
+        Assert(listResponse.Tasks!.Count >= 1, $"Expected at least 1 task, got {listResponse.Tasks.Count}");
     }
 
     /// <summary>
@@ -345,7 +345,7 @@ internal static class HttpA2AScenarios
             Assert(su.Status is not null, "StatusUpdate event has null Status");
             var validStates = new[] { A2AV1.TaskState.Working, A2AV1.TaskState.Submitted,
                 A2AV1.TaskState.Completed, A2AV1.TaskState.InputRequired };
-            Assert(validStates.Contains(su.Status.State),
+            Assert(validStates.Contains(su.Status!.State),
                 $"Unexpected StatusUpdate state: {su.Status.State}");
         }
     }
@@ -422,7 +422,7 @@ internal static class HttpA2AScenarios
         var listed = await a2aClient.ListTaskPushNotificationConfigAsync(
             new A2AV1.ListTaskPushNotificationConfigRequest { TaskId = taskId! }, ct);
         Assert(listed is not null, "ListTaskPushNotificationConfig returned null");
-        Assert(listed!.Configs.Any(c => c.Id == configId),
+        Assert(listed!.Configs?.Any(c => c.Id == configId) == true,
             "Created config not found in list");
 
         // Delete
@@ -436,7 +436,7 @@ internal static class HttpA2AScenarios
         // Verify deletion
         var afterDelete = await a2aClient.ListTaskPushNotificationConfigAsync(
             new A2AV1.ListTaskPushNotificationConfigRequest { TaskId = taskId! }, ct);
-        Assert(!afterDelete!.Configs.Any(c => c.Id == configId),
+        Assert(afterDelete!.Configs?.Any(c => c.Id == configId) != true,
             "Config still present after deletion");
     }
 

--- a/tests/RockBot.A2A.IntegrationTests/TestRunner.cs
+++ b/tests/RockBot.A2A.IntegrationTests/TestRunner.cs
@@ -51,6 +51,11 @@ internal sealed class TestRunner(IServiceProvider services, TestConfig config)
             ct => Scenarios.HttpA2AScenarios.SendStreamingMessageAsync(config.GatewayUrl, config.GatewayApiKey, services, ct),
             timeout: TimeSpan.FromSeconds(90)));
 
+        // Outbound streaming consumption — exercises the DispatchV1StreamingAsync event processing path
+        results.Add(await RunAsync("A2A: Outbound Streaming Consumption",
+            ct => Scenarios.HttpA2AScenarios.OutboundStreamingConsumptionAsync(config.GatewayUrl, config.GatewayApiKey, services, ct),
+            timeout: TimeSpan.FromSeconds(90)));
+
         // Push notification config CRUD
         results.Add(await RunAsync("A2A: Push Notification Config CRUD",
             ct => Scenarios.HttpA2AScenarios.PushNotificationConfigCrudAsync(config.GatewayUrl, config.GatewayApiKey, services, ct),

--- a/tests/RockBot.A2A.Tests/A2ACallerTests.cs
+++ b/tests/RockBot.A2A.Tests/A2ACallerTests.cs
@@ -640,6 +640,139 @@ public class A2ACallerTests
         Assert.AreEqual("1.0", card.ProtocolVersion);
     }
 
+    // ─── V1 streaming event mapping ────────────────────────────────────────────
+
+    [TestMethod]
+    public void MapV1StatusUpdateEvent_MapsWorkingState()
+    {
+        var statusUpdate = new A2AV1.TaskStatusUpdateEvent
+        {
+            TaskId = "task-sw",
+            ContextId = "ctx-sw",
+            Status = new A2AV1.TaskStatus
+            {
+                State = A2AV1.TaskState.Working,
+                Message = new A2AV1.Message
+                {
+                    Role = A2AV1.Role.Agent,
+                    Parts = [new A2AV1.Part { Text = "Processing..." }]
+                }
+            }
+        };
+
+        var result = InvokeAgentExecutor.MapV1StatusUpdateEvent(statusUpdate, "task-sw");
+
+        Assert.AreEqual("task-sw", result.TaskId);
+        Assert.AreEqual(AgentTaskState.Working, result.State);
+        Assert.AreEqual("ctx-sw", result.ContextId);
+        Assert.AreEqual("Processing...", result.Message?.Parts[0].Text);
+    }
+
+    [TestMethod]
+    public void MapV1StatusUpdateEvent_MapsCompletedState()
+    {
+        var statusUpdate = new A2AV1.TaskStatusUpdateEvent
+        {
+            TaskId = "task-sc",
+            Status = new A2AV1.TaskStatus
+            {
+                State = A2AV1.TaskState.Completed,
+                Message = new A2AV1.Message
+                {
+                    Role = A2AV1.Role.Agent,
+                    Parts = [new A2AV1.Part { Text = "All done" }]
+                }
+            }
+        };
+
+        var result = InvokeAgentExecutor.MapV1StatusUpdateEvent(statusUpdate, "task-sc");
+
+        Assert.AreEqual(AgentTaskState.Completed, result.State);
+        Assert.AreEqual("All done", result.Message?.Parts[0].Text);
+    }
+
+    [TestMethod]
+    public void MapV1StatusUpdateEvent_MapsInputRequiredState()
+    {
+        var statusUpdate = new A2AV1.TaskStatusUpdateEvent
+        {
+            TaskId = "task-sir",
+            ContextId = "ctx-sir",
+            Status = new A2AV1.TaskStatus
+            {
+                State = A2AV1.TaskState.InputRequired,
+                Message = new A2AV1.Message
+                {
+                    Role = A2AV1.Role.Agent,
+                    Parts = [new A2AV1.Part { Text = "What day?" }]
+                }
+            }
+        };
+
+        var result = InvokeAgentExecutor.MapV1StatusUpdateEvent(statusUpdate, "task-sir");
+
+        Assert.AreEqual(AgentTaskState.InputRequired, result.State);
+        Assert.AreEqual("What day?", result.Message?.Parts[0].Text);
+    }
+
+    [TestMethod]
+    public void MapV1StatusUpdateEvent_PreservesContextId()
+    {
+        var statusUpdate = new A2AV1.TaskStatusUpdateEvent
+        {
+            TaskId = "task-ctx",
+            ContextId = "ctx-preserved",
+            Status = new A2AV1.TaskStatus { State = A2AV1.TaskState.Working }
+        };
+
+        var result = InvokeAgentExecutor.MapV1StatusUpdateEvent(statusUpdate, "task-ctx");
+
+        Assert.AreEqual("ctx-preserved", result.ContextId);
+    }
+
+    [TestMethod]
+    public void MapV1StatusUpdateEvent_MapsRejected_ToFailed()
+    {
+        var statusUpdate = new A2AV1.TaskStatusUpdateEvent
+        {
+            TaskId = "task-rej",
+            Status = new A2AV1.TaskStatus { State = A2AV1.TaskState.Rejected }
+        };
+
+        var result = InvokeAgentExecutor.MapV1StatusUpdateEvent(statusUpdate, "task-rej");
+
+        Assert.AreEqual(AgentTaskState.Failed, result.State);
+    }
+
+    [TestMethod]
+    public void MapV1StatusUpdateEvent_MapsAuthRequired_ToInputRequired()
+    {
+        var statusUpdate = new A2AV1.TaskStatusUpdateEvent
+        {
+            TaskId = "task-auth",
+            Status = new A2AV1.TaskStatus { State = A2AV1.TaskState.AuthRequired }
+        };
+
+        var result = InvokeAgentExecutor.MapV1StatusUpdateEvent(statusUpdate, "task-auth");
+
+        Assert.AreEqual(AgentTaskState.InputRequired, result.State);
+    }
+
+    [TestMethod]
+    public void MapV1StatusUpdateEvent_HandlesNullMessage()
+    {
+        var statusUpdate = new A2AV1.TaskStatusUpdateEvent
+        {
+            TaskId = "task-nm",
+            Status = new A2AV1.TaskStatus { State = A2AV1.TaskState.Working }
+        };
+
+        var result = InvokeAgentExecutor.MapV1StatusUpdateEvent(statusUpdate, "task-nm");
+
+        Assert.AreEqual(AgentTaskState.Working, result.State);
+        Assert.IsNull(result.Message);
+    }
+
     // ─── A2ATaskStatusHandler ────────────────────────────────────────────────────
 
     [TestMethod]

--- a/tests/RockBot.Agent.Tests/A2A/RockBotTaskHandlerTests.cs
+++ b/tests/RockBot.Agent.Tests/A2A/RockBotTaskHandlerTests.cs
@@ -372,7 +372,7 @@ public class RockBotTaskHandlerTests
     }
 
     private static string ExtractText(AgentTaskResult result) =>
-        result.Message.Parts
+        result.Message?.Parts
             .Where(p => p.Kind == "text")
             .Select(p => p.Text)
             .FirstOrDefault() ?? "";


### PR DESCRIPTION
## Summary

- Add `SupportsStreaming` (`bool?`) to `AgentCard` for tracking remote agent streaming capability
- Extract `capabilities.streaming` from v1 agent card JSON during protocol auto-detection in `RegisterAgentExecutor`
- Add `DispatchV1StreamingAsync` to `InvokeAgentExecutor` — consumes `IAsyncEnumerable<StreamResponse>` via SSE, forwarding `StatusUpdate` events as real-time progress updates instead of polling with exponential backoff
- Full InputRequired multi-turn support in streaming path (max rounds, repetition detection, trust-gated follow-ups)
- Automatic fallback to polling if streaming throws a non-cancellation exception
- Add `StreamingEvents` counter and `transport` tag to diagnostics for observability
- Surface `supportsStreaming` in `get_agent_details` tool output

## Test plan

- [x] All 40 A2A caller tests pass (7 new `MapV1StatusUpdateEvent` tests)
- [x] Full test suite passes (0 failures across all projects)
- [ ] Manual verification with a streaming-capable A2A agent (gateway advertises `capabilities.streaming: true`)

Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)