### PR TITLE
A2A: add per-skill handler registration to the framework

### DIFF
--- a/docs/a2a.md
+++ b/docs/a2a.md
@@ -205,6 +205,35 @@ messages (state `Working`) while processing, and must publish either an
 
 See `RockBot.ResearchAgent` and `RockBot.SampleAgent` for working examples.
 
+#### Per-skill handlers (alternative to a single dispatcher)
+
+If the agent has more than one skill, use `AddSkillHandler<T>()` instead of
+writing a custom `IAgentTaskHandler` that switches on `request.Skill`. Each
+handler declares its own `AgentSkill` metadata, the framework dispatches by
+skill id (case-insensitive), and `AgentCard.Skills` is auto-populated:
+
+```csharp
+public sealed class EchoSkillHandler : IAgentSkillHandler
+{
+    public AgentSkill Skill { get; } = new()
+    {
+        Id = "echo",
+        Name = "Echo",
+        Description = "Echoes the input message back."
+    };
+
+    public Task<AgentTaskResult> ExecuteAsync(
+        AgentTaskRequest request, AgentTaskContext context) => /* ... */;
+}
+
+agent.AddA2A(opts => opts.Card = new AgentCard { AgentName = "MyAgent", Version = "1.0" })
+     .AddSkillHandler<EchoSkillHandler>()
+     .AddSkillHandler<SearchSkillHandler>();
+```
+
+Registering both an `IAgentTaskHandler` and one or more `IAgentSkillHandler`s
+on the same agent is an error: pick one model per agent.
+
 ---
 
 ### HTTP-based agent

--- a/src/RockBot.A2A/A2AServiceCollectionExtensions.cs
+++ b/src/RockBot.A2A/A2AServiceCollectionExtensions.cs
@@ -45,6 +45,12 @@ public static class A2AServiceCollectionExtensions
         // Summarizer — uses ILlmClient if available, otherwise falls back gracefully
         builder.Services.TryAddSingleton<AgentCardSummarizer>();
 
