### PR TITLE
Wisp param resilience, subagent max_iterations, and shared volume fixes

### DIFF
--- a/src/RockBot.Host/AgentLoopRunner.cs
+++ b/src/RockBot.Host/AgentLoopRunner.cs
@@ -239,9 +239,13 @@ public sealed partial class AgentLoopRunner(
         bool enableFollowUp = true,
         bool enableCompletionEval = true,
         double? complexityScore = null,
+        int? maxIterationsOverride = null,
         CancellationToken cancellationToken = default)
     {
         using var _ = ToolCallSessionContext.Set(sessionId);
+        // Set the per-async-flow override so RockBotFunctionInvokingChatClient
+        // (singleton, native path) picks it up for this request.
+        using var __ = MaxIterationsOverrideContext.Set(maxIterationsOverride);
 
         // Ensure a current datetime context is always present.
         EnsureDateTimeContext(chatMessages);
@@ -498,7 +502,9 @@ public sealed partial class AgentLoopRunner(
                 return;
         }
 
-        var maxIterations = modelBehavior.MaxToolIterationsOverride ?? hostOptions.Value.MaxToolIterations;
+        var maxIterations = MaxIterationsOverrideContext.Value
+            ?? modelBehavior.MaxToolIterationsOverride
+            ?? hostOptions.Value.MaxToolIterations;
 
         var text =
             $"You have up to {maxIterations} tool-calling iterations available for this request. " +
@@ -550,7 +556,9 @@ public sealed partial class AgentLoopRunner(
 
         ChatResponse? pendingResponse = firstResponse;
         var anyToolCalled = false;
-        var maxIterations = modelBehavior.MaxToolIterationsOverride ?? hostOptions.Value.MaxToolIterations;
+        var maxIterations = MaxIterationsOverrideContext.Value
+            ?? modelBehavior.MaxToolIterationsOverride
+            ?? hostOptions.Value.MaxToolIterations;
         var consecutiveTimeoutIterations = 0;
         var repetitiveCallDetector = new RepetitiveToolCallDetector();
 

--- a/src/RockBot.Host/MaxIterationsOverrideContext.cs
+++ b/src/RockBot.Host/MaxIterationsOverrideContext.cs
@@ -1,0 +1,32 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Ambient per-async-flow override for the maximum tool-calling iterations.
+/// Set by <see cref="AgentLoopRunner"/> when a caller (e.g. a subagent) requests
+/// more iterations than the default model behavior allows.
+/// <see cref="RockBotFunctionInvokingChatClient"/> reads this to temporarily
+/// override <c>MaximumIterationsPerRequest</c> for the current request.
+/// </summary>
+public static class MaxIterationsOverrideContext
+{
+    private static readonly AsyncLocal<int?> Current = new();
+
+    /// <summary>Gets the current override, or null if not set.</summary>
+    public static int? Value => Current.Value;
+
+    /// <summary>
+    /// Sets the max iterations override for the current async flow. Returns a
+    /// disposable that restores the previous value on dispose.
+    /// </summary>
+    public static IDisposable Set(int? maxIterations)
+    {
+        var previous = Current.Value;
+        Current.Value = maxIterations;
+        return new Scope(previous);
+    }
+
+    private sealed class Scope(int? previous) : IDisposable
+    {
+        public void Dispose() => Current.Value = previous;
+    }
+}

--- a/src/RockBot.Host/RockBotFunctionInvokingChatClient.cs
+++ b/src/RockBot.Host/RockBotFunctionInvokingChatClient.cs
@@ -173,11 +173,20 @@ public class RockBotFunctionInvokingChatClient : FunctionInvokingChatClient
     {
         _consecutiveTimeoutIterations = 0;
         _repetitiveCallDetector.Reset();
+
+        // Apply per-request max iterations override if set (e.g. by a subagent
+        // that was spawned with an elevated iteration budget).
+        var saved = MaximumIterationsPerRequest;
+        if (MaxIterationsOverrideContext.Value is int overrideValue)
+            MaximumIterationsPerRequest = overrideValue;
+
         _logger.LogInformation(
             "RockBotFunctionInvokingChatClient handling request (maxIterations={MaxIter})",
             MaximumIterationsPerRequest);
         var messageList = messages as List<ChatMessage> ?? [.. messages];
 
+        try
+        {
         if (_knownContextLimit is int preLimit)
             TrimLargeToolResults(messageList, preLimit);
 
@@ -268,6 +277,11 @@ public class RockBotFunctionInvokingChatClient : FunctionInvokingChatClient
         }
 
         return response;
+        }
+        finally
+        {
+            MaximumIterationsPerRequest = saved;
+        }
     }
 
     private void TrimLargeToolResults(List<ChatMessage> messages, int maxTokens)

--- a/src/RockBot.Scripts.Remote/ScriptToolSkillProvider.cs
+++ b/src/RockBot.Scripts.Remote/ScriptToolSkillProvider.cs
@@ -145,25 +145,35 @@ internal sealed class ScriptToolSkillProvider : IToolSkillProvider
           to stdout; be deliberate about what the script does
 
 
-        ## Producing Output Files (shared volume)
+        ## Reading and Writing Files (shared volume)
 
-        Script containers have the shared volume mounted at the path in the
-        `ROCKBOT_SHARED_PATH` environment variable. Files written there persist after the
-        container exits and are accessible to the agent and other services.
+        **CRITICAL:** Script containers do NOT share the agent's working directory.
+        The ONLY persistent filesystem is the shared volume, mounted at the path in
+        the `ROCKBOT_SHARED_PATH` environment variable (typically `/rockbot/shared`).
 
-        **Typical workflow:**
+        **You MUST use absolute paths built from `ROCKBOT_SHARED_PATH` for ALL file
+        access.** Relative paths like `staging/file.json` will fail — the container's
+        working directory is NOT the shared volume.
 
-        1. Write a script that saves output to `os.environ['ROCKBOT_SHARED_PATH']`:
-           ```python
-           import os
-           shared = os.environ['ROCKBOT_SHARED_PATH']
-           path = os.path.join(shared, 'exports', 'report.xlsx')
-           os.makedirs(os.path.dirname(path), exist_ok=True)
-           # ... write the file ...
-           print(f"exports/report.xlsx")
-           ```
-        2. Have the script print the relative path to stdout on success.
-        3. After the script completes, use `file_read` or `file_get_path` to access the output.
+        **Reading files** (e.g. files created by wisps via `output_to`):
+        ```python
+        import os, json
+        shared = os.environ['ROCKBOT_SHARED_PATH']
+        with open(os.path.join(shared, 'staging', 'events.json')) as f:
+            data = json.load(f)
+        ```
+
+        **Writing files:**
+        ```python
+        import os
+        shared = os.environ['ROCKBOT_SHARED_PATH']
+        path = os.path.join(shared, 'exports', 'report.xlsx')
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        # ... write the file ...
+        print(f"exports/report.xlsx")
+        ```
+
+        After the script completes, use `file_read` or `file_get_path` to access the output.
 
 
         ## Common Pitfalls
@@ -175,6 +185,10 @@ internal sealed class ScriptToolSkillProvider : IToolSkillProvider
           `timeout_seconds` when installing large dependencies like `torch` or `scipy`
         - Printing debug statements that pollute the output — use stderr for debug output:
           `import sys; print("debug", file=sys.stderr)`
+        - **Using relative file paths** — the container's cwd is NOT `/rockbot/shared`.
+          Always build paths with `os.path.join(os.environ['ROCKBOT_SHARED_PATH'], ...)`.
+          If wisps wrote files via `output_to: "staging/file.json"`, the script must read
+          them at `os.path.join(shared, 'staging', 'file.json')`, not `"staging/file.json"`
         - Writing files outside `ROCKBOT_SHARED_PATH` — only files on the shared volume
           persist after the container exits
         """;

--- a/src/RockBot.Subagent/ISubagentManager.cs
+++ b/src/RockBot.Subagent/ISubagentManager.cs
@@ -11,7 +11,7 @@ public interface ISubagentManager
     /// </summary>
     Task<string> SpawnAsync(string description, string? context, int? timeoutMinutes,
         string primarySessionId, CancellationToken ct,
-        string? batchId = null, bool consolidate = true);
+        string? batchId = null, bool consolidate = true, int? maxIterations = null);
 
     /// <summary>
     /// Cancels a running subagent by task ID. Returns true if found and cancelled.

--- a/src/RockBot.Subagent/SpawnSubagentExecutor.cs
+++ b/src/RockBot.Subagent/SpawnSubagentExecutor.cs
@@ -25,12 +25,13 @@ internal sealed class SpawnSubagentExecutor(ISubagentManager manager) : IToolExe
         var description = descEl.GetString()!;
         var context = args.TryGetValue("context", out var ctxEl) ? ctxEl.GetString() : null;
         int? timeoutMinutes = args.TryGetValue("timeout_minutes", out var toEl) && toEl.TryGetInt32(out var to) ? to : null;
+        int? maxIterations = args.TryGetValue("max_iterations", out var miEl) && miEl.TryGetInt32(out var mi) ? mi : null;
         bool consolidate = !args.TryGetValue("consolidate", out var consEl) || consEl.ValueKind != JsonValueKind.False;
 
         var primarySessionId = request.SessionId ?? "unknown";
 
         var taskId = await manager.SpawnAsync(description, context, timeoutMinutes, primarySessionId, ct,
-            batchId: request.BatchId, consolidate: consolidate);
+            batchId: request.BatchId, consolidate: consolidate, maxIterations: maxIterations);
 
         return new ToolInvokeResponse
         {

--- a/src/RockBot.Subagent/SubagentManager.cs
+++ b/src/RockBot.Subagent/SubagentManager.cs
@@ -26,7 +26,8 @@ public sealed class SubagentManager(
         string primarySessionId,
         CancellationToken ct,
         string? batchId = null,
-        bool consolidate = true)
+        bool consolidate = true,
+        int? maxIterations = null)
     {
         // Clean up completed tasks first
         foreach (var key in _active.Keys.ToList())
@@ -53,7 +54,7 @@ public sealed class SubagentManager(
         var cts = new CancellationTokenSource();
         cts.CancelAfter(TimeSpan.FromMinutes(timeout));
 
-        var task = RunSubagentAsync(taskId, subagentSessionId, description, context, primarySessionId, batchId, consolidate, cts.Token);
+        var task = RunSubagentAsync(taskId, subagentSessionId, description, context, primarySessionId, batchId, consolidate, maxIterations, cts.Token);
 
         var newEntry = new SubagentEntry
         {
@@ -111,6 +112,7 @@ public sealed class SubagentManager(
         string primarySessionId,
         string? batchId,
         bool consolidate,
+        int? maxIterations,
         CancellationToken ct)
     {
         // SubagentRunner.RunAsync handles all its own exit paths (success, failure,
@@ -121,7 +123,7 @@ public sealed class SubagentManager(
         {
             await using var scope = scopeFactory.CreateAsyncScope();
             var runner = scope.ServiceProvider.GetRequiredService<SubagentRunner>();
-            await runner.RunAsync(taskId, subagentSessionId, description, context, primarySessionId, batchId, consolidate, ct);
+            await runner.RunAsync(taskId, subagentSessionId, description, context, primarySessionId, batchId, consolidate, maxIterations, ct);
         }
         catch (Exception ex)
         {

--- a/src/RockBot.Subagent/SubagentRunner.cs
+++ b/src/RockBot.Subagent/SubagentRunner.cs
@@ -40,6 +40,7 @@ internal sealed class SubagentRunner(
         string primarySessionId,
         string? batchId,
         bool consolidate,
+        int? maxIterations,
         CancellationToken ct)
     {
         var classification = tierSelector.Classify(description, new TierRoutingContext(Origin: "subagent"));
@@ -56,6 +57,11 @@ internal sealed class SubagentRunner(
             "using your tools — do not design frameworks, save skills, or plan methodology. " +
             "Start calling the required tools immediately. " +
             "Call ReportProgress after each significant step so the user stays informed. " +
+            "For repetitive operations with known parameters (e.g., the same API call across " +
+            "multiple date ranges, accounts, or categories), use spawn_wisps to execute them " +
+            "in parallel rather than calling tools sequentially. Wisps don't consume your " +
+            "iteration budget and run concurrently. Use Direct mode steps with the correct " +
+            "gateway and put tool arguments in the \"params\" field. " +
             $"For large outputs (reports, document lists, structured data): use save_to_working_memory " +
             $"to store them (set ttl_minutes to 240 or more). Your outputs are stored under namespace " +
             $"'{subagentNamespace}' and the primary agent can retrieve them using " +
@@ -167,6 +173,7 @@ internal sealed class SubagentRunner(
             finalOutput = await agentLoopRunner.RunAsync(
                 chatMessages, chatOptions, subagentSessionId,
                 tier: tier, enableFollowUp: false, enableCompletionEval: false,
+                maxIterationsOverride: maxIterations,
                 cancellationToken: ct);
             finalOutput = ResponseSanitizer.StripTrailingOffers(finalOutput);
             isSuccess = true;

--- a/src/RockBot.Subagent/SubagentToolRegistrar.cs
+++ b/src/RockBot.Subagent/SubagentToolRegistrar.cs
@@ -28,6 +28,10 @@ internal sealed class SubagentToolRegistrar(
               "type": "integer",
               "description": "Optional timeout in minutes (default: 10)."
             },
+            "max_iterations": {
+              "type": "integer",
+              "description": "Optional maximum tool-calling iterations for this subagent (default: model-specific, typically 25). Increase for tasks that require many sequential tool calls. When the subagent will use spawn_wisps for parallel work, the default is usually sufficient."
+            },
             "consolidate": {
               "type": "boolean",
               "description": "When true (default), this subagent's result will be batched with sibling subagent results into a single consolidated response. Set to false to deliver this subagent's result immediately as its own response."

--- a/src/RockBot.Subagent/SubagentToolSkillProvider.cs
+++ b/src/RockBot.Subagent/SubagentToolSkillProvider.cs
@@ -30,6 +30,10 @@ public sealed class SubagentToolSkillProvider : IToolSkillProvider
           search terms, timezone, expected output format).
         - context (optional): Additional data or context the subagent needs
         - timeout_minutes (optional): How long to allow (default 10 minutes)
+        - max_iterations (optional): Maximum tool-calling iterations (default: model-
+          specific, typically 25). Increase when the subagent needs many sequential
+          tool calls. When the subagent will use spawn_wisps for parallel work, the
+          default is usually sufficient since wisps don't consume iteration budget.
         - consolidate (optional, default true): When true, this subagent's result is
           batched with sibling results into a single consolidated response. Set to false
           to deliver this subagent's result immediately as its own independent response.

--- a/src/RockBot.Tools.FileSystem/FileWriteToolExecutor.cs
+++ b/src/RockBot.Tools.FileSystem/FileWriteToolExecutor.cs
@@ -25,6 +25,20 @@ internal sealed class FileWriteToolExecutor(FileSystemOptions options) : IToolEx
             Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
             await File.WriteAllTextAsync(fullPath, content, ct);
 
+            // Make files world-writable so other containers sharing the volume
+            // (script pods, MCP servers) can read and overwrite them.
+            try
+            {
+                File.SetUnixFileMode(fullPath,
+                    UnixFileMode.UserRead | UnixFileMode.UserWrite |
+                    UnixFileMode.GroupRead | UnixFileMode.GroupWrite |
+                    UnixFileMode.OtherRead | UnixFileMode.OtherWrite);
+            }
+            catch
+            {
+                // Non-Unix platforms — best-effort only.
+            }
+
             return new ToolInvokeResponse
             {
                 ToolCallId = request.ToolCallId,

--- a/src/RockBot.Wisp/GatewayRouter.cs
+++ b/src/RockBot.Wisp/GatewayRouter.cs
@@ -53,8 +53,14 @@ internal static class GatewayRouter
             return ToolRouteResult.Failure("MCP gateway requires 'server' field", FailureCategory.Structural);
         if (string.IsNullOrEmpty(step.Tool))
             return ToolRouteResult.Failure("MCP gateway requires 'tool' field", FailureCategory.Structural);
+        if (step.ResolvedParams is null)
+            return ToolRouteResult.Failure(
+                $"MCP step '{step.Id}' has no 'params' field. Put the tool arguments " +
+                $"for {step.Server}/{step.Tool} in \"params\": {{...}}. Example: " +
+                $"\"params\": {{\"timeZone\": \"America/Chicago\", \"startDate\": \"2025-04-01\"}}",
+                FailureCategory.Structural);
 
-        var resolvedParams = ResolveTemplates(step.Params, priorResults);
+        var resolvedParams = ResolveTemplates(step.ResolvedParams, priorResults);
 
         var args = new Dictionary<string, object?>
         {
@@ -94,14 +100,14 @@ internal static class GatewayRouter
 
     private static ToolRouteResult RouteScript(WispStep step, string wispId, IReadOnlyDictionary<string, WispStepResult> priorResults)
     {
-        if (step.Params is null)
+        if (step.ResolvedParams is null)
             return ToolRouteResult.Failure("Script gateway requires 'params' with 'script' field", FailureCategory.Structural);
 
-        var paramsObj = step.Params.Value;
+        var paramsObj = step.ResolvedParams.Value;
         if (!paramsObj.TryGetProperty("script", out _))
             return ToolRouteResult.Failure("Script gateway requires 'script' in params", FailureCategory.Structural);
 
-        var resolvedParams = ResolveTemplates(step.Params, priorResults);
+        var resolvedParams = ResolveTemplates(step.ResolvedParams, priorResults);
         var language = step.Language ?? "python";
         var toolName = $"execute_{language}_script";
 
@@ -117,7 +123,7 @@ internal static class GatewayRouter
         if (step.Tool is not ("web_search" or "web_browse"))
             return ToolRouteResult.Failure($"Web gateway tool must be 'web_search' or 'web_browse', got '{step.Tool}'", FailureCategory.Structural);
 
-        var resolvedParams = ResolveTemplates(step.Params, priorResults);
+        var resolvedParams = ResolveTemplates(step.ResolvedParams, priorResults);
 
         return ToolRouteResult.Success(step.Tool,
             resolvedParams is JsonElement je ? je.GetRawText() : JsonSerializer.Serialize(resolvedParams ?? new object(), JsonOptions));

--- a/src/RockBot.Wisp/WispExecutor.cs
+++ b/src/RockBot.Wisp/WispExecutor.cs
@@ -592,6 +592,21 @@ internal sealed class WispExecutor(
 
         Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
         await File.WriteAllTextAsync(fullPath, content, ct);
+
+        // Make files world-writable so other containers sharing the volume
+        // (script pods, MCP servers) can read and overwrite them regardless
+        // of which user created them.
+        try
+        {
+            File.SetUnixFileMode(fullPath,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite |
+                UnixFileMode.GroupRead | UnixFileMode.GroupWrite |
+                UnixFileMode.OtherRead | UnixFileMode.OtherWrite);
+        }
+        catch
+        {
+            // Non-Unix platforms or permission errors — best-effort only.
+        }
     }
 
     private async Task<string?> ReadFromSharedVolumeAsync(string relativePath, CancellationToken ct)

--- a/src/RockBot.Wisp/WispStep.cs
+++ b/src/RockBot.Wisp/WispStep.cs
@@ -50,9 +50,35 @@ public sealed record WispStep
 
     /// <summary>
     /// Tool parameters as a JSON object. Interpretation depends on the gateway type.
+    /// Accepts both <c>"params"</c> and <c>"input"</c> as the JSON property name;
+    /// if both are present, <c>"params"</c> wins.
     /// </summary>
     [JsonPropertyName("params")]
     public JsonElement? Params { get; init; }
+
+    /// <summary>
+    /// Alias for <see cref="Params"/>. LLMs sometimes use <c>"input"</c> instead of
+    /// <c>"params"</c>; this property captures the value so the gateway router can
+    /// fall back to it when <c>Params</c> is null.
+    /// </summary>
+    [JsonPropertyName("input")]
+    public JsonElement? Input { get; init; }
+
+    /// <summary>
+    /// Alias for <see cref="Params"/>. LLMs sometimes use <c>"arguments"</c> instead of
+    /// <c>"params"</c>.
+    /// </summary>
+    [JsonPropertyName("arguments")]
+    public JsonElement? Arguments { get; init; }
+
+    /// <summary>
+    /// Resolved parameters: returns the first non-null of <see cref="Params"/>,
+    /// <see cref="Input"/>, <see cref="Arguments"/>. As a last resort, if
+    /// <see cref="InputFrom"/> looks like a JSON object (starts with '{'), it is
+    /// parsed and used — LLMs sometimes stuff tool arguments into that field.
+    /// </summary>
+    [JsonIgnore]
+    public JsonElement? ResolvedParams => Params ?? Input ?? Arguments ?? TryParseInputFromAsParams();
 
     /// <summary>
     /// Prompt/instruction for <c>llm</c> mode steps.
@@ -106,4 +132,24 @@ public sealed record WispStep
     /// </summary>
     [JsonPropertyName("on_failure")]
     public OnFailureAction? OnFailure { get; init; }
+
+    /// <summary>
+    /// Attempts to parse <see cref="InputFrom"/> as a JSON object. LLMs sometimes
+    /// stuff tool arguments into <c>input_from</c> as a JSON string instead of using
+    /// <c>params</c>. Returns null if <c>InputFrom</c> is null, empty, or not valid JSON.
+    /// </summary>
+    private JsonElement? TryParseInputFromAsParams()
+    {
+        if (string.IsNullOrEmpty(InputFrom) || !InputFrom.TrimStart().StartsWith('{'))
+            return null;
+
+        try
+        {
+            return JsonDocument.Parse(InputFrom).RootElement;
+        }
+        catch
+        {
+            return null;
+        }
+    }
 }

--- a/src/RockBot.Wisp/WispToolSkillProvider.cs
+++ b/src/RockBot.Wisp/WispToolSkillProvider.cs
@@ -94,7 +94,11 @@ public sealed class WispToolSkillProvider : IToolSkillProvider
 
         ### Gateways (for Direct steps)
 
-        Each Direct step routes through a gateway that maps to the correct registered tool:
+        Each Direct step routes through a gateway that maps to the correct registered tool.
+
+        **IMPORTANT:** Tool arguments go in the `"params"` field (not `"input"` or
+        `"arguments"`). Include ALL required parameters — the harness passes them
+        directly to the tool with no defaulting or inference.
 
         **MCP** — Call any MCP server tool:
         ```json

--- a/tests/RockBot.Subagent.Tests/SubagentResultGateTests.cs
+++ b/tests/RockBot.Subagent.Tests/SubagentResultGateTests.cs
@@ -218,7 +218,7 @@ public class SubagentResultGateTests
     {
         public Task<string> SpawnAsync(string description, string? context, int? timeoutMinutes,
             string primarySessionId, CancellationToken ct,
-            string? batchId = null, bool consolidate = true) =>
+            string? batchId = null, bool consolidate = true, int? maxIterations = null) =>
             Task.FromResult("fake-task-id");
 
         public Task<bool> CancelAsync(string taskId) =>

--- a/tests/RockBot.Subagent.Tests/SubagentToolExecutorTests.cs
+++ b/tests/RockBot.Subagent.Tests/SubagentToolExecutorTests.cs
@@ -170,6 +170,46 @@ public class SubagentToolExecutorTests
     }
 
     [TestMethod]
+    public async Task SpawnSubagentExecutor_WithMaxIterations_PassesToManager()
+    {
+        var manager = new FakeSubagentManager([]) { SpawnResult = "task456" };
+        var executor = new SpawnSubagentExecutor(manager);
+        var args = JsonSerializer.Serialize(new { description = "Heavy task", max_iterations = 50 });
+        var request = new ToolInvokeRequest
+        {
+            ToolCallId = "call-1",
+            ToolName = "spawn_subagent",
+            Arguments = args,
+            SessionId = "session-1"
+        };
+
+        var response = await executor.ExecuteAsync(request, CancellationToken.None);
+
+        Assert.IsFalse(response.IsError);
+        Assert.AreEqual(50, manager.LastMaxIterations);
+    }
+
+    [TestMethod]
+    public async Task SpawnSubagentExecutor_WithoutMaxIterations_PassesNullToManager()
+    {
+        var manager = new FakeSubagentManager([]) { SpawnResult = "task789" };
+        var executor = new SpawnSubagentExecutor(manager);
+        var args = JsonSerializer.Serialize(new { description = "Normal task" });
+        var request = new ToolInvokeRequest
+        {
+            ToolCallId = "call-1",
+            ToolName = "spawn_subagent",
+            Arguments = args,
+            SessionId = "session-1"
+        };
+
+        var response = await executor.ExecuteAsync(request, CancellationToken.None);
+
+        Assert.IsFalse(response.IsError);
+        Assert.IsNull(manager.LastMaxIterations);
+    }
+
+    [TestMethod]
     public async Task SpawnSubagentExecutor_InvalidJson_ReturnsError()
     {
         var manager = new FakeSubagentManager([]);
@@ -195,11 +235,15 @@ public class SubagentToolExecutorTests
     {
         public string SpawnResult { get; set; } = "fake-task-id";
         public bool CancelResult { get; set; }
+        public int? LastMaxIterations { get; private set; }
 
         public Task<string> SpawnAsync(string description, string? context, int? timeoutMinutes,
             string primarySessionId, CancellationToken ct,
-            string? batchId = null, bool consolidate = true) =>
-            Task.FromResult(SpawnResult);
+            string? batchId = null, bool consolidate = true, int? maxIterations = null)
+        {
+            LastMaxIterations = maxIterations;
+            return Task.FromResult(SpawnResult);
+        }
 
         public Task<bool> CancelAsync(string taskId) =>
             Task.FromResult(CancelResult);

--- a/tests/RockBot.Wisp.Tests/GatewayRouterTests.cs
+++ b/tests/RockBot.Wisp.Tests/GatewayRouterTests.cs
@@ -36,6 +36,57 @@ public class GatewayRouterTests
     }
 
     [TestMethod]
+    public void Route_Mcp_WithInputAlias_PassesArgumentsCorrectly()
+    {
+        var step = new WispStep
+        {
+            Id = "fetch_events",
+            Mode = StepMode.Direct,
+            Gateway = GatewayType.Mcp,
+            Server = "calendar-mcp",
+            Tool = "get_calendar_events",
+            // LLM used "input" instead of "params" — should still route correctly
+            Input = JsonDocument.Parse("""{"timeZone": "America/Chicago", "startDate": "2025-04-01"}""").RootElement
+        };
+
+        var result = GatewayRouter.Route(step, "wisp-123", EmptyResults);
+
+        Assert.IsTrue(result.IsSuccess);
+        Assert.AreEqual("mcp_invoke_tool", result.ToolName);
+        Assert.IsNotNull(result.Arguments);
+
+        var args = JsonDocument.Parse(result.Arguments!).RootElement;
+        Assert.AreEqual("calendar-mcp", args.GetProperty("server_name").GetString());
+        Assert.AreEqual("get_calendar_events", args.GetProperty("tool_name").GetString());
+        Assert.AreEqual("America/Chicago",
+            args.GetProperty("arguments").GetProperty("timeZone").GetString());
+    }
+
+    [TestMethod]
+    public void Route_Mcp_WithArgsInInputFrom_RescuesAndRoutes()
+    {
+        // LLM put tool arguments in input_from as a JSON string
+        var step = new WispStep
+        {
+            Id = "fetch_events",
+            Mode = StepMode.Direct,
+            Gateway = GatewayType.Mcp,
+            Server = "calendar-mcp",
+            Tool = "get_calendar_events",
+            InputFrom = """{"timeZone": "America/Chicago", "startDate": "2025-04-01"}"""
+        };
+
+        var result = GatewayRouter.Route(step, "wisp-123", EmptyResults);
+
+        Assert.IsTrue(result.IsSuccess, result.ErrorMessage);
+        Assert.AreEqual("mcp_invoke_tool", result.ToolName);
+
+        var args = JsonDocument.Parse(result.Arguments!).RootElement;
+        Assert.AreEqual("America/Chicago",
+            args.GetProperty("arguments").GetProperty("timeZone").GetString());
+    }
+
+    [TestMethod]
     public void Route_Mcp_MissingServer_ReturnsStructuralError()
     {
         var step = new WispStep

--- a/tests/RockBot.Wisp.Tests/WispDefinitionTests.cs
+++ b/tests/RockBot.Wisp.Tests/WispDefinitionTests.cs
@@ -179,6 +179,143 @@ public class WispDefinitionTests
     }
 
     [TestMethod]
+    public void Deserialize_InputAlias_MapsToResolvedParams()
+    {
+        var json = """
+        {
+          "description": "Using input instead of params",
+          "steps": [
+            {
+              "id": "fetch",
+              "gateway": "Mcp",
+              "mode": "Direct",
+              "server": "calendar-mcp",
+              "tool": "get_calendar_events",
+              "input": { "timeZone": "America/Chicago", "startDate": "2025-04-01" }
+            }
+          ]
+        }
+        """;
+
+        var definition = JsonSerializer.Deserialize<WispDefinition>(json, JsonOptions)!;
+
+        var step = definition.Steps[0];
+        Assert.IsNull(step.Params, "Params should be null when 'input' is used");
+        Assert.IsNotNull(step.Input, "Input should be populated from the 'input' field");
+        Assert.IsNotNull(step.ResolvedParams, "ResolvedParams should fall back to Input");
+        Assert.AreEqual("America/Chicago",
+            step.ResolvedParams!.Value.GetProperty("timeZone").GetString());
+    }
+
+    [TestMethod]
+    public void Deserialize_ArgumentsAlias_MapsToResolvedParams()
+    {
+        var json = """
+        {
+          "description": "Using arguments instead of params",
+          "steps": [
+            {
+              "id": "fetch",
+              "gateway": "Mcp",
+              "mode": "Direct",
+              "server": "calendar-mcp",
+              "tool": "get_calendar_events",
+              "arguments": { "timeZone": "America/Chicago" }
+            }
+          ]
+        }
+        """;
+
+        var definition = JsonSerializer.Deserialize<WispDefinition>(json, JsonOptions)!;
+
+        var step = definition.Steps[0];
+        Assert.IsNotNull(step.ResolvedParams);
+        Assert.AreEqual("America/Chicago",
+            step.ResolvedParams!.Value.GetProperty("timeZone").GetString());
+    }
+
+    [TestMethod]
+    public void Deserialize_InputFromWithJsonObject_RescuedAsParams()
+    {
+        var json = """
+        {
+          "description": "LLM stuffed args into input_from",
+          "steps": [
+            {
+              "id": "fetch",
+              "gateway": "Mcp",
+              "mode": "Direct",
+              "server": "calendar-mcp",
+              "tool": "get_calendar_events",
+              "input_from": "{\"timeZone\":\"America/Chicago\",\"startDate\":\"2025-04-01\"}"
+            }
+          ]
+        }
+        """;
+
+        var definition = JsonSerializer.Deserialize<WispDefinition>(json, JsonOptions)!;
+
+        var step = definition.Steps[0];
+        Assert.IsNull(step.Params);
+        Assert.IsNull(step.Input);
+        Assert.IsNotNull(step.ResolvedParams, "Should rescue JSON from input_from");
+        Assert.AreEqual("America/Chicago",
+            step.ResolvedParams!.Value.GetProperty("timeZone").GetString());
+    }
+
+    [TestMethod]
+    public void Deserialize_InputFromWithFilePath_DoesNotRescue()
+    {
+        var json = """
+        {
+          "description": "Normal file path in input_from",
+          "steps": [
+            {
+              "id": "process",
+              "mode": "Llm",
+              "prompt": "Summarize",
+              "input_from": "wisp-data/results.json"
+            }
+          ]
+        }
+        """;
+
+        var definition = JsonSerializer.Deserialize<WispDefinition>(json, JsonOptions)!;
+
+        var step = definition.Steps[0];
+        Assert.IsNull(step.ResolvedParams, "File path should not be rescued as params");
+    }
+
+    [TestMethod]
+    public void Deserialize_ParamsTakesPrecedenceOverInput()
+    {
+        var json = """
+        {
+          "description": "Both params and input present",
+          "steps": [
+            {
+              "id": "fetch",
+              "gateway": "Mcp",
+              "mode": "Direct",
+              "server": "test",
+              "tool": "test_tool",
+              "params": { "from_params": true },
+              "input": { "from_input": true }
+            }
+          ]
+        }
+        """;
+
+        var definition = JsonSerializer.Deserialize<WispDefinition>(json, JsonOptions)!;
+
+        var step = definition.Steps[0];
+        Assert.IsNotNull(step.Params);
+        Assert.IsNotNull(step.Input);
+        Assert.IsTrue(step.ResolvedParams!.Value.TryGetProperty("from_params", out _),
+            "ResolvedParams should prefer Params when both are set");
+    }
+
+    [TestMethod]
     public void Deserialize_LlmStep_WithInputFrom()
     {
         var json = """


### PR DESCRIPTION
## Summary
- **Wisp param resilience**: LLMs consistently put MCP tool arguments in wrong fields (`input`, `arguments`, `input_from` instead of `params`). `WispStep.ResolvedParams` now checks all plausible fields and rescues JSON objects from `input_from`. MCP gateway rejects steps with no params with an actionable error message.
- **Subagent `max_iterations` override**: Primary agent can now pass `max_iterations` to `spawn_subagent` to elevate the iteration cap for heavy tasks. Flows through `AsyncLocal` so the singleton `FunctionInvokingChatClient` picks it up per-request.
- **Shared volume file permissions**: Files written by wisps and `file_write` are now `666` so script containers and MCP servers running as different users can overwrite them.
- **Script tool guide**: Strengthened to emphasize absolute paths via `ROCKBOT_SHARED_PATH` and call out the wisp `output_to` → script relative path trap.
- **Subagent preamble**: Now coaches subagents to use `spawn_wisps` for repetitive parallel work.

## Test plan
- [x] All 800+ existing tests pass
- [x] New tests for wisp `input`/`arguments`/`input_from` aliases (deserialization + gateway routing)
- [x] New tests for `max_iterations` parsing in `SpawnSubagentExecutor`
- [x] Deployed to k8s and verified wisps succeed with `params` field
- [x] Verified script containers can read/write shared volume files

🤖 Generated with [Claude Code](https://claude.com/claude-code)