### PR TITLE
Research agent: wire BalancedModels fallback chain

### DIFF
--- a/deploy/k8s/research-agent-scaledjob.yaml
+++ b/deploy/k8s/research-agent-scaledjob.yaml
@@ -28,7 +28,7 @@ spec:
         restartPolicy: Never
         containers:
           - name: research-agent
-            image: rockylhotka/rockbot-research-agent:latest
+            image: rockylhotka/rockbot-research-agent:0.9.15
             imagePullPolicy: Always
             env:
               # Ephemeral working memory path — lives on the container's local filesystem

--- a/src/RockBot.ResearchAgent/Program.cs
+++ b/src/RockBot.ResearchAgent/Program.cs
@@ -33,12 +33,17 @@ if (!tierOptions.Balanced.IsConfigured)
     tierOptions.Balanced.ModelId  = llmSection["ModelId"];
 }
 
+// Seed single Balanced from BalancedModels[0] so Low/High tier fallback resolution works
+// when only the ordered fallback chain is configured.
+if (!tierOptions.Balanced.IsConfigured && tierOptions.BalancedModels.Count > 0)
+    tierOptions.Balanced = tierOptions.BalancedModels[0];
+
 // ModelBehavior: raise iteration limit — research tasks routinely need more than the default 12
 // to search, browse, cache, and then synthesise without hitting the wall mid-loop.
 // Pre-registered before AddRockBotTieredChatClients so the TryAdd in that method respects this override.
 builder.Services.AddSingleton(new ModelBehavior { MaxToolIterationsOverride = 50 });
 
-if (tierOptions.Balanced.IsConfigured)
+if (tierOptions.Balanced.IsConfigured || tierOptions.BalancedModels.Count > 0)
 {
     IChatClient BuildClient(LlmTierConfig config)
     {
@@ -48,10 +53,33 @@ if (tierOptions.Balanced.IsConfigured)
             .GetChatClient(config.ModelId!).AsIChatClient();
     }
 
+    // Build the balanced inner client: use FallbackChatClient when BalancedModels lists
+    // multiple models (e.g. Azure Foundry primary, OpenRouter fallback).
+    IChatClient balancedClient;
+    if (tierOptions.BalancedModels.Count > 1)
+    {
+        var fallbackLoggerFactory = LoggerFactory.Create(b =>
+            b.AddConsole().SetMinimumLevel(LogLevel.Warning));
+        var fallbackLogger = fallbackLoggerFactory.CreateLogger<FallbackChatClient>();
+
+        var entries = new List<(string ModelId, IChatClient Client)>();
+        foreach (var cfg in tierOptions.BalancedModels)
+            entries.Add((cfg.ModelId!, BuildClient(cfg)));
+
+        balancedClient = new FallbackChatClient(entries, fallbackLogger);
+    }
+    else if (tierOptions.BalancedModels.Count == 1)
+    {
+        balancedClient = BuildClient(tierOptions.BalancedModels[0]);
+    }
+    else
+    {
+        balancedClient = BuildClient(tierOptions.Balanced);
+    }
+
     // ResearchAgent only uses Balanced (fallback synthesis) and High (main research loop).
     // Low is not needed — pass Balanced for the Low slot so it is never exercised.
-    var balancedClient = BuildClient(tierOptions.Balanced);
-    var highClient     = BuildClient(tierOptions.Resolve(ModelTier.High));
+    var highClient = BuildClient(tierOptions.Resolve(ModelTier.High));
 
     builder.Services.AddRockBotTieredChatClients(
         lowInnerClient:      balancedClient,


### PR DESCRIPTION
## Summary

- `src/RockBot.ResearchAgent/Program.cs` now builds a `FallbackChatClient` over `LLM__BalancedModels__*` when two or more entries are configured, mirroring the pattern already in use by `RockBot.Agent`.
- Seeds the single `Balanced` tier from `BalancedModels[0]` when only the ordered chain is configured, so Low/High tier fallback resolution still works.
- Pins the research-agent image in `deploy/k8s/research-agent-scaledjob.yaml` to `0.9.15` (was `:latest`).

## Why

On High-tier failure, `LlmClient.cs:37` already drops to Balanced. Before this change, the research agent's Balanced slot was a single client (no chain), so a failure just hit one provider. The chain now gives the research agent Azure-foundry-first with OpenRouter fallback, matching the main agent.

## Test plan

- [x] `dotnet build src/RockBot.ResearchAgent/RockBot.ResearchAgent.csproj` — succeeds with 0 warnings.
- [x] `dotnet test tests/RockBot.Llm.Tests` — 121/121 pass.
- [x] Image `rockylhotka/rockbot-research-agent:0.9.15` built and pushed.
- [x] Live cluster ScaledJob patched to `:0.9.15` and verified.
- [ ] Next research A2A task launches a pod on the new image and logs the fallback chain on startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)