+        // Skill-handler validator — runs before AgentDiscoveryService so the
+        // card it publishes already reflects any auto-populated skills.
+        builder.Services.AddSingleton<SkillRegistrationValidator>();
+        builder.Services.AddSingleton<Microsoft.Extensions.Hosting.IHostedService>(
+            sp => sp.GetRequiredService<SkillRegistrationValidator>());
+
         // Discovery hosted service
         builder.Services.AddSingleton<AgentDiscoveryService>();
         builder.Services.AddSingleton<Microsoft.Extensions.Hosting.IHostedService>(

--- a/src/RockBot.A2A/A2ASkillHandlerExtensions.cs
+++ b/src/RockBot.A2A/A2ASkillHandlerExtensions.cs
@@ -1,0 +1,58 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using RockBot.Host;
+
+namespace RockBot.A2A;
+
+/// <summary>
+/// Extension methods for registering <see cref="IAgentSkillHandler"/> implementations
+/// with the framework's skill-dispatch plumbing. An agent that registers any skill
+/// handlers gets an automatically-wired <see cref="IAgentTaskHandler"/> that
+/// dispatches by skill id, and its <see cref="AgentCard.Skills"/> is auto-populated
+/// from the registered handlers' <see cref="IAgentSkillHandler.Skill"/> metadata.
+/// </summary>
+public static class A2ASkillHandlerExtensions
+{
+    /// <summary>
+    /// Register a concrete <see cref="IAgentSkillHandler"/> implementation. The
+    /// framework auto-wires dispatch and adds the handler's <see cref="AgentSkill"/>
+    /// to the advertised card at startup.
+    /// </summary>
+    public static AgentHostBuilder AddSkillHandler<T>(this AgentHostBuilder builder)
+        where T : class, IAgentSkillHandler
+    {
+        builder.Services.AddScoped<T>();
+        builder.Services.AddScoped<IAgentSkillHandler>(sp => sp.GetRequiredService<T>());
+        EnsureDispatcherRegistered(builder.Services);
+        return builder;
+    }
+
+    /// <summary>
+    /// Register multiple <see cref="IAgentSkillHandler"/> implementations by type.
+    /// Each type must implement <see cref="IAgentSkillHandler"/> and be instantiable
+    /// via DI.
+    /// </summary>
+    public static AgentHostBuilder AddSkillHandlers(
+        this AgentHostBuilder builder, params Type[] skillHandlerTypes)
+    {
+        foreach (var type in skillHandlerTypes)
+        {
+            if (!typeof(IAgentSkillHandler).IsAssignableFrom(type))
+            {
+                throw new ArgumentException(
+                    $"Type {type.FullName} does not implement {nameof(IAgentSkillHandler)}.",
+                    nameof(skillHandlerTypes));
+            }
+
+            builder.Services.AddScoped(type);
+            builder.Services.AddScoped(
+                typeof(IAgentSkillHandler),
+                sp => sp.GetRequiredService(type));
+        }
+        EnsureDispatcherRegistered(builder.Services);
+        return builder;
+    }
+
+    private static void EnsureDispatcherRegistered(IServiceCollection services) =>
+        services.TryAddScoped<IAgentTaskHandler, SkillDispatchingTaskHandler>();
+}

--- a/src/RockBot.A2A/IAgentSkillHandler.cs
+++ b/src/RockBot.A2A/IAgentSkillHandler.cs
@@ -1,0 +1,32 @@
+namespace RockBot.A2A;
+
+/// <summary>
+/// Handler for a single named skill on an agent. Each implementation declares
+/// the <see cref="AgentSkill"/> it serves and implements the logic for exactly
+/// that skill. The framework's <see cref="SkillDispatchingTaskHandler"/>
+/// resolves all registered skill handlers and dispatches inbound
+/// <see cref="AgentTaskRequest"/>s to the one whose <see cref="Skill"/>.Id
+/// matches <see cref="AgentTaskRequest.Skill"/> (case-insensitive).
+/// </summary>
+/// <remarks>
+/// Agents with a single custom dispatch model (payload-based, caller-based,
+/// etc.) can continue to register <see cref="IAgentTaskHandler"/> directly
+/// and ignore this interface. Registering both patterns on the same agent
+/// produces a startup error — see <see cref="A2ASkillHandlerExtensions"/>.
+/// </remarks>
+public interface IAgentSkillHandler
+{
+    /// <summary>
+    /// Metadata for the skill this handler serves. Used for dispatch
+    /// (matching <see cref="AgentTaskRequest.Skill"/> against
+    /// <see cref="AgentSkill.Id"/>) and for auto-populating the agent's
+    /// advertised <see cref="AgentCard.Skills"/>.
+    /// </summary>
+    AgentSkill Skill { get; }
+
+    /// <summary>
+    /// Execute the request. Called only when <see cref="AgentTaskRequest.Skill"/>
+    /// matches <see cref="Skill"/>.Id.
+    /// </summary>
+    Task<AgentTaskResult> ExecuteAsync(AgentTaskRequest request, AgentTaskContext context);
+}

--- a/src/RockBot.A2A/SkillDispatchingTaskHandler.cs
+++ b/src/RockBot.A2A/SkillDispatchingTaskHandler.cs
@@ -1,0 +1,81 @@
+using Microsoft.Extensions.Logging;
+
+namespace RockBot.A2A;
+
+/// <summary>
+/// <see cref="IAgentTaskHandler"/> implementation that routes inbound task
+/// requests to the registered <see cref="IAgentSkillHandler"/> whose
+/// <see cref="IAgentSkillHandler.Skill"/>.Id matches <see cref="AgentTaskRequest.Skill"/>
+/// (case-insensitive). Registered automatically by
+/// <see cref="A2ASkillHandlerExtensions.AddSkillHandler{T}"/>.
+/// </summary>
+internal sealed class SkillDispatchingTaskHandler(
+    IEnumerable<IAgentSkillHandler> skillHandlers,
+    ILogger<SkillDispatchingTaskHandler> logger) : IAgentTaskHandler
+{
+    private readonly IReadOnlyDictionary<string, IAgentSkillHandler> _handlers =
+        BuildIndex(skillHandlers, logger);
+
+    public Task<AgentTaskResult> HandleTaskAsync(AgentTaskRequest request, AgentTaskContext context)
+    {
+        if (_handlers.TryGetValue(request.Skill ?? string.Empty, out var handler))
+        {
+            logger.LogDebug(
+                "Dispatching task {TaskId} to skill handler '{Skill}' ({HandlerType})",
+                request.TaskId, handler.Skill.Id, handler.GetType().Name);
+            return handler.ExecuteAsync(request, context);
+        }
+
+        logger.LogWarning(
+            "No skill handler registered for skill '{Skill}' (task {TaskId}). Known skills: {Known}",
+            request.Skill, request.TaskId, string.Join(", ", _handlers.Keys));
+
+        return Task.FromResult(new AgentTaskResult
+        {
+            TaskId = request.TaskId,
+            ContextId = request.ContextId,
+            State = AgentTaskState.Failed,
+            Message = new AgentMessage
+            {
+                Role = "agent",
+                Parts =
+                [
+                    new AgentMessagePart
+                    {
+                        Kind = "text",
+                        Text = $"Skill '{request.Skill}' is not supported by this agent."
+                    }
+                ]
+            }
+        });
+    }
+
+    private static IReadOnlyDictionary<string, IAgentSkillHandler> BuildIndex(
+        IEnumerable<IAgentSkillHandler> handlers,
+        ILogger logger)
+    {
+        var index = new Dictionary<string, IAgentSkillHandler>(StringComparer.OrdinalIgnoreCase);
+        foreach (var handler in handlers)
+        {
+            var id = handler.Skill.Id;
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                logger.LogWarning(
+                    "Skill handler {HandlerType} has empty Skill.Id — skipping",
+                    handler.GetType().Name);
+                continue;
+            }
+
+            if (index.TryGetValue(id, out var existing))
+            {
+                throw new InvalidOperationException(
+                    $"Duplicate skill id '{id}' registered: " +
+                    $"{existing.GetType().FullName} and {handler.GetType().FullName}. " +
+                    "Each skill id must be handled by exactly one IAgentSkillHandler.");
+            }
+
+            index[id] = handler;
+        }
+        return index;
+    }
+}

