### PR TITLE
A2A invoke_agent: support structured data alongside text

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-    <Version>0.9.1</Version>
+    <Version>0.9.2</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/docs/a2a.md
+++ b/docs/a2a.md
@@ -9,7 +9,7 @@ result folded back into the conversation.
 
 ## How it works
 
-1. The primary agent calls `invoke_agent(agent_name, skill, message)`.
+1. The primary agent calls `invoke_agent(agent_name, skill, message, [data])`.
 2. The request is published to `agent.task.{agentName}`.
 3. The target agent processes the task, sending `Working` status updates.
 4. If the response is non-terminal (Working/Submitted), the caller polls or
@@ -31,6 +31,39 @@ ScaledJob spins up).
 > of size. The synthetic turn that arrives in the conversation is a notification,
 > not the result itself — the agent must call `get_from_working_memory` with the
 > provided key to read the actual content before responding to the user.
+
+---
+
+## Structured data alongside the text message
+
+A2A messages are composed of one or more `Part`s, where each part is either a
+`TextPart` or a `DataPart`. `invoke_agent` accepts an optional `data` argument
+that is sent as a `DataPart` alongside the required `message` text part:
+
+```json
+{
+  "agent_name": "ExtractionAgent",
+  "skill": "extract-structured-data",
+  "message": "Extract the title and author from this record.",
+  "data": {
+    "recordId": "rec-42",
+    "source": "https://example.com/doc"
+  }
+}
+```
+
+The `data` value must be a JSON **object** (per the A2A spec — non-object values
+are rejected). It is serialized to a `DataPart` with `media_type:
+application/json` and appended after the text part.
+
+Most A2A agents in the wild only understand text, so omit `data` unless the
+target agent's skill is known to consume structured input. On the receiving
+side, RockBot's `RockBotBridgeHandler.MapInboundParts` already preserves
+inbound `DataPart`s as `AgentMessagePart { Kind = "data" }` so skill handlers
+can read both parts from `AgentTaskRequest.Message.Parts`.
+
+`InputRequired` follow-ups remain text-only — only the initial `invoke_agent`
+call carries the structured payload.
 
 ---
 

--- a/src/RockBot.A2A/A2ACallerToolRegistrar.cs
+++ b/src/RockBot.A2A/A2ACallerToolRegistrar.cs
@@ -37,6 +37,10 @@ internal sealed class A2ACallerToolRegistrar(
               "type": "string",
               "description": "The message or instruction to send to the agent."
             },
