### PR TITLE
Skill/resource folder fix + wisp schema validation & auto-correction

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-    <Version>0.9.3</Version>
+    <Version>0.9.4</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-    <Version>0.9.4</Version>
+    <Version>0.9.5</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-    <Version>0.9.8</Version>
+    <Version>0.9.9</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-    <Version>0.9.2</Version>
+    <Version>0.9.3</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-    <Version>0.9.5</Version>
+    <Version>0.9.6</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-    <Version>0.9.6</Version>
+    <Version>0.9.7</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-    <Version>0.9.7</Version>
+    <Version>0.9.8</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.Host/FileSkillStore.cs
+++ b/src/RockBot.Host/FileSkillStore.cs
@@ -12,7 +12,10 @@ namespace RockBot.Host;
 /// <c>{basePath}/{name}.json</c>, where the name may contain forward slashes
 /// to form subcategories (e.g. <c>research/summarize-paper</c>).
 /// Sub-resource files for a skill named <c>myskill</c> live in the sibling
-/// folder <c>{basePath}/myskill/</c>.
+/// folder <c>{basePath}/myskill.resources/</c>. The <c>.resources</c> suffix is
+/// reserved (skill names cannot contain dots) and unambiguously distinguishes
+/// resource folders from subcategory folders, so a top-level skill <c>a</c> and
+/// a subcategory skill <c>a/b</c> can coexist without collision.
 /// Thread safety via <see cref="SemaphoreSlim"/>.
 /// </summary>
 internal sealed partial class FileSkillStore : ISkillStore
@@ -60,7 +63,6 @@ internal sealed partial class FileSkillStore : ISkillStore
         try
         {
             var index = await EnsureIndexAsync();
-            ValidateNoConflict(skill.Name, index);
 
             // Preserve the existing manifest when the caller hasn't provided one.
             // This prevents a plain metadata/markdown update from silently orphaning
@@ -107,7 +109,6 @@ internal sealed partial class FileSkillStore : ISkillStore
         try
         {
             var index = await EnsureIndexAsync();
-            ValidateNoConflict(skill.Name, index);
 
             var filePath = GetFilePath(skill.Name);
             var folderPath = GetResourceFolderPath(skill.Name);
@@ -323,9 +324,10 @@ internal sealed partial class FileSkillStore : ISkillStore
 
         foreach (var file in Directory.EnumerateFiles(_basePath, "*.json", SearchOption.AllDirectories))
         {
-            // Skip JSON files that live inside a skill's resource subfolder.
-            // A resource subfolder is identified by having a sibling .json file with the same name.
-            if (IsInsideResourceSubfolder(file))
+            // Skip JSON files that live inside a skill's resource folder.
+            // Resource folders are suffixed with ".resources" — skill names cannot
+            // contain dots, so there is no ambiguity with subcategory folders.
+            if (IsInsideResourceFolder(file))
                 continue;
 
             try
@@ -346,34 +348,32 @@ internal sealed partial class FileSkillStore : ISkillStore
     }
 
     /// <summary>
-    /// Returns <c>true</c> if <paramref name="filePath"/> lives inside a skill's resource subfolder
-    /// (i.e., the file's immediate parent directory has a sibling <c>.json</c> entry-point file).
+    /// Returns <c>true</c> if <paramref name="filePath"/> lives inside a skill's resource folder,
+    /// identified by the reserved <c>.resources</c> suffix on any path segment below
+    /// <see cref="_basePath"/>.
     /// </summary>
-    private bool IsInsideResourceSubfolder(string filePath)
+    private static bool IsInsideResourceFolder(string filePath)
     {
-        var parentDir = Path.GetDirectoryName(filePath);
-        if (parentDir is null)
-            return false;
-
-        // Top-level files are always skill entry points
-        if (string.Equals(Path.GetFullPath(parentDir), Path.GetFullPath(_basePath), StringComparison.OrdinalIgnoreCase))
-            return false;
-
-        // If there is a .json file with the same name as the parent directory, the parent is a resource subfolder
-        var siblingJson = parentDir.TrimEnd(Path.DirectorySeparatorChar) + ".json";
-        return File.Exists(siblingJson);
+        var dir = Path.GetDirectoryName(filePath);
+        return dir is not null
+            && dir.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                .Any(segment => segment.EndsWith(ResourceFolderSuffix, StringComparison.Ordinal));
     }
 
     private string GetFilePath(string name) =>
         Path.Combine(_basePath, name.Replace('/', Path.DirectorySeparatorChar) + ".json");
 
     /// <summary>
-    /// Returns the path of the resource subfolder for a skill.
-    /// For a skill named <c>myskill</c> the folder is <c>{basePath}/myskill/</c>;
-    /// for <c>research/summarize</c> it is <c>{basePath}/research/summarize/</c>.
+    /// Returns the path of the resource folder for a skill.
+    /// For a skill named <c>myskill</c> the folder is <c>{basePath}/myskill.resources/</c>;
+    /// for <c>research/summarize</c> it is <c>{basePath}/research/summarize.resources/</c>.
+    /// The <c>.resources</c> suffix is reserved — skill names cannot contain dots — so
+    /// the folder never collides with a subcategory folder.
     /// </summary>
     private string GetResourceFolderPath(string name) =>
-        Path.Combine(_basePath, name.Replace('/', Path.DirectorySeparatorChar));
+        Path.Combine(_basePath, name.Replace('/', Path.DirectorySeparatorChar) + ResourceFolderSuffix);
+
+    private const string ResourceFolderSuffix = ".resources";
 
     internal static string ResolvePath(string skillBasePath, string profileBasePath)
     {
@@ -425,43 +425,6 @@ internal sealed partial class FileSkillStore : ISkillStore
                 $"Resource filename contains invalid characters: '{filename}'. " +
                 "Only alphanumeric, hyphens, underscores, and dots are allowed.",
                 nameof(filename));
-    }
-
-    /// <summary>
-    /// Detects name conflicts that would make a skill invisible after indexing.
-    /// <list type="bullet">
-    ///   <item>Saving <c>a/b</c> when skill <c>a</c> already exists: <c>a/b.json</c> would land
-    ///   inside <c>a</c>'s resource folder and be skipped by <see cref="IsInsideResourceSubfolder"/>.</item>
-    ///   <item>Saving <c>a</c> when skill <c>a/b</c> already exists: <c>a/</c> would be treated as
-    ///   a resource folder after the save, making <c>a/b</c> unreachable.</item>
-    /// </list>
-    /// Must be called while the semaphore is held and the index is loaded.
-    /// </summary>
-    private static void ValidateNoConflict(string name, Dictionary<string, Skill> index)
-    {
-        var parts = name.Split('/');
-
-        // Case A: saving "a/b/c" — reject if any ancestor "a" or "a/b" is already a skill.
-        // If "a" exists, "a/" is its resource folder and "a/b/c.json" would land inside it.
-        for (var i = 1; i < parts.Length; i++)
-        {
-            var ancestorName = string.Join("/", parts[..i]);
-            if (index.ContainsKey(ancestorName))
-                throw new InvalidOperationException(
-                    $"Skill name conflict: cannot save '{name}' because ancestor skill '{ancestorName}' already exists. " +
-                    $"Saving '{name}' would place it inside '{ancestorName}'s resource folder, making it unreachable.");
-        }
-
-        // Case B: saving "a" — reject if any skill "a/b" already exists.
-        // After saving "a.json", "a/" would be treated as its resource folder, hiding "a/b".
-        var subcategoryPrefix = name + "/";
-        foreach (var existingName in index.Keys)
-        {
-            if (existingName.StartsWith(subcategoryPrefix, StringComparison.Ordinal))
-                throw new InvalidOperationException(
-                    $"Skill name conflict: cannot save '{name}' because subcategory skill '{existingName}' exists. " +
-                    $"Saving '{name}' would turn '{name}/' into a resource folder, making '{existingName}' unreachable.");
-        }
     }
 
     [GeneratedRegex(@"^[a-zA-Z0-9_\-]+(/[a-zA-Z0-9_\-]+)*$")]

--- a/src/RockBot.Host/StarterSkillService.cs
+++ b/src/RockBot.Host/StarterSkillService.cs
@@ -55,9 +55,19 @@ internal sealed class StarterSkillService : IHostedService
                 UpdatedAt: DateTimeOffset.UtcNow,
                 LastUsedAt: null);
 
