### PR TITLE
Retry preempted scheduled tasks + fix time rendering in list_scheduled_tasks (v0.10.4)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-    <Version>0.10.3</Version>
+    <Version>0.10.4</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.Agent/ScheduledTaskHandler.cs
+++ b/src/RockBot.Agent/ScheduledTaskHandler.cs
@@ -26,7 +26,6 @@ internal sealed class ScheduledTaskHandler(
     ISkillStore skillStore,
     ToolGuideTools toolGuideTools,
     ModelBehavior modelBehavior,
-    IAgentWorkSerializer workSerializer,
     AgentLoopRunner agentLoopRunner,
     AgentContextBuilder agentContextBuilder,
     IOptions<AgentProfileOptions> profileOptions,
@@ -83,46 +82,35 @@ internal sealed class ScheduledTaskHandler(
             Tools = allTools
         };
 
-        // Try to acquire the single execution slot. If a user loop is running,
-        // skip this tick — the next scheduled cron tick will try again.
-        var slot = await workSerializer.TryAcquireForScheduledAsync(ct);
-        if (slot is null)
-        {
-            logger.LogInformation(
-                "Skipping scheduled task '{TaskName}' — user session is active", message.TaskName);
-            return;
-        }
+        // The scheduler already holds the work-serializer slot and passes its
+        // cancellation token in via context.CancellationToken — a user session
+        // starting during execution will fire that token so the LLM loop stops
+        // cleanly. If preemption happens, re-throw so the scheduler can retry.
 
         var replySessionId = message.IsSystemTask ? "scheduled-system" : "scheduled";
 
         string finalText;
         try
         {
-            // Use slot.Token so a new user message can preempt this task cleanly.
-            await using (slot)
+            using var progressCtx = ToolProgressNotifier.SetContext(new ToolProgressContext
             {
-                using var progressCtx = ToolProgressNotifier.SetContext(new ToolProgressContext
-                {
-                    SessionId = replySessionId,
-                    AgentName = agent.Name,
-                    ReplyTo = $"{UserProxyTopics.UserResponse}.{agent.Name}"
-                });
+                SessionId = replySessionId,
+                AgentName = agent.Name,
+                ReplyTo = $"{UserProxyTopics.UserResponse}.{agent.Name}"
+            });
 
-                finalText = await agentLoopRunner.RunAsync(
-                    chatMessages, chatOptions, sessionId: sessionId,
-                    enableFollowUp: false, cancellationToken: slot.Token);
-            }
+            finalText = await agentLoopRunner.RunAsync(
+                chatMessages, chatOptions, sessionId: sessionId,
+                enableFollowUp: false, cancellationToken: ct);
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
-            return;
-        }
-        catch (OperationCanceledException)
-        {
-            // Preempted by a user session — exit silently, no error to report.
+            // Let the scheduler see the cancellation so it can distinguish
+            // host-shutdown from user-preemption and decide whether to retry.
             logger.LogInformation(
-                "Scheduled task '{TaskName}' was preempted by a user session", message.TaskName);
-            return;
+                "Scheduled task '{TaskName}' cancelled (host shutdown or user preemption)",
+                message.TaskName);
+            throw;
         }
         catch (Exception ex)
         {

--- a/src/RockBot.Host/SchedulerService.cs
+++ b/src/RockBot.Host/SchedulerService.cs
@@ -17,9 +17,17 @@ internal sealed class SchedulerService : IHostedService, ISchedulerService
     private readonly IMessagePipeline _pipeline;
     private readonly AgentClock _clock;
     private readonly AgentIdentity _identity;
+    private readonly IAgentWorkSerializer _workSerializer;
     private readonly ILogger<SchedulerService> _logger;
 
+    // Retry policy when a cron fires but a user session holds the work slot:
+    // re-arm the task every RetryDelay for up to MaxRetryAttempts, then fall
+    // back to the next natural cron occurrence.
+    private const int MaxRetryAttempts = 15;
+    private static readonly TimeSpan RetryDelay = TimeSpan.FromMinutes(2);
+
     private readonly Dictionary<string, Timer> _timers = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, int> _retryAttempts = new(StringComparer.OrdinalIgnoreCase);
     private readonly object _timerLock = new();
     private CancellationTokenSource _cts = new();
 
@@ -28,12 +36,14 @@ internal sealed class SchedulerService : IHostedService, ISchedulerService
         IMessagePipeline pipeline,
         AgentClock clock,
         AgentIdentity identity,
+        IAgentWorkSerializer workSerializer,
         ILogger<SchedulerService> logger)
     {
         _store = store;
         _pipeline = pipeline;
         _clock = clock;
         _identity = identity;
+        _workSerializer = workSerializer;
         _logger = logger;
     }
 
