### PR TITLE
Fix duplicate brief output when scheduled tasks spawn subagents (v0.10.6)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-    <Version>0.10.5</Version>
+    <Version>0.10.6</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.A2A/A2ATaskErrorHandler.cs
+++ b/src/RockBot.A2A/A2ATaskErrorHandler.cs
@@ -79,10 +79,8 @@ internal sealed class A2ATaskErrorHandler(
 
         var sessionWorkingMemoryTools = new WorkingMemoryTools(workingMemory, sessionNamespace, logger);
         var sessionSkillTools = new SkillTools(skillStore, llmClient, logger, rawSessionId);
-        var registryTools = toolRegistry.GetTools()
-            .Select(r => (AIFunction)new RegistryToolFunction(
-                r, toolRegistry.GetExecutor(r.Name)!, sessionNamespace))
-            .ToArray();
+        var batchId = Guid.NewGuid().ToString("N")[..12];
+        var registryTools = toolRegistry.BuildAgentToolFunctions(sessionNamespace, batchId);
 
         var chatOptions = new ChatOptions
         {

--- a/src/RockBot.A2A/A2ATaskResultHandler.cs
+++ b/src/RockBot.A2A/A2ATaskResultHandler.cs
@@ -258,11 +258,9 @@ internal sealed class A2ATaskResultHandler(
         // synthesis — the LLM should present the result, not start new agent interactions.
         var a2aToolNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
             { "invoke_agent", "register_agent", "unregister_agent", "list_known_agents", "get_agent_details" };
-        var registryTools = toolRegistry.GetTools()
-            .Where(r => !a2aToolNames.Contains(r.Name))
-            .Select(r => (AIFunction)new RegistryToolFunction(
-                r, toolRegistry.GetExecutor(r.Name)!, sessionNamespace))
-            .ToArray();
+        var batchId = Guid.NewGuid().ToString("N")[..12];
+        var registryTools = toolRegistry.BuildAgentToolFunctions(
+            sessionNamespace, batchId, r => !a2aToolNames.Contains(r.Name));
 
         var chatOptions = new ChatOptions
         {

--- a/src/RockBot.A2A/A2ATaskStatusHandler.cs
+++ b/src/RockBot.A2A/A2ATaskStatusHandler.cs
@@ -97,10 +97,8 @@ internal sealed class A2ATaskStatusHandler(
 
         var sessionWorkingMemoryTools = new WorkingMemoryTools(workingMemory, sessionNamespace, logger);
         var sessionSkillTools = new SkillTools(skillStore, llmClient, logger, rawSessionId);
-        var registryTools = toolRegistry.GetTools()
-            .Select(r => (AIFunction)new RegistryToolFunction(
-                r, toolRegistry.GetExecutor(r.Name)!, sessionNamespace))
-            .ToArray();
+        var batchId = Guid.NewGuid().ToString("N")[..12];
+        var registryTools = toolRegistry.BuildAgentToolFunctions(sessionNamespace, batchId);
 
         var chatOptions = new ChatOptions
         {

--- a/src/RockBot.A2A/InputRequiredHandler.cs
+++ b/src/RockBot.A2A/InputRequiredHandler.cs
@@ -90,10 +90,8 @@ internal sealed class InputRequiredHandler(
 
         var sessionWorkingMemoryTools = new WorkingMemoryTools(workingMemory, sessionNamespace, logger);
         var sessionSkillTools = new SkillTools(skillStore, llmClient, logger, rawSessionId);
-        var registryTools = toolRegistry.GetTools()
-            .Select(r => (AIFunction)new RegistryToolFunction(
-                r, toolRegistry.GetExecutor(r.Name)!, sessionNamespace))
-            .ToArray();
+        var batchId = Guid.NewGuid().ToString("N")[..12];
+        var registryTools = toolRegistry.BuildAgentToolFunctions(sessionNamespace, batchId);
 
         var chatOptions = new ChatOptions
         {

--- a/src/RockBot.Agent/ScheduledTaskHandler.cs
+++ b/src/RockBot.Agent/ScheduledTaskHandler.cs
@@ -64,9 +64,8 @@ internal sealed class ScheduledTaskHandler(
         var sessionWorkingMemoryTools = new WorkingMemoryTools(workingMemory, sessionId, logger);
         var sessionSkillTools = new SkillTools(skillStore, llmClient, logger, sessionId, skillUsageStore);
 
-        var registryTools = toolRegistry.GetTools()
-            .Select(r => (AIFunction)new RegistryToolFunction(r, toolRegistry.GetExecutor(r.Name)!, sessionId))
-            .ToArray();
+        var batchId = Guid.NewGuid().ToString("N")[..12];
+        var registryTools = toolRegistry.BuildAgentToolFunctions(sessionId, batchId);
 
         var allTools = memoryTools.Tools
             .Concat(sessionWorkingMemoryTools.Tools)

--- a/src/RockBot.Agent/UserFeedbackHandler.cs
+++ b/src/RockBot.Agent/UserFeedbackHandler.cs
@@ -131,10 +131,8 @@ internal sealed class UserFeedbackHandler(
                 var sessionNamespace = $"session/{message.SessionId}";
                 var sessionWorkingMemoryTools = new WorkingMemoryTools(workingMemory, sessionNamespace, logger);
                 var sessionSkillTools = new SkillTools(skillStore, llmClient, logger, message.SessionId);
-                var registryTools = toolRegistry.GetTools()
-                    .Select(r => (AIFunction)new RegistryToolFunction(
-                        r, toolRegistry.GetExecutor(r.Name)!, sessionNamespace))
-                    .ToArray();
+                var batchId = Guid.NewGuid().ToString("N")[..12];
+                var registryTools = toolRegistry.BuildAgentToolFunctions(sessionNamespace, batchId);
 
                 var chatOptions = new ChatOptions
                 {

--- a/src/RockBot.Agent/UserMessageHandler.cs
+++ b/src/RockBot.Agent/UserMessageHandler.cs
@@ -146,14 +146,8 @@ internal sealed class UserMessageHandler(
             // Per-session skill tools with usage tracking
             var sessionSkillTools = new SkillTools(skillStore, llmClient, logger, message.SessionId, skillUsageStore);
 
-            // Batch ID for subagent result consolidation — all spawn_subagent calls
-            // within this agent loop share the same batchId so results are grouped.
             var batchId = Guid.NewGuid().ToString("N")[..12];
-
-            // Registry tools (MCP, REST, etc.)
-            var registryTools = toolRegistry.GetTools()
-                .Select(r => (AIFunction)new RegistryToolFunction(r, toolRegistry.GetExecutor(r.Name)!, sessionNamespace, batchId))
-                .ToArray();
+            var registryTools = toolRegistry.BuildAgentToolFunctions(sessionNamespace, batchId);
 
             var allTools = memoryTools.Tools
                 .Concat(sessionWorkingMemoryTools.Tools)

--- a/src/RockBot.Tools/ToolRegistryExtensions.cs
+++ b/src/RockBot.Tools/ToolRegistryExtensions.cs
@@ -1,0 +1,35 @@
+using Microsoft.Extensions.AI;
+
+namespace RockBot.Tools;
+
+/// <summary>
+/// Helpers for materializing registry tools as <see cref="AIFunction"/> instances
+/// for an agent loop invocation.
+/// </summary>
+public static class ToolRegistryExtensions
+{
+    /// <summary>
+    /// Wraps every registered tool (optionally filtered) as an <see cref="AIFunction"/>
+    /// scoped to a single agent loop invocation. The <paramref name="batchId"/> is
+    /// required so that any <c>spawn_subagent</c> calls made during this loop share
+    /// a batch and produce a single consolidated synthesis when their results return,
+    /// rather than firing one synthesis per subagent completion. Pass null only for
+    /// invocations that genuinely cannot spawn subagents.
+    /// </summary>
+    public static AIFunction[] BuildAgentToolFunctions(
+        this IToolRegistry registry,
+        string? sessionId,
+        string? batchId,
+        Func<ToolRegistration, bool>? filter = null)
+    {
+        ArgumentNullException.ThrowIfNull(registry);
+
+        var tools = registry.GetTools().AsEnumerable();
+        if (filter is not null) tools = tools.Where(filter);
+
+        return tools
+            .Select(r => (AIFunction)new RegistryToolFunction(
+                r, registry.GetExecutor(r.Name)!, sessionId, batchId))
+            .ToArray();
+    }
+}


### PR DESCRIPTION
## Summary

- Scheduled tasks (and 5 other agent-loop entry points) were constructing \`RegistryToolFunction\` without a \`batchId\`, so every \`spawn_subagent\` call inside those loops produced a result with \`BatchId=null\`. \`SubagentResultGate\` short-circuits to solo synthesis on null batchId, so each subagent completion fired its own consolidated synthesis — producing N briefs instead of 1. Reproduced live by \`morning-daily-operational-brief\`: 3 subagents → 3 differently-formatted briefs delivered to the user.
- Extracted per-loop tool construction into \`IToolRegistry.BuildAgentToolFunctions(sessionId, batchId, filter)\`. Six handlers had been duplicating the \`.Select(r => new RegistryToolFunction(...))\` block — that's how the \`batchId\` argument got silently dropped from 6 of 7 call sites in the first place. The new helper makes \`batchId\` a required argument so it can't be forgotten.
- Version bump to 0.10.6.

## Affected handlers

- \`ScheduledTaskHandler\` ← root cause of the user-reported bug
- \`UserFeedbackHandler\`
- \`A2ATaskResultHandler\`
- \`A2ATaskStatusHandler\`
- \`A2ATaskErrorHandler\`
- \`InputRequiredHandler\`
- \`UserMessageHandler\` (already correct — refactored to use the new helper)

## Test plan

- [x] \`dotnet build\` clean (Debug)
- [x] \`dotnet test\` — 1410 passed, 0 failed
- [ ] Deploy 0.10.6 to live cluster and verify next morning-daily-operational-brief produces a single brief
- [ ] Spot-check a UserFeedback (thumbs-down re-evaluation) and an A2A task with multiple subagents to confirm single synthesis

🤖 Generated with [Claude Code](https://claude.com/claude-code)