### PR TITLE
Wisp guide polish + resource-type tags in skill index

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-    <Version>0.9.9</Version>
+    <Version>0.9.11</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.Host/AgentContextBuilder.cs
+++ b/src/RockBot.Host/AgentContextBuilder.cs
@@ -393,13 +393,15 @@ public sealed class AgentContextBuilder(
         if (shouldInjectSkillIndex && skillList.Count > 0)
         {
             var indexText =
-                "Available skills (use get_skill to load full instructions):\n" +
+                "Available skills (use get_skill to load full instructions; " +
+                "bracketed tags like [Wisp, Python] list resource types saved on the skill):\n" +
                 string.Join("\n", skillList.Select(s =>
                 {
                     var summary = string.IsNullOrWhiteSpace(s.Summary)
                         ? "(summary pending)"
                         : s.Summary;
-                    return $"- {s.Name}: {summary}";
+                    var resourceTag = SkillTools.FormatResourceTag(s.Manifest);
+                    return $"- {s.Name}{resourceTag}: {summary}";
                 }));
             chatMessages.Add(new ChatMessage(ChatRole.System, indexText));
             logger.LogInformation("Injected skill index ({Count} skills) for session {SessionId}",

--- a/src/RockBot.Memory/MemoryToolSkillProvider.cs
+++ b/src/RockBot.Memory/MemoryToolSkillProvider.cs
@@ -205,6 +205,29 @@ public sealed class MemoryToolSkillProvider : IToolSkillProvider
         If you need to navigate chunked content but the inline index has scrolled out of
         context, retrieve the `-index` key first to rediscover the document structure.
 
+        **Scanning all chunks: prefer parallel wisps over sequential reads.** When you need
+        to search, filter, or extract information across every chunk (not jump to one known
+        section), reading each chunk into your own context via `get_from_working_memory`
+        scales the agent-context cost with total document size. Instead, fan out with
+        `spawn_wisps` — one wisp per chunk, each with a single `Llm` step that calls
+        `get_from_working_memory` on its assigned full-path chunk key and returns a compact
+        JSON extract (e.g. matched sentences, pulled entities). The wisp LLM has a fresh
+        context per chunk, so only the extracted results come back to your turn — not the
+        full chunk content. This is the right pattern for "find everywhere X is mentioned,"
+        "aggregate all entities of type Y," or "summarise each section" across a chunked
+        document.
+
+        Minimal per-chunk wisp step:
+        ```json
+        {
+          "id": "scan",
+          "mode": "Llm",
+          "prompt": "Call get_from_working_memory with key 'session/abc123/research-chunk3'. From that content, extract every sentence mentioning 'Northstar'. Return ONLY a JSON array of strings ([] if none)."
+        }
+        ```
+        Spawn N of these — one per chunk key from the `-index` — in a single `spawn_wisps`
+        call. See the wisp guide for full pipeline mechanics.
+
 
         ### list_working_memory
 

--- a/src/RockBot.Scripts.Remote/ScriptToolSkillProvider.cs
+++ b/src/RockBot.Scripts.Remote/ScriptToolSkillProvider.cs
@@ -28,18 +28,24 @@ internal sealed class ScriptToolSkillProvider : IToolSkillProvider
         code. If you have a saved script skill for this type of task, load it first.
 
 
-        ## Step 0 — Check for an Existing Script Skill
+        ## Step 0 — Check for an Existing Script
 
-        Before writing a new script, check whether a reusable script for this task type
-        already exists:
+        Before writing a new script, check whether a working script for this task already
+        exists. The injected skill index shows a bracketed `[Python, ...]` tag after any
+        skill that has saved resources — scan for tags containing `Python` on skills whose
+        summary matches your task.
 
-        ```
-        list_skills()
-        ```
+        Two places scripts may live:
 
-        Look for skills named `scripts/{task-type}` (e.g. `scripts/csv-processing`,
-        `scripts/date-calculations`, `scripts/image-resize`). If one exists, load it
-        with `get_skill`, adapt the script to the current inputs, and run it.
+        1. **As a `Python`-type resource on a task-relevant skill** — the preferred pattern.
+           If a relevant skill shows `[Python]` (or `[Python, ...]`), call `get_skill` to see
+           the manifest, then `get_skill_resource(<skill>, <filename>.py)` to fetch the script.
+           Adapt it to the current inputs and run.
+        2. **As a standalone `scripts/{task-type}` skill** — an older pattern, still valid.
+           Skills named `scripts/csv-processing`, `scripts/date-calculations`, etc. Load with
+           `get_skill` and use the script inside the markdown content.
+
+        Either way: don't re-derive a script the system has already debugged.
 
 
         ## Step 1 — Write the Script
@@ -114,22 +120,32 @@ internal sealed class ScriptToolSkillProvider : IToolSkillProvider
         - If the script failed after multiple attempts, explain what was tried and why it failed
 
 
-        ## Step 5 — Save Reusable Scripts as Skills
+        ## Step 5 — Save Working Scripts for Reuse
 
-        When you write a script that solves a general problem worth reusing, save it as
-        a skill so future tasks can skip the writing step.
+        Once a script has been written, debugged, and confirmed to produce the right output,
+        save it so future sessions can skip the writing and debugging steps.
 
-        Call `save_skill` with:
-        - **name**: `scripts/{task-type}` in lowercase with hyphens
-          (e.g. `scripts/csv-summary`, `scripts/timezone-conversion`, `scripts/base64-decode`)
-        - **content**: a markdown document containing:
-          - What the script does and when to use it
-          - The script itself in a fenced code block
-          - How to pass input data and what format it expects
-          - Expected output format and how to interpret it
-          - Any pip packages required and why
+        **Preferred: save as a `Python` resource on a task-relevant skill.** If there's an
+        existing skill covering the task the script supports (or if the task itself deserves
+        a new skill), attach the script as a resource via `save_skill` with a `resources`
+        list entry of type `Python`. This keeps the script next to the narrative that explains
+        *when* and *why* to use it, and the skill index auto-surfaces a `[Python]` tag so
+        future sessions find it without loading the skill first.
 
-        Future tasks load the skill in Step 0 and run the proven script with adapted inputs.
+        Example resource entry:
+        ```
+        { "filename": "summary.py", "type": "Python",
+          "description": "Summarise a CSV of daily sales into totals by category.",
+          "content": "<script source>" }
+        ```
+
+        **Alternative: standalone `scripts/{task-type}` skill.** For general-purpose utility
+        scripts that aren't tied to a specific task domain (timezone conversion, base64
+        decoding, etc.), save as a skill of its own with markdown explaining usage and the
+        script in a fenced code block.
+
+        Either way, Step 0 on the next invocation will surface it via the skill index
+        `[Python]` tag and the agent can run the proven script with adapted inputs.
 
 
         ## Best Practices

--- a/src/RockBot.Skills/SkillTools.cs
+++ b/src/RockBot.Skills/SkillTools.cs
@@ -233,8 +233,28 @@ public sealed class SkillTools
             var lastUsedPart = s.LastUsedAt.HasValue
                 ? $"last used {(int)(now - s.LastUsedAt.Value).TotalDays}d ago"
                 : "never used";
-            sb.AppendLine($"- {s.Name} ({ageDays}d old, {lastUsedPart}): {summary}");
+            var resourceTag = FormatResourceTag(s.Manifest);
+            sb.AppendLine($"- {s.Name} ({ageDays}d old, {lastUsedPart}){resourceTag}: {summary}");
         }
         return sb.ToString().TrimEnd();
+    }
+
+    /// <summary>
+    /// Produces a compact <c>[Wisp, Python]</c>-style tag listing the distinct resource types
+    /// attached to a skill, or an empty string if the skill has no resources. Lets the LLM see
+    /// at a glance (from the skill index) which skills already carry a saved wisp, script, etc.
+    /// </summary>
+    public static string FormatResourceTag(IReadOnlyList<SkillResource>? manifest)
+    {
+        if (manifest is null || manifest.Count == 0)
+            return "";
+
+        var types = manifest
+            .Select(r => r.Type.ToString())
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(t => t, StringComparer.Ordinal)
+            .ToList();
+
+        return $" [{string.Join(", ", types)}]";
     }
 }