-            await _skillStore.SaveAsync(skill);
-            seeded++;
-            _logger.LogInformation("StarterSkillService: seeded starter skill '{Name}'", provider.Name);
+            try
+            {
+                await _skillStore.SaveAsync(skill);
+                seeded++;
+                _logger.LogInformation("StarterSkillService: seeded starter skill '{Name}'", provider.Name);
+            }
+            catch (Exception ex)
+            {
+                // Seeding is best-effort — a starter skill failing to save must not crash the host.
+                _logger.LogWarning(ex,
+                    "StarterSkillService: failed to seed starter skill '{Name}'; continuing",
+                    provider.Name);
+            }
         }
 
         _logger.LogInformation(

--- a/src/RockBot.Skills/SkillToolSkillProvider.cs
+++ b/src/RockBot.Skills/SkillToolSkillProvider.cs
@@ -242,6 +242,14 @@ public sealed class SkillToolSkillProvider : IToolSkillProvider
           wisp definitions, and similar files into `resources` rather than embedding them
           in the markdown body; this keeps the markdown readable and lets `get_skill_resource`
           load them on demand without bloating the context
+        - **Save working wisps back to their skill** — once a wisp is authored, debugged,
+          and confirmed working, save the final definition as a `Wisp`-type resource on the
+          relevant skill with a description. Future sessions that load the skill will see
+          the resource in the manifest and can reuse it via `get_skill_resource` + `spawn_wisps`
+          instead of re-authoring from scratch
+        - **Check for Wisp resources before authoring** — when a loaded skill's manifest
+          lists a Wisp resource, fetch it first; start from the saved definition and adapt
+          it rather than composing a new one
         - **Rules are permanent and broad** — confirm intent with the user before adding
           one; they affect every future interaction
         - **Use `list_rules` to audit** — periodically surfacing active rules helps

--- a/src/RockBot.Wisp/GatewayRouter.cs
+++ b/src/RockBot.Wisp/GatewayRouter.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using RockBot.Tools;
 
 namespace RockBot.Wisp;
@@ -7,7 +8,7 @@ namespace RockBot.Wisp;
 /// Maps wisp step definitions to concrete tool invocations via the tool registry.
 /// Each gateway type routes to a specific registered tool with appropriately formatted arguments.
 /// </summary>
-internal static class GatewayRouter
+internal static partial class GatewayRouter
 {
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -152,25 +153,41 @@ internal static class GatewayRouter
 
     /// <summary>
     /// Resolves template references in the input string. Supports:
-    /// <c>{{steps.id.result}}</c> — replaced with step's output content.
-    /// <c>{{steps.id.output_to}}</c> — replaced with step's output_to file path (from definition).
+    /// <c>{{steps.id.result}}</c> — replaced with the step's full output content.
+    /// <c>{{steps.id.result.a.b.c}}</c> — replaced with the value at the dotted path
+    ///   within the step's output parsed as JSON. A string value is inserted as its
+    ///   string value (quotes stripped); non-string values are inserted as their JSON
+    ///   representation. If the step's content isn't JSON or the path doesn't resolve,
+    ///   the literal template is left in place — downstream validation/soft-error
+    ///   detection surfaces the failure.
+    /// <c>{{steps.id.output_to}}</c> — replaced with the step's output_to file path
+    ///   (from the wisp definition).
     /// </summary>
     internal static string ResolveTemplateString(
         string input,
         IReadOnlyDictionary<string, WispStepResult> priorResults,
         WispDefinition? definition)
     {
-        var result = input;
-
-        foreach (var (stepId, stepResult) in priorResults)
+        // Match {{steps.<stepId>.result}} or {{steps.<stepId>.result.<dot.path>}}
+        var result = ResultTemplatePattern().Replace(input, match =>
         {
-            var resultPlaceholder = $"{{{{steps.{stepId}.result}}}}";
-            if (result.Contains(resultPlaceholder))
-            {
-                var escaped = JsonEscapeForEmbedding(stepResult.Content ?? "");
-                result = result.Replace(resultPlaceholder, escaped);
-            }
-        }
+            var stepId = match.Groups[1].Value;
+            var path = match.Groups[2].Success ? match.Groups[2].Value : null;
+
+            if (!priorResults.TryGetValue(stepId, out var stepResult))
+                return match.Value;
+
+            var content = stepResult.Content ?? "";
+
+            if (path is null)
+                return JsonEscapeForEmbedding(content);
+
+            // Path present — parse as JSON and navigate.
+            if (!TryNavigateJsonPath(content, path, out var extracted))
+                return match.Value; // not JSON, or path not found → leave literal
+
+            return JsonEscapeForEmbedding(extracted);
+        });
 
         // Resolve {{steps.id.output_to}} from the definition's step declarations
         if (definition is not null)
@@ -188,6 +205,48 @@ internal static class GatewayRouter
 
         return result;
     }
+
+    /// <summary>
+    /// Parses <paramref name="json"/> and walks the dotted <paramref name="path"/>
+    /// (object-property access only). Returns the extracted value as a string —
+    /// JSON strings are unwrapped; other kinds serialize to their raw JSON text.
+    /// Returns <c>false</c> when the content isn't a JSON object or the path misses.
+    /// </summary>
+    private static bool TryNavigateJsonPath(string json, string path, out string value)
+    {
+        value = "";
+        if (string.IsNullOrWhiteSpace(json))
+            return false;
+
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            var current = doc.RootElement;
+            foreach (var segment in path.Split('.', StringSplitOptions.RemoveEmptyEntries))
+            {
+                if (current.ValueKind != JsonValueKind.Object)
+                    return false;
+                if (!current.TryGetProperty(segment, out var next))
+                    return false;
+                current = next;
+            }
+
+            value = current.ValueKind switch
+            {
+                JsonValueKind.String => current.GetString() ?? "",
+                JsonValueKind.Null => "",
+                _ => current.GetRawText()
+            };
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+    [GeneratedRegex(@"\{\{steps\.([a-zA-Z0-9_\-]+)\.result(?:\.([a-zA-Z0-9_\-.]+))?\}\}")]
+    private static partial Regex ResultTemplatePattern();
 
     /// <summary>
     /// Escapes a string value for embedding within an already-quoted JSON string.

--- a/src/RockBot.Wisp/McpStepValidator.cs
+++ b/src/RockBot.Wisp/McpStepValidator.cs
@@ -1,0 +1,168 @@
+using System.Text;
+using System.Text.Json;
+using RockBot.Tools;
+
+namespace RockBot.Wisp;
+
+/// <summary>
+/// Validates MCP wisp step parameters against the target tool's JSON Schema
+/// before the step is invoked. Catches the common authoring failure mode where
+/// the LLM composes a wisp from training priors (e.g. <c>startDate</c>/<c>endDate</c>)
+/// rather than the tool's real contract (e.g. <c>timeMin</c>/<c>timeMax</c>).
+///
+/// Validation is intentionally narrow — "required fields present" and (when the
+/// schema says so) "unknown fields rejected". On failure, the error message
+/// includes a compact schema summary so an auto-retry call can correct the
+/// params without re-discovering the tool.
+/// </summary>
+internal static class McpStepValidator
+{
+    /// <summary>
+    /// Validates an MCP-gateway step's resolved params against the target tool's
+    /// schema. Returns <c>null</c> if valid, a schema-free step (non-MCP, or the
+    /// tool is unregistered/unschematized), or if the params JSON is malformed —
+    /// the existing executor path will produce a more informative failure in those
+    /// cases. Returns a <see cref="WispStepError"/> with <see cref="FailureCategory.Structural"/>
+    /// when required fields are missing or unknown fields are present under a
+    /// closed schema.
+    /// </summary>
+    public static WispStepError? Validate(WispStep step, IToolRegistry registry)
+    {
+        if (step.Gateway != GatewayType.Mcp)
+            return null;
+        if (string.IsNullOrEmpty(step.Server) || string.IsNullOrEmpty(step.Tool))
+            return null;
+
+        var tool = FindMcpTool(registry, step.Server, step.Tool);
+        if (tool?.ParametersSchema is null)
+            return null;
+
+        JsonElement schema;
+        try
+        {
+            schema = JsonDocument.Parse(tool.ParametersSchema).RootElement;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+
+        var paramsElement = step.ResolvedParams;
+        if (paramsElement is null || paramsElement.Value.ValueKind != JsonValueKind.Object)
+            paramsElement = EmptyObject;
+
+        var (missing, unknown) = Compare(schema, paramsElement.Value);
+        if (missing.Count == 0 && unknown.Count == 0)
+            return null;
+
+        return new WispStepError
+        {
+            Category = FailureCategory.Structural,
+            Message = BuildErrorMessage(step.Server!, step.Tool!, missing, unknown, schema),
+            ToolName = $"{step.Server}/{step.Tool}"
+        };
+    }
+
+    private static ToolRegistration? FindMcpTool(IToolRegistry registry, string server, string tool)
+    {
+        var source = $"mcp:{server}";
+        foreach (var reg in registry.GetTools())
+        {
+            if (string.Equals(reg.Name, tool, StringComparison.Ordinal)
+                && string.Equals(reg.Source, source, StringComparison.Ordinal))
+                return reg;
+        }
+        return null;
+    }
+
+    private static (List<string> Missing, List<string> Unknown) Compare(JsonElement schema, JsonElement paramsObj)
+    {
+        var required = new HashSet<string>(StringComparer.Ordinal);
+        if (schema.TryGetProperty("required", out var requiredEl)
+            && requiredEl.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in requiredEl.EnumerateArray())
+                if (item.ValueKind == JsonValueKind.String)
+                    required.Add(item.GetString()!);
+        }
+
+        var known = new HashSet<string>(StringComparer.Ordinal);
+        if (schema.TryGetProperty("properties", out var propsEl)
+            && propsEl.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var p in propsEl.EnumerateObject())
+                known.Add(p.Name);
+        }
+
+        var closed = schema.TryGetProperty("additionalProperties", out var addEl)
+                     && addEl.ValueKind == JsonValueKind.False;
+
+        var supplied = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var p in paramsObj.EnumerateObject())
+            supplied.Add(p.Name);
+
+        var missing = required.Where(r => !supplied.Contains(r)).ToList();
+        var unknown = closed
+            ? supplied.Where(s => !known.Contains(s)).ToList()
+            : [];
+
+        return (missing, unknown);
+    }
+
+    private static string BuildErrorMessage(
+        string server, string tool,
+        List<string> missing, List<string> unknown,
+        JsonElement schema)
+    {
+        var sb = new StringBuilder();
+        sb.Append($"Params for {server}/{tool} did not match the tool's schema.");
+        if (missing.Count > 0)
+            sb.Append(" Missing required field(s): ").Append(string.Join(", ", missing)).Append('.');
+        if (unknown.Count > 0)
+            sb.Append(" Unknown field(s): ").Append(string.Join(", ", unknown)).Append('.');
+
+        sb.AppendLine();
+        sb.Append("Expected shape:");
+        sb.AppendLine();
+        AppendSchemaSummary(sb, schema);
+
+        return sb.ToString().TrimEnd();
+    }
+
+    private static void AppendSchemaSummary(StringBuilder sb, JsonElement schema)
+    {
+        if (!schema.TryGetProperty("properties", out var propsEl)
+            || propsEl.ValueKind != JsonValueKind.Object)
+        {
+            sb.Append("  (schema has no 'properties' block)");
+            return;
+        }
+
+        var required = new HashSet<string>(StringComparer.Ordinal);
+        if (schema.TryGetProperty("required", out var requiredEl)
+            && requiredEl.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in requiredEl.EnumerateArray())
+                if (item.ValueKind == JsonValueKind.String)
+                    required.Add(item.GetString()!);
+        }
+
+        foreach (var prop in propsEl.EnumerateObject())
+        {
+            var type = prop.Value.TryGetProperty("type", out var t) && t.ValueKind == JsonValueKind.String
+                ? t.GetString()
+                : "any";
+            var req = required.Contains(prop.Name) ? " (required)" : "";
+            var desc = prop.Value.TryGetProperty("description", out var d) && d.ValueKind == JsonValueKind.String
+                ? " — " + Truncate(d.GetString()!, 80)
+                : "";
+            sb.AppendLine($"  {prop.Name}: {type}{req}{desc}");
+        }
+    }
+
+    private static string Truncate(string s, int max) =>
+        s.Length <= max ? s : s[..max] + "…";
+
+    private static readonly JsonElement EmptyObject =
+        JsonDocument.Parse("{}").RootElement;
+}

--- a/src/RockBot.Wisp/WispExecutor.cs
+++ b/src/RockBot.Wisp/WispExecutor.cs
@@ -19,7 +19,8 @@ internal sealed class WispExecutor(
     IWorkingMemory workingMemory,
     AgentLoopRunner agentLoopRunner,
     WispOptions options,
-    ILogger<WispExecutor> logger)
+    ILogger<WispExecutor> logger,
+    ILlmClient? llmClient = null)
 {
     private const int DefaultLlmStepMaxIterations = 10;
     private const int InputChunkingThreshold = 8_000;
@@ -224,6 +225,66 @@ internal sealed class WispExecutor(
                 },
                 Duration = stepSw.Elapsed
             };