@@ -191,25 +201,66 @@ internal sealed class SchedulerService : IHostedService, ISchedulerService
     {
         if (_cts.IsCancellationRequested) return;
 
-        var firedAt = _clock.Now;
-        _logger.LogInformation("Firing scheduled task '{Name}'", task.Name);
-
-        try
+        // Acquire the work slot before dispatching. If a user session already
+        // holds it, we'd only have dispatched a message that the handler would
+        // immediately skip — so retry in a few minutes instead.
+        var slot = await _workSerializer.TryAcquireForScheduledAsync(_cts.Token);
+        if (slot is null)
         {
-            var message = new ScheduledTaskMessage(task.Name, task.Description, task.IsSystemTask);
-            var envelope = message.ToEnvelope(source: _identity.Name);
-            await _pipeline.DispatchAsync(envelope, _cts.Token);
-        }
-        catch (OperationCanceledException) when (_cts.IsCancellationRequested)
-        {
+            _logger.LogInformation(
+                "Scheduled task '{Name}' preempted by active user session — scheduling retry",
+                task.Name);
+            ScheduleRetry(task);
             return;
         }
-        catch (Exception ex)
+
+        var firedAt = _clock.Now;
+        var preempted = false;
+        var handlerCompleted = false;
+
+        await using (slot)
         {
-            _logger.LogError(ex, "Error executing scheduled task '{Name}'", task.Name);
+            _logger.LogInformation("Firing scheduled task '{Name}'", task.Name);
+            try
+            {
+                var message = new ScheduledTaskMessage(task.Name, task.Description, task.IsSystemTask);
+                var envelope = message.ToEnvelope(source: _identity.Name);
+                // Pass the slot's cancellation token so the handler (and the LLM
+                // loop it drives) stops cleanly when a user message arrives.
+                await _pipeline.DispatchAsync(envelope, slot.Token);
+                handlerCompleted = true;
+            }
+            catch (OperationCanceledException) when (_cts.IsCancellationRequested)
+            {
+                // Host is shutting down — do not retry, do not update state.
+                return;
+            }
+            catch (OperationCanceledException)
+            {
+                // User session preempted the task mid-run.
+                preempted = true;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error executing scheduled task '{Name}'", task.Name);
+                // Treat errors as "ran" so we don't loop on a broken task — the next
+                // cron occurrence will try again.
+                handlerCompleted = true;
+            }
         }
 
+        if (preempted)
+        {
+            _logger.LogInformation(
+                "Scheduled task '{Name}' preempted mid-run — scheduling retry", task.Name);
+            ScheduleRetry(task);
+            return;
+        }
+
+        if (!handlerCompleted) return;
+
         await _store.UpdateLastFiredAsync(task.Name, firedAt);
+        lock (_timerLock) { _retryAttempts.Remove(task.Name); }
 
         if (task.RunOnce)
         {
@@ -223,6 +274,32 @@ internal sealed class SchedulerService : IHostedService, ISchedulerService
         // Re-arm for the next occurrence
         var updated = task with { LastFiredAt = firedAt };
         ArmTimer(updated);
+    }
+
+    private void ScheduleRetry(ScheduledTask task)
+    {
+        int attempt;
+        lock (_timerLock)
+        {
+            _retryAttempts.TryGetValue(task.Name, out attempt);
+            attempt++;
+            if (attempt > MaxRetryAttempts)
+            {
+                _retryAttempts.Remove(task.Name);
+                _logger.LogWarning(
+                    "Scheduled task '{Name}' exceeded retry budget ({Max}); falling back to next cron occurrence",
+                    task.Name, MaxRetryAttempts);
+                ArmTimer(task);
+                return;
+            }
+            _retryAttempts[task.Name] = attempt;
+        }
+
+        var target = _clock.Now + RetryDelay;
+        _logger.LogInformation(
+            "Retry {Attempt}/{Max} for '{Name}' armed for {Target:yyyy-MM-dd HH:mm:ss} ({Zone})",
+            attempt, MaxRetryAttempts, task.Name, target, _clock.Zone.Id);
+        ArmTimerForTarget(task, target);
     }
 
     private static CronExpression ParseCron(string expression)

--- a/src/RockBot.Tools.Scheduling/ListScheduledTasksExecutor.cs
+++ b/src/RockBot.Tools.Scheduling/ListScheduledTasksExecutor.cs
@@ -37,9 +37,13 @@ internal sealed class ListScheduledTasksExecutor(ISchedulerService scheduler, Ag
                     else
                         sb.AppendLine($"  Next fire: none (cron has no future occurrence — task will be removed)");
                     sb.AppendLine($"  Description: {task.Description}");
-                    sb.AppendLine($"  Created: {task.CreatedAt:u}");
+                    var createdLocal = TimeZoneInfo.ConvertTime(task.CreatedAt, clock.Zone);
+                    sb.AppendLine($"  Created: {createdLocal:yyyy-MM-dd HH:mm:ss} ({clock.Zone.Id})");
                     if (task.LastFiredAt.HasValue)
-                        sb.AppendLine($"  Last fired: {task.LastFiredAt.Value:u}");
+                    {
+                        var firedLocal = TimeZoneInfo.ConvertTime(task.LastFiredAt.Value, clock.Zone);
+                        sb.AppendLine($"  Last fired: {firedLocal:yyyy-MM-dd HH:mm:ss} ({clock.Zone.Id})");
+                    }
                     sb.AppendLine();
                 }
                 content = sb.ToString().TrimEnd();

--- a/tests/RockBot.Host.Tests/SchedulerServiceTests.cs
+++ b/tests/RockBot.Host.Tests/SchedulerServiceTests.cs
@@ -14,11 +14,13 @@ public sealed class SchedulerServiceTests
 
     private static SchedulerService MakeService(
         IScheduledTaskStore store,
-        IMessagePipeline pipeline) =>
+        IMessagePipeline pipeline,
+        IAgentWorkSerializer? workSerializer = null) =>
         new(store,
             pipeline,
             MakeClock(),
             new AgentIdentity("test-agent"),
+            workSerializer ?? new AlwaysFreeWorkSerializer(),
             NullLogger<SchedulerService>.Instance);
 
     // ── ListAsync ─────────────────────────────────────────────────────────────
