### PR TITLE
Dedupe MCP server entries by URL+credentials (v0.10.5)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-    <Version>0.10.4</Version>
+    <Version>0.10.5</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/deploy/helm/rockbot/templates/configmap.yaml
+++ b/deploy/helm/rockbot/templates/configmap.yaml
@@ -30,6 +30,10 @@ data:
   McpBridge__ConfigPath: "/data/agent/mcp.json"
 
   # ── Default MCP servers (auto-seeded into mcp.json on startup) ────────────
+  # The agent skips seeding an entry when an existing mcp.json entry already points
+  # at the same URL (under any name) — this prevents duplicates when a server has
+  # also been registered manually. Duplicate entries (same URL + credentials, any
+  # name) are deduplicated at startup regardless of how they were introduced.
   {{- if .Values.routingStatsMcp.enabled }}
   McpBridge__DefaultServers__routing-stats: "http://localhost:8080/"
   {{- end }}

--- a/src/RockBot.Agent/McpBridge/McpBridgeServerConfig.cs
+++ b/src/RockBot.Agent/McpBridge/McpBridgeServerConfig.cs
@@ -58,4 +58,45 @@ public sealed class McpBridgeServerConfig
     /// Whether this config uses HTTP-based transport (SSE or streamable HTTP).
     /// </summary>
     public bool IsSse => Type?.ToLowerInvariant() is "sse" or "http" or "streamable-http";
+
+    /// <summary>
+    /// Computes a stable identity string for this server configuration that excludes the
+    /// server's dictionary name. Two entries with the same canonical identity point at the
+    /// same underlying server with the same credentials and options, and should be treated
+    /// as duplicates even if registered under different names.
+    /// </summary>
+    public string CanonicalIdentity()
+    {
+        var type = Type?.Trim().ToLowerInvariant() ?? string.Empty;
+        var url = NormalizeUrl(Url);
+        var transportMode = TransportMode?.Trim().ToLowerInvariant() ?? "auto";
+        var command = Command?.Trim() ?? string.Empty;
+        var args = string.Join("", Args);
+        var env = string.Join("", Env
+            .OrderBy(kvp => kvp.Key, StringComparer.Ordinal)
+            .Select(kvp => $"{kvp.Key}={kvp.Value}"));
+        var headers = string.Join("", Headers
+            .OrderBy(kvp => kvp.Key, StringComparer.OrdinalIgnoreCase)
+            .Select(kvp => $"{kvp.Key.ToLowerInvariant()}={kvp.Value}"));
+        var allowedTools = string.Join("", AllowedTools.OrderBy(s => s, StringComparer.OrdinalIgnoreCase));
+        var deniedTools = string.Join("", DeniedTools.OrderBy(s => s, StringComparer.OrdinalIgnoreCase));
+        return string.Join("", type, url, transportMode, command, args, env, headers, allowedTools, deniedTools);
+    }
+
+    /// <summary>
+    /// Normalizes a URL for duplicate detection: lowercases the scheme and authority,
+    /// preserves path case, and strips a trailing slash. Returns empty string for null/blank.
+    /// </summary>
+    internal static string NormalizeUrl(string? url)
+    {
+        if (string.IsNullOrWhiteSpace(url)) return string.Empty;
+        var trimmed = url.Trim();
+        if (Uri.TryCreate(trimmed, UriKind.Absolute, out var uri))
+        {
+            var authority = uri.GetLeftPart(UriPartial.Authority).ToLowerInvariant();
+            var pathAndQuery = uri.PathAndQuery;
+            return (authority + pathAndQuery).TrimEnd('/');
+        }
+        return trimmed.TrimEnd('/').ToLowerInvariant();
+    }
 }

--- a/src/RockBot.Agent/McpBridge/McpBridgeService.cs
+++ b/src/RockBot.Agent/McpBridge/McpBridgeService.cs
@@ -175,23 +175,43 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
             }
         }
 