+        }
+
+        // Pre-flight schema validation for MCP gateway steps. Catches authoring
+        // mistakes (missing required fields, unknown fields under a closed schema)
+        // before the tool is invoked, so a silent "empty result" can't be mistaken
+        // for a valid answer. On failure, attempt a single focused auto-correction
+        // LLM call — a tool-less one-shot that sees only the failing params and the
+        // schema summary. If the correction passes validation, the step proceeds
+        // with corrected params; otherwise the original error is surfaced.
+        var validationError = McpStepValidator.Validate(step, toolRegistry);
+        if (validationError is not null)
+        {
+            var corrected = await TryAutoCorrectMcpParamsAsync(step, validationError, ct);
+            if (corrected is null)
+            {
+                return new WispStepResult
+                {
+                    StepId = step.Id,
+                    StepIndex = index,
+                    IsSuccess = false,
+                    Error = validationError,
+                    Duration = stepSw.Elapsed
+                };
+            }
+
+            // Re-route with corrected params. A fresh validation pass proves the
+            // correction is schema-clean; if it isn't, bubble the original error
+            // rather than trying again.
+            step = corrected;
+            route = GatewayRouter.Route(step, wispId, priorResults);
+            if (!route.IsSuccess)
+            {
+                return new WispStepResult
+                {
+                    StepId = step.Id,
+                    StepIndex = index,
+                    IsSuccess = false,
+                    Error = new WispStepError
+                    {
+                        Category = route.ErrorCategory ?? FailureCategory.Structural,
+                        Message = route.ErrorMessage!
+                    },
+                    Duration = stepSw.Elapsed
+                };
+            }
+            var recheck = McpStepValidator.Validate(step, toolRegistry);
+            if (recheck is not null)
+            {
+                return new WispStepResult
+                {
+                    StepId = step.Id,
+                    StepIndex = index,
+                    IsSuccess = false,
+                    Error = validationError,
+                    Duration = stepSw.Elapsed
+                };
+            }
+            logger.LogInformation(
+                "Wisp {WispId} step {StepId}: auto-corrected schema validation failure for {Server}/{Tool}",
+                wispId, step.Id, step.Server, step.Tool);
         }
 
         // Resolve the executor from the registry
@@ -663,5 +724,76 @@ internal sealed class WispExecutor(
             return FailureCategory.Data;
 
         return FailureCategory.External;
+    }
+
+    /// <summary>
+    /// Single-shot focused LLM call that rewrites the failing step's <c>params</c>
+    /// to match the tool's schema. No tools available, narrow prompt, cheap tier.
+    /// Returns a new <see cref="WispStep"/> with corrected params on success, or
+    /// <c>null</c> if the correction attempt was skipped (no llm client wired up),
+    /// threw, or produced something we couldn't parse as a JSON object.
+    /// The caller re-validates — we don't trust this output blindly.
+    /// </summary>
+    private async Task<WispStep?> TryAutoCorrectMcpParamsAsync(
+        WispStep step, WispStepError error, CancellationToken ct)
+    {
+        if (llmClient is null)
+            return null;
+
+        var currentParams = step.ResolvedParams?.GetRawText() ?? "{}";
+        var prompt =
+            $"A wisp step's `params` failed schema validation. " +
+            $"Rewrite the params to match the tool's schema.\n\n" +
+            $"Tool: {step.Server}/{step.Tool}\n\n" +
+            $"Current params:\n{currentParams}\n\n" +
+            $"Validation error (includes the expected schema):\n{error.Message}\n\n" +
+            "Return ONLY a single JSON object containing the corrected params — " +
+            "no code fences, no commentary, no prose. The object must contain every " +
+            "required field and no unknown fields.";
+
+        try
+        {
+            var response = await llmClient.GetResponseAsync(
+                [new ChatMessage(ChatRole.User, prompt)],
+                ModelTier.Low,
+                options: null,
+                cancellationToken: ct);
+
+            var text = StripCodeFences(response.Text?.Trim() ?? "");
+            if (string.IsNullOrEmpty(text))
+                return null;
+
+            using var doc = JsonDocument.Parse(text);
+            if (doc.RootElement.ValueKind != JsonValueKind.Object)
+                return null;
+
+            // Clone the element so it outlives the JsonDocument's dispose
+            var corrected = JsonDocument.Parse(doc.RootElement.GetRawText()).RootElement;
+            return step with { Params = corrected, Input = null, Arguments = null };
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "Wisp auto-correction attempt failed for step {StepId} on {Server}/{Tool}",
+                step.Id, step.Server, step.Tool);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Strips optional ```json / ``` fences an LLM may emit around a JSON payload.
+    /// </summary>
+    private static string StripCodeFences(string text)
+    {
+        if (text.StartsWith("```"))
+        {
+            var firstNewline = text.IndexOf('\n');
+            if (firstNewline > 0)
+                text = text[(firstNewline + 1)..];
+            if (text.EndsWith("```"))
+                text = text[..^3];
+            text = text.Trim();
+        }
+        return text;
     }
 }

