### PR TITLE
Blazor UI: close activity-log bubble on unsolicited-turn final reply

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-    <Version>0.9.0</Version>
+    <Version>0.9.1</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.UserProxy.Blazor/Services/ChatStateService.cs
+++ b/src/RockBot.UserProxy.Blazor/Services/ChatStateService.cs
@@ -408,7 +408,9 @@ public sealed class ChatStateService
     }
 
     private static string ActivityLogKey(MessageCategory category, string? agentName)
-        => $"{category}:{agentName ?? ""}";
+        => category == MessageCategory.PrimaryProgress
+            ? $"{category}:"
+            : $"{category}:{agentName ?? ""}";
 
     private void NotifyStateChanged() => OnStateChanged?.Invoke();
 }


### PR DESCRIPTION
## Summary

- Fix Blazor UI activity-log spinner that kept spinning on A2A/subagent/scheduled turns (e.g. after `GetFromWorkingMemory` during an A2A result handler run)
- Bump to 0.9.1

## Root cause

Two paths create `PrimaryProgress` activity-log bubbles with inconsistent keys:

- `Chat.razor:494` (user-initiated turns): `AppendActivityLogEntry(reply.Content)` with default `agentName=null` → key `"PrimaryProgress:"`
- `BlazorUserFrontend.DisplayReplyAsync:35` (unsolicited turns — A2A result/status/error handlers, subagent handlers): passes `reply.AgentName` → key `"PrimaryProgress:<agentName>"`

`ChatStateService.AddAgentReply:148` removes only the null-keyed version on a `PrimaryFinal` reply, so bubbles created by the unsolicited path never closed — their spinner spun until the next user message cleared `_activeActivityLogs` via `SetProcessing(true)`.

`invoke_agent` appeared to "work fine" because it was called during the user-initiated turn (null-keyed, closes correctly). The same tool called during an A2A result synthesis would have exhibited the same stuck-spinner behavior.

## Fix

Enforce the invariant "there is one `PrimaryProgress` bubble" at the key-derivation layer in `ChatStateService.ActivityLogKey`. Subagent / A2A / scheduled categories still key by agent name, so per-source bubbles are unaffected.

## Test plan

- [ ] Start a user turn that triggers an A2A call; verify the first turn's bubble closes after the final reply, as before
- [ ] When the A2A result arrives and RockBot synthesizes a follow-up response (calling `GetFromWorkingMemory` to read the stored result), verify the second activity-log bubble stops spinning after the final reply
- [ ] Verify subagent and scheduled-task activity logs still appear as separate bubbles and close on their own final/completion replies

🤖 Generated with [Claude Code](https://claude.com/claude-code)