-        // Seed default servers from infrastructure config (Helm values)
+        // Remove duplicate entries that point at the same URL with the same credentials/options.
+        // Multiple entries can accumulate when the helm auto-seed adds a default name while the
+        // user has already registered the same server manually under a different name.
+        var removedDupes = DeduplicateByIdentity(config);
+
+        // Seed default servers from infrastructure config (Helm values). Skip seeding when an
+        // entry with the same URL already exists under any name — the user's existing entry
+        // (which may carry auth headers) takes precedence.
         var seeded = false;
         foreach (var (name, url) in _options.DefaultServers)
         {
-            if (!config.McpServers.ContainsKey(name))
+            var normalizedDefaultUrl = McpBridgeServerConfig.NormalizeUrl(url);
+            var matchByUrl = string.IsNullOrEmpty(normalizedDefaultUrl)
+                ? default
+                : config.McpServers.FirstOrDefault(kvp =>
+                    McpBridgeServerConfig.NormalizeUrl(kvp.Value.Url) == normalizedDefaultUrl);
+            if (matchByUrl.Key is not null)
             {
-                _logger.LogInformation("Seeding default MCP server {Name} at {Url}", name, url);
-                config.McpServers[name] = new McpBridgeServerConfig
+                if (!string.Equals(matchByUrl.Key, name, StringComparison.OrdinalIgnoreCase))
                 {
-                    Type = "sse",
-                    Url = url
-                };
-                seeded = true;
+                    _logger.LogInformation(
+                        "Default MCP server {Name} ({Url}) already exists as {ExistingName}; skipping seed",
+                        name, url, matchByUrl.Key);
+                }
+                continue;
             }
+
+            _logger.LogInformation("Seeding default MCP server {Name} at {Url}", name, url);
+            config.McpServers[name] = new McpBridgeServerConfig
+            {
+                Type = "sse",
+                Url = url
+            };
+            seeded = true;
         }
 
-        if (seeded)
+        if (seeded || removedDupes > 0)
         {
             try
             {
@@ -201,7 +221,9 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
                     WriteIndented = true
                 });
                 await File.WriteAllTextAsync(_configPath, updatedJson, ct);
-                _logger.LogInformation("Persisted seeded MCP servers to {Path}", _configPath);
+                _logger.LogInformation(
+                    "Persisted MCP config changes to {Path} (seeded={Seeded}, duplicatesRemoved={Removed})",
+                    _configPath, seeded, removedDupes);
             }
             catch (Exception ex)
             {
@@ -257,6 +279,48 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
             _logger.LogError(backupEx, "Failed to read backup MCP config from {BackupPath}", backupPath);
             return null;
         }
+    }
+
+    /// <summary>
+    /// Removes entries from <paramref name="config"/> that share a canonical identity
+    /// (same URL, credentials, transport, and options) with another entry. When duplicates
+    /// are found, prefers keeping the entry whose name matches a helm-default server name
+    /// so a subsequent seed does not re-add what we just removed; otherwise keeps the
+    /// alphabetically first name. Returns the number of entries removed.
+    /// </summary>
+    private int DeduplicateByIdentity(McpBridgeConfig config)
+    {
+        var groups = config.McpServers
+            .GroupBy(kvp => kvp.Value.CanonicalIdentity(), StringComparer.Ordinal)
+            .Where(g => !string.IsNullOrEmpty(g.Key) && g.Count() > 1)
+            .ToList();
+
+        var removed = 0;
+        foreach (var group in groups)
+        {
+            var entries = group.ToList();
+            var preferred = entries.FirstOrDefault(e =>
+                _options.DefaultServers.ContainsKey(e.Key));
+            if (preferred.Key is null)
+            {
+                preferred = entries
+                    .OrderBy(e => e.Key, StringComparer.OrdinalIgnoreCase)
+                    .First();
+            }
+
+            foreach (var entry in entries)
+            {
+                if (string.Equals(entry.Key, preferred.Key, StringComparison.Ordinal))
+                    continue;
+
+                config.McpServers.Remove(entry.Key);
+                removed++;
+                _logger.LogWarning(
+                    "Removed duplicate MCP server entry {DuplicateName} (same URL/credentials as kept entry {KeptName}: {Url})",
+                    entry.Key, preferred.Key, entry.Value.Url);
+            }
+        }
+        return removed;
     }
 
     private async Task ConnectServerAsync(string name, McpBridgeServerConfig config, CancellationToken ct)
@@ -855,6 +919,30 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
                     Args = req.Args,
                     Env = req.Env
                 };
+
+                // Reject registrations that duplicate an existing server's URL and credentials
+                // under a different name. The name doesn't matter for dedup — URL + headers +
+                // transport + command/args/env must all match for this to be considered a dup.
+                var newIdentity = config.CanonicalIdentity();
+                if (!string.IsNullOrEmpty(newIdentity))
+                {
+                    var existingDup = _serverConfigs.FirstOrDefault(kvp =>
+                        !string.Equals(kvp.Key, req.ServerName, StringComparison.OrdinalIgnoreCase)
+                        && string.Equals(kvp.Value.CanonicalIdentity(), newIdentity, StringComparison.Ordinal));
+
+                    if (existingDup.Key is not null)
+                    {
+                        var dupResponse = new McpRegisterServerResponse
+                        {
+                            ServerName = req.ServerName,
+                            Success = false,
+                            Error = $"An MCP server with the same URL and credentials is already registered as '{existingDup.Key}'. " +
+                                    $"Use the existing registration, or unregister it before registering under a different name."
+                        };
+                        await PublishResponseAsync(dupResponse, replyTo, envelope.CorrelationId, ct);
+                        return MessageResult.Ack;
+                    }
+                }
 
                 await ConnectServerAsync(req.ServerName, config, ct);
                 await PersistServerConfigAsync(req.ServerName, config, remove: false);

