### PR TITLE
Bump version to 0.9.3

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-    <Version>0.9.2</Version>
+    <Version>0.9.3</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->


### PR DESCRIPTION
## Summary
- Bump `<Version>` from 0.9.2 to 0.9.3 for the next agent image deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)