--- a/src/RockBot.A2A/SkillRegistrationValidator.cs
+++ b/src/RockBot.A2A/SkillRegistrationValidator.cs
@@ -1,0 +1,82 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace RockBot.A2A;
+
+/// <summary>
+/// Hosted service that runs at startup to (1) validate the agent's skill
+/// registration is consistent and (2) populate <see cref="A2AOptions.Card"/>.Skills
+/// from the registered <see cref="IAgentSkillHandler"/> set. Registered automatically
+/// by <see cref="A2ASkillHandlerExtensions.AddSkillHandler{T}"/>.
+/// </summary>
+/// <remarks>
+/// This is registered as an <see cref="IHostedService"/> in <c>AddA2A</c> and runs
+/// before <c>AgentDiscoveryService</c>, so the agent card announced on the bus and
+/// served from the HTTP gateway already reflects the registered skills.
+/// </remarks>
+internal sealed class SkillRegistrationValidator(
+    IServiceProvider rootProvider,
+    A2AOptions options,
+    ILogger<SkillRegistrationValidator> logger) : IHostedService
+{
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        using var scope = rootProvider.CreateScope();
+        var sp = scope.ServiceProvider;
+
+        var skillHandlers = sp.GetServices<IAgentSkillHandler>().ToList();
+        if (skillHandlers.Count == 0)
+        {
+            // No skill-handler registrations — agent is using the traditional
+            // single-IAgentTaskHandler model. Nothing to validate or auto-populate.
+            return Task.CompletedTask;
+        }
+
+        var taskHandlers = sp.GetServices<IAgentTaskHandler>().ToList();
+        var nonDispatcher = taskHandlers
+            .Where(h => h is not SkillDispatchingTaskHandler)
+            .ToList();
+        if (nonDispatcher.Count > 0)
+        {
+            throw new InvalidOperationException(
+                "Agent has both IAgentSkillHandler registrations and a custom " +
+                $"IAgentTaskHandler ({string.Join(", ", nonDispatcher.Select(h => h.GetType().FullName))}). " +
+                "Pick one model: either register IAgentSkillHandler implementations via " +
+                "AddSkillHandler<T>(), or register a single IAgentTaskHandler for custom dispatch.");
+        }
+
+        MergeSkillsIntoCard(skillHandlers);
+
+        logger.LogInformation(
+            "Skill dispatch wired up: {Count} skill handler(s) registered ({Ids})",
+            skillHandlers.Count,
+            string.Join(", ", skillHandlers.Select(h => h.Skill.Id)));
+
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    private void MergeSkillsIntoCard(IReadOnlyList<IAgentSkillHandler> handlers)
+    {
+        if (options.Card is null)
+            return;
+
+        var existing = options.Card.Skills is null
+            ? new List<AgentSkill>()
+            : [.. options.Card.Skills];
+
+        var seen = new HashSet<string>(
+            existing.Select(s => s.Id),
+            StringComparer.OrdinalIgnoreCase);
+
+        foreach (var handler in handlers)
+        {
+            if (seen.Add(handler.Skill.Id))
+                existing.Add(handler.Skill);
+        }
+
+        options.Card = options.Card with { Skills = existing };
+    }
+}

