### PR TITLE
claude/fix-patrol-file-deletion-3JolY

### DIFF
--- a/src/RockBot.Host.Abstractions/DreamOptions.cs
+++ b/src/RockBot.Host.Abstractions/DreamOptions.cs
@@ -110,6 +110,15 @@ public sealed class DreamOptions
     /// </summary>
     public string GraphConsolidationDirectivePath { get; set; } = "graph-consolidation-dream.md";
 
+    /// <summary>
+    /// Skill name prefixes that are protected from deletion by dream consolidation and
+    /// optimization passes. Skills whose names start with any of these prefixes (case-insensitive)
+    /// will never be deleted, even if the LLM proposes merging or removing them.
+    /// Default: <c>["patrol/"]</c> — protects the patrol checklist skills that are referenced
+    /// by system directives.
+    /// </summary>
+    public List<string> ProtectedSkillPrefixes { get; set; } = ["patrol/"];
+
     /// <summary>Whether the narrative identity reflection pass is enabled.</summary>
     public bool IdentityReflectionEnabled { get; set; } = true;
 

--- a/src/RockBot.Host/DreamService.cs
+++ b/src/RockBot.Host/DreamService.cs
@@ -550,11 +550,14 @@ internal sealed class DreamService : IHostedService, IDisposable
     {
         var all = await _skillStore!.ListAsync();
 
-        // Prune skills that have not been used in 18 months
+        // Prune skills that have not been used in 18 months (skip protected skills)
         var threshold = DateTimeOffset.UtcNow.AddMonths(-18);
         var pruned = 0;
         foreach (var skill in all)
         {
+            if (IsProtectedSkill(skill.Name))
+                continue;
+
             var lastActivity = skill.LastUsedAt ?? skill.UpdatedAt ?? skill.CreatedAt;
             if (lastActivity < threshold)
             {
@@ -712,6 +715,17 @@ internal sealed class DreamService : IHostedService, IDisposable
         foreach (var dto in result.ToSave ?? [])
             foreach (var srcName in dto.SourceNames ?? [])
                 allToDelete.Add(srcName);
+
+        // Guard: never delete skills whose names match a protected prefix (e.g. patrol/).
+        // These skills are referenced by system directives and must not be removed by dream passes.
+        var protectedNames = allToDelete.Where(IsProtectedSkill).ToList();
+        foreach (var name in protectedNames)
+        {
+            allToDelete.Remove(name);
+            _logger.LogWarning(
+                "DreamService: skill consolidation LLM proposed deleting protected skill '{Name}' — skipping",
+                name);
+        }
 
         // Safety guard: refuse to delete skills when nothing is being saved in return.
         // The directive says "never delete without replacement" — enforce it in code so an
@@ -964,6 +978,16 @@ internal sealed class DreamService : IHostedService, IDisposable
         foreach (var dto in result.ToSave ?? [])
             foreach (var srcName in dto.SourceNames ?? [])
                 allToDelete.Add(srcName);
+
+        // Guard: never delete skills whose names match a protected prefix (e.g. patrol/).
+        var protectedOptNames = allToDelete.Where(IsProtectedSkill).ToList();
+        foreach (var name in protectedOptNames)
+        {
+            allToDelete.Remove(name);
+            _logger.LogWarning(
+                "DreamService: skill optimization LLM proposed deleting protected skill '{Name}' — skipping",
+                name);
+        }
 
         foreach (var name in allToDelete)
         {
@@ -2687,6 +2711,17 @@ internal sealed class DreamService : IHostedService, IDisposable
                 context, ex.Message, preview);
             return default;
         }
+    }
+
+    private bool IsProtectedSkill(string name)
+    {
+        foreach (var prefix in _options.ProtectedSkillPrefixes)
+        {
+            if (name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
     }
 
     private static string ExtractJsonObject(string text)

--- a/src/RockBot.Skills/SkillTools.cs
+++ b/src/RockBot.Skills/SkillTools.cs
@@ -105,7 +105,7 @@ public sealed class SkillTools
         var existing = await _skillStore.GetAsync(name);
 
         // Save immediately with empty summary; LLM generates it in the background
-        var skill = new Skill(name, "", content, existing?.CreatedAt ?? now, now);
+        var skill = new Skill(name, "", content, existing?.CreatedAt ?? now, now, LastUsedAt: now);
         await _skillStore.SaveAsync(skill);
 
         _ = Task.Run(() => GenerateSummaryAsync(name, content));


### PR DESCRIPTION
The DreamService had three code paths that could delete patrol/proactive-actions:
1. 18-month staleness pruning (skill recreated by patrol but never marked as "used")
2. LLM-driven skill consolidation (merges patrol skill with similar ones)
3. LLM-driven skill optimization (deletes without the safety guard consolidation has)

Add a configurable ProtectedSkillPrefixes list (default: ["patrol/"]) and filter
protected skills from all three deletion paths. Logs a warning when the LLM
proposes deleting a protected skill so the behavior is visible.

https://claude.ai/code/session_01WHpCxoamUsrmABRvxbFr96