### PR TITLE
Auto-inject shared/ working-memory namespace for cross-session handoff

### DIFF
--- a/deploy/helm/rockbot/templates/shared/cronjob.yaml
+++ b/deploy/helm/rockbot/templates/shared/cronjob.yaml
@@ -25,6 +25,9 @@ spec:
                   find /rockbot/shared/tmp     -mindepth 1 -mtime +{{ .Values.shared.tmpTtlDays }}     -delete
                   find /rockbot/shared/drafts  -mindepth 1 -mtime +{{ .Values.shared.draftsTtlDays }}  -delete
                   find /rockbot/shared/exports -mindepth 1 -mtime +{{ .Values.shared.exportsTtlDays }} -delete
+                  # Catch-all: any remaining file anywhere on the shared volume older than
+                  # globalTtlDays. Uses -type f so directory structure is preserved.
+                  find /rockbot/shared -mindepth 1 -type f -mtime +{{ .Values.shared.globalTtlDays }} -delete
               volumeMounts:
                 - name: shared-data
                   mountPath: /rockbot/shared

--- a/deploy/helm/rockbot/values.yaml
+++ b/deploy/helm/rockbot/values.yaml
@@ -180,6 +180,11 @@ shared:
   tmpTtlDays: 1
   draftsTtlDays: 14
   exportsTtlDays: 14
+  # Catch-all sweep: after the per-directory sweeps, delete any remaining file
+  # anywhere under /rockbot/shared older than this many days. Directories are
+  # not touched, so empty structure is preserved. Safety net for ad-hoc paths
+  # (e.g. patrol drafts, subagent artifacts) that don't have a dedicated TTL.
+  globalTtlDays: 30
 
 # ── TodoApp MCP server ────────────────────────────────────────────────────────
 # Standalone MCP server that exposes a persistent to-do list to the agent.

--- a/src/RockBot.Agent/agent/memory-rules.md
+++ b/src/RockBot.Agent/agent/memory-rules.md
@@ -33,6 +33,7 @@ under your own namespace automatically, but you can read from other namespaces
 **Your namespace**: `session/{your-session-id}` — all saves go here automatically.
 **Subagent outputs**: `subagent/{task-id}/` — surfaced as a hint in the synthetic user turn when the subagent completes.
 **Patrol findings**: `patrol/{task-name}/` — automatically injected into your context each turn (see "Patrol findings" section below). Use `get_from_working_memory` with the full key to read them.
+**Shared handoff**: `shared/` — cross-session drop zone. Entries here are auto-listed in every session, patrol, and subagent. Use this when a piece of short-term data needs to be picked up by a different session than the one that produced it (see "Shared namespace" section below).
 
 Use working memory for **situational awareness** — context that improves decision-making
 now but will be irrelevant or stale in a future session.
@@ -113,6 +114,42 @@ To act on patrol findings:
 **Patrol tasks** store findings using `save_to_working_memory` with a TTL that spans at
 least one full patrol cycle (e.g. 5 hours for an hourly patrol), so entries are available
 to the primary agent between runs. Each run overwrites the previous entries.
+
+### Shared namespace (cross-session handoff)
+
+The `shared/` namespace is a cross-session drop zone. Its inventory is automatically
+injected into every context — user sessions, patrols, and subagents — listed under
+**"Shared working memory"** in the system context. Unlike `patrol/` (patrol → user only)
+or `subagent/` (only `-index` keys), every `shared/` entry is visible to every session.
+
+Use it when a piece of short-term data must be picked up by a different session than the
+one that produced it. Common cases:
+
+- A patrol drafts something (reply, summary, plan) that needs the user's next interactive
+  turn to approve or act on — patrol writes to `shared/drafts/...` and the user session
+  discovers the key automatically.
+- A subagent produces a small intermediate artifact that a sibling subagent or future turn
+  should consume without the primary having to relay it.
+- Any "I finished X, somebody else will act on it" handoff where you don't know which
+  session will pick it up.
+
+**How to write**: pass a full-path key beginning with `shared/` to `save_to_working_memory`
+(keys containing `/` bypass the automatic namespace prefix). Example:
+`save_to_working_memory(key: "shared/drafts/tina-vslive-2026-04-17", ...)`.
+
+**How to read**: the key appears in the "Shared working memory" inventory at the start of
+each turn. Use `get_from_working_memory` with the full key to fetch the value.
+
+**Key naming matters**: discovery is by *key name*, not content. Choose descriptive keys
+(`shared/drafts/tina-vslive-2026-04-17`, not `shared/draft-1`) so the receiving session
+can recognise what the entry is without fetching it.
+
+**What NOT to put here**:
+- Anything durable — that's long-term memory.
+- Anything large or irreplaceable — `shared/` is still in-memory working memory with a
+  TTL. If the pod restarts it is gone. Store tangible assets (full draft bodies, file
+  contents) on the shared volume and use `shared/` to carry a short pointer.
+- Anything that only your own session will consume — use your own namespace.
 
 ### What does NOT belong in working memory
 