@@ -105,6 +107,32 @@ public sealed class SchedulerServiceTests
     }
 
     [TestMethod]
+    public async Task FireTask_WhenWorkSlotBusy_DoesNotDispatchAndDoesNotUpdateLastFired()
+    {
+        // Cron fires every second; work serializer always denies. Scheduler should
+        // never dispatch to the pipeline and never stamp LastFiredAt — instead it
+        // arms a 2-minute retry (which won't fire in the test window).
+        var task = new ScheduledTask("busy-task", "* * * * * *", "Should be skipped", DateTimeOffset.UtcNow);
+        var store = new FakeScheduledTaskStore([task]);
+        var pipeline = new CapturingPipeline();
+        var serializer = new AlwaysBusyWorkSerializer();
+        var service = MakeService(store, pipeline, serializer);
+
+        await service.StartAsync(CancellationToken.None);
+
+        // Wait long enough for at least one cron tick.
+        await Task.Delay(1500);
+
+        await service.StopAsync(CancellationToken.None);
+
+        Assert.AreEqual(0, pipeline.DispatchCount, "Pipeline should not receive dispatches when work slot is busy");
+        Assert.IsTrue(serializer.AttemptCount >= 1, "Scheduler should have attempted to acquire the slot at least once");
+        var stored = await store.GetAsync("busy-task");
+        Assert.IsNotNull(stored);
+        Assert.IsNull(stored.LastFiredAt, "LastFiredAt must not be stamped when the task was skipped");
+    }
+
+    [TestMethod]
     public async Task FiresTask_WhenTimerElapses()
     {
         // Use a 6-field cron with seconds so we can test with a 1-second interval
@@ -176,6 +204,49 @@ public sealed class SchedulerServiceTests
         {
             Interlocked.Increment(ref DispatchCount);
             return Task.FromResult(MessageResult.Ack);
+        }
+    }
+
+    /// <summary>
+    /// Test double that always grants the work slot and hands back a token
+    /// that only fires on the passed-in host cancellation token. Adequate for
+    /// scheduler-level tests that don't exercise user/scheduled contention.
+    /// </summary>
+    private sealed class AlwaysFreeWorkSerializer : IAgentWorkSerializer
+    {
+        public Task<IAsyncDisposable> AcquireForUserAsync(CancellationToken ct) =>
+            Task.FromResult<IAsyncDisposable>(new NullSlot());
+
+        public Task<IScheduledTaskSlot?> TryAcquireForScheduledAsync(CancellationToken ct) =>
+            Task.FromResult<IScheduledTaskSlot?>(new Slot(ct));
+
+        private sealed class NullSlot : IAsyncDisposable
+        {
+            public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        }
+
+        private sealed class Slot(CancellationToken token) : IScheduledTaskSlot
+        {
+            public CancellationToken Token { get; } = token;
+            public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        }
+    }
+
+    /// <summary>
+    /// Test double that always reports the work slot busy — used to verify the
+    /// scheduler's skip-and-retry path when a user session has the slot.
+    /// </summary>
+    private sealed class AlwaysBusyWorkSerializer : IAgentWorkSerializer
+    {
+        public int AttemptCount;
+
+        public Task<IAsyncDisposable> AcquireForUserAsync(CancellationToken ct) =>
+            throw new InvalidOperationException("Not used in this test");
+
+        public Task<IScheduledTaskSlot?> TryAcquireForScheduledAsync(CancellationToken ct)
+        {
+            Interlocked.Increment(ref AttemptCount);
+            return Task.FromResult<IScheduledTaskSlot?>(null);
         }
     }
 }


