### PR TITLE
A2A: propagate request and message metadata through the bridge

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-    <Version>0.8.4</Version>
+    <Version>0.8.5</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.A2A.Abstractions/AgentMessage.cs
+++ b/src/RockBot.A2A.Abstractions/AgentMessage.cs
@@ -7,4 +7,12 @@ public sealed record AgentMessage
 {
     public required string Role { get; init; }
     public required IReadOnlyList<AgentMessagePart> Parts { get; init; }
+
+    /// <summary>
+    /// Optional structured metadata associated with this message. Mirrors the
+    /// A2A v1 <c>Message.metadata</c> field. Bridges propagate this between the
+    /// HTTP boundary and the bus so callers can attach per-message inputs
+    /// (URLs, identifiers, selector hints, etc.) alongside the text parts.
+    /// </summary>
+    public IReadOnlyDictionary<string, string>? Metadata { get; init; }
 }

--- a/src/RockBot.A2A.Abstractions/AgentTaskRequest.cs
+++ b/src/RockBot.A2A.Abstractions/AgentTaskRequest.cs
@@ -10,4 +10,12 @@ public sealed record AgentTaskRequest
     public string? ContextId { get; init; }
     public required string Skill { get; init; }
     public required AgentMessage Message { get; init; }
+
+    /// <summary>
+    /// Optional structured metadata attached to the overall request, propagated
+    /// from the A2A v1 <c>SendMessageRequest.metadata</c> field. Bridges carry
+    /// this through the bus so capability handlers can read per-task
+    /// configuration or identifiers alongside the message payload.
+    /// </summary>
+    public IReadOnlyDictionary<string, string>? Metadata { get; init; }
 }

--- a/src/RockBot.A2A.Gateway/RockBotBridgeHandler.cs
+++ b/src/RockBot.A2A.Gateway/RockBotBridgeHandler.cs
@@ -1,4 +1,5 @@
 using System.Security.Claims;
+using System.Text.Json;
 using A2A;
 using Microsoft.Extensions.Options;
 
