### PR TITLE
Per-model accommodations for GPT leaks + tool-failure retry (v0.9.17)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-    <Version>0.9.16</Version>
+    <Version>0.9.17</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/docs/agent-host.md
+++ b/docs/agent-host.md
@@ -355,6 +355,8 @@ Additional properties are configurable in `appsettings.json` under `ModelBehavio
 | Property | Type | Default | Purpose |
 |---|---|---|---|
 | `NudgeOnHallucinatedToolCalls` | bool | false | Inject a nudge when the model describes tool actions without emitting calls |
+| `NudgeOnLeakedToolSyntax` | bool | false | Retry when the model leaks tool-calling scaffolding (`to=multi_tool_use.parallel`, `to=functions.X`) into its text output. Language-agnostic; targets a documented OpenAI GPT-family failure mode. Safe to enable for any deployment |
+| `NudgeOnUnexpectedCjkOutput` | bool | false | Retry when the model emits 3+ consecutive CJK codepoints — a heuristic for English-primary deployments where CJK output correlates with training-data contamination. **Leave off for agents that legitimately respond in Chinese or Japanese** |
 | `MaxToolIterationsOverride` | int? | null (uses `AgentHost:MaxToolIterations`) | Override the per-request tool-loop iteration cap |
 | `ToolResultChunkingThreshold` | int? | null (uses 64 000) | Char count above which tool results are chunked into working memory instead of appended inline |
 | `ScheduledTaskResultMode` | enum | `Summarize` | How scheduled task output is presented (`Summarize`, `VerbatimOutput`, `SummarizeWithOutput`) |

--- a/docs/agent-host.md
+++ b/docs/agent-host.md
@@ -357,6 +357,7 @@ Additional properties are configurable in `appsettings.json` under `ModelBehavio
 | `NudgeOnHallucinatedToolCalls` | bool | false | Inject a nudge when the model describes tool actions without emitting calls |
 | `NudgeOnLeakedToolSyntax` | bool | false | Retry when the model leaks tool-calling scaffolding (`to=multi_tool_use.parallel`, `to=functions.X`) into its text output. Language-agnostic; targets a documented OpenAI GPT-family failure mode. Safe to enable for any deployment |
 | `NudgeOnUnexpectedCjkOutput` | bool | false | Retry when the model emits 3+ consecutive CJK codepoints — a heuristic for English-primary deployments where CJK output correlates with training-data contamination. **Leave off for agents that legitimately respond in Chinese or Japanese** |
+| `NudgeOnToolFailureGiveup` | bool? | true | Retry once when the model gives up after a tool returned an error (matches phrasings like "tool failure", "errored on both", "from the current tool state") instead of retrying the tool itself. General-purpose; on by default. Set to `false` to opt out for a specific model |
 | `MaxToolIterationsOverride` | int? | null (uses `AgentHost:MaxToolIterations`) | Override the per-request tool-loop iteration cap |
 | `ToolResultChunkingThreshold` | int? | null (uses 64 000) | Char count above which tool results are chunked into working memory instead of appended inline |
 | `ScheduledTaskResultMode` | enum | `Summarize` | How scheduled task output is presented (`Summarize`, `VerbatimOutput`, `SummarizeWithOutput`) |

--- a/src/RockBot.Agent/appsettings.json
+++ b/src/RockBot.Agent/appsettings.json
@@ -15,6 +15,10 @@
       },
       "claude": {
         "MaxToolIterationsOverride": 25
+      },
+      "gpt": {
+        "NudgeOnLeakedToolSyntax": true,
+        "NudgeOnUnexpectedCjkOutput": true
       }
     }
   }