--- a/src/RockBot.Host/AgentContextBuilder.cs
+++ b/src/RockBot.Host/AgentContextBuilder.cs
@@ -145,14 +145,18 @@ public sealed class AgentContextBuilder(
         var subagentTask = isUserSession
             ? workingMemory.ListAsync("subagent")
             : Task.FromResult<IReadOnlyList<WorkingMemoryEntry>>([]);
+        // shared/ is the conventional cross-session handoff namespace — visible to every
+        // context (user, patrol, subagent) so entries written by one session are discoverable
+        // by any other without prior knowledge of the writer's namespace.
+        var sharedTask = workingMemory.ListAsync("shared");
 
         // Await all wave-1 tasks. graphTask may be null when no knowledge graph is configured.
         if (graphTask is not null)
             await Task.WhenAll(historyTask, ltmTask, episodicTask, identityTask,
-                skillListTask, skillSearchTask, wmTask, graphTask, patrolTask, subagentTask);
+                skillListTask, skillSearchTask, wmTask, graphTask, patrolTask, subagentTask, sharedTask);
         else
             await Task.WhenAll(historyTask, ltmTask, episodicTask, identityTask,
-                skillListTask, skillSearchTask, wmTask, patrolTask, subagentTask);
+                skillListTask, skillSearchTask, wmTask, patrolTask, subagentTask, sharedTask);
 
         var history = historyTask.Result;
         var recalled = ltmTask.Result;
@@ -164,6 +168,7 @@ public sealed class AgentContextBuilder(
         var matchedEntities = graphTask?.Result;
         var patrolEntries = patrolTask.Result;
         var subagentEntries = subagentTask.Result;
+        var sharedEntries = sharedTask.Result;
 
         // ── Wave 2: conditional lookups that depend on wave 1 results ─────────
 
@@ -408,6 +413,36 @@ public sealed class AgentContextBuilder(
                 "The patrol runs on a schedule and loads that skill as its directive each run.";
             chatMessages.Add(new ChatMessage(ChatRole.System, patrolContext));
             logger.LogInformation("Injected {Count} patrol working memory entries into context", patrolEntries.Count);
+        }
+
+        // Shared working memory — cross-session handoff namespace. Visible to every context
+        // (user sessions, patrols, subagents). Skipped when the caller's own namespace is
+        // already "shared" to avoid double-listing.
+        if (sharedEntries.Count > 0 &&
+            !wmNamespace.Equals("shared", StringComparison.OrdinalIgnoreCase))
+        {
+            var now = DateTimeOffset.UtcNow;
+            var lines = sharedEntries.Select(e =>
+            {
+                var remaining = e.ExpiresAt - now;
+                var remainingStr = remaining.TotalMinutes >= 1
+                    ? $"{(int)remaining.TotalMinutes}m{remaining.Seconds:D2}s"
+                    : $"{Math.Max(0, remaining.Seconds)}s";
+                var meta = new System.Text.StringBuilder($"- {e.Key}: expires in {remainingStr}");
+                if (e.Category is not null) meta.Append($", category: {e.Category}");
+                if (e.Tags is { Count: > 0 }) meta.Append($", tags: {string.Join(", ", e.Tags)}");
+                return meta.ToString();
+            });
+            var sharedContext =
+                "Shared working memory (cross-session handoff — any session, patrol, or subagent can write here):\n" +
+                string.Join("\n", lines) + "\n\n" +
+                "- Use get_from_working_memory with the full key (e.g. 'shared/drafts/tina-vslive') to read an entry.\n" +
+                "- To write here, pass a full path key beginning with 'shared/' to save_to_working_memory " +
+                "(e.g. 'shared/drafts/...', 'shared/pending/...'). Choose self-describing keys — other sessions " +
+                "discover entries by name, not content.\n" +
+                "- Prefer this over your own namespace when the entry is meant for another session to pick up.";
+            chatMessages.Add(new ChatMessage(ChatRole.System, sharedContext));
+            logger.LogInformation("Injected {Count} shared working memory entries into context", sharedEntries.Count);
         }
 
         // Subagent research index chunks

--- a/src/RockBot.Memory/MemoryToolSkillProvider.cs
+++ b/src/RockBot.Memory/MemoryToolSkillProvider.cs
@@ -128,6 +128,23 @@ public sealed class MemoryToolSkillProvider : IToolSkillProvider
         outputs, patrol findings) using `list_working_memory(namespace: ...)`. Entries expire
         automatically based on their TTL (default: 5 minutes).
 
