### PR TITLE
Close wisp/A2A duplicate-execution hole (#300, #301)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-    <Version>0.9.13</Version>
+    <Version>0.9.15</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.A2A/A2ACallerServiceCollectionExtensions.cs
+++ b/src/RockBot.A2A/A2ACallerServiceCollectionExtensions.cs
@@ -57,6 +57,12 @@ public static class A2ACallerServiceCollectionExtensions
         // Pending task tracker
         builder.Services.AddSingleton<A2ATaskTracker>();
 
+        // Session-scoped A2A cancellation seam. Wisp code (which doesn't reference
+        // RockBot.A2A) uses this to cancel any in-flight A2A tasks dispatched by a
+        // wisp that then failed locally — preventing duplicate remote execution
+        // when the LLM retries the wisp.
+        builder.Services.AddSingleton<ISessionA2ACanceller, A2ATaskCanceller>();
+
         // InputRequired handler for multi-turn follow-up (trust-gated LLM response generation)
         builder.Services.AddSingleton<InputRequiredHandler>();
 

--- a/src/RockBot.A2A/A2ATaskCanceller.cs
+++ b/src/RockBot.A2A/A2ATaskCanceller.cs
@@ -1,0 +1,90 @@
+using Microsoft.Extensions.Logging;
+using RockBot.Host;
+using RockBot.Messaging;
+
+namespace RockBot.A2A;
+
+/// <summary>
+/// Cancels in-flight A2A tasks by <c>PrimarySessionId</c>. Invoked by wisp
+/// failure handling (via the <see cref="ISessionA2ACanceller"/> seam) so that
+/// a dispatched agent call doesn't keep running — and producing a duplicate
+/// result — after the wisp that dispatched it aborts.
+///
+/// For each matching task:
+/// <list type="number">
+///   <item>Remove from the tracker (late results will then be ignored by
+///     <c>A2ATaskResultHandler</c>'s unknown-correlationId path).</item>
+///   <item>Cancel the local <see cref="CancellationTokenSource"/> so any
+///     HTTP dispatch / polling loop unwinds.</item>
+///   <item>Publish <see cref="AgentTaskCancelRequest"/> to
+///     <c>agent.task.cancel.{TargetAgent}</c>. Receivers that implement
+///     cancellation will stop work; stub handlers will respond with
+///     <c>TaskNotCancelable</c> and we ignore it — removing locally is still
+///     the correct caller-side behavior.</item>
+/// </list>
+/// </summary>
+internal sealed class A2ATaskCanceller(
+    A2ATaskTracker tracker,
+    IMessagePublisher publisher,
+    A2AOptions options,
+    AgentIdentity identity,
+    ILogger<A2ATaskCanceller> logger) : ISessionA2ACanceller
+{
+    public async Task<int> CancelForSessionAsync(string sessionId, string reason, CancellationToken ct)
+    {
+        if (string.IsNullOrEmpty(sessionId))
+            return 0;
+
+        var matches = tracker.ListBySession(sessionId);
+        if (matches.Count == 0)
+            return 0;
+
+        logger.LogWarning(
+            "Cancelling {Count} in-flight A2A task(s) for session {SessionId}: {Reason}",
+            matches.Count, sessionId, reason);
+
+        var cancelled = 0;
+        foreach (var pending in matches)
+        {
+            // Drop from tracker first so a result arriving mid-cancel is treated
+            // as an unknown-correlationId and ignored.
+            tracker.TryRemove(pending.TaskId, out _);
+
+            try
+            {
+                pending.Cts.Cancel();
+            }
+            catch (ObjectDisposedException)
+            {
+                // Already disposed by a concurrent terminal path — benign.
+            }
+
+            var cancelRequest = new AgentTaskCancelRequest
+            {
+                TaskId = pending.TaskId,
+                ContextId = pending.ContextId
+            };
+            var replyTo = $"{options.CallerResultTopic}.{identity.Name}";
+            var envelope = cancelRequest.ToEnvelope<AgentTaskCancelRequest>(
+                source: identity.Name,
+                correlationId: pending.TaskId,
+                replyTo: replyTo);
+
+            try
+            {
+                await publisher.PublishAsync(
+                    $"{options.CancelTopic}.{pending.TargetAgent}", envelope, ct);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                logger.LogWarning(ex,
+                    "Failed to publish cancel for A2A task {TaskId} to agent '{Agent}' — local state dropped anyway",
+                    pending.TaskId, pending.TargetAgent);
+            }
+
+            cancelled++;
+        }
+
+        return cancelled;
+    }
+}

--- a/src/RockBot.A2A/A2ATaskTracker.cs
+++ b/src/RockBot.A2A/A2ATaskTracker.cs
@@ -20,4 +20,9 @@ internal sealed class A2ATaskTracker
 
     public IReadOnlyList<PendingA2ATask> ListActive() =>
         _tasks.Values.ToList();
+
+    public IReadOnlyList<PendingA2ATask> ListBySession(string sessionId) =>
+        _tasks.Values
+            .Where(t => string.Equals(t.PrimarySessionId, sessionId, StringComparison.Ordinal))
+            .ToList();
 }