--- a/tests/RockBot.Agent.Tests/McpBridgeServerConfigTests.cs
+++ b/tests/RockBot.Agent.Tests/McpBridgeServerConfigTests.cs
@@ -1,0 +1,168 @@
+using RockBot.Agent.McpBridge;
+
+namespace RockBot.Agent.Tests;
+
+[TestClass]
+public class McpBridgeServerConfigTests
+{
+    // ── NormalizeUrl ──────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void NormalizeUrl_NullOrEmpty_ReturnsEmpty()
+    {
+        Assert.AreEqual(string.Empty, McpBridgeServerConfig.NormalizeUrl(null));
+        Assert.AreEqual(string.Empty, McpBridgeServerConfig.NormalizeUrl(""));
+        Assert.AreEqual(string.Empty, McpBridgeServerConfig.NormalizeUrl("   "));
+    }
+
+    [TestMethod]
+    public void NormalizeUrl_TrailingSlash_IsStripped()
+    {
+        Assert.AreEqual(
+            McpBridgeServerConfig.NormalizeUrl("http://mcp-todo.rockbot.svc.cluster.local"),
+            McpBridgeServerConfig.NormalizeUrl("http://mcp-todo.rockbot.svc.cluster.local/"));
+    }
+
+    [TestMethod]
+    public void NormalizeUrl_AuthorityCase_IsIgnored()
+    {
+        Assert.AreEqual(
+            McpBridgeServerConfig.NormalizeUrl("http://Mcp-Todo.Rockbot.Svc.Cluster.Local/"),
+            McpBridgeServerConfig.NormalizeUrl("http://mcp-todo.rockbot.svc.cluster.local/"));
+    }
+
+    [TestMethod]
+    public void NormalizeUrl_PathCase_IsPreserved()
+    {
+        // Path is case-sensitive in HTTP; do not collapse different paths into one identity.
+        Assert.AreNotEqual(
+            McpBridgeServerConfig.NormalizeUrl("http://host/PathOne"),
+            McpBridgeServerConfig.NormalizeUrl("http://host/pathone"));
+    }
+
+    // ── CanonicalIdentity ─────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void CanonicalIdentity_DiffersOnlyByName_AreEqual()
+    {
+        // Two entries registered under different names but pointing at the exact
+        // same server with the same config must hash to the same identity — this
+        // is the whole point of dedup.
+        var a = new McpBridgeServerConfig { Type = "sse", Url = "http://mcp-todo/" };
+        var b = new McpBridgeServerConfig { Type = "sse", Url = "http://mcp-todo/" };
+
+        Assert.AreEqual(a.CanonicalIdentity(), b.CanonicalIdentity());
+    }
+
+    [TestMethod]
+    public void CanonicalIdentity_UrlDiffersIgnoringTrailingSlashAndCase_AreEqual()
+    {
+        var a = new McpBridgeServerConfig { Type = "sse", Url = "http://Mcp-Todo/" };
+        var b = new McpBridgeServerConfig { Type = "sse", Url = "http://mcp-todo" };
+
+        Assert.AreEqual(a.CanonicalIdentity(), b.CanonicalIdentity());
+    }
+
+    [TestMethod]
+    public void CanonicalIdentity_DifferentUrls_AreDifferent()
+    {
+        var a = new McpBridgeServerConfig { Type = "sse", Url = "http://host-a/" };
+        var b = new McpBridgeServerConfig { Type = "sse", Url = "http://host-b/" };
+
+        Assert.AreNotEqual(a.CanonicalIdentity(), b.CanonicalIdentity());
+    }
+
+    [TestMethod]
+    public void CanonicalIdentity_DifferentHeaders_AreDifferent()
+    {
+        // Same URL but different auth headers — NOT a duplicate. This is the
+        // staging-vs-helm-seed scenario: auth-bearing entry must not be collapsed
+        // with an unauthenticated seed.
+        var a = new McpBridgeServerConfig { Type = "sse", Url = "http://host/" };
+        var b = new McpBridgeServerConfig
+        {
+            Type = "sse",
+            Url = "http://host/",
+            Headers = { ["X-Api-Key"] = "secret" }
+        };
+
+        Assert.AreNotEqual(a.CanonicalIdentity(), b.CanonicalIdentity());
+    }
+
+    [TestMethod]
+    public void CanonicalIdentity_SameHeadersDifferentCase_AreEqual()
+    {
+        var a = new McpBridgeServerConfig
+        {
+            Type = "sse",
+            Url = "http://host/",
+            Headers = { ["X-Api-Key"] = "secret" }
+        };
+        var b = new McpBridgeServerConfig
+        {
+            Type = "sse",
+            Url = "http://host/",
+            Headers = { ["x-api-key"] = "secret" }
+        };
+
+        Assert.AreEqual(a.CanonicalIdentity(), b.CanonicalIdentity());
+    }
+
+    [TestMethod]
+    public void CanonicalIdentity_DifferentHeaderValues_AreDifferent()
+    {
+        // Same header name, different secret — different credentials, keep both.
+        var a = new McpBridgeServerConfig
+        {
+            Type = "sse",
+            Url = "http://host/",
+            Headers = { ["X-Api-Key"] = "secret-1" }
+        };
+        var b = new McpBridgeServerConfig
+        {
+            Type = "sse",
+            Url = "http://host/",
+            Headers = { ["X-Api-Key"] = "secret-2" }
+        };
+
+        Assert.AreNotEqual(a.CanonicalIdentity(), b.CanonicalIdentity());
+    }
+
+    [TestMethod]
+    public void CanonicalIdentity_DifferentTransportMode_AreDifferent()
+    {
+        var a = new McpBridgeServerConfig { Type = "sse", Url = "http://host/", TransportMode = "sse" };
+        var b = new McpBridgeServerConfig { Type = "sse", Url = "http://host/", TransportMode = "streamable-http" };
+
+        Assert.AreNotEqual(a.CanonicalIdentity(), b.CanonicalIdentity());
+    }
+
+    [TestMethod]
+    public void CanonicalIdentity_DefaultTransportMode_MatchesAuto()
+    {
+        // "auto" is the default; an entry written without TransportMode should equal one with "auto".
+        var a = new McpBridgeServerConfig { Type = "sse", Url = "http://host/" };
+        var b = new McpBridgeServerConfig { Type = "sse", Url = "http://host/", TransportMode = "auto" };
+
+        Assert.AreEqual(a.CanonicalIdentity(), b.CanonicalIdentity());
+    }
+
+    [TestMethod]
+    public void CanonicalIdentity_HeaderOrder_DoesNotAffectIdentity()
+    {
+        var a = new McpBridgeServerConfig
+        {
+            Type = "sse",
+            Url = "http://host/",
+            Headers = { ["A"] = "1", ["B"] = "2" }
+        };
+        var b = new McpBridgeServerConfig
+        {
+            Type = "sse",
+            Url = "http://host/",
+            Headers = { ["B"] = "2", ["A"] = "1" }
+        };
+
+        Assert.AreEqual(a.CanonicalIdentity(), b.CanonicalIdentity());
+    }
+}


