### PR TITLE
A2A peer registry: discover skills from agent-card instead of duplicating

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-    <Version>0.9.11</Version>
+    <Version>0.9.12</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/deploy/docker-compose/a2a-peer/alice/well-known-agents.json
+++ b/deploy/docker-compose/a2a-peer/alice/well-known-agents.json
@@ -1,16 +1,8 @@
 [
   {
     "agentName": "Bob",
-    "description": "Bob's RockBot agent — available for A2A collaboration via HTTP gateway.",
-    "version": "1.0",
     "url": "http://gateway-bob:5200",
-    "protocolVersion": "1.0",
     "authHeaderName": "X-Api-Key",
-    "authHeaderValueBase64": "YWxpY2UtY2FsbHMtYm9i",
-    "skills": [
-      { "id": "notify-user", "name": "Notify User", "description": "Send a notification to Bob's user." },
-      { "id": "query-availability", "name": "Query Availability", "description": "Check if Bob's user is available." },
-      { "id": "negotiate-meeting", "name": "Negotiate Meeting", "description": "Multi-turn meeting negotiation with Bob's agent. Also accepts skill ID 'schedule-meeting'." }
-    ]
+    "authHeaderValueBase64": "YWxpY2UtY2FsbHMtYm9i"
   }
 ]

--- a/deploy/docker-compose/a2a-peer/bob/well-known-agents.json
+++ b/deploy/docker-compose/a2a-peer/bob/well-known-agents.json
@@ -1,16 +1,8 @@
 [
   {
     "agentName": "Alice",
-    "description": "Alice's RockBot agent — available for A2A collaboration via HTTP gateway.",
-    "version": "1.0",
     "url": "http://gateway-alice:5200",
-    "protocolVersion": "1.0",
     "authHeaderName": "X-Api-Key",
-    "authHeaderValueBase64": "Ym9iLWNhbGxzLWFsaWNl",
-    "skills": [
-      { "id": "notify-user", "name": "Notify User", "description": "Send a notification to Alice's user." },
-      { "id": "query-availability", "name": "Query Availability", "description": "Check if Alice's user is available." },
-      { "id": "negotiate-meeting", "name": "Negotiate Meeting", "description": "Multi-turn meeting negotiation with Alice's agent. Also accepts skill ID 'schedule-meeting'." }
-    ]
+    "authHeaderValueBase64": "Ym9iLWNhbGxzLWFsaWNl"
   }
 ]

--- a/docs/a2a.md
+++ b/docs/a2a.md
@@ -178,22 +178,42 @@ agents on a different restart schedule, or any agent you want to guarantee is
 always listed — add them to the **`well-known-agents.json`** file on the agent
 PVC (`/data/agent/well-known-agents.json`).
 
+Entries hold just the peer's coordinates (and optional auth headers). The peer's
+skills, description, version, and protocol capabilities are discovered at
+startup from `{url}/.well-known/agent-card.json` — the A2A-spec source of truth.
+
 ```json
 [
   {
     "agentName": "ResearchAgent",
-    "description": "On-demand research agent. Searches the web, fetches pages, and synthesises answers using an LLM.",
-    "version": "1.0",
-    "skills": [
-      {
-        "id": "research",
-        "name": "Research",
-        "description": "Research a topic using web search and page fetching, then synthesise a concise answer."
-      }
-    ]
+    "url": "http://researchagent:5100"
   }
 ]
 ```