+        ### Namespaces auto-injected into your context
+
+        At the start of every turn the framework lists entry keys from these namespaces in
+        your system context — you do not need to call `list_working_memory` to see them:
+
+        - **Your own namespace** — always.
+        - **`patrol/`** — in user sessions only; lets you see patrol findings.
+        - **`subagent/*-index`** — in user sessions only; lets you see subagent research indexes.
+        - **`shared/`** — in every context (user, patrol, subagent). This is the conventional
+          cross-session handoff namespace. If you need to leave something short-lived for
+          another session to pick up, write a full-path key beginning with `shared/`
+          (e.g. `save_to_working_memory(key: "shared/drafts/tina-vslive-2026-04-17", data: ...)`).
+          Other sessions will see the key automatically and can fetch the value with
+          `get_from_working_memory`. Choose self-describing keys — discovery is by name, not
+          content. Use `shared/` for pointers to files on the shared volume, not for large
+          payloads that would be lost if the pod restarts.
+
         ### When to save
 
         - After receiving a large payload from any tool (email list, calendar events,

--- a/src/RockBot.Memory/WorkingMemoryTools.cs
+++ b/src/RockBot.Memory/WorkingMemoryTools.cs
@@ -42,7 +42,9 @@ public sealed class WorkingMemoryTools
                  "Data is stored under your namespace automatically — just provide a descriptive key. " +
                  "Use this after receiving a large payload from any tool, or to store intermediate results " +
                  "that a subagent or patrol task should leave for the primary agent to pick up. " +
-                 "Assign a category and tags to make the data easier to find with search_working_memory.")]
+                 "To hand data off to a different session, patrol, or subagent, pass a full-path key beginning " +
+                 "with 'shared/' (e.g. 'shared/drafts/tina-vslive') — entries under shared/ are auto-listed in " +
+                 "every context. Assign a category and tags to make the data easier to find with search_working_memory.")]
     public async Task<string> SaveToWorkingMemory(
         [Description("Short descriptive key (e.g. 'emails_inbox', 'research_results', 'patrol_alert')")] string key,
         [Description("The data to cache — can be a large string, JSON payload, or formatted summary")] string data,
@@ -90,7 +92,7 @@ public sealed class WorkingMemoryTools
     [Description("List all keys currently in working memory with their category, tags, and expiry times. " +
                  "Defaults to your own namespace. Pass a namespace prefix to browse another context — " +
                  "for example 'subagent/task1' to see what a completed subagent stored, " +
-                 "or 'patrol' to see all patrol task outputs.")]
+                 "'patrol' to see all patrol task outputs, or 'shared' to see the cross-session handoff namespace.")]
     public async Task<string> ListWorkingMemory(
         [Description("Optional namespace prefix to browse (e.g. 'subagent/task1', 'patrol'). Omit to list your own namespace.")] string? @namespace = null)
     {


### PR DESCRIPTION
## Summary
- Adds `shared/` as an auto-injected working-memory namespace so patrol tasks, user sessions, and subagents can hand off short-lived artifacts to each other without prior coordination on the receiving session's namespace
- Documents the convention in `memory-rules.md`, the `memory` skill doc, and inline tool descriptions so agents know when and how to use it
- Extends the existing shared-volume cleanup cronjob with a 30-day `-type f -mtime` catch-all so ad-hoc files dropped under `/rockbot/shared/` don't accumulate forever

## Motivation
The morning-communications-triage patrol drafted a reply to a colleague and saved it under `subagent/{id}/...` working-memory. When the user later said "send that draft" in their interactive session, the interactive session had no visibility into the patrol's draft — different sessions have independent conversation histories, and the existing `subagent/` auto-injection only surfaces `-index` keys. This pattern will recur for any patrol → user approval handoff, so we need a conventional discovery channel.

## How it works
`AgentContextBuilder.BuildAsync` now lists keys under `shared/` alongside own-namespace, `patrol/`, and `subagent/` inventories. Unlike `patrol/` (user-session only) or `subagent/-index` (user-session only, index keys only), `shared/` is visible to **every** context type. Writers pass a full-path key (e.g. `save_to_working_memory(key: "shared/drafts/tina-vslive", ...)`); readers discover the key automatically in their system context.

The directive docs are explicit that `shared/` is still TTL-backed in-memory storage — tangible assets still belong on the shared volume, with `shared/` carrying a short pointer.

## Deploy status (tested in cluster)
- Agent image `rockylhotka/rockbot-agent:0.8.2` rebuilt and running (`rockbot-agent-7cc8898d5b-nrk8s`)
- `memory-rules.md` copied to the agent PVC
- Cronjob patched in place via `kubectl patch` (preserved helm ownership labels)
- All three classes of shared-volume writers verified writable: agent pod, onedrive MCP pods, ephemeral script-pod template unchanged

## Unrelated drift surfaced (not fixed here)
A full `helm upgrade --reuse-values` fails because the `mcp-todo-data` PVC in the `rockbot` namespace lacks helm ownership annotations (`meta.helm.sh/release-name`, `app.kubernetes.io/managed-by`). Someone created it out-of-band. This is pre-existing and should be resolved separately before the next real helm upgrade — either by adopting the PVC into the release or by recreating it under helm's management.

## Test plan
- [ ] Start a blazor-session turn — confirm the "Shared working memory" block is absent when shared/ is empty
- [ ] Have the patrol (or a manual `save_to_working_memory` call) write to `shared/test/hello`
- [ ] Next blazor-session turn should list the key in the "Shared working memory" inventory
- [ ] Confirm `get_from_working_memory(key: "shared/test/hello")` returns the value
- [ ] Confirm patrol session also sees shared/ entries in its own context

🤖 Generated with [Claude Code](https://claude.com/claude-code)