### PR DESCRIPTION
## Summary
- mcp-bridge now dedupes entries by canonical identity (URL + headers + transport + command/args/env + tool filters) rather than dictionary name
- on startup, duplicates are removed (preferring a name that matches a helm `DefaultServers` key so the seed doesn't re-add what was just removed)
- helm-default seeding now skips when an existing entry already points at the same URL under any name — protects user-added auth headers on the same URL
- `mcp_register_server` rejects requests whose URL+credentials match an existing registration under a different name

## Background
The live cluster ended up with two `todo` MCP entries: a helm-seeded `todo` and a manually-added `todo-mcp-cluster`. Both connected to the same backing service (the .NET MCP server exposes both legacy SSE and streamable-http endpoints), but the dedup only checked names, so they coexisted forever. Same pattern previously bit `staging` (#245).

## Test plan
- [x] `dotnet test RockBot.slnx` — all suites pass, 13 new tests for `CanonicalIdentity` / `NormalizeUrl` / header sensitivity
- [x] Built and pushed `rockylhotka/rockbot-agent:0.10.5`, deployed via `helm upgrade --reuse-values`, agent started clean and logged `Persisted MCP config changes ... (seeded=True, duplicatesRemoved=0)` (the live duplicate had different paths `/sse` vs `/`, so by the strict-exact-match rule it was correctly *not* auto-removed — the agent + user resolved that one manually)

🤖 Generated with [Claude Code](https://claude.com/claude-code)