@@ -47,6 +48,15 @@ internal sealed class RockBotBridgeHandler(
 
         var messageText = context.UserText ?? "(empty)";
         var timeout = TimeSpan.FromSeconds(gatewayOptions.Value.TaskTimeoutSeconds);
+
+        // Request-level metadata — everything except the "skill" key already consumed for routing.
+        var requestMetadata = ExtractRequestMetadata(context.Metadata);
+
+        // Message-level metadata — propagate straight through.
+        var messageMetadata = StringifyMetadata(context.Message.Metadata);
+
+        // Map all inbound parts — not just the first text — so data parts round-trip too.
+        var inboundParts = MapInboundParts(context.Message.Parts, messageText);
 
         logger.LogInformation(
             "Bridging A2A task {TaskId} skill={Skill} caller={CallerId} streaming={Streaming} to RockBot via RabbitMQ",
@@ -126,10 +136,12 @@ internal sealed class RockBotBridgeHandler(
                 TaskId = taskId,
                 ContextId = context.ContextId,
                 Skill = skill,
+                Metadata = requestMetadata,
                 Message = new RbAgentMessage
                 {
                     Role = "user",
-                    Parts = [new RbAgentMessagePart { Kind = "text", Text = messageText }]
+                    Parts = inboundParts,
+                    Metadata = messageMetadata
                 }
             };
 
@@ -145,17 +157,16 @@ internal sealed class RockBotBridgeHandler(
 
             logger.LogInformation("Got response for task {TaskId}: state={State}", taskId, result.State);
 
-            // Map RockBot result back to A2A v1
-            var responseText = result.Message?.Parts
-                .Where(p => p.Kind == "text")
-                .Select(p => p.Text)
-                .FirstOrDefault() ?? "(no response)";
-
+            // Map RockBot result back to A2A v1 — carry all parts (text + data) and metadata through.
+            var responseParts = MapOutboundParts(result.Message?.Parts);
             var responseMessage = new Message
             {
                 Role = Role.Agent,
-                Parts = [new Part { Text = responseText }]
+                Parts = responseParts
             };
+            var outboundMetadata = ToJsonElementMetadata(result.Message?.Metadata);
+            if (outboundMetadata is not null)
+                responseMessage.Metadata = outboundMetadata;
 
             var a2aState = MapTaskState(result.State);
             // Use the contextId from the agent's response (it may have created one
@@ -172,11 +183,7 @@ internal sealed class RockBotBridgeHandler(
                     Timestamp = DateTimeOffset.UtcNow
                 },
                 History = [
-                    new Message
-                    {
-                        Role = Role.User,
-                        Parts = [new Part { Text = messageText }]
-                    },
+                    BuildUserHistoryMessage(context.Message, messageText, messageMetadata),
                     responseMessage
                 ]
             };
@@ -218,6 +225,132 @@ internal sealed class RockBotBridgeHandler(
             correlationId: taskId);
 
         await publisher.PublishAsync($"agent.task.cancel.{gatewayOptions.Value.RoutingName}", envelope, cancellationToken);
+    }
+
+    internal static IReadOnlyDictionary<string, string>? ExtractRequestMetadata(
+        IReadOnlyDictionary<string, JsonElement>? metadata)
+    {
+        if (metadata is null || metadata.Count == 0)
+            return null;
+
+        var result = new Dictionary<string, string>(metadata.Count, StringComparer.Ordinal);
+        foreach (var kvp in metadata)
+        {
+            // "skill" is already consumed for routing; don't double-propagate it.
+            if (string.Equals(kvp.Key, "skill", StringComparison.Ordinal))
+                continue;
+            result[kvp.Key] = JsonElementToString(kvp.Value);
+        }
+        return result.Count == 0 ? null : result;
+    }
+
+    internal static IReadOnlyDictionary<string, string>? StringifyMetadata(
+        IReadOnlyDictionary<string, JsonElement>? metadata)
+    {
+        if (metadata is null || metadata.Count == 0)
+            return null;
+
+        var result = new Dictionary<string, string>(metadata.Count, StringComparer.Ordinal);
+        foreach (var kvp in metadata)
+            result[kvp.Key] = JsonElementToString(kvp.Value);
+        return result;
+    }
+
+    private static string JsonElementToString(JsonElement value) => value.ValueKind switch
+    {
+        JsonValueKind.String => value.GetString() ?? string.Empty,
+        JsonValueKind.Null or JsonValueKind.Undefined => string.Empty,
+        _ => value.GetRawText()
+    };
+
+    internal static Dictionary<string, JsonElement>? ToJsonElementMetadata(
+        IReadOnlyDictionary<string, string>? metadata)
+    {
+        if (metadata is null || metadata.Count == 0)
+            return null;
+
+        var result = new Dictionary<string, JsonElement>(metadata.Count, StringComparer.Ordinal);
+        foreach (var kvp in metadata)
+            result[kvp.Key] = JsonSerializer.SerializeToElement(kvp.Value);
+        return result;
+    }
+
+    internal static IReadOnlyList<RbAgentMessagePart> MapInboundParts(
+        IReadOnlyList<Part>? parts, string fallbackText)
+    {
+        if (parts is null || parts.Count == 0)
+            return [new RbAgentMessagePart { Kind = "text", Text = fallbackText }];
+
+        var mapped = new List<RbAgentMessagePart>(parts.Count);
+        foreach (var part in parts)
+        {
+            switch (part.ContentCase)
+            {
+                case PartContentCase.Text:
+                    mapped.Add(new RbAgentMessagePart { Kind = "text", Text = part.Text });
+                    break;
+                case PartContentCase.Data:
+                    mapped.Add(new RbAgentMessagePart
+                    {
+                        Kind = "data",
+                        Data = part.Data?.GetRawText(),
+                        MimeType = part.MediaType
+                    });
+                    break;
+                // Raw/Url parts fall outside the current RbAgentMessagePart model; skip them
+                // so handlers see only what the RockBot contract can represent.
+            }
+        }
+
+        if (mapped.Count == 0)
+            mapped.Add(new RbAgentMessagePart { Kind = "text", Text = fallbackText });
+
+        return mapped;
+    }
+
+    internal static List<Part> MapOutboundParts(IReadOnlyList<RbAgentMessagePart>? parts)
+    {
+        if (parts is null || parts.Count == 0)
+            return [new Part { Text = "(no response)" }];
+
+        var mapped = new List<Part>(parts.Count);
+        foreach (var part in parts)
+        {
+            if (string.Equals(part.Kind, "data", StringComparison.Ordinal) && part.Data is not null)
+            {
+                var element = JsonSerializer.Deserialize<JsonElement>(part.Data);
+                var a2aPart = Part.FromData(element);
+                if (!string.IsNullOrEmpty(part.MimeType))
+                    a2aPart.MediaType = part.MimeType;
+                mapped.Add(a2aPart);
+            }
+            else
+            {
+                mapped.Add(new Part { Text = part.Text ?? string.Empty });
+            }
+        }
+        return mapped;
+    }
+
+    private static Message BuildUserHistoryMessage(
+        Message? originalMessage,
+        string messageText,
+        IReadOnlyDictionary<string, string>? messageMetadata)
+    {
+        // Preserve the client's original parts and metadata verbatim when available
+        // so the task history reflects what was actually sent.
+        if (originalMessage is not null && originalMessage.Parts.Count > 0)
+            return originalMessage;
+
+        var history = new Message
+        {
+            Role = Role.User,
+            Parts = [new Part { Text = messageText }]
+        };
+        var meta = ToJsonElementMetadata(messageMetadata);
+        if (meta is not null)
+            history.Metadata = meta;
+        return history;
     }
 
     private static TaskState MapTaskState(AgentTaskState state) => state switch

--- a/tests/RockBot.A2A.Gateway.Tests/RockBotBridgeHandlerTests.cs
+++ b/tests/RockBot.A2A.Gateway.Tests/RockBotBridgeHandlerTests.cs
@@ -1,0 +1,197 @@
+using System.Text.Json;
+using A2A;
+using RockBot.A2A;
+
+namespace RockBot.A2A.Gateway.Tests;
+
+/// <summary>
+/// Tests for the metadata and part-mapping helpers in <see cref="RockBotBridgeHandler"/>.
+/// These helpers carry A2A v1 request/message metadata and non-text parts across
+/// the HTTP → RabbitMQ bridge so capability handlers can read them.
+/// </summary>
+[TestClass]
+public class RockBotBridgeHandlerTests
+{
+    [TestMethod]
+    public void ExtractRequestMetadata_DropsSkillKey_AndStringifiesRest()
+    {
+        var metadata = new Dictionary<string, JsonElement>
+        {
+            ["skill"] = JsonDocument.Parse("\"extract-structured-data\"").RootElement,
+            ["tenant"] = JsonDocument.Parse("\"acme\"").RootElement,
+            ["priority"] = JsonDocument.Parse("42").RootElement
+        };
+
+        var result = RockBotBridgeHandler.ExtractRequestMetadata(metadata);
+
+        Assert.IsNotNull(result);
+        Assert.IsFalse(result.ContainsKey("skill"), "skill key should be consumed for routing, not duplicated");
+        Assert.AreEqual("acme", result["tenant"]);
+        Assert.AreEqual("42", result["priority"]);
+    }
+
+    [TestMethod]
+    public void ExtractRequestMetadata_NullOrEmpty_ReturnsNull()
+    {
+        Assert.IsNull(RockBotBridgeHandler.ExtractRequestMetadata(null));
+        Assert.IsNull(RockBotBridgeHandler.ExtractRequestMetadata(new Dictionary<string, JsonElement>()));
+    }
+
+    [TestMethod]
+    public void ExtractRequestMetadata_OnlySkillKey_ReturnsNull()
+    {
+        var metadata = new Dictionary<string, JsonElement>
+        {
+            ["skill"] = JsonDocument.Parse("\"foo\"").RootElement
+        };
+
+        Assert.IsNull(RockBotBridgeHandler.ExtractRequestMetadata(metadata));
+    }
+
+    [TestMethod]
+    public void StringifyMetadata_PreservesAllKeys()
+    {
+        var metadata = new Dictionary<string, JsonElement>
+        {
+            ["url"] = JsonDocument.Parse("\"https://example.com\"").RootElement,
+            ["count"] = JsonDocument.Parse("7").RootElement,
+            ["enabled"] = JsonDocument.Parse("true").RootElement
+        };
+
+        var result = RockBotBridgeHandler.StringifyMetadata(metadata);
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual("https://example.com", result["url"]);
+        Assert.AreEqual("7", result["count"]);
+        Assert.AreEqual("true", result["enabled"]);
+    }
+
+    [TestMethod]
+    public void MapInboundParts_TextPart_MapsToTextKind()
+    {
+        var parts = new List<Part>
+        {
+            new() { Text = "hello" }
+        };
+
+        var mapped = RockBotBridgeHandler.MapInboundParts(parts, fallbackText: "(empty)");
+
+        Assert.AreEqual(1, mapped.Count);
+        Assert.AreEqual("text", mapped[0].Kind);
+        Assert.AreEqual("hello", mapped[0].Text);
+    }
+
+    [TestMethod]
+    public void MapInboundParts_DataPart_MapsToDataKindWithRawJson()
+    {
+        var dataJson = JsonDocument.Parse("{\"url\":\"https://example.com\"}").RootElement;
+        var parts = new List<Part>
+        {
+            Part.FromData(dataJson)
+        };
+        parts[0].MediaType = "application/json";
+
+        var mapped = RockBotBridgeHandler.MapInboundParts(parts, fallbackText: "(empty)");
+
+        Assert.AreEqual(1, mapped.Count);
+        Assert.AreEqual("data", mapped[0].Kind);
+        Assert.AreEqual("application/json", mapped[0].MimeType);
+        Assert.IsNotNull(mapped[0].Data);
+        var parsed = JsonDocument.Parse(mapped[0].Data!).RootElement;
+        Assert.AreEqual("https://example.com", parsed.GetProperty("url").GetString());
+    }
+
+    [TestMethod]
+    public void MapInboundParts_MixedTextAndData_PreservesBoth()
+    {
+        var dataJson = JsonDocument.Parse("{\"k\":1}").RootElement;
+        var parts = new List<Part>
+        {
+            new() { Text = "describe" },
+            Part.FromData(dataJson)
+        };
+
+        var mapped = RockBotBridgeHandler.MapInboundParts(parts, fallbackText: "(empty)");
+
+        Assert.AreEqual(2, mapped.Count);
+        Assert.AreEqual("text", mapped[0].Kind);
+        Assert.AreEqual("data", mapped[1].Kind);
+    }
+
+    [TestMethod]
+    public void MapInboundParts_EmptyList_UsesFallbackText()
+    {
+        var mapped = RockBotBridgeHandler.MapInboundParts([], fallbackText: "(empty)");
+
+        Assert.AreEqual(1, mapped.Count);
+        Assert.AreEqual("text", mapped[0].Kind);
+        Assert.AreEqual("(empty)", mapped[0].Text);
+    }
+
+    [TestMethod]
+    public void MapOutboundParts_TextPart_MapsToA2ATextPart()
+    {
+        var parts = new List<AgentMessagePart>
+        {
+            new() { Kind = "text", Text = "reply" }
+        };
+
+        var mapped = RockBotBridgeHandler.MapOutboundParts(parts);
+
+        Assert.AreEqual(1, mapped.Count);
+        Assert.AreEqual(PartContentCase.Text, mapped[0].ContentCase);
+        Assert.AreEqual("reply", mapped[0].Text);
+    }
+
+    [TestMethod]
+    public void MapOutboundParts_DataPart_MapsToA2ADataPart()
+    {
+        var parts = new List<AgentMessagePart>
+        {
+            new() { Kind = "data", Data = "{\"ok\":true}", MimeType = "application/json" }
+        };
+
+        var mapped = RockBotBridgeHandler.MapOutboundParts(parts);
+
+        Assert.AreEqual(1, mapped.Count);
+        Assert.AreEqual(PartContentCase.Data, mapped[0].ContentCase);
+        Assert.AreEqual("application/json", mapped[0].MediaType);
+        Assert.IsTrue(mapped[0].Data!.Value.GetProperty("ok").GetBoolean());
+    }
+
+    [TestMethod]
+    public void MapOutboundParts_NullOrEmpty_EmitsPlaceholder()
+    {
+        var mapped = RockBotBridgeHandler.MapOutboundParts(null);
+        Assert.AreEqual(1, mapped.Count);
+        Assert.AreEqual("(no response)", mapped[0].Text);
+
+        mapped = RockBotBridgeHandler.MapOutboundParts([]);
+        Assert.AreEqual(1, mapped.Count);
+        Assert.AreEqual("(no response)", mapped[0].Text);
+    }
+
+    [TestMethod]
+    public void ToJsonElementMetadata_StringValues_ProduceStringJsonElements()
+    {
+        var source = new Dictionary<string, string>
+        {
+            ["url"] = "https://example.com",
+            ["description"] = "pick the title"
+        };
+
+        var result = RockBotBridgeHandler.ToJsonElementMetadata(source);
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual(JsonValueKind.String, result["url"].ValueKind);
+        Assert.AreEqual("https://example.com", result["url"].GetString());
+        Assert.AreEqual("pick the title", result["description"].GetString());
+    }
+
+    [TestMethod]
+    public void ToJsonElementMetadata_NullOrEmpty_ReturnsNull()
+    {
+        Assert.IsNull(RockBotBridgeHandler.ToJsonElementMetadata(null));
+        Assert.IsNull(RockBotBridgeHandler.ToJsonElementMetadata(new Dictionary<string, string>()));
+    }
+}

--- a/tests/RockBot.A2A.Tests/AgentMessageSerializationTests.cs
+++ b/tests/RockBot.A2A.Tests/AgentMessageSerializationTests.cs
@@ -1,0 +1,108 @@
+using System.Text.Json;
+
+namespace RockBot.A2A.Tests;
+
+/// <summary>
+/// JSON round-trip tests for the A2A abstractions. These guard the wire
+/// contract that the gateway bridge relies on — the <c>Metadata</c> maps on
+/// <see cref="AgentMessage"/> and <see cref="AgentTaskRequest"/> must survive
+/// serialization so capability handlers can read values a caller attached
+/// to the request.
+/// </summary>
+[TestClass]
+public class AgentMessageSerializationTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true
+    };
+
+    [TestMethod]
+    public void AgentMessage_Metadata_RoundTripsThroughJson()
+    {
+        var original = new AgentMessage
+        {
+            Role = "user",
+            Parts = [new AgentMessagePart { Kind = "text", Text = "extract" }],
+            Metadata = new Dictionary<string, string>
+            {
+                ["url"] = "https://example.com/page",
+                ["description"] = "the product name"
+            }
+        };
+
+        var json = JsonSerializer.Serialize(original, JsonOptions);
+        var deserialized = JsonSerializer.Deserialize<AgentMessage>(json, JsonOptions);
+
+        Assert.IsNotNull(deserialized);
+        Assert.IsNotNull(deserialized.Metadata);
+        Assert.AreEqual("https://example.com/page", deserialized.Metadata["url"]);
+        Assert.AreEqual("the product name", deserialized.Metadata["description"]);
+    }
+
+    [TestMethod]
+    public void AgentMessage_Metadata_IsOptional()
+    {
+        var message = new AgentMessage
+        {
+            Role = "user",
+            Parts = [new AgentMessagePart { Kind = "text", Text = "hi" }]
+        };
+
+        var json = JsonSerializer.Serialize(message, JsonOptions);
+        var deserialized = JsonSerializer.Deserialize<AgentMessage>(json, JsonOptions);
+
+        Assert.IsNotNull(deserialized);
+        Assert.IsNull(deserialized.Metadata);
+    }
+
+    [TestMethod]
+    public void AgentTaskRequest_Metadata_RoundTripsThroughJson()
+    {
+        var original = new AgentTaskRequest
+        {
+            TaskId = "t1",
+            Skill = "extract-structured-data",
+            Metadata = new Dictionary<string, string>
+            {
+                ["tenant"] = "acme",
+                ["priority"] = "high"
+            },
+            Message = new AgentMessage
+            {
+                Role = "user",
+                Parts = [new AgentMessagePart { Kind = "text", Text = "go" }]
+            }
+        };
+
+        var json = JsonSerializer.Serialize(original, JsonOptions);
+        var deserialized = JsonSerializer.Deserialize<AgentTaskRequest>(json, JsonOptions);
+
+        Assert.IsNotNull(deserialized);
+        Assert.IsNotNull(deserialized.Metadata);
+        Assert.AreEqual("acme", deserialized.Metadata["tenant"]);
+        Assert.AreEqual("high", deserialized.Metadata["priority"]);
+    }
+
+    [TestMethod]
+    public void AgentTaskRequest_Metadata_IsOptional()
+    {
+        var request = new AgentTaskRequest
+        {
+            TaskId = "t1",
+            Skill = "summarize",
+            Message = new AgentMessage
+            {
+                Role = "user",
+                Parts = [new AgentMessagePart { Kind = "text", Text = "hi" }]
+            }
+        };
+
+        var json = JsonSerializer.Serialize(request, JsonOptions);
+        var deserialized = JsonSerializer.Deserialize<AgentTaskRequest>(json, JsonOptions);
+
+        Assert.IsNotNull(deserialized);
+        Assert.IsNull(deserialized.Metadata);
+    }
+}