--- a/src/RockBot.Host.Abstractions/ISessionA2ACanceller.cs
+++ b/src/RockBot.Host.Abstractions/ISessionA2ACanceller.cs
@@ -1,0 +1,18 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Cancels any in-flight A2A tasks that were dispatched with the given
+/// <c>PrimarySessionId</c> (e.g. a wispId). Cross-assembly seam: wisp code
+/// doesn't reference RockBot.A2A directly, but a wisp that fails locally after
+/// dispatching an A2A task needs to cancel the remote work so the target
+/// agent doesn't run duplicate work when the LLM retries.
+///
+/// Implementations cancel the local <c>CancellationTokenSource</c>, drop the
+/// task from the tracker (so any late result is ignored cleanly), and publish
+/// an <c>AgentTaskCancelRequest</c> to the target agent's cancel topic.
+/// Returns the number of tasks cancelled.
+/// </summary>
+public interface ISessionA2ACanceller
+{
+    Task<int> CancelForSessionAsync(string sessionId, string reason, CancellationToken ct);
+}

--- a/src/RockBot.Wisp/A2AStepValidator.cs
+++ b/src/RockBot.Wisp/A2AStepValidator.cs
@@ -1,0 +1,39 @@
+namespace RockBot.Wisp;
+
+/// <summary>
+/// Validates A2A wisp step definitions for semantic incompatibilities that the
+/// JSON-schema layer in <see cref="WispToolRegistrar"/> can't express. Kept
+/// narrow on purpose — today it only rejects <c>output_to</c> on A2A steps
+/// (A2A results are asynchronous; <c>output_to</c> would capture the dispatch
+/// stub, not the real result, and a downstream reader would see garbage and
+/// fail the wisp — which is how duplicate agent executions were happening in
+/// practice).
+/// </summary>
+internal static class A2AStepValidator
+{
+    public static WispStepError? Validate(WispStep step)
+    {
+        if (step.Gateway != GatewayType.A2A)
+            return null;
+
+        if (!string.IsNullOrEmpty(step.OutputTo))
+        {
+            return new WispStepError
+            {
+                Category = FailureCategory.Structural,
+                Message =
+                    "A2A steps cannot use 'output_to'. invoke_agent returns synchronously " +
+                    "with a dispatch acknowledgement, not the real agent result (which " +
+                    "arrives asynchronously on the message bus). Writing that stub to a " +
+                    "shared-volume file and reading it back in a later step will produce " +
+                    "garbage and fail the wisp — leaving the dispatched A2A task running " +
+                    "on the remote side. Remove 'output_to' from this step; downstream steps " +
+                    "should consume the result after it arrives (e.g. via a follow-up wisp " +
+                    "keyed on the task_id) rather than reading a file.",
+                ToolName = "invoke_agent"
+            };
+        }
+
+        return null;
+    }
+}

--- a/src/RockBot.Wisp/WispExecutor.cs
+++ b/src/RockBot.Wisp/WispExecutor.cs
@@ -20,7 +20,8 @@ internal sealed class WispExecutor(
     AgentLoopRunner agentLoopRunner,
     WispOptions options,
     ILogger<WispExecutor> logger,
-    ILlmClient? llmClient = null)
+    ILlmClient? llmClient = null,
+    ISessionA2ACanceller? a2aCanceller = null)
 {
     private const int DefaultLlmStepMaxIterations = 10;
     private const int InputChunkingThreshold = 8_000;
@@ -160,9 +161,32 @@ internal sealed class WispExecutor(
                     }
                 }
 
-                // Default: abort on failure
+                // Default: abort on failure. Cancel any in-flight A2A tasks this
+                // wisp dispatched so the remote agent doesn't keep running work
+                // whose result has nowhere to go — the LLM's wisp retry would
+                // otherwise cause duplicate remote execution.
                 logger.LogWarning("Wisp {WispId} aborting at step {StepId}: {Error}",
                     wispId, step.Id, stepResult.Error?.Message);