--- a/tests/RockBot.A2A.Tests/A2ASkillHandlerRegistrationTests.cs
+++ b/tests/RockBot.A2A.Tests/A2ASkillHandlerRegistrationTests.cs
@@ -1,0 +1,260 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using RockBot.Host;
+using RockBot.Messaging;
+
+namespace RockBot.A2A.Tests;
+
+[TestClass]
+public class A2ASkillHandlerRegistrationTests
+{
+    private static ServiceCollection BaseServices()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IMessagePublisher, TrackingPublisher>();
+        services.AddSingleton<IMessageSubscriber, StubSubscriber>();
+        return services;
+    }
+
+    [TestMethod]
+    public void AddSkillHandler_RegistersHandler_AsIAgentSkillHandler()
+    {
+        var services = BaseServices();
+        services.AddRockBotHost(agent => agent
+            .WithIdentity("test-agent")
+            .AddA2A()
+            .AddSkillHandler<EchoSkillHandler>());
+
+        var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+
+        var handlers = scope.ServiceProvider.GetServices<IAgentSkillHandler>().ToList();
+        Assert.AreEqual(1, handlers.Count);
+        Assert.AreEqual("echo", handlers[0].Skill.Id);
+    }
+
+    [TestMethod]
+    public void AddSkillHandler_WiresUpDispatcher_AsIAgentTaskHandler()
+    {
+        var services = BaseServices();
+        services.AddRockBotHost(agent => agent
+            .WithIdentity("test-agent")
+            .AddA2A()
+            .AddSkillHandler<EchoSkillHandler>());
+
+        var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+
+        var taskHandler = scope.ServiceProvider.GetRequiredService<IAgentTaskHandler>();
+        Assert.IsInstanceOfType<SkillDispatchingTaskHandler>(taskHandler);
+    }
+
+    [TestMethod]
+    public void AddSkillHandlers_RegistersMultiple()
+    {
+        var services = BaseServices();
+        services.AddRockBotHost(agent => agent
+            .WithIdentity("test-agent")
+            .AddA2A()
+            .AddSkillHandlers(typeof(EchoSkillHandler), typeof(SearchSkillHandler)));
+
+        var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+
+        var handlers = scope.ServiceProvider.GetServices<IAgentSkillHandler>().ToList();
+        CollectionAssert.AreEquivalent(
+            new[] { "echo", "search" },
+            handlers.Select(h => h.Skill.Id).ToArray());
+    }
+
+    [TestMethod]
+    public void AddSkillHandlers_NonSkillHandlerType_Throws()
+    {
+        var services = BaseServices();
+
+        Assert.ThrowsExactly<ArgumentException>(() =>
+            services.AddRockBotHost(agent => agent
+                .WithIdentity("test-agent")
+                .AddA2A()
+                .AddSkillHandlers(typeof(string))));
+    }
+
+    [TestMethod]
+    public async Task Validator_PopulatesAgentCardSkills_FromRegisteredHandlers()
+    {
+        var services = BaseServices();
+        services.AddRockBotHost(agent => agent
+            .WithIdentity("test-agent")
+            .AddA2A(opts =>
+            {
+                opts.Card = new AgentCard
+                {
+                    AgentName = "test-agent",
+                    Version = "1.0"
+                };
+            })
+            .AddSkillHandler<EchoSkillHandler>()
+            .AddSkillHandler<SearchSkillHandler>());
+
+        var provider = services.BuildServiceProvider();
+
+        // Run only the validator, not the discovery service (which would try to publish).
+        var validator = provider.GetRequiredService<SkillRegistrationValidator>();
+        await validator.StartAsync(CancellationToken.None);
+
+        var options = provider.GetRequiredService<A2AOptions>();
+        var skillIds = options.Card!.Skills!.Select(s => s.Id).ToList();
+        CollectionAssert.Contains(skillIds, "echo");
+        CollectionAssert.Contains(skillIds, "search");
+    }
+
+    [TestMethod]
+    public async Task Validator_MergesWithExistingCardSkills_WithoutDuplicates()
+    {
+        var services = BaseServices();
+        services.AddRockBotHost(agent => agent
+            .WithIdentity("test-agent")
+            .AddA2A(opts =>
+            {
+                opts.Card = new AgentCard
+                {
+                    AgentName = "test-agent",
+                    Version = "1.0",
+                    Skills =
+                    [
+                        new AgentSkill { Id = "echo", Name = "Pre-declared echo" },
+                        new AgentSkill { Id = "preexisting", Name = "Preexisting" }
+                    ]
+                };
+            })
+            .AddSkillHandler<EchoSkillHandler>()
+            .AddSkillHandler<SearchSkillHandler>());
+
+        var provider = services.BuildServiceProvider();
+        var validator = provider.GetRequiredService<SkillRegistrationValidator>();
+        await validator.StartAsync(CancellationToken.None);
+
+        var options = provider.GetRequiredService<A2AOptions>();
+        var skills = options.Card!.Skills!.ToList();
+        // echo should not be duplicated — the pre-declared entry wins.
+        Assert.AreEqual(1, skills.Count(s => string.Equals(s.Id, "echo", StringComparison.OrdinalIgnoreCase)));
+        Assert.AreEqual("Pre-declared echo", skills.First(s => s.Id == "echo").Name);
+        Assert.IsTrue(skills.Any(s => s.Id == "preexisting"));
+        Assert.IsTrue(skills.Any(s => s.Id == "search"));
+    }
+
+    [TestMethod]
+    public async Task Validator_UserAlsoRegisteredIAgentTaskHandler_Throws()
+    {
+        var services = BaseServices();
+        services.AddRockBotHost(agent =>
+        {
+            agent.WithIdentity("test-agent")
+                 .AddA2A()
+                 .AddSkillHandler<EchoSkillHandler>();
+            // Ambiguous: user adds their own IAgentTaskHandler alongside skill handlers.
+            agent.Services.AddScoped<IAgentTaskHandler, StubAgentTaskHandler>();
+        });
+
+        var provider = services.BuildServiceProvider();
+        var validator = provider.GetRequiredService<SkillRegistrationValidator>();
+
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(
+            () => validator.StartAsync(CancellationToken.None));
+    }
+
+    [TestMethod]
+    public async Task Validator_NoSkillHandlers_Noop_ExistingFlowUnchanged()
+    {
+        var services = BaseServices();
+        services.AddRockBotHost(agent =>
+        {
+            agent.WithIdentity("test-agent")
+                 .AddA2A(opts => opts.Card = new AgentCard
+                 {
+                     AgentName = "test-agent",
+                     Version = "1.0"
+                 });
+            agent.Services.AddScoped<IAgentTaskHandler, StubAgentTaskHandler>();
+        });
+
+        var provider = services.BuildServiceProvider();
+        var validator = provider.GetRequiredService<SkillRegistrationValidator>();
+
+        await validator.StartAsync(CancellationToken.None);
+
+        // The traditional IAgentTaskHandler registration should still resolve fine.
+        using var scope = provider.CreateScope();
+        var handler = scope.ServiceProvider.GetRequiredService<IAgentTaskHandler>();
+        Assert.IsInstanceOfType<StubAgentTaskHandler>(handler);
+    }
+
+    [TestMethod]
+    public void Validator_IsRegisteredBeforeDiscoveryService()
+    {
+        var services = BaseServices();
+        services.AddRockBotHost(agent => agent
+            .WithIdentity("test-agent")
+            .AddA2A());
+        services.AddScoped<IAgentTaskHandler, StubAgentTaskHandler>();
+
+        var provider = services.BuildServiceProvider();
+
+        // The validator must start before discovery so it can populate the card
+        // before it is announced. .NET generic host runs hosted services in
+        // registration order, so checking the resolution order is sufficient.
+        var hosted = provider.GetServices<IHostedService>().ToList();
+        var validatorIndex = hosted.FindIndex(h => h is SkillRegistrationValidator);
+        var discoveryIndex = hosted.FindIndex(h => h is AgentDiscoveryService);
+        Assert.IsTrue(validatorIndex >= 0, "SkillRegistrationValidator should be registered");
+        Assert.IsTrue(discoveryIndex >= 0, "AgentDiscoveryService should be registered");
+        Assert.IsTrue(validatorIndex < discoveryIndex,
+            $"Validator (at {validatorIndex}) must run before discovery (at {discoveryIndex})");
+    }
+
+    // ── Stubs ────────────────────────────────────────────────────────────
+
+    private sealed class EchoSkillHandler : IAgentSkillHandler
+    {
+        public AgentSkill Skill { get; } = new() { Id = "echo", Name = "Echo" };
+        public Task<AgentTaskResult> ExecuteAsync(AgentTaskRequest request, AgentTaskContext context) =>
+            Task.FromResult(new AgentTaskResult
+            {
+                TaskId = request.TaskId,
+                State = AgentTaskState.Completed
+            });
+    }
+
+    private sealed class SearchSkillHandler : IAgentSkillHandler
+    {
+        public AgentSkill Skill { get; } = new() { Id = "search", Name = "Search" };
+        public Task<AgentTaskResult> ExecuteAsync(AgentTaskRequest request, AgentTaskContext context) =>
+            Task.FromResult(new AgentTaskResult
+            {
+                TaskId = request.TaskId,
+                State = AgentTaskState.Completed
+            });
+    }
+
+    private sealed class StubSubscriber : IMessageSubscriber
+    {
+        public Task<ISubscription> SubscribeAsync(
+            string topic, string subscriptionName,
+            Func<MessageEnvelope, CancellationToken, Task<MessageResult>> handler,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<ISubscription>(new StubSubscription());
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private sealed class StubSubscription : ISubscription
+    {
+        public string Topic => string.Empty;
+        public string SubscriptionName => string.Empty;
+        public bool IsActive => false;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/tests/RockBot.A2A.Tests/SkillDispatchingTaskHandlerTests.cs
+++ b/tests/RockBot.A2A.Tests/SkillDispatchingTaskHandlerTests.cs
@@ -1,0 +1,132 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using RockBot.Host;
+using RockBot.Messaging;
+
+namespace RockBot.A2A.Tests;
+
+[TestClass]
+public class SkillDispatchingTaskHandlerTests
+{
+    private static MessageHandlerContext CreateMessageContext() => new()
+    {
+        Envelope = TestEnvelopeHelper.CreateEnvelope(
+            new AgentTaskRequest
+            {
+                TaskId = "probe",
+                Skill = "probe",
+                Message = new AgentMessage
+                {
+                    Role = "user",
+                    Parts = [new AgentMessagePart { Kind = "text", Text = "x" }]
+                }
+            }),
+        Agent = new AgentIdentity("test-agent"),
+        Services = null!,
+        CancellationToken = CancellationToken.None
+    };
+
+    private static AgentTaskContext CreateTaskContext() => new()
+    {
+        MessageContext = CreateMessageContext(),
+        PublishStatus = (_, _) => Task.CompletedTask
+    };
+
+    private static AgentTaskRequest Request(string skill) => new()
+    {
+        TaskId = "t1",
+        Skill = skill,
+        Message = new AgentMessage
+        {
+            Role = "user",
+            Parts = [new AgentMessagePart { Kind = "text", Text = "hi" }]
+        }
+    };
+
+    [TestMethod]
+    public async Task RoutesRequest_ToMatchingSkillHandler()
+    {
+        var echo = new StubSkillHandler("echo", "Echo");
+        var search = new StubSkillHandler("search", "Search");
+        var dispatcher = new SkillDispatchingTaskHandler(
+            [echo, search],
+            NullLogger<SkillDispatchingTaskHandler>.Instance);
+
+        await dispatcher.HandleTaskAsync(Request("search"), CreateTaskContext());
+
+        Assert.AreEqual(1, search.InvocationCount);
+        Assert.AreEqual(0, echo.InvocationCount);
+    }
+
+    [TestMethod]
+    public async Task SkillIdMatch_IsCaseInsensitive()
+    {
+        var echo = new StubSkillHandler("echo", "Echo");
+        var dispatcher = new SkillDispatchingTaskHandler(
+            [echo],
+            NullLogger<SkillDispatchingTaskHandler>.Instance);
+
+        await dispatcher.HandleTaskAsync(Request("ECHO"), CreateTaskContext());
+
+        Assert.AreEqual(1, echo.InvocationCount);
+    }
+
+    [TestMethod]
+    public async Task UnknownSkill_ReturnsFailedResult_WithClearMessage()
+    {
+        var echo = new StubSkillHandler("echo", "Echo");
+        var dispatcher = new SkillDispatchingTaskHandler(
+            [echo],
+            NullLogger<SkillDispatchingTaskHandler>.Instance);
+
+        var result = await dispatcher.HandleTaskAsync(Request("unknown-skill"), CreateTaskContext());
+
+        Assert.AreEqual(AgentTaskState.Failed, result.State);
+        Assert.AreEqual(0, echo.InvocationCount);
+        var text = result.Message?.Parts[0].Text ?? string.Empty;
+        Assert.IsTrue(text.Contains("unknown-skill"), $"Expected error to mention skill id, got: {text}");
+    }
+
+    [TestMethod]
+    public void DuplicateSkillId_ThrowsAtConstruction()
+    {
+        var a = new StubSkillHandler("echo", "Echo A");
+        var b = new StubSkillHandler("echo", "Echo B");
+
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+            _ = new SkillDispatchingTaskHandler([a, b], NullLogger<SkillDispatchingTaskHandler>.Instance));
+    }
+
+    [TestMethod]
+    public async Task SingleSkill_RoutesCorrectly()
+    {
+        var only = new StubSkillHandler("only", "Only");
+        var dispatcher = new SkillDispatchingTaskHandler(
+            [only],
+            NullLogger<SkillDispatchingTaskHandler>.Instance);
+
+        await dispatcher.HandleTaskAsync(Request("only"), CreateTaskContext());
+
+        Assert.AreEqual(1, only.InvocationCount);
+    }
+
+    private sealed class StubSkillHandler(string id, string name) : IAgentSkillHandler
+    {
+        public AgentSkill Skill { get; } = new() { Id = id, Name = name };
+        public int InvocationCount { get; private set; }
+
+        public Task<AgentTaskResult> ExecuteAsync(AgentTaskRequest request, AgentTaskContext context)
+        {
+            InvocationCount++;
+            return Task.FromResult(new AgentTaskResult
+            {
+                TaskId = request.TaskId,
+                State = AgentTaskState.Completed,
+                Message = new AgentMessage
+                {
+                    Role = "agent",
+                    Parts = [new AgentMessagePart { Kind = "text", Text = $"{id}-done" }]
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Additive, non-breaking framework feature. Agents with more than one skill no longer need to reinvent a dispatcher.

- **New interface** `IAgentSkillHandler` — each implementation declares its own `AgentSkill` and handles exactly that skill.
- **`SkillDispatchingTaskHandler`** (internal) — implements `IAgentTaskHandler` and routes inbound requests by `request.Skill` to the registered handler whose `Skill.Id` matches (case-insensitive). Returns a standard `Failed` result on unknown skill; throws at construction on duplicate-id registration.
- **Registration extensions** `AddSkillHandler<T>()` and `AddSkillHandlers(params Type[])` on `AgentHostBuilder`. Auto-wires the dispatcher as `IAgentTaskHandler` via `TryAddScoped`.
- **`SkillRegistrationValidator`** (internal hosted service) — registered by `AddA2A` before `AgentDiscoveryService`. On startup: noops if no `IAgentSkillHandler`s are registered; otherwise validates no user-registered `IAgentTaskHandler` exists alongside skill handlers (throws if so) and auto-populates `A2AOptions.Card.Skills` from the registered handlers (merged with any pre-declared skills; existing ids win).
- **Back-compat**: existing agents that register `IAgentTaskHandler` directly (`SampleAgent`, `ResearchAgent`, `RockBot.Agent`, `Foragent`) are unchanged. Migration to the new pattern is opt-in.
- Docs updated with an `AddSkillHandler<T>()` example.

## Test plan

- [x] `SkillDispatchingTaskHandlerTests` — single skill, multi-skill routing, case-insensitive match, unknown-skill failure, duplicate-id rejection
- [x] `A2ASkillHandlerRegistrationTests` — DI registration, dispatcher wiring, `AddSkillHandlers(params)`, non-skill type rejection, card auto-population, merge-with-existing, ambiguous-registration error, no-skill-handlers noop path, validator-before-discovery ordering
- [x] Full suite green (A2A.Tests: 91 → 105; all other projects unchanged)

Closes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)