### PR DESCRIPTION
## Summary

- **`list_scheduled_tasks` time rendering fix** — `Created` and `Last fired` were formatted with `:u` (UTC+Z) while `Current time` and `Next fire` used the agent's zone. The mixed-timezone output forced the LLM to convert some fields and not others, and it sometimes botched the conversion — that's how a 10:00 CDT fire came back reported as "3 AM". All four fields now render in the agent's configured zone.
- **Preempted scheduled tasks now retry** — Previously, if a user session held the work-serializer slot when a cron fired, the handler skipped the run silently and `LastFiredAt` was still stamped, so `list_scheduled_tasks` lied about having run. The scheduler now owns slot acquisition. Busy slot or mid-run preemption → re-arm for 2 minutes, up to 15 attempts (~30-minute window), then fall back to the next natural cron occurrence.
- **`LastFiredAt` only stamps on actual completion** — No longer updated when the task is skipped or preempted.

## Background

Diagnosed from a real case today where a 10 AM weekday briefing didn't run (user was chatting with rockbot right at 10:00) but rockbot confidently reported that it had fired "at 3 AM" — two bugs compounding.

## Test plan

- [x] `SchedulerServiceTests` — 7 existing + 1 new (`FireTask_WhenWorkSlotBusy_DoesNotDispatchAndDoesNotUpdateLastFired`)
- [x] Full solution `dotnet test` green (532 host tests + others)
- [ ] Deploy to lhotkalake, observe behavior over the next weekday 10 AM briefing window

🤖 Generated with [Claude Code](https://claude.com/claude-code)