+                if (a2aCanceller is not null)
+                {
+                    try
+                    {
+                        var cancelled = await a2aCanceller.CancelForSessionAsync(
+                            wispId, $"wisp aborted at step '{step.Id}'", ct);
+                        if (cancelled > 0)
+                        {
+                            logger.LogInformation(
+                                "Wisp {WispId} cancelled {Count} in-flight A2A task(s) on abort",
+                                wispId, cancelled);
+                        }
+                    }
+                    catch (Exception ex) when (ex is not OperationCanceledException)
+                    {
+                        logger.LogWarning(ex,
+                            "Wisp {WispId}: failure-driven A2A cancellation threw — continuing abort",
+                            wispId);
+                    }
+                }
                 break;
             }
 
@@ -209,6 +233,23 @@ internal sealed class WispExecutor(
         CancellationToken ct)
     {
         var stepSw = Stopwatch.StartNew();
+
+        // Structural validation that doesn't depend on the registry. Catches
+        // semantic-incompatibility authoring mistakes (e.g. output_to on an A2A
+        // step, which would silently capture a dispatch stub and cause a
+        // downstream step to fail while the remote task kept running).
+        var structuralError = A2AStepValidator.Validate(step);
+        if (structuralError is not null)
+        {
+            return new WispStepResult
+            {
+                StepId = step.Id,
+                StepIndex = index,
+                IsSuccess = false,
+                Error = structuralError,
+                Duration = stepSw.Elapsed
+            };
+        }
 
         // Route the step to a tool invocation
         var route = GatewayRouter.Route(step, wispId, priorResults);

--- a/tests/RockBot.A2A.Tests/A2ATaskCancellerTests.cs
+++ b/tests/RockBot.A2A.Tests/A2ATaskCancellerTests.cs
@@ -1,0 +1,96 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using RockBot.Host;
+using RockBot.Messaging;
+
+namespace RockBot.A2A.Tests;
+
+[TestClass]
+public class A2ATaskCancellerTests
+{
+    private static AgentIdentity TestIdentity => new("primary");
+
+    private static A2ATaskCanceller Build(A2ATaskTracker tracker, TrackingPublisher publisher) =>
+        new(tracker, publisher, new A2AOptions(), TestIdentity,
+            NullLogger<A2ATaskCanceller>.Instance);
+
+    private static PendingA2ATask MakeTask(string taskId, string targetAgent, string sessionId) =>
+        new()
+        {
+            TaskId = taskId,
+            TargetAgent = targetAgent,
+            Skill = "skill",
+            PrimarySessionId = sessionId,
+            StartedAt = DateTimeOffset.UtcNow,
+            Cts = new CancellationTokenSource()
+        };
+
+    [TestMethod]
+    public async Task CancelForSessionAsync_NoMatch_ReturnsZero_AndPublishesNothing()
+    {
+        var tracker = new A2ATaskTracker();
+        var publisher = new TrackingPublisher();
+        tracker.Track(MakeTask("t1", "foragent", "wisp-other"));
+
+        var canceller = Build(tracker, publisher);
+        var count = await canceller.CancelForSessionAsync("wisp-missing", "test", CancellationToken.None);
+
+        Assert.AreEqual(0, count);
+        Assert.AreEqual(0, publisher.Published.Count);
+        Assert.AreEqual(1, tracker.ListActive().Count);
+    }
+
+    [TestMethod]
+    public async Task CancelForSessionAsync_MatchingSession_CancelsCtsRemovesAndPublishes()
+    {
+        var tracker = new A2ATaskTracker();
+        var publisher = new TrackingPublisher();
+        var task1 = MakeTask("t1", "foragent", "wisp-1");
+        var task2 = MakeTask("t2", "otheragent", "wisp-1");
+        var task3 = MakeTask("t3", "foragent", "wisp-2"); // unrelated session
+        tracker.Track(task1);
+        tracker.Track(task2);
+        tracker.Track(task3);
+
+        var canceller = Build(tracker, publisher);
+        var count = await canceller.CancelForSessionAsync("wisp-1", "test-abort", CancellationToken.None);
+
+        Assert.AreEqual(2, count);
+        Assert.IsTrue(task1.Cts.IsCancellationRequested);
+        Assert.IsTrue(task2.Cts.IsCancellationRequested);
+        Assert.IsFalse(task3.Cts.IsCancellationRequested);
+
+        // Unrelated task still tracked
+        var remaining = tracker.ListActive();
+        Assert.AreEqual(1, remaining.Count);
+        Assert.AreEqual("t3", remaining[0].TaskId);
+
+        // Cancel published on per-target topics
+        Assert.AreEqual(2, publisher.Published.Count);
+        var topics = publisher.Published.Select(p => p.Topic).OrderBy(t => t).ToList();
+        CollectionAssert.AreEquivalent(
+            new[] { "agent.task.cancel.foragent", "agent.task.cancel.otheragent" },
+            topics);
+
+        // Correlation ids equal the task ids
+        foreach (var (topic, envelope) in publisher.Published)
+        {
+            var payload = envelope.GetPayload<AgentTaskCancelRequest>();
+            Assert.IsNotNull(payload);
+            Assert.AreEqual(envelope.CorrelationId, payload.TaskId);
+        }
+    }
+
+    [TestMethod]
+    public async Task CancelForSessionAsync_EmptySessionId_ReturnsZero()
+    {
+        var tracker = new A2ATaskTracker();
+        var publisher = new TrackingPublisher();
+        tracker.Track(MakeTask("t1", "foragent", "wisp-1"));
+
+        var canceller = Build(tracker, publisher);
+        var count = await canceller.CancelForSessionAsync("", "test", CancellationToken.None);
+
+        Assert.AreEqual(0, count);
+        Assert.AreEqual(1, tracker.ListActive().Count);
+    }
+}

--- a/tests/RockBot.Wisp.Tests/WispExecutorTests.cs
+++ b/tests/RockBot.Wisp.Tests/WispExecutorTests.cs
@@ -809,6 +809,95 @@ public class WispExecutorTests
         Assert.IsTrue(wispKeys.Count > 0, "Wisp working memory should be kept on failure for debugging");
     }
 