--- a/src/RockBot.Wisp/WispExecutor.cs
+++ b/src/RockBot.Wisp/WispExecutor.cs
@@ -25,6 +25,7 @@ internal sealed class WispExecutor(
     private const int DefaultLlmStepMaxIterations = 10;
     private const int InputChunkingThreshold = 8_000;
     private const int ChunkMaxLength = 20_000;
+    private const string NoCorrectionSentinel = "NO_CORRECTION";
     private static readonly TimeSpan WispChunkTtl = TimeSpan.FromMinutes(30);
 
     internal static readonly string WispDirectives =
@@ -747,9 +748,15 @@ internal sealed class WispExecutor(
             $"Tool: {step.Server}/{step.Tool}\n\n" +
             $"Current params:\n{currentParams}\n\n" +
             $"Validation error (includes the expected schema):\n{error.Message}\n\n" +
-            "Return ONLY a single JSON object containing the corrected params — " +
-            "no code fences, no commentary, no prose. The object must contain every " +
-            "required field and no unknown fields.";
+            "Use ONLY values already present in the current params.\n" +
+            "- If a required field matches a current param's meaning under a different " +
+            "name (e.g. current `startDate` → schema `timeMin`, same value), remap it.\n" +
+            "- If a required field has NO semantic match in the current params, do NOT " +
+            $"invent one. Respond with exactly the word {NoCorrectionSentinel} and nothing " +
+            "else. The caller will surface the validation error so it can fetch the " +
+            "missing information itself.\n\n" +
+            "Return ONLY a single JSON object (corrected params) or the exact string " +
+            $"{NoCorrectionSentinel}. No code fences, no commentary, no prose.";
 
         try
         {
@@ -762,6 +769,16 @@ internal sealed class WispExecutor(
             var text = StripCodeFences(response.Text?.Trim() ?? "");
             if (string.IsNullOrEmpty(text))
                 return null;
+
+            // LLM declined to correct — it couldn't fill a required field honestly.
+            // Surface the original validation error to the caller instead.
+            if (text.Equals(NoCorrectionSentinel, StringComparison.Ordinal))
+            {
+                logger.LogInformation(
+                    "Wisp {StepId}: auto-correction declined (NO_CORRECTION) — bubbling validation error",
+                    step.Id);
+                return null;
+            }
 
             using var doc = JsonDocument.Parse(text);
             if (doc.RootElement.ValueKind != JsonValueKind.Object)

--- a/src/RockBot.Wisp/WispExecutor.cs
+++ b/src/RockBot.Wisp/WispExecutor.cs
@@ -339,6 +339,29 @@ internal sealed class WispExecutor(
             };
         }
 
+        // "Soft" error detection: some MCP servers return 200 OK with a body like
+        // {"error":"accountId is required"} instead of an MCP-transport error.
+        // Without this check the wisp treats the error text as valid output and
+        // propagates it to downstream steps.
+        var softErrorMessage = TryExtractSoftError(response.Content);
+        if (softErrorMessage is not null)
+        {
+            return new WispStepResult
+            {
+                StepId = step.Id,
+                StepIndex = index,
+                IsSuccess = false,
+                Content = response.Content,
+                Error = new WispStepError
+                {
+                    Category = ClassifyToolError(softErrorMessage),
+                    Message = softErrorMessage,
+                    ToolName = route.ToolName
+                },
+                Duration = stepSw.Elapsed
+            };
+        }
+
         // Always write step output to working memory for inter-step access by LLM steps
         var stepContent = response.Content ?? "";
         var outputKey = $"{wispNamespace}/{step.Id}/output";
@@ -694,6 +717,39 @@ internal sealed class WispExecutor(
     }
 
     /// <summary>
+    /// Inspects a (nominally successful) tool response body for a "soft error" —
+    /// a JSON object whose top-level <c>error</c> property is a string. Some MCP
+    /// servers return these instead of flagging a transport-level error. Returns
+    /// the error message when detected, or <c>null</c> when the content is not a
+    /// soft-error shape.
+    /// </summary>
+    private static string? TryExtractSoftError(string? content)
+    {
+        if (string.IsNullOrWhiteSpace(content))
+            return null;
+
+        var trimmed = content.TrimStart();
+        if (trimmed.Length == 0 || trimmed[0] != '{')
+            return null;
+
+        try
+        {
+            using var doc = JsonDocument.Parse(content);
+            if (doc.RootElement.ValueKind != JsonValueKind.Object)
+                return null;
+            if (!doc.RootElement.TryGetProperty("error", out var errorEl))
+                return null;
+            if (errorEl.ValueKind != JsonValueKind.String)
+                return null;
+            return errorEl.GetString();
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
     /// Classifies a tool error response into a failure category.
     /// </summary>
     private static FailureCategory ClassifyToolError(string? errorContent)
@@ -703,6 +759,9 @@ internal sealed class WispExecutor(
 
         // Structural: tool/param validation errors
         if (errorContent.Contains("Missing required parameter", StringComparison.OrdinalIgnoreCase)
+            || errorContent.Contains("is required", StringComparison.OrdinalIgnoreCase)
+            || errorContent.Contains("required parameter", StringComparison.OrdinalIgnoreCase)
+            || errorContent.Contains("was not provided", StringComparison.OrdinalIgnoreCase)
             || errorContent.Contains("not registered", StringComparison.OrdinalIgnoreCase)
             || errorContent.Contains("Unknown tool", StringComparison.OrdinalIgnoreCase)
             || errorContent.Contains("invalid", StringComparison.OrdinalIgnoreCase))

--- a/src/RockBot.Wisp/WispToolRegistrar.cs
+++ b/src/RockBot.Wisp/WispToolRegistrar.cs
@@ -101,6 +101,15 @@ internal sealed class WispToolRegistrar(
                 rather than composing from scratch. Conversely, once you've authored a wisp
                 that works — especially after debugging through a failure — save it back as
                 a Wisp resource on the relevant skill so future sessions can reuse it.
+
+                Template references between steps:
+                - `{{steps.<id>.result}}` — the entire raw output of step <id>
+                - `{{steps.<id>.result.a.b.c}}` — extracts field `a.b.c` from step <id>'s
+                  output parsed as JSON. Object-property navigation only (no array index).
+                  Only valid when the upstream step produced a JSON object.
+                - `{{steps.<id>.output_to}}` — the file path that step wrote to.
+                If a template can't be resolved it is left literal in the params and the
+                tool call will fail — check your path against the upstream step's output.
                 """,
             ParametersSchema = SpawnWispsSchema,
             Source = "wisp"

--- a/src/RockBot.Wisp/WispToolRegistrar.cs
+++ b/src/RockBot.Wisp/WispToolRegistrar.cs
@@ -89,6 +89,18 @@ internal sealed class WispToolRegistrar(
                 zero LLM tokens. LLM steps use minimal context. Much cheaper than subagents for
                 procedural tasks. Returns a batch result with per-wisp success/failure and writes
                 a summary to working memory.
+
+                Before authoring a wisp that targets an MCP server, call
+                mcp_get_service_details(server_name=...) once so you have the exact parameter
+                schema for each tool in context. Authoring from training priors is where wisps
+                most often go wrong — parameter names (e.g. `timeMin` vs `startDate`) vary by
+                server and cannot be guessed reliably.
+
+                Reuse before authoring: if a skill you've loaded has a Wisp resource listed in
+                its manifest, fetch it with get_skill_resource and start from that definition
+                rather than composing from scratch. Conversely, once you've authored a wisp
+                that works — especially after debugging through a failure — save it back as
+                a Wisp resource on the relevant skill so future sessions can reuse it.
                 """,
             ParametersSchema = SpawnWispsSchema,
             Source = "wisp"

--- a/src/RockBot.Wisp/WispToolSkillProvider.cs
+++ b/src/RockBot.Wisp/WispToolSkillProvider.cs
@@ -44,6 +44,18 @@ public sealed class WispToolSkillProvider : IToolSkillProvider
         | Data pipeline: fetch → transform → output | Open-ended research or analysis |
         | 2-12K tokens total | 60-80K tokens acceptable |
 
+        **Wisps are a bad fit when:**
+
+        - The number of steps isn't known until something earlier runs.
+        - A loop is required (for-each over a discovered list, while-condition, retry-until).
+        - Results of one step determine how many downstream steps there should be.
+        - Complex conditional branching is needed (if/else trees beyond simple `on_failure`).
+        - Heavy reasoning or multi-turn deliberation is required inside the pipeline.
+
+        In those cases, either the **parent agent** does the iteration (spawning additional
+        wisp batches — see next section), or the whole task belongs in a **subagent** that
+        can itself spawn wisps for the procedural sub-steps.
+
         ## When a single wisp is not enough
 
         A wisp has a static step graph — it cannot loop over results or generate new steps
@@ -85,6 +97,28 @@ public sealed class WispToolSkillProvider : IToolSkillProvider
         Do **not** try to write a single wisp of the form
         `list_accounts → [something that loops] → get_calendar_events`. There is no "for
         each" step. The outer iteration belongs in the parent agent.
+
+        **Multi-stage fan-out — a worked example.** Suppose the user asks "show me every
+        meeting tomorrow across all my accounts." The enumeration shape is
+        `accounts → calendars per account → events per calendar`. Each stage's count
+        depends on the previous stage's data, so no single wisp can express it. The
+        parent agent runs it as a sequence of batches:
+
+        1. **Batch 1 — discover accounts.** One wisp (or a direct `mcp_invoke_tool` call):
+           `list_accounts` → returns `["marimer-work", "xebia", "personal"]`.
+        2. **Read** the result in the parent agent.
+        3. **Batch 2 — parallel per account.** One `spawn_wisps` call with N=3 definitions,
+           each calling `list_calendars` with a literal `accountId`. They run concurrently.
+        4. **Read** the batch summary; collect the (accountId, calendarId) pairs.
+        5. **Batch 3 — parallel per calendar.** One `spawn_wisps` call with one definition
+           per (accountId, calendarId) pair, each calling `get_calendar_events` with literal
+           params. Again concurrent.
+        6. **Aggregate** the results in the parent agent and answer the user.
+
+        Every wisp in every batch is static and deterministic. The dynamism lives in the
+        agent's decision to build the next batch from the previous batch's output. This
+        is much cheaper than a subagent — each per-item wisp costs zero LLM tokens — but
+        it does require the parent agent to hold state between batches.
 
         ## spawn_wisps
 

--- a/src/RockBot.Wisp/WispToolSkillProvider.cs
+++ b/src/RockBot.Wisp/WispToolSkillProvider.cs
@@ -14,10 +14,26 @@ public sealed class WispToolSkillProvider : IToolSkillProvider
         """
         # Wisp Pipeline Guide
 
-        A wisp is a **lightweight, harness-supervised pipeline** for procedural multi-step
-        tasks. Unlike subagents (which receive full agent context on every LLM round-trip),
+        A wisp is a **deterministic pipeline** — a static step graph the harness executes
+        top-down. No loops. No runtime branching on discovered data. No cross-wisp state.
+        If your workflow requires iterating over items that aren't known when you write
+        the definition, the iteration happens in the *parent agent* — by calling
+        `spawn_wisps` multiple times — not inside a single wisp.
+
+        Unlike subagents (which receive full agent context on every LLM round-trip),
         wisps execute steps with minimal or zero LLM involvement — saving 80-95% of tokens
         for structured workflows.
+
+        **Shape check before authoring:**
+
+        | Good wisp | Bad wisp |
+        |-----------|----------|
+        | `fetch_event → transform → write_file → send_email` | `discover_accounts → for-each-account: discover_calendars → for-each-calendar: fetch_events` |
+        | Every step's inputs are known (or come from a prior step) | Step count depends on runtime data |
+        | Fan-out is over a list you already have | Fan-out requires looping over a discovered list |
+
+        If the shape on the right is what you need, the iteration lives in the parent agent
+        (see "When a single wisp is not enough" below).
 
         ## When to use wisps vs. subagents
 
@@ -27,6 +43,48 @@ public sealed class WispToolSkillProvider : IToolSkillProvider
         | Mostly tool calls with known parameters | Heavy judgment or multi-turn reasoning |
         | Data pipeline: fetch → transform → output | Open-ended research or analysis |
         | 2-12K tokens total | 60-80K tokens acceptable |
+
+        ## When a single wisp is not enough
+
+        A wisp has a static step graph — it cannot loop over results or generate new steps
+        from runtime data. When you need per-item processing of items you don't know in
+        advance, iterate at the agent level by calling `spawn_wisps` more than once.
+
+        **Static fan-out** — you know the N items up front (e.g. a known list of accounts
+        to query). Put N definitions in a single `spawn_wisps` call; each has a literal
+        per-item `params`:
+
+        ```json
+        {
+          "definitions": [
+            { "description": "Events for marimer-work",
+              "steps": [{ "id": "e", "mode": "Direct", "gateway": "Mcp",
+                          "server": "calendar-mcp", "tool": "get_calendar_events",
+                          "params": { "accountId": "marimer-work", "timeZone": "America/Chicago",
+                                      "startDate": "2026-04-23", "endDate": "2026-04-23" }}]
+            },
+            { "description": "Events for xebia",
+              "steps": [{ "id": "e", "mode": "Direct", "gateway": "Mcp",
+                          "server": "calendar-mcp", "tool": "get_calendar_events",
+                          "params": { "accountId": "xebia", "timeZone": "America/Chicago",
+                                      "startDate": "2026-04-23", "endDate": "2026-04-23" }}]
+            }
+          ]
+        }
+        ```
+
+        **Dynamic fan-out** — you discover the N items at runtime:
+
+        1. Discover. Either a direct tool call (`mcp_invoke_tool(list_accounts)`) or a
+           small discovery wisp that returns the list.
+        2. Read the result in the parent agent.
+        3. Compose a second `spawn_wisps` call with N definitions, one per discovered
+           item. Each has a literal `params` — no template can insert a per-account
+           value into a fixed-shape step graph.
+
+        Do **not** try to write a single wisp of the form
+        `list_accounts → [something that loops] → get_calendar_events`. There is no "for
+        each" step. The outer iteration belongs in the parent agent.
 
         ## spawn_wisps
 
@@ -189,15 +247,88 @@ public sealed class WispToolSkillProvider : IToolSkillProvider
         { "message": "Process file at {{steps.fetch.output_to}}" }
         ```
 
-        **Important:** Template references (`{{steps.id.result}}`) work within a single
-        wisp's steps. Cross-wisp references are not supported — wisps in a batch are
-        fully independent.
+        Two template forms are supported:
+
+        - `{{steps.<id>.result}}` — inlines the upstream step's entire output string.
+          Use when the downstream consumer wants the whole blob.
+        - `{{steps.<id>.result.a.b.c}}` — parses the upstream output as JSON and inserts
+          the value at the dotted path. Strings are unwrapped; objects and arrays become
+          their JSON representation.
+
+        **Constraints on field-path templates — all of these are enforced:**
+
+        - Upstream content must parse as a **JSON object**. Plain text, arrays at the root,
+          or invalid JSON all cause the template to fall back to the literal.
+        - **No array indexing.** There is no `[0]` syntax. If the upstream output is an
+          array, add an `Llm` step between that flattens the element you want into a
+          top-level object (e.g. `{ "eventId": "...", "accountId": "..." }`), then
+          field-path the next step's params from that.
+        - **Silent fallback** — if the upstream isn't JSON or the path doesn't resolve,
+          the literal `{{steps.id.result.path}}` is passed to the tool unchanged. The
+          downstream call will then fail visibly (soft-error detection catches these).
+        - **Single-wisp scope.** Templates resolve within one wisp only. Cross-wisp
+          references are not supported — wisps in a batch are fully independent.
+        - **Static resolution.** You cannot use substitution to generate new steps — the
+          step graph is fixed at submission time. Templates only fill in string values
+          inside an existing step's params/message/input_from.
 
         **Transition patterns:**
         - `Direct → Direct`: Data passes via files on the shared volume
         - `Direct → Llm`: Harness reads file, chunks into working memory if large
         - `Llm → Direct`: Harness writes LLM output to shared volume
         - `Llm → Llm`: Data stays in working memory, no file round-trip
+
+        **Worked example — find an event and get its details:**
+
+        The pattern is list → LLM-pluck → fetch. The middle `Llm` step reads a JSON
+        blob and outputs a small top-level object whose keys match the downstream
+        step's required params.
+
+        ```json
+        {
+          "description": "Find 'Microsoft AI Demonstration' and fetch its details",
+          "steps": [
+            {
+              "id": "list",
+              "mode": "Direct",
+              "gateway": "Mcp",
+              "server": "calendar-mcp",
+              "tool": "get_calendar_events",
+              "params": {
+                "accountId": "xebia",
+                "timeZone": "America/Chicago",
+                "startDate": "2026-04-23",
+                "endDate": "2026-04-23"
+              },
+              "output_to": "wisp-data/events.json"
+            },
+            {
+              "id": "pick",
+              "mode": "Llm",
+              "prompt": "From the events JSON, find the event whose subject is 'Microsoft AI Demonstration'. Return ONLY a single JSON object with string fields accountId, calendarId, eventId — no prose, no code fences.",
+              "input_from": "wisp-data/events.json",
+              "output_to": "wisp-data/target.json"
+            },
+            {
+              "id": "details",
+              "mode": "Direct",
+              "gateway": "Mcp",
+              "server": "calendar-mcp",
+              "tool": "get_calendar_event_details",
+              "params": {
+                "accountId":  "{{steps.pick.result.accountId}}",
+                "calendarId": "{{steps.pick.result.calendarId}}",
+                "eventId":    "{{steps.pick.result.eventId}}",
+                "timeZone":   "America/Chicago"
+              }
+            }
+          ]
+        }
+        ```
+
+        Note how `pick`'s output shape is chosen so `details`'s field-paths match
+        directly. If `pick` returned a nested object like `{"event":{"id":"..."}}`, the
+        field-paths would need to be `{{steps.pick.result.event.id}}` etc.
 
         ### Error handling
 
@@ -221,6 +352,62 @@ public sealed class WispToolSkillProvider : IToolSkillProvider
         - **External** — Timeout, service unavailable, rate limit (transient, retry may help)
         - **Data** — Unexpected format, empty results, schema mismatch (fix assumptions)
         - **Judgment** — LLM step picked wrong result or missed data (refine the prompt)
+
+        ### Failure modes you will see
+
+        Three concrete patterns appear in batch output when a wisp step fails. Read the
+        message — it tells you exactly what to fix.
+
+        **Schema validation rejected the params before the call.** The validator read
+        the target tool's parameter schema from the registry and the supplied `params`
+        didn't match:
+
+        ```
+        - `wisp-xyz`: "Fetch events" [failed] (12ms)
+          Error (Structural): Params for calendar-mcp/get_calendar_events did not match
+          the tool's schema. Missing required field(s): accountId, timeZone. Expected shape:
+            accountId: string (required)
+            calendarId: string
+            timeMin: string
+            timeMax: string
+            timeZone: string (required)
+          Tool: calendar-mcp/get_calendar_events
+        ```
+
+        Fix: add the missing fields to `params`. The expected shape is right there —
+        you don't need to call `mcp_get_service_details` again.
+
+        **Server returned a soft error.** The MCP call succeeded at the transport level
+        (HTTP 200) but the server's JSON body contained an `error` field. The runner
+        surfaces these as step failures instead of letting the error text propagate into
+        the next step's input:
+
+        ```
+        - `wisp-xyz`: "Fetch events" [failed] (13ms)
+          Error (Structural): accountId is required
+          Tool: mcp_invoke_tool
+        ```
+
+        Fix: usually the same as above — add the missing field. Soft errors commonly
+        appear when the server enforces a conditional requirement that isn't in the
+        declared JSON schema (e.g. "accountId required unless calendarId provided").
+
+        **Template failed to resolve, and the downstream call choked on the literal.**
+        You wrote `{{steps.pick.result.eventId}}` but `pick`'s output wasn't a JSON
+        object with an `eventId` key. The literal `{{...}}` string went to the tool,
+        which returned a soft error:
+
+        ```
+        - `wisp-xyz`: "Fetch details" [failed] (8ms)
+          Error (Data): Event '{{steps.pick.result.eventId}}' not found
+          Tool: mcp_invoke_tool
+        ```
+
+        Fix: check what the upstream step actually produced (the batch summary shows
+        each step's output). Common causes — the `Llm` pick step wrapped its JSON in
+        code fences or prose, or the shape is nested (`{"event":{...}}` instead of the
+        flat object you templated against). Tighten the `Llm` step's prompt to emit
+        ONLY a bare JSON object with the exact keys you reference downstream.
 
         ### Best practices
 

--- a/tests/RockBot.Host.Tests/FileSkillStoreTests.cs
+++ b/tests/RockBot.Host.Tests/FileSkillStoreTests.cs
@@ -264,8 +264,8 @@ public class FileSkillStoreTests
 
         await store.SaveAsync(skill, resources);
 
-        Assert.IsTrue(File.Exists(Path.Combine(_tempDir, "my-skill", "script.py")));
-        Assert.AreEqual("print('hello')", await File.ReadAllTextAsync(Path.Combine(_tempDir, "my-skill", "script.py")));
+        Assert.IsTrue(File.Exists(Path.Combine(_tempDir, "my-skill.resources", "script.py")));
+        Assert.AreEqual("print('hello')", await File.ReadAllTextAsync(Path.Combine(_tempDir, "my-skill.resources", "script.py")));
     }
 
     [TestMethod]
@@ -353,8 +353,8 @@ public class FileSkillStoreTests
             new("a.py", SkillResourceType.Python, "desc", "code a v2")
         ]);
 
-        Assert.IsTrue(File.Exists(Path.Combine(_tempDir, "my-skill", "a.py")));
-        Assert.IsFalse(File.Exists(Path.Combine(_tempDir, "my-skill", "b.py")));
+        Assert.IsTrue(File.Exists(Path.Combine(_tempDir, "my-skill.resources", "a.py")));
+        Assert.IsFalse(File.Exists(Path.Combine(_tempDir, "my-skill.resources", "b.py")));
 
         var manifest = (await store.GetAsync("my-skill"))?.Manifest;
         Assert.IsNotNull(manifest);
@@ -369,18 +369,18 @@ public class FileSkillStoreTests
         await store.SaveAsync(MakeSkill("my-skill", "summary", "content"),
             [new("script.py", SkillResourceType.Python, "desc", "code")]);
 
-        Assert.IsTrue(Directory.Exists(Path.Combine(_tempDir, "my-skill")));
+        Assert.IsTrue(Directory.Exists(Path.Combine(_tempDir, "my-skill.resources")));
 
         await store.DeleteAsync("my-skill");
 
         Assert.IsFalse(File.Exists(Path.Combine(_tempDir, "my-skill.json")));
-        Assert.IsFalse(Directory.Exists(Path.Combine(_tempDir, "my-skill")));
+        Assert.IsFalse(Directory.Exists(Path.Combine(_tempDir, "my-skill.resources")));
     }
 
     [TestMethod]
-    public async Task EnsureIndexAsync_SkipsResourceSubfolderJsonFiles()
+    public async Task EnsureIndexAsync_SkipsResourceFolderJsonFiles()
     {
-        // Write a skill and a resource JSON inside its subfolder
+        // Write a skill and a resource JSON inside its resource folder
         var store1 = CreateStore();
         await store1.SaveAsync(MakeSkill("my-skill", "summary", "content"),
             [new("extra.json", SkillResourceType.JsonSchema, "desc", "{\"type\":\"object\"}")]);
@@ -401,7 +401,7 @@ public class FileSkillStoreTests
             [new("helper.py", SkillResourceType.Python, "desc", "# code")]);
 
         Assert.IsTrue(File.Exists(Path.Combine(_tempDir, "research", "summarize.json")));
-        Assert.IsTrue(File.Exists(Path.Combine(_tempDir, "research", "summarize", "helper.py")));
+        Assert.IsTrue(File.Exists(Path.Combine(_tempDir, "research", "summarize.resources", "helper.py")));
     }
 
     [TestMethod]
@@ -424,50 +424,44 @@ public class FileSkillStoreTests
         Assert.IsNotNull(result.Manifest);
         Assert.AreEqual(1, result.Manifest!.Count);
         Assert.AreEqual("script.py", result.Manifest[0].Filename);
-        Assert.IsTrue(File.Exists(Path.Combine(_tempDir, "my-skill", "script.py")));
+        Assert.IsTrue(File.Exists(Path.Combine(_tempDir, "my-skill.resources", "script.py")));
     }
 
-    // ── Name conflict detection ────────────────────────────────────────────────
+    // ── Top-level and subcategory skill coexistence ───────────────────────────
+    // The reserved ".resources" folder suffix means top-level skill "a" (which
+    // stores its resources under "a.resources/") cannot collide with subcategory
+    // skill "a/b" (which lives under "a/b.json"). Both layouts must coexist.
 
     [TestMethod]
-    public async Task SaveAsync_AncestorSkillExists_ThrowsInvalidOperation()
+    public async Task SaveAsync_TopLevelAndSubcategorySkillsCoexist()
     {
-        // Saving "research/summarize" when "research" already exists would place
-        // "research/summarize.json" inside "research"'s resource folder, making it unreachable.
         var store = CreateStore();
-        await store.SaveAsync(MakeSkill("research", "summary", "content"));
+        await store.SaveAsync(MakeSkill("research", "summary", "top-level"));
+        await store.SaveAsync(MakeSkill("research/summarize", "summary", "subcategory"));
 
-        await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
-            store.SaveAsync(MakeSkill("research/summarize", "summary", "content")));
-    }
-
-    [TestMethod]
-    public async Task SaveAsync_SubcategorySkillExists_ThrowsInvalidOperation()
-    {
-        // Saving "research" when "research/summarize" already exists would turn
-        // "research/" into a resource folder, making "research/summarize" unreachable.
-        var store = CreateStore();
-        await store.SaveAsync(MakeSkill("research/summarize", "summary", "content"));
-
-        await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
-            store.SaveAsync(MakeSkill("research", "summary", "content")));
+        Assert.IsNotNull(await store.GetAsync("research"));
+        Assert.IsNotNull(await store.GetAsync("research/summarize"));
     }
 
     [TestMethod]
-    public async Task SaveAsync_DeepNestingAncestorConflict_ThrowsInvalidOperation()
+    public async Task SaveAsync_TopLevelSkillWithResources_DoesNotShadowSubcategory()
     {
-        // "a" exists; saving "a/b/c" should fail because "a" is an ancestor
-        var store = CreateStore();
-        await store.SaveAsync(MakeSkill("a", "summary", "content"));
+        var store1 = CreateStore();
+        await store1.SaveAsync(MakeSkill("research/summarize", "summary", "subcategory"));
+        await store1.SaveAsync(MakeSkill("research", "summary", "top-level"),
+            [new("helper.py", SkillResourceType.Python, "desc", "# code")]);
 
-        await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
-            store.SaveAsync(MakeSkill("a/b/c", "summary", "content")));
+        // A new store must see both skills after re-indexing
+        var store2 = CreateStore();
+        var names = (await store2.ListAsync()).Select(s => s.Name).ToList();
+
+        CollectionAssert.Contains(names, "research");
+        CollectionAssert.Contains(names, "research/summarize");
     }
 
     [TestMethod]
     public async Task SaveAsync_NoConflict_SiblingSkillsSucceed()
     {
-        // "alpha" and "alpha-extended" share no prefix relationship — both should save fine.
         var store = CreateStore();
         await store.SaveAsync(MakeSkill("alpha", "summary", "content"));
         await store.SaveAsync(MakeSkill("alpha-extended", "summary", "content"));
@@ -479,7 +473,6 @@ public class FileSkillStoreTests
     [TestMethod]
     public async Task SaveAsync_NoConflict_SiblingSubcategorySkillsSucceed()
     {
-        // "research/plan" and "research/summarize" are siblings — both should save fine.
         var store = CreateStore();
         await store.SaveAsync(MakeSkill("research/plan", "summary", "content"));
         await store.SaveAsync(MakeSkill("research/summarize", "summary", "content"));

--- a/tests/RockBot.Wisp.Tests/GatewayRouterTests.cs
+++ b/tests/RockBot.Wisp.Tests/GatewayRouterTests.cs
@@ -387,6 +387,144 @@ public class GatewayRouterTests
     }
 
     [TestMethod]
+    public void ResolveTemplateString_WithFieldPath_ExtractsJsonFieldValue()
+    {
+        var priorResults = new Dictionary<string, WispStepResult>
+        {
+            ["extract"] = new()
+            {
+                StepId = "extract",
+                StepIndex = 0,
+                IsSuccess = true,
+                Content = """{"accountId":"xebia","calendarId":"abc","eventId":"evt-1"}""",
+                Duration = TimeSpan.Zero
+            }
+        };
+
+        var resolved = GatewayRouter.ResolveTemplateString(
+            "{\"accountId\":\"{{steps.extract.result.accountId}}\",\"calendarId\":\"{{steps.extract.result.calendarId}}\"}",
+            priorResults);
+
+        Assert.AreEqual(
+            "{\"accountId\":\"xebia\",\"calendarId\":\"abc\"}",
+            resolved);
+    }
+
+    [TestMethod]
+    public void ResolveTemplateString_WithNestedFieldPath_ExtractsDeepValue()
+    {
+        var priorResults = new Dictionary<string, WispStepResult>
+        {
+            ["find"] = new()
+            {
+                StepId = "find",
+                StepIndex = 0,
+                IsSuccess = true,
+                Content = """{"event":{"id":"evt-42","meta":{"organizer":"bruce@example.com"}}}""",
+                Duration = TimeSpan.Zero
+            }
+        };
+
+        var resolved = GatewayRouter.ResolveTemplateString(
+            "{{steps.find.result.event.meta.organizer}}", priorResults);
+
+        Assert.AreEqual("bruce@example.com", resolved);
+    }
+
+    [TestMethod]
+    public void ResolveTemplateString_FieldPathOnNonJsonContent_LeavesLiteral()
+    {
+        var priorResults = new Dictionary<string, WispStepResult>
+        {
+            ["text"] = new()
+            {
+                StepId = "text",
+                StepIndex = 0,
+                IsSuccess = true,
+                Content = "not json at all",
+                Duration = TimeSpan.Zero
+            }
+        };
+
+        var resolved = GatewayRouter.ResolveTemplateString(
+            "{{steps.text.result.someField}}", priorResults);
+
+        Assert.AreEqual("{{steps.text.result.someField}}", resolved,
+            "Unresolvable path should leave the literal in place so downstream validation can flag it");
+    }
+
+    [TestMethod]
+    public void ResolveTemplateString_FieldPathMissing_LeavesLiteral()
+    {
+        var priorResults = new Dictionary<string, WispStepResult>
+        {
+            ["s"] = new()
+            {
+                StepId = "s",
+                StepIndex = 0,
+                IsSuccess = true,
+                Content = """{"present":"yes"}""",
+                Duration = TimeSpan.Zero
+            }
+        };
+
+        var resolved = GatewayRouter.ResolveTemplateString(
+            "{{steps.s.result.missing}}", priorResults);
+
+        Assert.AreEqual("{{steps.s.result.missing}}", resolved);
+    }
+
+    [TestMethod]
+    public void ResolveTemplateString_ResultWithoutPath_StillReplacesWholeContent()
+    {
+        // Backwards compatibility: bare {{steps.id.result}} still inserts the full content
+        var priorResults = new Dictionary<string, WispStepResult>
+        {
+            ["raw"] = new()
+            {
+                StepId = "raw",
+                StepIndex = 0,
+                IsSuccess = true,
+                Content = """{"some":"json"}""",
+                Duration = TimeSpan.Zero
+            }
+        };
+
+        var resolved = GatewayRouter.ResolveTemplateString(
+            "body: {{steps.raw.result}}", priorResults);
+
+        // JSON content gets escaped for embedding
+        StringAssert.Contains(resolved, "some");
+        StringAssert.Contains(resolved, "json");
+    }
+
+    [TestMethod]
+    public void ResolveTemplateString_FieldPathYieldingNonString_InsertsJsonRepresentation()
+    {
+        var priorResults = new Dictionary<string, WispStepResult>
+        {
+            ["s"] = new()
+            {
+                StepId = "s",
+                StepIndex = 0,
+                IsSuccess = true,
+                Content = """{"count":42,"items":["a","b"]}""",
+                Duration = TimeSpan.Zero
+            }
+        };
+
+        var num = GatewayRouter.ResolveTemplateString(
+            "{{steps.s.result.count}}", priorResults);
+        Assert.AreEqual("42", num);
+
+        var arr = GatewayRouter.ResolveTemplateString(
+            "{{steps.s.result.items}}", priorResults);
+        // Non-string values serialize to their JSON representation (escaped for embedding)
+        StringAssert.Contains(arr, "a");
+        StringAssert.Contains(arr, "b");
+    }
+
+    [TestMethod]
     public void ResolveTemplateString_ContentWithSpecialChars_EscapesForJson()
     {
         var priorResults = new Dictionary<string, WispStepResult>

--- a/tests/RockBot.Wisp.Tests/McpStepValidatorTests.cs
+++ b/tests/RockBot.Wisp.Tests/McpStepValidatorTests.cs
@@ -1,0 +1,214 @@
+using System.Text.Json;
+using RockBot.Tools;
+using RockBot.Wisp;
+
+namespace RockBot.Wisp.Tests;
+
+[TestClass]
+public class McpStepValidatorTests
+{
+    private const string GetCalendarEventsSchema = """
+        {
+          "type": "object",
+          "properties": {
+            "accountId":   { "type": "string", "description": "The account identifier" },
+            "calendarId":  { "type": "string" },
+            "timeMin":     { "type": "string" },
+            "timeMax":     { "type": "string" },
+            "timeZone":    { "type": "string" }
+          },
+          "required": ["accountId", "calendarId", "timeMin", "timeMax"],
+          "additionalProperties": false
+        }
+        """;
+
+    [TestMethod]
+    public void Validate_ValidParams_ReturnsNull()
+    {
+        var registry = RegistryWith("calendar-mcp", "get_calendar_events", GetCalendarEventsSchema);
+        var step = McpStep("calendar-mcp", "get_calendar_events",
+            """{"accountId":"a","calendarId":"c","timeMin":"t1","timeMax":"t2"}""");
+
+        var error = McpStepValidator.Validate(step, registry);
+
+        Assert.IsNull(error);
+    }
+
+    [TestMethod]
+    public void Validate_MissingRequiredField_ReturnsStructuralError()
+    {
+        var registry = RegistryWith("calendar-mcp", "get_calendar_events", GetCalendarEventsSchema);
+        var step = McpStep("calendar-mcp", "get_calendar_events",
+            """{"accountId":"a","timeMin":"t1","timeMax":"t2"}""");
+
+        var error = McpStepValidator.Validate(step, registry);
+
+        Assert.IsNotNull(error);
+        Assert.AreEqual(FailureCategory.Structural, error.Category);
+        StringAssert.Contains(error.Message, "calendarId", "Error should name the missing field");
+        StringAssert.Contains(error.Message, "Expected shape", "Error should include schema summary");
+        StringAssert.Contains(error.Message, "(required)", "Schema summary should mark required fields");
+    }
+
+    [TestMethod]
+    public void Validate_UnknownFieldUnderClosedSchema_ReturnsStructuralError()
+    {
+        // Reproduces the calendar bug: LLM used startDate/endDate (not in schema)
+        // and got silently-empty results. With a closed schema we catch this.
+        var registry = RegistryWith("calendar-mcp", "get_calendar_events", GetCalendarEventsSchema);
+        var step = McpStep("calendar-mcp", "get_calendar_events",
+            """{"accountId":"a","calendarId":"c","startDate":"2026-04-23","endDate":"2026-04-23"}""");
+
+        var error = McpStepValidator.Validate(step, registry);
+
+        Assert.IsNotNull(error);
+        Assert.AreEqual(FailureCategory.Structural, error.Category);
+        StringAssert.Contains(error.Message, "startDate");
+        StringAssert.Contains(error.Message, "endDate");
+        StringAssert.Contains(error.Message, "timeMin", "Schema summary should show the real fields");
+    }
+
+    [TestMethod]
+    public void Validate_UnknownFieldUnderOpenSchema_Accepted()
+    {
+        // No additionalProperties: false → JSON Schema default allows extras.
+        const string openSchema = """
+            {
+              "type": "object",
+              "properties": { "accountId": { "type": "string" } },
+              "required": ["accountId"]
+            }
+            """;
+        var registry = RegistryWith("server", "tool", openSchema);
+        var step = McpStep("server", "tool", """{"accountId":"a","extra":"ok"}""");
+
+        var error = McpStepValidator.Validate(step, registry);
+
+        Assert.IsNull(error);
+    }
+
+    [TestMethod]
+    public void Validate_NonMcpGateway_ReturnsNull()
+    {
+        var registry = RegistryWith("any-server", "any-tool", GetCalendarEventsSchema);
+        var step = new WispStep
+        {
+            Id = "s",
+            Mode = StepMode.Direct,
+            Gateway = GatewayType.Web,
+            Tool = "web_search",
+            Params = JsonDocument.Parse("""{"query":"x"}""").RootElement
+        };
+
+        var error = McpStepValidator.Validate(step, registry);
+
+        Assert.IsNull(error);
+    }
+
+    [TestMethod]
+    public void Validate_ToolNotRegistered_ReturnsNull()
+    {
+        // When the MCP tool isn't in the registry (e.g. server not connected),
+        // let the existing "tool not registered" failure path produce the error
+        // rather than short-circuiting here with a less-informative message.
+        var registry = new FakeToolRegistry();
+        var step = McpStep("calendar-mcp", "get_calendar_events",
+            """{"accountId":"a"}""");
+
+        var error = McpStepValidator.Validate(step, registry);
+
+        Assert.IsNull(error);
+    }
+
+    [TestMethod]
+    public void Validate_ToolWithNoSchema_ReturnsNull()
+    {
+        // Some MCP tools register with no schema. We can't validate; skip quietly.
+        var registry = new FakeToolRegistry();
+        registry.Register(
+            new ToolRegistration { Name = "bare", Description = "", Source = "mcp:server", ParametersSchema = null },
+            new NoopExecutor());
+        var step = McpStep("server", "bare", """{"anything":"goes"}""");
+
+        var error = McpStepValidator.Validate(step, registry);
+
+        Assert.IsNull(error);
+    }
+
+    [TestMethod]
+    public void Validate_SameToolNameDifferentServer_MatchesOnlyCorrectSource()
+    {
+        // Two MCP servers could each register a tool named "list_accounts".
+        // The validator must match on (server, tool), not tool name alone.
+        var registry = new FakeToolRegistry();
+        registry.Register(
+            new ToolRegistration { Name = "list_accounts", Description = "", Source = "mcp:calendar-mcp",
+                ParametersSchema = """{"type":"object","properties":{"calKey":{"type":"string"}},"required":["calKey"],"additionalProperties":false}""" },
+            new NoopExecutor());
+        registry.Register(
+            new ToolRegistration { Name = "list_accounts", Description = "", Source = "mcp:email-mcp",
+                ParametersSchema = """{"type":"object","properties":{"mailKey":{"type":"string"}},"required":["mailKey"],"additionalProperties":false}""" },
+            new NoopExecutor());
+
+        var step = McpStep("email-mcp", "list_accounts", """{"mailKey":"v"}""");
+
+        var error = McpStepValidator.Validate(step, registry);
+
+        Assert.IsNull(error, "Should validate against email-mcp's schema, not calendar-mcp's");
+    }
+
+    [TestMethod]
+    public void Validate_MissingParams_TreatedAsEmptyObject()
+    {
+        // A step with null params and a schema that requires fields should fail.
+        var registry = RegistryWith("server", "tool", GetCalendarEventsSchema);
+        var step = new WispStep
+        {
+            Id = "s",
+            Mode = StepMode.Direct,
+            Gateway = GatewayType.Mcp,
+            Server = "server",
+            Tool = "tool",
+            Params = null
+        };
+
+        var error = McpStepValidator.Validate(step, registry);
+
+        Assert.IsNotNull(error);
+        StringAssert.Contains(error.Message, "Missing required");
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static FakeToolRegistry RegistryWith(string server, string tool, string schema)
+    {
+        var registry = new FakeToolRegistry();
+        registry.Register(
+            new ToolRegistration
+            {
+                Name = tool,
+                Description = "",
+                Source = $"mcp:{server}",
+                ParametersSchema = schema
+            },
+            new NoopExecutor());
+        return registry;
+    }
+
+    private static WispStep McpStep(string server, string tool, string paramsJson) =>
+        new()
+        {
+            Id = "s",
+            Mode = StepMode.Direct,
+            Gateway = GatewayType.Mcp,
+            Server = server,
+            Tool = tool,
+            Params = JsonDocument.Parse(paramsJson).RootElement
+        };
+
+    private sealed class NoopExecutor : IToolExecutor
+    {
+        public Task<ToolInvokeResponse> ExecuteAsync(ToolInvokeRequest request, CancellationToken ct) =>
+            Task.FromResult(new ToolInvokeResponse { ToolCallId = request.ToolCallId, ToolName = request.ToolName, Content = "" });
+    }
+}

--- a/tests/RockBot.Wisp.Tests/WispAutoCorrectTests.cs
+++ b/tests/RockBot.Wisp.Tests/WispAutoCorrectTests.cs
@@ -108,6 +108,29 @@ public class WispAutoCorrectTests
     }
 
     [TestMethod]
+    public async Task ValidationFailure_LlmReturnsNoCorrectionSentinel_OriginalErrorBubbled()
+    {
+        // When a required field is genuinely absent from the current params (no
+        // remappable equivalent), the rewriter must refuse to invent a value and
+        // instead emit NO_CORRECTION so the main agent can fetch the missing info.
+        var llm = new ScriptedLlmClient("NO_CORRECTION");
+        var (executor, registry, _) = CreateExecutor(llm);
+        RegisterCalendarMcp(registry, capturedArgs: null);
+
+        // Missing accountId entirely — no way for the rewriter to fill it honestly.
+        var definition = MakeCalendarWisp(
+            """{"calendarId":"c","timeMin":"t1","timeMax":"t2"}""");
+
+        var result = await executor.ExecuteAsync(definition, "wisp-ac-6", CancellationToken.None);
+
+        Assert.IsFalse(result.IsSuccess);
+        Assert.AreEqual(FailureCategory.Structural, result.FailedStep!.Error!.Category);
+        StringAssert.Contains(result.FailedStep.Error.Message, "accountId",
+            "Original validation error should be surfaced so the caller can fetch the missing field");
+        Assert.AreEqual(1, llm.CallCount, "LLM was called (and declined), not skipped");
+    }
+
+    [TestMethod]
     public async Task ValidationFailure_LlmWrapsResponseInCodeFences_StillParsed()
     {
         var llm = new ScriptedLlmClient("""
@@ -151,7 +174,7 @@ public class WispAutoCorrectTests
                 Source = "mcp-management"
             },
             capturedArgs is not null
-                ? new CapturingToolExecutor(r => capturedArgs.Add(r.Arguments), "{\"events\":[]}")
+                ? new CapturingToolExecutor(r => capturedArgs.Add(r.Arguments ?? ""), "{\"events\":[]}")
                 : new FakeToolExecutor("{\"events\":[]}"));
 
         // The target MCP tool whose schema the validator consults.

--- a/tests/RockBot.Wisp.Tests/WispAutoCorrectTests.cs
+++ b/tests/RockBot.Wisp.Tests/WispAutoCorrectTests.cs
@@ -1,0 +1,206 @@
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+using RockBot.Host;
+using RockBot.Tools;
+using RockBot.Wisp;
+
+namespace RockBot.Wisp.Tests;
+
+[TestClass]
+public class WispAutoCorrectTests
+{
+    private const string CalendarSchema = """
+        {
+          "type": "object",
+          "properties": {
+            "accountId":  { "type": "string" },
+            "calendarId": { "type": "string" },
+            "timeMin":    { "type": "string" },
+            "timeMax":    { "type": "string" }
+          },
+          "required": ["accountId", "calendarId", "timeMin", "timeMax"],
+          "additionalProperties": false
+        }
+        """;
+
+    [TestMethod]
+    public async Task ValidationFailure_AutoCorrectionRewritesParams_StepSucceeds()
+    {
+        // LLM rewrites bad params (startDate/endDate) into the real schema.
+        var llm = new ScriptedLlmClient("""
+            {"accountId":"a","calendarId":"c","timeMin":"2026-04-23T00:00:00","timeMax":"2026-04-23T23:59:59"}
+            """);
+
+        var (executor, registry, captured) = CreateExecutor(llm);
+        RegisterCalendarMcp(registry, captured);
+
+        var definition = MakeCalendarWisp(
+            """{"accountId":"a","calendarId":"c","startDate":"2026-04-23","endDate":"2026-04-23"}""");
+
+        var result = await executor.ExecuteAsync(definition, "wisp-ac-1", CancellationToken.None);
+
+        Assert.IsTrue(result.IsSuccess, "Step should succeed after auto-correction");
+        Assert.AreEqual(1, llm.CallCount);
+
+        // The executor was called with the corrected params wrapped in mcp_invoke_tool args.
+        Assert.AreEqual(1, captured.Count);
+        var args = JsonDocument.Parse(captured[0]).RootElement;
+        var innerArgs = args.GetProperty("arguments");
+        Assert.IsTrue(innerArgs.TryGetProperty("timeMin", out _),
+            "Corrected params should contain 'timeMin'");
+        Assert.IsFalse(innerArgs.TryGetProperty("startDate", out _),
+            "Corrected params should not contain 'startDate'");
+    }
+
+    [TestMethod]
+    public async Task ValidationFailure_LlmReturnsInvalidJson_OriginalErrorBubbled()
+    {
+        var llm = new ScriptedLlmClient("this is not JSON");
+        var (executor, registry, _) = CreateExecutor(llm);
+        RegisterCalendarMcp(registry, capturedArgs: null);
+
+        var definition = MakeCalendarWisp(
+            """{"accountId":"a","calendarId":"c","startDate":"x","endDate":"y"}""");
+
+        var result = await executor.ExecuteAsync(definition, "wisp-ac-2", CancellationToken.None);
+
+        Assert.IsFalse(result.IsSuccess);
+        Assert.AreEqual(FailureCategory.Structural, result.FailedStep!.Error!.Category);
+        StringAssert.Contains(result.FailedStep.Error.Message, "startDate",
+            "Original validation error (naming the unknown field) should be preserved");
+    }
+
+    [TestMethod]
+    public async Task ValidationFailure_LlmReturnsStillInvalidParams_OriginalErrorBubbled()
+    {
+        // LLM emits syntactically-valid JSON but it still misses `calendarId`.
+        // We don't trust the LLM's output — a re-validation catches this.
+        var llm = new ScriptedLlmClient("""
+            {"accountId":"a","timeMin":"t1","timeMax":"t2"}
+            """);
+        var (executor, registry, _) = CreateExecutor(llm);
+        RegisterCalendarMcp(registry, capturedArgs: null);
+
+        var definition = MakeCalendarWisp(
+            """{"accountId":"a","startDate":"x"}""");
+
+        var result = await executor.ExecuteAsync(definition, "wisp-ac-3", CancellationToken.None);
+
+        Assert.IsFalse(result.IsSuccess);
+        Assert.AreEqual(FailureCategory.Structural, result.FailedStep!.Error!.Category);
+    }
+
+    [TestMethod]
+    public async Task ValidationFailure_NoLlmClientWired_OriginalErrorBubbled()
+    {
+        // With no ILlmClient injected, the auto-correction path is a no-op.
+        var (executor, registry, _) = CreateExecutor(llmClient: null);
+        RegisterCalendarMcp(registry, capturedArgs: null);
+
+        var definition = MakeCalendarWisp(
+            """{"accountId":"a","startDate":"x"}""");
+
+        var result = await executor.ExecuteAsync(definition, "wisp-ac-4", CancellationToken.None);
+
+        Assert.IsFalse(result.IsSuccess);
+        Assert.AreEqual(FailureCategory.Structural, result.FailedStep!.Error!.Category);
+    }
+
+    [TestMethod]
+    public async Task ValidationFailure_LlmWrapsResponseInCodeFences_StillParsed()
+    {
+        var llm = new ScriptedLlmClient("""
+            ```json
+            {"accountId":"a","calendarId":"c","timeMin":"t1","timeMax":"t2"}
+            ```
+            """);
+        var (executor, registry, captured) = CreateExecutor(llm);
+        RegisterCalendarMcp(registry, captured);
+
+        var definition = MakeCalendarWisp(
+            """{"accountId":"a","calendarId":"c","startDate":"x","endDate":"y"}""");
+
+        var result = await executor.ExecuteAsync(definition, "wisp-ac-5", CancellationToken.None);
+
+        Assert.IsTrue(result.IsSuccess, "Code-fenced JSON from the LLM should still be accepted");
+    }
+
+    // ── Fixture ──────────────────────────────────────────────────────────────
+
+    private static (WispExecutor Executor, FakeToolRegistry Registry, List<string> CapturedArgs)
+        CreateExecutor(ILlmClient? llmClient)
+    {
+        var registry = new FakeToolRegistry();
+        var memory = new FakeWorkingMemory();
+        var options = new WispOptions { SharedVolumePath = null };
+        var captured = new List<string>();
+        var executor = new WispExecutor(registry, memory, agentLoopRunner: null!, options,
+            NullLogger<WispExecutor>.Instance, llmClient);
+        return (executor, registry, captured);
+    }
+
+    private static void RegisterCalendarMcp(FakeToolRegistry registry, List<string>? capturedArgs)
+    {
+        // mcp_invoke_tool is the wrapper the wisp router invokes for Mcp gateway steps.
+        registry.Register(
+            new ToolRegistration
+            {
+                Name = "mcp_invoke_tool",
+                Description = "",
+                Source = "mcp-management"
+            },
+            capturedArgs is not null
+                ? new CapturingToolExecutor(r => capturedArgs.Add(r.Arguments), "{\"events\":[]}")
+                : new FakeToolExecutor("{\"events\":[]}"));
+
+        // The target MCP tool whose schema the validator consults.
+        registry.Register(
+            new ToolRegistration
+            {
+                Name = "get_calendar_events",
+                Description = "",
+                Source = "mcp:calendar-mcp",
+                ParametersSchema = CalendarSchema
+            },
+            new FakeToolExecutor("{\"events\":[]}"));
+    }
+
+    private static WispDefinition MakeCalendarWisp(string paramsJson) => new()
+    {
+        Description = "calendar fetch",
+        Steps =
+        [
+            new WispStep
+            {
+                Id = "get",
+                Mode = StepMode.Direct,
+                Gateway = GatewayType.Mcp,
+                Server = "calendar-mcp",
+                Tool = "get_calendar_events",
+                Params = JsonDocument.Parse(paramsJson).RootElement
+            }
+        ]
+    };
+
+    private sealed class ScriptedLlmClient(string responseText) : ILlmClient
+    {
+        public int CallCount { get; private set; }
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            CallCount++;
+            return Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, responseText)));
+        }
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages, ModelTier tier,
+            ChatOptions? options = null, CancellationToken cancellationToken = default)
+        {
+            CallCount++;
+            return Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, responseText)));
+        }
+    }
+}