+            "data": {
+              "type": "object",
+              "description": "Optional structured data payload sent alongside the text message as an A2A DataPart. Use when the target agent's skill accepts structured inputs (fields, records, identifiers). Must be a JSON object; most A2A agents only understand text, so omit unless the agent is known to consume data."
+            },
             "timeout_minutes": {
               "type": "integer",
               "description": "Optional timeout in minutes (default: 5)."

--- a/src/RockBot.A2A/InvokeAgentExecutor.cs
+++ b/src/RockBot.A2A/InvokeAgentExecutor.cs
@@ -72,6 +72,18 @@ internal sealed class InvokeAgentExecutor(
         var messageText = messageEl.GetString()!;
         int timeoutMinutes = args.TryGetValue("timeout_minutes", out var toEl) && toEl.TryGetInt32(out var to) ? to : 5;
 
+        // Optional structured-data payload. Spec requires data to be a JSON object;
+        // reject other JSON shapes early so callers learn the contract instead of
+        // silently dropping the value or failing downstream in the A2A SDK.
+        string? dataJson = null;
+        if (args.TryGetValue("data", out var dataEl) && dataEl.ValueKind != JsonValueKind.Null &&
+            dataEl.ValueKind != JsonValueKind.Undefined)
+        {
+            if (dataEl.ValueKind != JsonValueKind.Object)
+                return Error(request, "Argument 'data' must be a JSON object.");
+            dataJson = dataEl.GetRawText();
+        }
+
         // Reject self-invocation — the LLM sometimes uses its own identity name
         // instead of the target agent's name from the directory.
         if (agentName.Equals(identity.Name, StringComparison.OrdinalIgnoreCase))
@@ -90,6 +102,20 @@ internal sealed class InvokeAgentExecutor(
                 "An agent task is already in progress for this session. " +
                 "Wait for the pending result before invoking another agent.");
 
+        var parts = new List<AgentMessagePart>
+        {
+            new() { Kind = "text", Text = messageText }
+        };
+        if (dataJson is not null)
+        {
+            parts.Add(new AgentMessagePart
+            {
+                Kind = "data",
+                Data = dataJson,
+                MimeType = "application/json"
+            });
+        }
+
         var taskRequest = new AgentTaskRequest
         {
             TaskId = taskId,
@@ -97,7 +123,7 @@ internal sealed class InvokeAgentExecutor(
             Message = new AgentMessage
             {
                 Role = "user",
-                Parts = [new AgentMessagePart { Kind = "text", Text = messageText }]
+                Parts = parts
             }
         };
 
@@ -201,8 +227,7 @@ internal sealed class InvokeAgentExecutor(
             httpActivity?.SetTag("rockbot.a2a.correlation_id", taskId);
             var httpSw = Stopwatch.StartNew();
 
-            var messageText = taskRequest.Message.Parts.FirstOrDefault(p => p.Kind == "text")?.Text
-                ?? string.Empty;
+            var outboundParts = taskRequest.Message.Parts;
 
             AgentTaskResult? result;
             if (useV1)
@@ -216,7 +241,7 @@ internal sealed class InvokeAgentExecutor(
                     try
                     {
                         result = await DispatchV1StreamingAsync(
-                            a2aClient, taskRequest, taskId, messageText, pending, ct);
+                            a2aClient, taskRequest, taskId, outboundParts, pending, ct);
                     }
                     catch (Exception ex) when (ex is not OperationCanceledException)
                     {
@@ -225,19 +250,19 @@ internal sealed class InvokeAgentExecutor(
                             taskId, agentName);
                         httpActivity?.SetTag("rockbot.a2a.transport", "streaming-fallback");
                         result = await DispatchV1Async(
-                            a2aClient, taskRequest, taskId, messageText, pending, supportsStreaming, ct);
+                            a2aClient, taskRequest, taskId, outboundParts, pending, supportsStreaming, ct);
                     }
                 }
                 else
                 {
                     httpActivity?.SetTag("rockbot.a2a.transport", "polling");
                     result = await DispatchV1Async(
-                        a2aClient, taskRequest, taskId, messageText, pending, supportsStreaming, ct);
+                        a2aClient, taskRequest, taskId, outboundParts, pending, supportsStreaming, ct);
                 }
             }
             else
             {
-                result = await DispatchV03Async(httpClient, endpoint, taskRequest, taskId, messageText, pending, ct);
+                result = await DispatchV03Async(httpClient, endpoint, taskRequest, taskId, outboundParts, pending, ct);
             }
 
             httpSw.Stop();