+    // ── A2A step guardrails ──────────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task ExecuteAsync_A2AStepWithOutputTo_FailsStructurallyAndDoesNotInvokeAgent()
+    {
+        // Regression: an A2A step with output_to used to dispatch invoke_agent, fail
+        // downstream on the dispatch-stub file content, and leave the remote task
+        // running — duplicating work when the LLM retried. The validator now rejects
+        // the combo up front so no dispatch happens.
+        var (executor, registry) = CreateExecutor();
+
+        var invoked = false;
+        registry.Register(
+            new ToolRegistration { Name = "invoke_agent", Description = "A2A", Source = "a2a" },
+            new CapturingToolExecutor(_ => invoked = true, "should not be called"));
+
+        var definition = new WispDefinition
+        {
+            Description = "Illegal A2A + output_to",
+            Steps =
+            [
+                new WispStep
+                {
+                    Id = "call",
+                    Mode = StepMode.Direct,
+                    Gateway = GatewayType.A2A,
+                    Agent = "foragent",
+                    Skill = "research",
+                    Message = "find something",
+                    OutputTo = "foragent_result.json"
+                }
+            ]
+        };
+
+        var result = await executor.ExecuteAsync(definition, "wisp-a2a-output-to", CancellationToken.None);
+
+        Assert.IsFalse(result.IsSuccess);
+        Assert.IsFalse(invoked, "invoke_agent must not be called when the A2A step is invalid");
+        Assert.AreEqual(FailureCategory.Structural, result.StepResults[0].Error?.Category);
+        StringAssert.Contains(result.StepResults[0].Error?.Message ?? "", "output_to");
+    }
+
+    [TestMethod]
+    public async Task ExecuteAsync_WispAborts_CancelsInFlightA2ATasksForThisWisp()
+    {
+        var (_, registry) = CreateExecutor();
+        var canceller = new RecordingA2ACanceller();
+        var executor = CreateExecutorWithCanceller(registry, canceller);
+
+        registry.Register(
+            new ToolRegistration { Name = "invoke_agent", Description = "A2A", Source = "a2a" },
+            new FakeToolExecutor(content: "Task dispatched to agent 'foragent' with task_id: abc123."));
+        registry.Register(
+            new ToolRegistration { Name = "web_search", Description = "Search", Source = "web" },
+            new FakeToolExecutor(error: "boom"));
+
+        var definition = new WispDefinition
+        {
+            Description = "A2A dispatch then failing step",
+            Steps =
+            [
+                new WispStep
+                {
+                    Id = "dispatch",
+                    Mode = StepMode.Direct,
+                    Gateway = GatewayType.A2A,
+                    Agent = "foragent",
+                    Skill = "research",
+                    Message = "find something"
+                },
+                new WispStep
+                {
+                    Id = "boom",
+                    Mode = StepMode.Direct,
+                    Gateway = GatewayType.Web,
+                    Tool = "web_search",
+                    Params = JsonDocument.Parse("""{"query":"x"}""").RootElement
+                }
+            ]
+        };
+
+        var result = await executor.ExecuteAsync(definition, "wisp-cancel-1", CancellationToken.None);
+
+        Assert.IsFalse(result.IsSuccess);
+        Assert.AreEqual(1, canceller.Calls.Count,
+            "The wisp abort should trigger exactly one cancellation pass");
+        Assert.AreEqual("wisp-cancel-1", canceller.Calls[0].SessionId);
+    }
+
     // ── Helpers ──────────────────────────────────────────────────────────────
 
     private static (WispExecutor Executor, FakeToolRegistry Registry) CreateExecutor(
@@ -826,6 +915,17 @@ public class WispExecutorTests
         return (executor, registry);
     }
 