--- a/tests/RockBot.Wisp.Tests/WispExecutorTests.cs
+++ b/tests/RockBot.Wisp.Tests/WispExecutorTests.cs
@@ -169,6 +169,105 @@ public class WispExecutorTests
         Assert.AreEqual(FailureCategory.External, result.StepResults[0].Error!.Category);
     }
 
+    [TestMethod]
+    public async Task ExecuteAsync_SoftErrorInOkResponse_TreatedAsFailure()
+    {
+        // Some MCP servers return 200 OK with {"error":"..."} instead of flagging an
+        // MCP-transport error. The wisp runner must surface these as step failures.
+        var (executor, registry) = CreateExecutor();
+
+        registry.Register(
+            new ToolRegistration { Name = "web_search", Description = "", Source = "web" },
+            new FakeToolExecutor(content: """{"error":"accountId is required"}"""));
+
+        var definition = new WispDefinition
+        {
+            Description = "Soft-error",
+            Steps =
+            [
+                new WispStep
+                {
+                    Id = "s",
+                    Mode = StepMode.Direct,
+                    Gateway = GatewayType.Web,
+                    Tool = "web_search",
+                    Params = JsonDocument.Parse("""{"query":"x"}""").RootElement
+                }
+            ]
+        };
+
+        var result = await executor.ExecuteAsync(definition, "wisp-soft", CancellationToken.None);
+
+        Assert.IsFalse(result.IsSuccess);
+        Assert.IsNotNull(result.FailedStep?.Error);
+        StringAssert.Contains(result.FailedStep!.Error!.Message, "accountId is required");
+        Assert.AreEqual(FailureCategory.Structural, result.FailedStep.Error.Category,
+            "'is required' classifies as Structural via ClassifyToolError");
+    }
+
+    [TestMethod]
+    public async Task ExecuteAsync_ResponseContainingErrorFieldThatIsNotTopLevel_RemainsSuccess()
+    {
+        // A legitimate data payload that happens to contain an `error` key nested
+        // inside should NOT be misclassified as a soft error. The detector only
+        // looks at the top-level `error` property being a string.
+        var (executor, registry) = CreateExecutor();
+
+        registry.Register(
+            new ToolRegistration { Name = "web_search", Description = "", Source = "web" },
+            new FakeToolExecutor(content: """{"results":[{"error":"diagnostic info"}]}"""));
+
+        var definition = new WispDefinition
+        {
+            Description = "Nested-error",
+            Steps =
+            [
+                new WispStep
+                {
+                    Id = "s",
+                    Mode = StepMode.Direct,
+                    Gateway = GatewayType.Web,
+                    Tool = "web_search",
+                    Params = JsonDocument.Parse("""{"query":"x"}""").RootElement
+                }
+            ]
+        };
+
+        var result = await executor.ExecuteAsync(definition, "wisp-nested", CancellationToken.None);
+
+        Assert.IsTrue(result.IsSuccess, "Nested 'error' field should not trigger soft-error detection");
+    }
+
+    [TestMethod]
+    public async Task ExecuteAsync_NonJsonResponse_NotMisclassifiedAsSoftError()
+    {
+        var (executor, registry) = CreateExecutor();
+
+        registry.Register(
+            new ToolRegistration { Name = "web_search", Description = "", Source = "web" },
+            new FakeToolExecutor(content: "just plain text output"));
+
+        var definition = new WispDefinition
+        {
+            Description = "Plain-text",
+            Steps =
+            [
+                new WispStep
+                {
+                    Id = "s",
+                    Mode = StepMode.Direct,
+                    Gateway = GatewayType.Web,
+                    Tool = "web_search",
+                    Params = JsonDocument.Parse("""{"query":"x"}""").RootElement
+                }
+            ]
+        };
+
+        var result = await executor.ExecuteAsync(definition, "wisp-text", CancellationToken.None);
+
+        Assert.IsTrue(result.IsSuccess);
+    }
+
     // ── On-failure branching ─────────────────────────────────────────────────
 
     [TestMethod]