@@ -338,7 +363,7 @@ internal sealed class InvokeAgentExecutor(
         Uri endpoint,
         AgentTaskRequest taskRequest,
         string taskId,
-        string messageText,
+        IReadOnlyList<AgentMessagePart> initialParts,
         PendingA2ATask pending,
         CancellationToken ct)
     {
@@ -347,7 +372,7 @@ internal sealed class InvokeAgentExecutor(
         var repetitionDetector = new InputRequiredRepetitionDetector(options.InputRequiredRepetitionThreshold);
 
         // Initial send
-        var sendParams = BuildV03SendParams(taskId, messageText, contextId, taskRequest.Skill);
+        var sendParams = BuildV03SendParams(taskId, initialParts, contextId, taskRequest.Skill);
         var a2aResponse = await a2aClient.SendMessageAsync(sendParams, ct);
         var result = MapV03Response(a2aResponse, taskId);
 
@@ -416,7 +441,7 @@ internal sealed class InvokeAgentExecutor(
                     taskId, pending.InputRequiredRound, followUp.WasAutonomous);
 
                 // Send follow-up with contextId
-                sendParams = BuildV03SendParams(taskId, followUp.ResponseText, contextId, taskRequest.Skill);
+                sendParams = BuildV03SendParams(taskId, TextOnlyParts(followUp.ResponseText), contextId, taskRequest.Skill);
                 a2aResponse = await a2aClient.SendMessageAsync(sendParams, ct);
                 result = MapV03Response(a2aResponse, taskId);
                 continue;
@@ -429,7 +454,7 @@ internal sealed class InvokeAgentExecutor(
     }
 
     private static A2AV03.MessageSendParams BuildV03SendParams(
-        string taskId, string messageText, string? contextId, string skill)
+        string taskId, IReadOnlyList<AgentMessagePart> parts, string? contextId, string skill)
     {
         return new A2AV03.MessageSendParams
         {
@@ -438,7 +463,7 @@ internal sealed class InvokeAgentExecutor(
                 Role = A2AV03.MessageRole.User,
                 MessageId = taskId,
                 ContextId = contextId,
-                Parts = [new A2AV03.TextPart { Text = messageText }]
+                Parts = parts.Select(MapOutboundV03Part).ToList()
             },
             Metadata = new Dictionary<string, JsonElement>
             {
@@ -446,6 +471,21 @@ internal sealed class InvokeAgentExecutor(
             }
         };
     }
+
+    internal static A2AV03.Part MapOutboundV03Part(AgentMessagePart part)
+    {
+        if (string.Equals(part.Kind, "data", StringComparison.Ordinal) && part.Data is not null)
+        {
+            var data = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(part.Data)
+                       ?? new Dictionary<string, JsonElement>();
+            return new A2AV03.DataPart { Data = data };
+        }
+
+        return new A2AV03.TextPart { Text = part.Text ?? string.Empty };
+    }
+
+    private static IReadOnlyList<AgentMessagePart> TextOnlyParts(string text) =>
+        [new AgentMessagePart { Kind = "text", Text = text }];
 
     private async Task<AgentTaskResult?> PollV03UntilNonWorkingAsync(
         A2AV03.A2AClient a2aClient,
@@ -567,7 +607,7 @@ internal sealed class InvokeAgentExecutor(
         A2AV1.A2AClient a2aClient,
         AgentTaskRequest taskRequest,
         string taskId,
-        string messageText,
+        IReadOnlyList<AgentMessagePart> initialParts,
         PendingA2ATask pending,
         bool supportsStreaming,
         CancellationToken ct)
@@ -576,7 +616,7 @@ internal sealed class InvokeAgentExecutor(
         var repetitionDetector = new InputRequiredRepetitionDetector(options.InputRequiredRepetitionThreshold);
 
         // Initial send
-        var sendRequest = BuildV1SendRequest(taskId, messageText, contextId, taskRequest.Skill);
+        var sendRequest = BuildV1SendRequest(taskId, initialParts, contextId, taskRequest.Skill);
         var a2aResponse = await a2aClient.SendMessageAsync(sendRequest, ct);
         var result = MapV1Response(a2aResponse, taskId);
 
@@ -645,7 +685,7 @@ internal sealed class InvokeAgentExecutor(
                     taskId, pending.InputRequiredRound, followUp.WasAutonomous);
 
                 // Send follow-up with contextId
-                sendRequest = BuildV1SendRequest(taskId, followUp.ResponseText, contextId, taskRequest.Skill);
+                sendRequest = BuildV1SendRequest(taskId, TextOnlyParts(followUp.ResponseText), contextId, taskRequest.Skill);
                 a2aResponse = await a2aClient.SendMessageAsync(sendRequest, ct);
                 result = MapV1Response(a2aResponse, taskId);
                 continue;
@@ -668,7 +708,7 @@ internal sealed class InvokeAgentExecutor(
         A2AV1.A2AClient a2aClient,
         AgentTaskRequest taskRequest,
         string taskId,
-        string messageText,
+        IReadOnlyList<AgentMessagePart> initialParts,
         PendingA2ATask pending,
         CancellationToken ct)
     {
@@ -679,7 +719,7 @@ internal sealed class InvokeAgentExecutor(
 
         string? contextId = null;
         var repetitionDetector = new InputRequiredRepetitionDetector(options.InputRequiredRepetitionThreshold);
-        var sendRequest = BuildV1SendRequest(taskId, messageText, contextId, taskRequest.Skill);
+        var sendRequest = BuildV1SendRequest(taskId, initialParts, contextId, taskRequest.Skill);
 
         while (!ct.IsCancellationRequested)
         {
@@ -798,7 +838,7 @@ internal sealed class InvokeAgentExecutor(
                     taskId, pending.InputRequiredRound, followUp.WasAutonomous);
 
                 // Send follow-up with contextId — continue streaming
-                sendRequest = BuildV1SendRequest(taskId, followUp.ResponseText, contextId, taskRequest.Skill);
+                sendRequest = BuildV1SendRequest(taskId, TextOnlyParts(followUp.ResponseText), contextId, taskRequest.Skill);
                 continue;
             }
 
@@ -837,7 +877,7 @@ internal sealed class InvokeAgentExecutor(
     }
 
     private static A2AV1.SendMessageRequest BuildV1SendRequest(
-        string taskId, string messageText, string? contextId, string skill)
+        string taskId, IReadOnlyList<AgentMessagePart> parts, string? contextId, string skill)
     {
         return new A2AV1.SendMessageRequest
         {
@@ -846,13 +886,27 @@ internal sealed class InvokeAgentExecutor(
                 Role = A2AV1.Role.User,
                 MessageId = taskId,
                 ContextId = contextId,
-                Parts = [new A2AV1.Part { Text = messageText }]
+                Parts = parts.Select(MapOutboundV1Part).ToList()
             },
             Metadata = new Dictionary<string, JsonElement>
             {
                 ["skill"] = JsonSerializer.SerializeToElement(skill)
             }
         };
+    }
+
+    internal static A2AV1.Part MapOutboundV1Part(AgentMessagePart part)
+    {
+        if (string.Equals(part.Kind, "data", StringComparison.Ordinal) && part.Data is not null)
+        {
+            var element = JsonSerializer.Deserialize<JsonElement>(part.Data);
+            var a2aPart = A2AV1.Part.FromData(element);
+            if (!string.IsNullOrEmpty(part.MimeType))
+                a2aPart.MediaType = part.MimeType;
+            return a2aPart;
+        }
+
+        return new A2AV1.Part { Text = part.Text ?? string.Empty };
     }
 
     /// <summary>

--- a/tests/RockBot.A2A.Tests/A2ACallerTests.cs
+++ b/tests/RockBot.A2A.Tests/A2ACallerTests.cs
@@ -146,6 +146,149 @@ public class A2ACallerTests
         Assert.IsTrue(response.IsError);
     }
 
+    [TestMethod]
+    public async Task InvokeAgentExecutor_OmitsDataPart_WhenDataArgMissing()
+    {
+        var publisher = new TrackingPublisher();
+        var tracker = new A2ATaskTracker();
+        var executor = BuildExecutor(publisher, tracker);
+
+        var request = BuildToolRequest("""
+            { "agent_name": "TargetAgent", "skill": "chat", "message": "Hi." }
+            """);
+
+        await executor.ExecuteAsync(request, CancellationToken.None);
+
+        var taskReq = publisher.Published[0].Envelope.GetPayload<AgentTaskRequest>()!;
+        Assert.AreEqual(1, taskReq.Message.Parts.Count);
+        Assert.AreEqual("text", taskReq.Message.Parts[0].Kind);
+    }
+
+    [TestMethod]
+    public async Task InvokeAgentExecutor_AddsDataPart_WhenDataObjectProvided()
+    {
+        var publisher = new TrackingPublisher();
+        var tracker = new A2ATaskTracker();
+        var executor = BuildExecutor(publisher, tracker);
+
+        var request = BuildToolRequest("""
+            {
+              "agent_name": "TargetAgent",
+              "skill": "summarize",
+              "message": "Summarize this record.",
+              "data": { "recordId": "abc-123", "fields": ["title", "body"] }
+            }
+            """);
+
+        await executor.ExecuteAsync(request, CancellationToken.None);
+
+        var taskReq = publisher.Published[0].Envelope.GetPayload<AgentTaskRequest>()!;
+        Assert.AreEqual(2, taskReq.Message.Parts.Count);
+        Assert.AreEqual("text", taskReq.Message.Parts[0].Kind);
+        Assert.AreEqual("Summarize this record.", taskReq.Message.Parts[0].Text);
+
+        var dataPart = taskReq.Message.Parts[1];
+        Assert.AreEqual("data", dataPart.Kind);
+        Assert.AreEqual("application/json", dataPart.MimeType);
+        Assert.IsNotNull(dataPart.Data);
+
+        using var parsed = System.Text.Json.JsonDocument.Parse(dataPart.Data!);
+        Assert.AreEqual("abc-123", parsed.RootElement.GetProperty("recordId").GetString());
+        Assert.AreEqual(2, parsed.RootElement.GetProperty("fields").GetArrayLength());
+    }
+
+    [TestMethod]
+    public async Task InvokeAgentExecutor_ReturnsError_WhenDataIsNotObject()
+    {
+        var publisher = new TrackingPublisher();
+        var tracker = new A2ATaskTracker();
+        var executor = BuildExecutor(publisher, tracker);
+
+        var request = BuildToolRequest("""
+            { "agent_name": "TargetAgent", "skill": "chat", "message": "Hi.", "data": "not-an-object" }
+            """);
+
+        var response = await executor.ExecuteAsync(request, CancellationToken.None);
+
+        Assert.IsTrue(response.IsError);
+        StringAssert.Contains(response.Content, "data");
+        Assert.AreEqual(0, publisher.Published.Count);
+    }
+
+    [TestMethod]
+    public async Task InvokeAgentExecutor_AcceptsNullData_AsMissing()
+    {
+        var publisher = new TrackingPublisher();
+        var tracker = new A2ATaskTracker();
+        var executor = BuildExecutor(publisher, tracker);
+
+        var request = BuildToolRequest("""
+            { "agent_name": "TargetAgent", "skill": "chat", "message": "Hi.", "data": null }
+            """);
+
+        var response = await executor.ExecuteAsync(request, CancellationToken.None);
+
+        Assert.IsFalse(response.IsError);
+        var taskReq = publisher.Published[0].Envelope.GetPayload<AgentTaskRequest>()!;
+        Assert.AreEqual(1, taskReq.Message.Parts.Count);
+    }
+
+    [TestMethod]
+    public void MapOutboundV03Part_TextPart_MapsToV03TextPart()
+    {
+        var part = new AgentMessagePart { Kind = "text", Text = "hello" };
+
+        var mapped = InvokeAgentExecutor.MapOutboundV03Part(part);
+
+        var textPart = (A2AV03.TextPart)mapped;
+        Assert.AreEqual("hello", textPart.Text);
+    }
+
+    [TestMethod]
+    public void MapOutboundV03Part_DataPart_MapsToV03DataPartWithDictionary()
+    {
+        var part = new AgentMessagePart
+        {
+            Kind = "data",
+            Data = """{ "id": "x-1", "count": 3 }""",
+            MimeType = "application/json"
+        };
+
+        var mapped = InvokeAgentExecutor.MapOutboundV03Part(part);
+
+        var dataPart = (A2AV03.DataPart)mapped;
+        Assert.AreEqual("x-1", dataPart.Data["id"].GetString());
+        Assert.AreEqual(3, dataPart.Data["count"].GetInt32());
+    }
+
+    [TestMethod]
+    public void MapOutboundV1Part_TextPart_MapsToV1TextPart()
+    {
+        var part = new AgentMessagePart { Kind = "text", Text = "hello" };
+
+        var mapped = InvokeAgentExecutor.MapOutboundV1Part(part);
+
+        Assert.AreEqual(A2AV1.PartContentCase.Text, mapped.ContentCase);
+        Assert.AreEqual("hello", mapped.Text);
+    }
+
+    [TestMethod]
+    public void MapOutboundV1Part_DataPart_MapsToV1DataPartWithMediaType()
+    {
+        var part = new AgentMessagePart
+        {
+            Kind = "data",
+            Data = """{ "ok": true }""",
+            MimeType = "application/json"
+        };
+
+        var mapped = InvokeAgentExecutor.MapOutboundV1Part(part);
+
+        Assert.AreEqual(A2AV1.PartContentCase.Data, mapped.ContentCase);
+        Assert.AreEqual("application/json", mapped.MediaType);
+        Assert.IsTrue(mapped.Data!.Value.GetProperty("ok").GetBoolean());
+    }
+
     // ─── ListKnownAgentsExecutor ─────────────────────────────────────────────────
 
     [TestMethod]


### PR DESCRIPTION
## Summary
- Adds an optional `data` object argument to the `invoke_agent` tool. When present, it is serialized as an A2A `DataPart` and sent alongside the required `message` text part.
- Works for both HTTP transport (v0.3 and v1, including the streaming path) and queue transport. `InputRequired` follow-ups stay text-only; only the initial dispatch carries structured input.
- Non-object `data` values are rejected with a clear error — the A2A spec requires `DataPart.data` to be a JSON object.
- Receiving side needs no change: `RockBotBridgeHandler.MapInboundParts` already maps inbound `DataPart`s, and skill handlers receive `AgentTaskRequest.Message.Parts` intact over the bus.
- Bumps version to 0.9.2.

## Test plan
- [x] `dotnet test RockBot.slnx` — full suite green (113 A2A tests, 8 new)
- [ ] Manual: invoke a peer agent with a `data` payload and confirm the receiver sees both parts