--- a/src/RockBot.Wisp/WispToolSkillProvider.cs
+++ b/src/RockBot.Wisp/WispToolSkillProvider.cs
@@ -456,6 +456,18 @@ public sealed class WispToolSkillProvider : IToolSkillProvider
            and failure pattern analysis across sessions.
         6. **Batch independent work.** When you need multiple unrelated data fetches,
            put them in a single `spawn_wisps` call to run concurrently.
+        7. **Save working wisps as skill resources.** Once a wisp has been authored,
+           debugged, and confirmed working, save the final definition as a `Wisp`-type
+           resource on the relevant skill (via `save_skill`). Future sessions can then
+           reuse the proven pipeline via `get_skill_resource` + `spawn_wisps` instead of
+           rebuilding it — and re-running schema/template/judgment mistakes in the process.
+
+           **Check before you author.** The skill index injected at session start shows a
+           compact `[Wisp, ...]` tag after each skill that has saved resources. If a skill
+           relevant to your task already shows `[Wisp]`, call `get_skill` to see the
+           manifest, then `get_skill_resource` to fetch the definition — adapt the saved
+           wisp rather than building a new one from scratch. No tag means no saved wisp
+           on that skill; author as normal and save the working result back.
 
         ### Example: Parallel data gathering
 


### PR DESCRIPTION
## Summary

- Skill index now shows a `[Wisp, Python]`-style tag after each skill that has saved resources, so the agent can decide whether a relevant skill already has a saved wisp or script *before* loading it. Without this, the "reuse before authoring" nudge costs extra `get_skill` calls; with it, the nudge is free.
- Wisp guide: explicit "wisps are a bad fit when..." list, a worked multi-stage fan-out example (accounts → calendars → events) showing the batch cadence when each stage's cardinality depends on the prior stage, and a new best practice #7 pointing at the `[Wisp]` tag.
- Script guide: Step 0 and Step 5 rewritten around the same pattern — preferred path is saving working scripts as `Python` resources on a task-relevant skill (surfaced via `[Python]` in the index); standalone `scripts/{task-type}` kept as an alternative.
- Memory guide: next to the existing `-index` chunk paragraph, documents parallel-wisp fan-out for scanning chunked working-memory content — one wisp per chunk, each `Llm` step reads its chunk by full-path key and returns a compact JSON extract, keeping the parent agent's context small.

Motivation: after two rounds of live calendar testing, the agent's own self-assessment called out missing pieces in the wisp guide (hard-to-find constraints on templates, no explicit bad-fit list, no multi-stage fan-out example). Separately, the "save working wisps as resources" nudge only pays off if the agent can cheaply tell *which* skills already carry saved resources — hence the index tag.

Bumps version to 0.9.11.

## Test plan

- [x] `dotnet build RockBot.slnx` passes
- [x] `dotnet test` for `SkillToolsTests` and `AgentContextBuilder` related tests pass — existing tests tolerate the new `[...]` tag because it's only appended when a skill has resources
- [ ] Live smoke: deploy 0.9.11 to cluster, exercise a calendar-details flow and confirm the wisp worked, check skill-index injection in agent context for the new tag