### PR DESCRIPTION
Two fixes, both uncovered while testing PR #290's skill-resource feature end-to-end.

## Commit 1 — `.resources` suffix for skill resource folders

Top-level skill `memory` and subcategory skill `memory/agent-memory-management` couldn't coexist under PR #290's layout: the `memory/` directory was treated as the resource folder of `memory.json`, and the subcategory skill was silently dropped from the index. The startup `ValidateNoConflict` guard caught this by throwing — which took the agent pod into `CrashLoopBackOff`.

Fix: resource folders now use a reserved `.resources` suffix (e.g. `memory.resources/`). Skill names cannot contain dots, so there is no overlap with subcategory folders. `ValidateNoConflict` and the sibling-JSON heuristic both go away. `StarterSkillService` also catches exceptions from `SaveAsync` so a single bad seed can't take the host down.

## Commit 2 — wisp schema validation, one-shot auto-correction, reuse nudges

When the LLM composes a wisp step targeting an MCP tool, it's authoring the `params` blob schema-blind — the tool's real parameter schema sits on the other side of the MCP gateway, not in the LLM's tool list. In live testing this produced the calendar bug: the LLM invented `startDate`/`endDate` instead of `timeMin`/`timeMax`, the calendar MCP server answered malformed queries with `{"events": []}`, and the agent reported empty days as truth.