+    private static WispExecutor CreateExecutorWithCanceller(
+        FakeToolRegistry registry, ISessionA2ACanceller canceller)
+    {
+        var memory = new FakeWorkingMemory();
+        var options = new WispOptions();
+        var logger = NullLogger<WispExecutor>.Instance;
+        return new WispExecutor(
+            registry, memory, agentLoopRunner: null!, options, logger,
+            llmClient: null, a2aCanceller: canceller);
+    }
+
     private static string CreateTempSharedVolume()
     {
         var path = Path.Combine(Path.GetTempPath(), $"rockbot-wisp-test-{Guid.NewGuid():N}");
@@ -840,6 +940,17 @@ public class WispExecutorTests
 }
 
 // ── Test doubles ─────────────────────────────────────────────────────────────
+
+internal sealed class RecordingA2ACanceller : ISessionA2ACanceller
+{
+    public List<(string SessionId, string Reason)> Calls { get; } = [];
+
+    public Task<int> CancelForSessionAsync(string sessionId, string reason, CancellationToken ct)
+    {
+        Calls.Add((sessionId, reason));
+        return Task.FromResult(1);
+    }
+}
 
 internal sealed class FakeToolExecutor(string? content = null, string? error = null) : IToolExecutor
 {


### PR DESCRIPTION
Closes #300, closes #301.

## Summary
Fixes two coordination bugs between wisps and dispatched A2A tasks that together caused remote agents to execute the same work twice when a wisp dispatched an A2A call and then failed locally. Follow-up schema-validation work tracked in #302.

### #300 — `output_to` on an A2A step
`invoke_agent` returns synchronously with a dispatch-ack stub ("Task dispatched to agent 'x' with task_id: ..."), not the real result. `output_to` was writing that stub to the shared volume, a downstream step would read it, fail on the garbage, and the wisp would roll back — but the remote task kept running. New `A2AStepValidator` rejects the combo before routing, with a message that points the LLM at the right pattern.

### #301 — wisp failure didn't cancel in-flight A2A tasks
New `ISessionA2ACanceller` seam lives in `RockBot.Host.Abstractions` so `RockBot.Wisp` (which doesn't reference `RockBot.A2A`) can trigger cancellation. Implementation `A2ATaskCanceller`:
- Enumerates `A2ATaskTracker` by `PrimarySessionId` (wispId)
- Drops matching tasks from the tracker (late results then flow through the existing unknown-correlationId ignore path in `A2ATaskResultHandler`)
- Cancels each task's local `CancellationTokenSource`
- Publishes `AgentTaskCancelRequest` to `agent.task.cancel.{target}`

Receivers that honor cancels stop work. Stub receivers return `TaskNotCancelable` and we ignore it — dropping local state is still the right caller-side behavior. Foragent's receiver-side cancel handler is being updated separately.

## Test plan
- [x] `dotnet build RockBot.slnx -c Release`
- [x] `dotnet test RockBot.slnx -c Release` — all 1198 tests pass (added 5 new)
- [x] Unit: wisp with `output_to` on A2A step fails structurally and `invoke_agent` is never invoked
- [x] Unit: wisp abort after A2A dispatch triggers `ISessionA2ACanceller.CancelForSessionAsync(wispId, ...)`
- [x] Unit: `A2ATaskCanceller` cancels only the session's tasks, removes them from the tracker, and publishes to the correct per-target topic; empty session-id is a no-op; non-matching session is a no-op
- [ ] Cluster smoke: dispatch an A2A task from a wisp, fail the wisp, verify foragent receives the cancel and doesn't duplicate work on retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)