### PR TITLE
mcp_invoke_tool: accept params/args aliases for nested payload

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-    <Version>0.9.15</Version>
+    <Version>0.9.16</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.Tools.Mcp/McpManagementExecutor.cs
+++ b/src/RockBot.Tools.Mcp/McpManagementExecutor.cs
@@ -135,7 +135,7 @@ public sealed class McpManagementExecutor : IToolExecutor, IAsyncDisposable
 
         // Serialize the nested arguments object if present
         string? toolArgs = null;
-        if (args.TryGetValue("arguments", out var argsObj) && argsObj is not null)
+        if (TryGetNestedArgs(args, out var argsObj))
         {
             toolArgs = argsObj is JsonElement je ? je.GetRawText() : JsonSerializer.Serialize(argsObj, JsonOptions);
         }
@@ -238,7 +238,7 @@ public sealed class McpManagementExecutor : IToolExecutor, IAsyncDisposable
             return Error(request, "Missing required parameter: prompt_name");
 
         var promptArgs = new Dictionary<string, string>();
-        if (args.TryGetValue("arguments", out var argsObj) && argsObj is not null)
+        if (TryGetNestedArgs(args, out var argsObj))
         {
             var argsJson = argsObj is JsonElement je ? je.GetRawText() : JsonSerializer.Serialize(argsObj, JsonOptions);
             try
@@ -397,6 +397,25 @@ public sealed class McpManagementExecutor : IToolExecutor, IAsyncDisposable
             return false;
         serverName = serverName.ToLowerInvariant();
         return true;
+    }
+
+    // Some models (notably gpt-5.4) emit the nested tool arguments under "params" or "args"
+    // instead of the schema-declared "arguments". Accept all three so the payload isn't
+    // silently dropped when the model deviates from the declared field name.
+    private static readonly string[] NestedArgAliases = ["arguments", "params", "args"];
+
+    private static bool TryGetNestedArgs(Dictionary<string, object?> args, out object argsObj)
+    {
+        foreach (var alias in NestedArgAliases)
+        {
+            if (args.TryGetValue(alias, out var v) && v is not null)
+            {
+                argsObj = v;
+                return true;
+            }
+        }
+        argsObj = null!;
+        return false;
     }
 
     private static ToolInvokeResponse Error(ToolInvokeRequest request, string message) => new()

--- a/tests/RockBot.Tools.Tests/McpManagementExecutorTests.cs
+++ b/tests/RockBot.Tools.Tests/McpManagementExecutorTests.cs
@@ -216,6 +216,44 @@ public class McpManagementExecutorTests
     }
 
     [TestMethod]
+    [DataRow("arguments")]
+    [DataRow("params")]
+    [DataRow("args")]
+    public async Task InvokeTool_AcceptsNestedArgAliases(string nestedKey)
+    {
+        // Some models (notably gpt-5.4) emit the nested payload under "params" or "args"
+        // instead of the schema-declared "arguments". All three should be forwarded.
+        var (executor, publisher, subscriber) = CreateExecutor();
+
+        var request = new ToolInvokeRequest
+        {
+            ToolCallId = "call-alias",
+            ToolName = "mcp_invoke_tool",
+            Arguments = "{\"server_name\":\"filesystem\",\"tool_name\":\"read_file\",\"" + nestedKey + "\":{\"path\":\"/tmp/x.txt\"}}"
+        };
+
+        var executeTask = executor.ExecuteAsync(request, CancellationToken.None);
+        await Task.Delay(100);
+
+        Assert.AreEqual(1, publisher.Published.Count);
+        var innerRequest = publisher.Published[0].Envelope.GetPayload<ToolInvokeRequest>();
+        Assert.IsNotNull(innerRequest);
+        Assert.IsNotNull(innerRequest.Arguments, $"nested payload under '{nestedKey}' was dropped");
+        StringAssert.Contains(innerRequest.Arguments, "/tmp/x.txt");
+
+        var response = new ToolInvokeResponse
+        {
+            ToolCallId = "call-alias",
+            ToolName = "read_file",
+            Content = "ok"
+        };
+        var responseEnvelope = response.ToEnvelope("bridge",
+            correlationId: publisher.Published[0].Envelope.CorrelationId);
+        await subscriber.DeliverAsync($"tool.result.{_identity.Name}", responseEnvelope);
+        await executeTask;
+    }
+
+    [TestMethod]
     public async Task InvokeTool_MissingServerName_ReturnsError()
     {
         var (executor, _, _) = CreateExecutor();


### PR DESCRIPTION
## Summary

- `McpManagementExecutor.InvokeToolAsync` and `GetPromptAsync` now accept the nested payload under `arguments`, `params`, or `args`. The first non-null one wins.
- Bumps version to `0.9.16`.

## Why

After switching the Balanced tier to `gpt-5.4` (Azure Foundry), MCP calls that need nested arguments started failing universally — the MCP server would reject them with "Required parameter 'X' was not provided", because `gpt-5.4` emits the nested payload under `params` rather than the schema-declared `arguments`. The executor only read `args["arguments"]`, so the entire nested object was silently dropped. Wisp calls kept working because wisp bypasses `mcp_invoke_tool` and invokes the MCP client directly.

This is the same class of model-drift hardening as `LlmClient.InvokeWithNullArgRetryAsync` — cheap defensive alias handling that keeps the call path alive across provider quirks.

## Test plan

- [x] New parameterized test `InvokeTool_AcceptsNestedArgAliases` covers all three alias names.
- [x] Full test suite passes (1250+ tests, 0 failures).
- [x] Agent image `rockylhotka/rockbot-agent:0.9.16` built, pushed, deployed to live cluster (helm rev 120), and pod is Running.
- [ ] Observe next MCP tool call that previously failed now succeeds in agent logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)