Three changes:

1. **Pre-flight validation (`McpStepValidator`).** For every MCP gateway step, look up the target tool's `parametersSchema` from the tool registry and check required-fields-present + unknown-fields-rejected-under-closed-schema. On failure, produce a `Structural` `WispStepError` whose message includes a compact rendering of the expected shape.

2. **One-shot auto-correction on `Structural` failures.** `WispExecutor` bundles `{failing params, schema-bearing error message}` into a tool-less `ILlmClient.GetResponseAsync` call at `ModelTier.Low`, parses a JSON object out of the response, and re-validates. If the correction passes, the step proceeds with corrected params; if not, the original error is surfaced. One attempt, no loops. Skipped when no `ILlmClient` is wired in.

3. **Reuse nudges.** `spawn_wisps` tool description now tells the LLM to call `mcp_get_service_details(server_name=...)` before authoring a wisp that targets an MCP server, and to save working wisps back as `Wisp` skill resources (the `SkillResourceType.Wisp` enum existed from PR #290 but nothing consumed it). The skill-provider doc covers the other half: fetch existing `Wisp` resources before re-authoring.

Bumps version to 0.9.5.

## Test plan
- [x] `dotnet test RockBot.slnx` — all suites green, 14 new wisp tests
- [x] Deployed `rockylhotka/rockbot-agent:0.9.5` to cluster; pod starts cleanly and the starter-skill seeding path no longer crashes
- [ ] Exercise calendar MCP flow via wisps end-to-end to confirm (a) validation catches mis-authored params before they hit the server and (b) auto-correction recovers on the first failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)