+
+For peers that require an API key on inbound calls, add the auth header fields
+(the value is base64-encoded so it doesn't show up in logs in cleartext):
+
+```json
+[
+  {
+    "agentName": "Bob",
+    "url": "http://gateway-bob:5200",
+    "authHeaderName": "X-Api-Key",
+    "authHeaderValueBase64": "YWxpY2UtY2FsbHMtYm9i"
+  }
+]
+```
+
+At startup, RockBot fetches each listed peer's agent-card and merges the
+returned `description`, `version`, `protocolVersion`, `supportsStreaming`, and
+`skills` into the directory entry. Adding a new capability to a peer therefore
+propagates without editing `well-known-agents.json` — just restart the primary
+agent (or wait for the next restart).
+
+**Offline override:** if an entry carries its own `skills` array, that array is
+used as-is and no fetch is performed. Useful for airgapped deployments or when
+you want to pin a peer's advertised skills regardless of what the peer reports.
 
 Well-known agents:
 - Always appear in `list_known_agents` regardless of whether they are running.
@@ -203,6 +223,8 @@ Well-known agents:
   (e.g. a KEDA pod shutting down after completing its task).
 - Can be invoked with `invoke_agent` at any time — the message waits on the
   queue until the agent pod starts.
+- If the peer is unreachable at startup, the entry is kept as a callable skeleton
+  (by name/URL) but skills are empty until the next restart retry.
 
 > **Rule of thumb**: Any agent that is not a permanently-running deployment
 > should be listed in `well-known-agents.json`. This includes KEDA ScaledJobs,
@@ -298,16 +320,13 @@ auto-announce themselves via the discovery topic. Register them in
 [
   {
     "agentName": "SampleAgent-Http",
-    "description": "Sample HTTP agent.",
-    "version": "1.0",
-    "url": "http://sampleagent-http:5100",
-    "skills": [
-      { "id": "echo", "name": "Echo", "description": "Echoes the input back." },
-      { "id": "general", "name": "General Task", "description": "General-purpose LLM task." }
-    ]
+    "url": "http://sampleagent-http:5100"
   }
 ]
 ```
+
+Skills and description are discovered from the HTTP agent's own
+`/.well-known/agent-card.json` endpoint at startup.
 
 When `invoke_agent` is called for an agent whose `AgentCard` has a non-empty `Url`,
 the primary agent dispatches the task over HTTP to `{Url}/tasks/send` instead of

--- a/src/RockBot.A2A/A2AServiceCollectionExtensions.cs
+++ b/src/RockBot.A2A/A2AServiceCollectionExtensions.cs
@@ -21,6 +21,11 @@ public static class A2AServiceCollectionExtensions
         configure?.Invoke(options);
         builder.Services.AddSingleton(options);
 
+        // HttpClient factory — AgentDirectory uses it to fetch peers' /.well-known/agent-card.json
+        // at startup and enrich well-known seed entries. Safe to call whether or not AddA2ACaller
+        // also runs; AddHttpClient is idempotent.
+        builder.Services.AddHttpClient();
+
         // Agent directory — guard IHostedService registration with a marker so
         // calling both AddA2A() and AddA2ACaller() doesn't wire StartAsync twice.
         builder.Services.TryAddSingleton<AgentDirectory>();

--- a/src/RockBot.A2A/AgentDirectory.cs
+++ b/src/RockBot.A2A/AgentDirectory.cs
@@ -16,7 +16,8 @@ namespace RockBot.A2A;
 /// </summary>
 internal sealed class AgentDirectory(
     A2AOptions options,
-    ILogger<AgentDirectory> logger) : IAgentDirectory, IHostedService
+    ILogger<AgentDirectory> logger,
+    IHttpClientFactory? httpClientFactory = null) : IAgentDirectory, IHostedService
 {
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -98,6 +99,93 @@ internal sealed class AgentDirectory(
                 };
             }
             logger.LogInformation("Seeded well-known agent '{AgentName}'", card.AgentName);
+        }
+
+        // Enrich seeded well-known entries by fetching the peer's published
+        // /.well-known/agent-card.json — the A2A-spec source of truth for
+        // skills/description/version. Entries that already carry a skills array
+        // in well-known-agents.json are treated as explicit overrides and left alone
+        // (supports offline/airgapped deployments).
+        await EnrichWellKnownFromRemoteAsync(cancellationToken);
+    }
+
+    private async Task EnrichWellKnownFromRemoteAsync(CancellationToken cancellationToken)
+    {
+        if (httpClientFactory is null) return;
+
+        var toEnrich = options.WellKnownAgents
+            .Where(c => !string.IsNullOrWhiteSpace(c.Url) && (c.Skills is null || c.Skills.Count == 0))
+            .ToList();
+
+        if (toEnrich.Count == 0) return;
+
+        var tasks = toEnrich.Select(seed => FetchAndMergeAsync(seed, cancellationToken));
+        await Task.WhenAll(tasks);
+    }
+
+    private async Task FetchAndMergeAsync(AgentCard seed, CancellationToken ct)
+    {
+        try
+        {
+            using var httpClient = httpClientFactory!.CreateClient();
+            httpClient.Timeout = TimeSpan.FromSeconds(10);
+
+            if (!string.IsNullOrEmpty(seed.AuthHeaderName) &&
+                !string.IsNullOrEmpty(seed.AuthHeaderValueBase64))
+            {
+                var headerValue = System.Text.Encoding.UTF8.GetString(
+                    Convert.FromBase64String(seed.AuthHeaderValueBase64));
+                httpClient.DefaultRequestHeaders.TryAddWithoutValidation(seed.AuthHeaderName, headerValue);
+            }
+
+            var url = $"{seed.Url!.TrimEnd('/')}/.well-known/agent-card.json";
+            var response = await httpClient.GetAsync(url, ct);
+            if (!response.IsSuccessStatusCode)
+            {
+                logger.LogWarning(
+                    "Could not fetch agent-card for well-known peer '{AgentName}' from {Url}: HTTP {Status}",
+                    seed.AgentName, url, (int)response.StatusCode);
+                return;
+            }
+
+            var json = await response.Content.ReadAsStringAsync(ct);
+            var remote = JsonSerializer.Deserialize<AgentCard>(json, JsonOptions);
+            if (remote is null)
+            {
+                logger.LogWarning(
+                    "Empty agent-card response for well-known peer '{AgentName}' from {Url}",
+                    seed.AgentName, url);
+                return;
+            }
+
+            // Merge remote fields into the seeded card while preserving locally-configured
+            // coordinates (Url, AuthHeader*) and the AgentName key.
+            var merged = seed with
+            {
+                Description = remote.Description ?? seed.Description,
+                Version = remote.Version ?? seed.Version,
+                Skills = remote.Skills ?? seed.Skills,
+                ProtocolVersion = remote.ProtocolVersion ?? seed.ProtocolVersion,
+                SupportsStreaming = remote.SupportsStreaming ?? seed.SupportsStreaming
+            };
+
+            if (_agents.TryGetValue(seed.AgentName, out var existing))
+            {
+                _agents[seed.AgentName] = existing with { Card = merged };
+                logger.LogInformation(
+                    "Enriched well-known agent '{AgentName}' from {Url} ({SkillCount} skill(s))",
+                    seed.AgentName, url, merged.Skills?.Count ?? 0);
+            }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "Failed to enrich well-known agent '{AgentName}' from {Url} — entry kept without remote data",
+                seed.AgentName, seed.Url);
         }
     }
 

--- a/src/RockBot.Agent/agent/well-known-agents.json
+++ b/src/RockBot.Agent/agent/well-known-agents.json
@@ -1,20 +1,6 @@
 [
   {
     "agentName": "SampleAgent-Http",
-    "description": "A sample agent demonstrating the A2A protocol pattern over HTTP.",
-    "version": "1.0",
-    "url": "http://rockbot-sample-agent-http.rockbot.svc.cluster.local",
-    "skills": [
-      {
-        "id": "general",
-        "name": "General Task",
-        "description": "General-purpose task execution using an LLM."
-      },
-      {
-        "id": "echo",
-        "name": "Echo",
-        "description": "Echoes the input message back as confirmation."
-      }
-    ]
+    "url": "http://rockbot-sample-agent-http.rockbot.svc.cluster.local"
   }
 ]

--- a/tests/RockBot.A2A.Tests/WellKnownAgentEnrichmentTests.cs
+++ b/tests/RockBot.A2A.Tests/WellKnownAgentEnrichmentTests.cs
@@ -1,0 +1,209 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace RockBot.A2A.Tests;
+
+[TestClass]
+public class WellKnownAgentEnrichmentTests
+{
+    private static readonly JsonSerializerOptions CamelCase = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    [TestMethod]
+    public async Task StartAsync_EnrichesSkeletonEntry_FromRemoteAgentCard()
+    {
+        var remote = new AgentCard
+        {
+            AgentName = "Bob",
+            Description = "Bob's agent",
+            Version = "1.0",
+            ProtocolVersion = "1.0",
+            SupportsStreaming = true,
+            Skills =
+            [
+                new AgentSkill { Id = "notify-user", Name = "Notify User", Description = "x" },
+                new AgentSkill { Id = "query-availability", Name = "Query", Description = "y" }
+            ]
+        };
+
+        var handler = new RecordingHandler(JsonSerializer.Serialize(remote, CamelCase));
+        var options = new A2AOptions
+        {
+            DirectoryPersistencePath = string.Empty,
+            WellKnownAgents =
+            [
+                new AgentCard
+                {
+                    AgentName = "Bob",
+                    Url = "http://gateway-bob:5200",
+                    AuthHeaderName = "X-Api-Key",
+                    AuthHeaderValueBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes("secret"))
+                }
+            ]
+        };
+
+        var directory = new AgentDirectory(options, NullLogger<AgentDirectory>.Instance, new StubFactory(handler));
+
+        await directory.StartAsync(CancellationToken.None);
+
+        var card = directory.GetAgent("Bob");
+        Assert.IsNotNull(card);
+        Assert.AreEqual("http://gateway-bob:5200", card.Url);
+        Assert.AreEqual("X-Api-Key", card.AuthHeaderName);
+        Assert.IsNotNull(card.Skills);
+        Assert.AreEqual(2, card.Skills.Count);
+        Assert.IsTrue(card.Skills.Any(s => s.Id == "notify-user"));
+        Assert.AreEqual("Bob's agent", card.Description);
+        Assert.AreEqual("1.0", card.ProtocolVersion);
+        Assert.AreEqual(true, card.SupportsStreaming);
+
+        Assert.AreEqual("http://gateway-bob:5200/.well-known/agent-card.json",
+            handler.LastRequestUri?.ToString());
+        Assert.IsTrue(handler.LastRequestHeaders?.Contains("X-Api-Key") == true);
+        Assert.AreEqual("secret", handler.LastRequestHeaders?.GetValues("X-Api-Key").First());
+
+        var entry = directory.GetAllEntries().Single();
+        Assert.IsTrue(entry.IsWellKnown);
+    }
+
+    [TestMethod]
+    public async Task StartAsync_PreservesPrepopulatedSkills_AsOffllineOverride()
+    {
+        var handler = new RecordingHandler("""{"agentName":"Bob","skills":[{"id":"other"}]}""");
+        var options = new A2AOptions
+        {
+            DirectoryPersistencePath = string.Empty,
+            WellKnownAgents =
+            [
+                new AgentCard
+                {
+                    AgentName = "Bob",
+                    Url = "http://gateway-bob:5200",
+                    Skills = [new AgentSkill { Id = "override-skill", Name = "Override", Description = "z" }]
+                }
+            ]
+        };
+
+        var directory = new AgentDirectory(options, NullLogger<AgentDirectory>.Instance, new StubFactory(handler));
+
+        await directory.StartAsync(CancellationToken.None);
+
+        var card = directory.GetAgent("Bob");
+        Assert.IsNotNull(card);
+        Assert.IsNotNull(card.Skills);
+        Assert.AreEqual(1, card.Skills.Count);
+        Assert.AreEqual("override-skill", card.Skills[0].Id);
+        Assert.IsNull(handler.LastRequestUri, "No fetch should have happened when skills were pre-populated");
+    }
+
+    [TestMethod]
+    public async Task StartAsync_LeavesSkeletonIntact_WhenFetchFails()
+    {
+        var handler = new RecordingHandler(status: HttpStatusCode.ServiceUnavailable);
+        var options = new A2AOptions
+        {
+            DirectoryPersistencePath = string.Empty,
+            WellKnownAgents =
+            [
+                new AgentCard
+                {
+                    AgentName = "Bob",
+                    Url = "http://gateway-bob:5200",
+                    AuthHeaderName = "X-Api-Key",
+                    AuthHeaderValueBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes("secret"))
+                }
+            ]
+        };
+
+        var directory = new AgentDirectory(options, NullLogger<AgentDirectory>.Instance, new StubFactory(handler));
+
+        await directory.StartAsync(CancellationToken.None);
+
+        var card = directory.GetAgent("Bob");
+        Assert.IsNotNull(card, "Agent should remain callable by name even if enrichment fails");
+        Assert.IsNull(card.Skills);
+        Assert.AreEqual("http://gateway-bob:5200", card.Url);
+        Assert.AreEqual("X-Api-Key", card.AuthHeaderName);
+
+        var entry = directory.GetAllEntries().Single();
+        Assert.IsTrue(entry.IsWellKnown);
+    }
+
+    [TestMethod]
+    public async Task StartAsync_SkipsEnrichment_WhenUrlMissing()
+    {
+        var handler = new RecordingHandler("""{}""");
+        var options = new A2AOptions
+        {
+            DirectoryPersistencePath = string.Empty,
+            WellKnownAgents =
+            [
+                new AgentCard { AgentName = "Local-Only" }
+            ]
+        };
+
+        var directory = new AgentDirectory(options, NullLogger<AgentDirectory>.Instance, new StubFactory(handler));
+
+        await directory.StartAsync(CancellationToken.None);
+
+        Assert.IsNotNull(directory.GetAgent("Local-Only"));
+        Assert.IsNull(handler.LastRequestUri, "No URL means no fetch");
+    }
+
+    [TestMethod]
+    public async Task StartAsync_NoEnrichment_WhenHttpFactoryNotProvided()
+    {
+        var options = new A2AOptions
+        {
+            DirectoryPersistencePath = string.Empty,
+            WellKnownAgents =
+            [
+                new AgentCard { AgentName = "Bob", Url = "http://gateway-bob:5200" }
+            ]
+        };
+
+        // Back-compat: the old two-arg ctor is still valid — enrichment is simply skipped.
+        var directory = new AgentDirectory(options, NullLogger<AgentDirectory>.Instance);
+
+        await directory.StartAsync(CancellationToken.None);
+
+        var card = directory.GetAgent("Bob");
+        Assert.IsNotNull(card);
+        Assert.IsNull(card.Skills);
+    }
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        private readonly string _body;
+        private readonly HttpStatusCode _status;
+
+        public RecordingHandler(string body = "", HttpStatusCode status = HttpStatusCode.OK)
+        {
+            _body = body;
+            _status = status;
+        }
+
+        public Uri? LastRequestUri { get; private set; }
+        public System.Net.Http.Headers.HttpRequestHeaders? LastRequestHeaders { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastRequestUri = request.RequestUri;
+            LastRequestHeaders = request.Headers;
+            return Task.FromResult(new HttpResponseMessage(_status)
+            {
+                Content = new StringContent(_body, Encoding.UTF8, "application/json")
+            });
+        }
+    }
+
+    private sealed class StubFactory(HttpMessageHandler handler) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new(handler, disposeHandler: false);
+    }
+}


### PR DESCRIPTION
## Summary

- Shrink `well-known-agents.json` entries to peer coordinates + optional auth headers — `AgentName`, `Url`, `AuthHeaderName`, `AuthHeaderValueBase64`.
- `AgentDirectory.StartAsync` now fetches `{url}/.well-known/agent-card.json` (10 s timeout, parallel per peer) and merges `Description`, `Version`, `Skills`, `ProtocolVersion`, and `SupportsStreaming` into the seeded entry.
- Locally-configured fields (`AgentName`, `Url`, auth headers, `IsWellKnown`) are preserved; remote fields fill in what the seed omitted.
- Back-compat: entries with a populated `skills` array are treated as an explicit override and no fetch is issued — offline/airgapped deployments keep working.
- Fetch failures log a warning and leave the skeleton entry in place (still callable by name/URL).
- Added `AddHttpClient()` to `AddA2A` so the directory's fetch path resolves even without `AddA2ACaller`.
- Updated seed files in `src/RockBot.Agent/agent/` and both `deploy/docker-compose/a2a-peer/{alice,bob}/` to the new minimal shape.
- Updated `docs/a2a.md` with the new shape and the override semantics.
- Added `WellKnownAgentEnrichmentTests` (5 tests) covering enrichment, override, fetch failure, missing-URL skip, and the ctor back-compat path.

## Test plan

- [x] `dotnet build RockBot.slnx` — clean.
- [x] `dotnet test RockBot.slnx` — all tests pass (RockBot.A2A.Tests 113 → 118).
- [ ] Manual verification: edit alice/bob seeds on the docker-compose harness, start stacks, `list_known_agents` on alice should return Bob's skills (fetched from the gateway); adding a Bob-side skill and restarting alice picks it up without editing alice's seed.

Closes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)