--- a/src/RockBot.Host/AgentLoopRunner.cs
+++ b/src/RockBot.Host/AgentLoopRunner.cs
@@ -76,6 +76,39 @@ public sealed partial class AgentLoopRunner(
         "mcp_list_services or search_known_services, then use mcp_invoke_tool to call them.";
 
     /// <summary>
+    /// Detects internal tool-call scaffolding that has leaked into the model's text output
+    /// (e.g. <c>to=multi_tool_use.parallel</c>, <c>to=functions.X</c>). A specific,
+    /// language-agnostic signature of a known OpenAI GPT-family failure mode. Gated by
+    /// <see cref="ModelBehavior.NudgeOnLeakedToolSyntax"/>.
+    /// </summary>
+    public static readonly Regex LeakedToolSyntaxRegex = new(
+        @"\bto\s*=\s*multi_tool_use\.parallel\b" +
+        @"|\bto\s*=\s*functions\.[A-Za-z_]\w*",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    public const string LeakedToolSyntaxNudge =
+        "Your previous response contained leaked tool-call scaffolding (e.g. " +
+        "'to=multi_tool_use.parallel' or 'to=functions.*') as literal text. " +
+        "Discard that response and answer again using valid tool calls and normal prose only. " +
+        "Never emit those internal formatting tokens as output.";
+
+    /// <summary>
+    /// Detects runs of 3+ consecutive CJK codepoints — a heuristic signal that an
+    /// English-primary agent has drifted off-distribution (e.g. into gambling-SEO
+    /// training-data contamination). Covers CJK Unified Ideographs and Extension A.
+    /// Does not cover hiragana / katakana. Gated by
+    /// <see cref="ModelBehavior.NudgeOnUnexpectedCjkOutput"/> — only enable for
+    /// deployments that never legitimately respond in Chinese or Japanese.
+    /// </summary>
+    public static readonly Regex UnexpectedCjkRegex = new(
+        @"[㐀-䶿一-鿿]{3,}",
+        RegexOptions.Compiled);
+
+    public const string UnexpectedCjkNudge =
+        "Your previous response contained unexpected Chinese or Japanese text that was " +
+        "not requested. Discard that response and answer the user again in English only.";
+
+    /// <summary>
     /// Context window limit in tokens, learned from the first overflow error (text-based path only).
     /// </summary>
     private int? _knownContextLimit;
@@ -275,6 +308,49 @@ public sealed partial class AgentLoopRunner(
                 HostDiagnostics.CompletionCheckSkipped.Add(1);
                 logger.LogInformation("Completion evaluator: SKIPPED (consecutive timeouts)");
                 return result.Response;
+            }
+
+            // Model-specific sanity checks on the output. Each is independently gated by
+            // a flag in ModelBehavior so operators can enable only what applies to their
+            // deployment (e.g. CJK detection is wrong for a Chinese- or Japanese-language
+            // agent). If any enabled check matches, force a retry using the existing
+            // reprompt budget.
+            var toolSyntaxLeak = modelBehavior.NudgeOnLeakedToolSyntax
+                && LeakedToolSyntaxRegex.IsMatch(result.Response);
+            var cjkLeak = modelBehavior.NudgeOnUnexpectedCjkOutput
+                && UnexpectedCjkRegex.IsMatch(result.Response);
+
+            if (toolSyntaxLeak || cjkLeak)
+            {
+                var diagnostic = (toolSyntaxLeak, cjkLeak) switch
+                {
+                    (true, true) => "leaked tool-call scaffolding AND unexpected CJK output",
+                    (true, false) => "leaked tool-call scaffolding",
+                    (false, true) => "unexpected CJK output",
+                    _ => "broken output",
+                };
+
+                if (reprompt < maxReprompts)
+                {
+                    logger.LogWarning(
+                        "Output quality check failed ({Diagnostic}) in response ({Length} chars); " +
+                        "forcing retry (reprompt {Reprompt}/{Max})",
+                        diagnostic, result.Response.Length, reprompt, maxReprompts);
+
+                    chatMessages.Add(new ChatMessage(ChatRole.Assistant, result.Response));
+                    var qualityNudge = toolSyntaxLeak && cjkLeak
+                        ? LeakedToolSyntaxNudge + " " + UnexpectedCjkNudge
+                        : toolSyntaxLeak
+                            ? LeakedToolSyntaxNudge
+                            : UnexpectedCjkNudge;
+                    chatMessages.Add(new ChatMessage(ChatRole.User, qualityNudge));
+                    continue;
+                }
+
+                logger.LogError(
+                    "Output quality check failed ({Diagnostic}) in final response ({Length} chars); " +
+                    "no reprompt budget remaining — returning as-is",
+                    diagnostic, result.Response.Length);
             }
 
             // Skip evaluation when disabled or on the final re-prompt.

--- a/src/RockBot.Host/AgentLoopRunner.cs
+++ b/src/RockBot.Host/AgentLoopRunner.cs
@@ -109,6 +109,28 @@ public sealed partial class AgentLoopRunner(
         "not requested. Discard that response and answer the user again in English only.";
 
     /// <summary>
+    /// Detects responses where the model gives up after a tool returned an error instead of
+    /// retrying. Matches phrasings that specifically invoke tool failure ("tool failure",
+    /// "errored on both", "from the current tool state", <c>tool_name errored</c>, etc.),
+    /// not generic business-logic failures. Gated by
+    /// <see cref="ModelBehavior.NudgeOnToolFailureGiveup"/>.
+    /// </summary>
+    public static readonly Regex ToolFailureGiveupRegex = new(
+        @"\btool\s+(?:failure|error|call\s+failed|call\s+errored)\b" +
+        @"|\bfrom\s+(?:the\s+)?current\s+tool\s+state\b" +
+        @"|\b[a-z][a-z0-9]*_[a-z0-9_]+\s+(?:errored|failed|returned\s+an?\s+error)\b" +
+        @"|\berrored\s+on\s+(?:both|all|every|the)\b" +
+        @"|\b(?:tool|call)\s+returned\s+an?\s+error\b" +
+        @"|\bfailed\s+to\s+(?:invoke|call|execute)\s+(?:the\s+)?(?:tool|[a-z][a-z0-9]*_[a-z0-9_]+)\b",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    public const string ToolFailureRetryNudge =
+        "A tool call returned an error, but you reported failure to the user without retrying. " +
+        "Transient tool errors are common — call the same tool again once before giving up. " +
+        "If it fails again with the same error, try a different approach or different arguments. " +
+        "Only report failure to the user after a retry has also failed.";
+
+    /// <summary>
     /// Context window limit in tokens, learned from the first overflow error (text-based path only).
     /// </summary>
     private int? _knownContextLimit;
@@ -289,6 +311,7 @@ public sealed partial class AgentLoopRunner(
         var originalUserRequest = ExtractOriginalUserRequest(chatMessages);
         var maxReprompts = modelBehavior.MaxCompletionRepromptsOverride
             ?? hostOptions.Value.MaxCompletionReprompts;
+        var alreadyNudgedToolFailure = false;
 
         for (var reprompt = 0; reprompt <= maxReprompts; reprompt++)
         {
@@ -351,6 +374,29 @@ public sealed partial class AgentLoopRunner(
                     "Output quality check failed ({Diagnostic}) in final response ({Length} chars); " +
                     "no reprompt budget remaining — returning as-is",
                     diagnostic, result.Response.Length);
+            }
+
+            // Model-gave-up-on-tool-failure check. Fires when the final response strongly
+            // suggests the model saw a tool error and reported failure to the user without
+            // retrying. One nudge (per reprompt slot) asks it to try once more. The
+            // RepetitiveToolCallDetector caps runaway repeated-failure loops at 3 identical
+            // calls; the reprompt budget caps total turns. Only fires once per RunAsync
+            // invocation so we don't loop on the same nudge.
+            if (modelBehavior.NudgeOnToolFailureGiveup
+                && !alreadyNudgedToolFailure
+                && result.ExitReason == LoopExitReason.ModelStopped
+                && ToolFailureGiveupRegex.IsMatch(result.Response)
+                && reprompt < maxReprompts)
+            {
+                logger.LogWarning(
+                    "Tool-failure giveup detected in response ({Length} chars); " +
+                    "nudging model to retry the tool (reprompt {Reprompt}/{Max})",
+                    result.Response.Length, reprompt, maxReprompts);
+
+                chatMessages.Add(new ChatMessage(ChatRole.Assistant, result.Response));
+                chatMessages.Add(new ChatMessage(ChatRole.User, ToolFailureRetryNudge));
+                alreadyNudgedToolFailure = true;
+                continue;
             }
 
             // Skip evaluation when disabled or on the final re-prompt.

--- a/src/RockBot.Llm.Abstractions/ModelBehavior.cs
+++ b/src/RockBot.Llm.Abstractions/ModelBehavior.cs
@@ -87,4 +87,23 @@ public sealed class ModelBehavior
     /// Null means use the host's built-in default (<see cref="Host.AgentHostOptions.MaxFollowUpPasses"/>).
     /// </summary>
     public int? MaxFollowUpPassesOverride { get; init; }
+
+    /// <summary>
+    /// When true, detect leaked internal tool-call scaffolding in the model's text output
+    /// (e.g. <c>to=multi_tool_use.parallel</c> or <c>to=functions.X</c>) and force a retry
+    /// (consuming one completion-reprompt slot) instead of returning the malformed response.
+    /// Targets a specific, documented failure mode of OpenAI GPT-family models where the
+    /// model emits training-time scaffolding as literal text. Language-agnostic and safe
+    /// to enable for any deployment; legitimate responses never contain these tokens.
+    /// </summary>
+    public bool NudgeOnLeakedToolSyntax { get; init; }
+
+    /// <summary>
+    /// When true, detect runs of 3+ consecutive CJK codepoints in the model's output and
+    /// force a retry. Intended for English-primary deployments where CJK output correlates
+    /// with the model producing gambling-SEO spam or other training-data contamination.
+    /// This is a heuristic — DO NOT enable for agents that legitimately process or respond
+    /// in Chinese or Japanese, or it will force unnecessary retries on valid responses.
+    /// </summary>
+    public bool NudgeOnUnexpectedCjkOutput { get; init; }
 }

--- a/src/RockBot.Llm.Abstractions/ModelBehavior.cs
+++ b/src/RockBot.Llm.Abstractions/ModelBehavior.cs
@@ -17,7 +17,11 @@ public sealed class ModelBehavior
     public int ToolResultChunkingThreshold { get; init; } = 64_000;
 
     /// <summary>Behavior profile that applies no tweaks — used when no overrides are configured.</summary>
-    public static readonly ModelBehavior Default = new() { NudgeOnHallucinatedToolCalls = true };
+    public static readonly ModelBehavior Default = new()
+    {
+        NudgeOnHallucinatedToolCalls = true,
+        NudgeOnToolFailureGiveup = true,
+    };
 
     /// <summary>
     /// When true, detect responses where the model claims to have called tools (e.g. "I've
@@ -106,4 +110,14 @@ public sealed class ModelBehavior
     /// in Chinese or Japanese, or it will force unnecessary retries on valid responses.
     /// </summary>
     public bool NudgeOnUnexpectedCjkOutput { get; init; }
+
+    /// <summary>
+    /// When true, detect responses where the model gives up after a tool returned an
+    /// error ("I hit a tool failure", "errored on both", "from the current tool state",
+    /// etc.) and inject a nudge telling it to retry the tool once before reporting failure.
+    /// The <see cref="Host.AgentLoopRunner.RepetitiveToolCallDetector"/> and the existing
+    /// reprompt budget bound total retries, so persistent failures still surface to the user.
+    /// Enabled by default — general-purpose and model-agnostic.
+    /// </summary>
+    public bool NudgeOnToolFailureGiveup { get; init; }
 }

--- a/src/RockBot.Llm/DefaultModelBehaviorProvider.cs
+++ b/src/RockBot.Llm/DefaultModelBehaviorProvider.cs
@@ -65,6 +65,9 @@ internal sealed class DefaultModelBehaviorProvider(
 
             UseTextBasedToolCalling = entry?.UseTextBasedToolCalling ?? false,
 
+            NudgeOnLeakedToolSyntax = entry?.NudgeOnLeakedToolSyntax ?? false,
+            NudgeOnUnexpectedCjkOutput = entry?.NudgeOnUnexpectedCjkOutput ?? false,
+
             // String properties: file takes priority over config value
             AdditionalSystemPrompt = additionalPrompt ?? entry?.AdditionalSystemPrompt,
             PreToolLoopPrompt = preToolPrompt ?? entry?.PreToolLoopPrompt,

--- a/src/RockBot.Llm/DefaultModelBehaviorProvider.cs
+++ b/src/RockBot.Llm/DefaultModelBehaviorProvider.cs
@@ -67,6 +67,7 @@ internal sealed class DefaultModelBehaviorProvider(
 
             NudgeOnLeakedToolSyntax = entry?.NudgeOnLeakedToolSyntax ?? false,
             NudgeOnUnexpectedCjkOutput = entry?.NudgeOnUnexpectedCjkOutput ?? false,
+            NudgeOnToolFailureGiveup = entry?.NudgeOnToolFailureGiveup ?? true,
 
             // String properties: file takes priority over config value
             AdditionalSystemPrompt = additionalPrompt ?? entry?.AdditionalSystemPrompt,

--- a/src/RockBot.Llm/ModelBehaviorOptions.cs
+++ b/src/RockBot.Llm/ModelBehaviorOptions.cs
@@ -56,4 +56,8 @@ public sealed class ModelBehaviorEntry
 
     /// <inheritdoc cref="ModelBehavior.NudgeOnUnexpectedCjkOutput"/>
     public bool NudgeOnUnexpectedCjkOutput { get; set; }
+
+    /// <inheritdoc cref="ModelBehavior.NudgeOnToolFailureGiveup"/>
+    /// <remarks>Defaults to true when this entry is absent; nullable so individual entries can opt out.</remarks>
+    public bool? NudgeOnToolFailureGiveup { get; set; }
 }

--- a/src/RockBot.Llm/ModelBehaviorOptions.cs
+++ b/src/RockBot.Llm/ModelBehaviorOptions.cs
@@ -50,4 +50,10 @@ public sealed class ModelBehaviorEntry
 
     /// <inheritdoc cref="ModelBehavior.UseTextBasedToolCalling"/>
     public bool UseTextBasedToolCalling { get; set; }
+
+    /// <inheritdoc cref="ModelBehavior.NudgeOnLeakedToolSyntax"/>
+    public bool NudgeOnLeakedToolSyntax { get; set; }
+
+    /// <inheritdoc cref="ModelBehavior.NudgeOnUnexpectedCjkOutput"/>
+    public bool NudgeOnUnexpectedCjkOutput { get; set; }
 }

--- a/tests/RockBot.Host.Tests/LeakedToolSyntaxRegexTests.cs
+++ b/tests/RockBot.Host.Tests/LeakedToolSyntaxRegexTests.cs
@@ -100,4 +100,71 @@ public class LeakedToolSyntaxRegexTests
         Assert.IsFalse(AgentLoopRunner.UnexpectedCjkRegex.IsMatch(
             "Here is a summary:\n- Item 1\n- Item 2\n\n## Next steps\nI will do X."));
     }
+
+    // ── ToolFailureGiveupRegex — model gave up after a tool error ────────────
+
+    [TestMethod]
+    public void ToolFailureGiveup_Matches_HitToolFailure()
+    {
+        Assert.IsTrue(AgentLoopRunner.ToolFailureGiveupRegex.IsMatch(
+            "I hit a tool failure completing the todo: complete_task errored on both todo backends."));
+    }
+
+    [TestMethod]
+    public void ToolFailureGiveup_Matches_FromCurrentToolState()
+    {
+        Assert.IsTrue(AgentLoopRunner.ToolFailureGiveupRegex.IsMatch(
+            "I've verified the task details, but I could not mark it complete from the current tool state."));
+    }
+
+    [TestMethod]
+    public void ToolFailureGiveup_Matches_SnakeCaseToolNameErrored()
+    {
+        Assert.IsTrue(AgentLoopRunner.ToolFailureGiveupRegex.IsMatch(
+            "complete_task errored and delete_task also errored on the cluster."));
+    }
+
+    [TestMethod]
+    public void ToolFailureGiveup_Matches_ErroredOnBoth()
+    {
+        Assert.IsTrue(AgentLoopRunner.ToolFailureGiveupRegex.IsMatch(
+            "The call errored on both backends so I stopped."));
+    }
+
+    [TestMethod]
+    public void ToolFailureGiveup_Matches_FailedToInvokeToolName()
+    {
+        Assert.IsTrue(AgentLoopRunner.ToolFailureGiveupRegex.IsMatch(
+            "I failed to invoke mcp_invoke_tool and could not proceed."));
+    }
+
+    [TestMethod]
+    public void ToolFailureGiveup_DoesNotMatch_NormalSuccess()
+    {
+        Assert.IsFalse(AgentLoopRunner.ToolFailureGiveupRegex.IsMatch(
+            "I completed the task and the record was updated successfully."));
+    }
+
+    [TestMethod]
+    public void ToolFailureGiveup_DoesNotMatch_EmptySearchResult()
+    {
+        Assert.IsFalse(AgentLoopRunner.ToolFailureGiveupRegex.IsMatch(
+            "The search returned no results, so I could not find a matching entry."));
+    }
+
+    [TestMethod]
+    public void ToolFailureGiveup_DoesNotMatch_BusinessLogicFailure()
+    {
+        // A business-level failure that doesn't mention tools shouldn't trip this.
+        Assert.IsFalse(AgentLoopRunner.ToolFailureGiveupRegex.IsMatch(
+            "Your cancellation request failed because the event has already started."));
+    }
+
+    [TestMethod]
+    public void ToolFailureGiveup_DoesNotMatch_ProseAboutErrors()
+    {
+        // Describing an error value from a log or output as part of normal analysis.
+        Assert.IsFalse(AgentLoopRunner.ToolFailureGiveupRegex.IsMatch(
+            "The log line mentioned an error code 503, which usually indicates rate limiting."));
+    }
 }

--- a/tests/RockBot.Host.Tests/LeakedToolSyntaxRegexTests.cs
+++ b/tests/RockBot.Host.Tests/LeakedToolSyntaxRegexTests.cs
@@ -1,0 +1,103 @@
+namespace RockBot.Host.Tests;
+
+[TestClass]
+public class LeakedToolSyntaxRegexTests
+{
+    // ── LeakedToolSyntaxRegex — specific OpenAI scaffolding leaks ─────────────
+
+    [TestMethod]
+    public void LeakedToolSyntax_Matches_MultiToolUseParallel()
+    {
+        Assert.IsTrue(AgentLoopRunner.LeakedToolSyntaxRegex.IsMatch(
+            "sure, let me help\nto=multi_tool_use.parallel\n{\"tool_uses\":[]}"));
+    }
+
+    [TestMethod]
+    public void LeakedToolSyntax_Matches_MultiToolUseParallel_WithExtraSpaces()
+    {
+        Assert.IsTrue(AgentLoopRunner.LeakedToolSyntaxRegex.IsMatch(
+            "▶\nSubagent\nto = multi_tool_use.parallel extra text"));
+    }
+
+    [TestMethod]
+    public void LeakedToolSyntax_Matches_FunctionsScaffoldingLeak()
+    {
+        Assert.IsTrue(AgentLoopRunner.LeakedToolSyntaxRegex.IsMatch(
+            "calling to=functions.spawn_subagent with args"));
+    }
+
+    [TestMethod]
+    public void LeakedToolSyntax_DoesNotMatch_PlainEnglish()
+    {
+        Assert.IsFalse(AgentLoopRunner.LeakedToolSyntaxRegex.IsMatch(
+            "I scheduled the meeting for 3pm tomorrow. Let me know if you need anything else."));
+    }
+
+    [TestMethod]
+    public void LeakedToolSyntax_DoesNotMatch_ProseWithToAndFunctions()
+    {
+        // Regular tool-result prose that mentions "to" and "functions" separately.
+        Assert.IsFalse(AgentLoopRunner.LeakedToolSyntaxRegex.IsMatch(
+            "The function returned a value. I will forward it to the next step."));
+    }
+
+    [TestMethod]
+    public void LeakedToolSyntax_DoesNotMatch_ChineseText()
+    {
+        // Tool-syntax regex is language-agnostic — Chinese alone should not trip it.
+        // (That case is covered by the separate UnexpectedCjkRegex.)
+        Assert.IsFalse(AgentLoopRunner.LeakedToolSyntaxRegex.IsMatch("北京赛车计划 大发游戏"));
+    }
+
+    // ── UnexpectedCjkRegex — heuristic for English-only deployments ──────────
+
+    [TestMethod]
+    public void UnexpectedCjk_Matches_GamblingSpam()
+    {
+        // The exact pattern observed in the wild: CJK gambling-SEO content.
+        Assert.IsTrue(AgentLoopRunner.UnexpectedCjkRegex.IsMatch("北京赛车计划 大发游戏 盈立_json"));
+    }
+
+    [TestMethod]
+    public void UnexpectedCjk_Matches_ThreeOrMoreConsecutiveCjk()
+    {
+        Assert.IsTrue(AgentLoopRunner.UnexpectedCjkRegex.IsMatch("some text 中文内容 more"));
+    }
+
+    [TestMethod]
+    public void UnexpectedCjk_DoesNotMatch_SingleCjkCharacter()
+    {
+        // A lone kanji (e.g. from a name like "zashiki (座)") should not trip.
+        Assert.IsFalse(AgentLoopRunner.UnexpectedCjkRegex.IsMatch("the character 座 means 'seat'"));
+    }
+
+    [TestMethod]
+    public void UnexpectedCjk_DoesNotMatch_TwoConsecutiveCjkCharacters()
+    {
+        // Two in a row — e.g. 座敷 (zashiki) in the identity prompt — should not trip.
+        Assert.IsFalse(AgentLoopRunner.UnexpectedCjkRegex.IsMatch(
+            "in the tradition of the Japanese 座敷 household spirit"));
+    }
+
+    [TestMethod]
+    public void UnexpectedCjk_DoesNotMatch_HiraganaAlone()
+    {
+        // Hiragana is outside the regex range by design — a long わらし string should not trip.
+        Assert.IsFalse(AgentLoopRunner.UnexpectedCjkRegex.IsMatch("the word わらし means 'child'"));
+    }
+
+    [TestMethod]
+    public void UnexpectedCjk_DoesNotMatch_ToolSyntaxAlone()
+    {
+        // CJK regex is CJK-only — tool-syntax leak alone should not trip this one.
+        // (That case is covered by the separate LeakedToolSyntaxRegex.)
+        Assert.IsFalse(AgentLoopRunner.UnexpectedCjkRegex.IsMatch("to=multi_tool_use.parallel"));
+    }
+
+    [TestMethod]
+    public void UnexpectedCjk_DoesNotMatch_PlainEnglishMarkdown()
+    {
+        Assert.IsFalse(AgentLoopRunner.UnexpectedCjkRegex.IsMatch(
+            "Here is a summary:\n- Item 1\n- Item 2\n\n## Next steps\nI will do X."));
+    }
+}


### PR DESCRIPTION
## Summary

Three new per-model accommodations in the existing `ModelBehavior` system, plus a version bump.

- **`NudgeOnLeakedToolSyntax`** — detects OpenAI internal scaffolding that leaks into text output (`to=multi_tool_use.parallel`, `to=functions.X`) and forces a retry. Language-agnostic; enabled on the `"gpt"` prefix in `appsettings.json`. Observed in a real subagent run on `gpt-5.4`.
- **`NudgeOnUnexpectedCjkOutput`** — heuristic for English-primary deployments: 3+ consecutive CJK codepoints (e.g. Chinese gambling-SEO spam) trigger a retry. Hiragana/katakana excluded, 2-CJK runs don't trip (so `座敷` in soul.md is safe). Enabled alongside the syntax-leak flag for `"gpt"`. Documented as **do not enable for CN/JP agents**.
- **`NudgeOnToolFailureGiveup`** — new failure mode spotted while investigating: the model sees a tool error and reports failure to the user without retrying. Regex keys on tool-specific phrasings ("tool failure", "from the current tool state", `snake_case_tool errored`, "errored on both", "failed to invoke X"). General-purpose; **default true**. Fires at most once per `RunAsync` (local flag) so it doesn't ping-pong.

All three hook into `AgentLoopRunner.RunAsync` alongside the existing hallucination/denial nudges and use the existing `MaxCompletionReprompts` budget. `RepetitiveToolCallDetector` still caps runaway loops.

## Commits

- `6896109` — GPT tool-syntax / CJK leak detection
- `1157c77` — Retry once when the model gives up after a tool error
- `915dc41` — Bump version to 0.9.17

## Test plan

- [x] 22 new regex tests (13 for leak detection, 9 for tool-failure giveup) — positive + negative cases including the exact observed subagent output and the exact observed tool-failure response
- [x] Full test suite: 511 Host tests + all others pass
- [x] `docs/agent-host.md` per-model behaviors table updated with all three flags and their safety guidance
- [x] Deployed `rockylhotka/rockbot-agent:0.9.17` to cluster; pod logs confirm `ModelBehavior resolution for model 'gpt-5.4': configEntry=matched` — new flags active
- [ ] Watch for `logger.LogWarning("Output quality check failed …")` and `"Tool-failure giveup detected …"` entries in live traffic to confirm detection firing