### PR DESCRIPTION
## Summary

- Add optional `Metadata: IReadOnlyDictionary<string, string>?` to `AgentMessage` and `AgentTaskRequest`.
- In `RockBotBridgeHandler`, populate `AgentTaskRequest.Metadata` from `RequestContext.Metadata` (minus the `"skill"` key already consumed for routing) and `AgentMessage.Metadata` from the incoming `Message.Metadata`. JsonElement values are stringified; non-string kinds are preserved via their raw JSON text.
- Map all inbound `Part`s (not just the first text) into `AgentMessagePart`, propagating `Kind = "data"` parts with their JSON body and `MediaType`.
- On the reply path, map the handler-returned `AgentMessage.Metadata` back onto outbound `Message.Metadata`, and emit data parts via `Part.FromData` — text parts continue to pass through as before.
- Task history now preserves the client's original `Message` verbatim instead of a text-only rebuild, so captured history reflects what was actually sent.

## Test plan

- [x] Existing tests pass (all projects)
- [x] New JSON round-trip tests for `AgentMessage.Metadata` and `AgentTaskRequest.Metadata` in `RockBot.A2A.Tests`
- [x] New bridge-helper tests in `RockBot.A2A.Gateway.Tests` covering: `"skill"` key stripped from request metadata, text/data part mapping in both directions, stringification of JsonElement values, and `JsonElement` round-trip for replies

Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)