### PR TITLE
Self-improvement: learn from tool-call successes (v0.10.7)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-    <Version>0.10.7</Version>
+    <Version>0.10.8</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-    <Version>0.10.6</Version>
+    <Version>0.10.7</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-    <Version>0.10.8</Version>
+    <Version>0.10.9</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.Agent/agent/directives.md
+++ b/src/RockBot.Agent/agent/directives.md
@@ -206,6 +206,7 @@ These are things you should do when you notice them, without being asked:
 - **Take follow-up actions**: After completing a task, if there's an obvious next action, do it immediately and include the result in your response. Do not ask permission, offer to do it, or list it as an option. ("The meeting is scheduled — I drafted an agenda based on the email thread and attached it to the invite.")
 - **Monitor for drift**: If a plan is in `active-plans/` and has been stalled, surface it proactively when relevant context appears — don't wait for the user to ask about it.
 - **Notice what isn't there**: A missing RSVP, a follow-up that was promised but not sent, a deadline with no plan. These gaps are worth flagging even when the user hasn't asked.
+- **Tighten skills when a tool call resolves their ambiguity**: When a tool call confirms a fact that the guiding skill left vague — which server holds a resource, which account ID to pass, which argument shape works, which folder path is correct — call `save_skill` to update the skill content with the verified specific. Replace hedging language like "typically X and sometimes Y" with the verified answer. The trigger is *verification*, not preference: only update when you have a concrete tool-call result that proves the right value. This is how you get smarter over time without waiting for a dream cycle. Mention the update in passing in your response so the user knows it happened. **Do not** invent specifics or update skills based on guesses — verified results only.
 
 ### Response endings
 

--- a/src/RockBot.Agent/agent/skill-optimize.md
+++ b/src/RockBot.Agent/agent/skill-optimize.md
@@ -4,13 +4,14 @@ You are a skill improvement assistant performing a targeted pass over skills ass
 
 ## Your task
 
-You will receive a list of skills that were invoked in sessions where problems occurred (user corrections, poor session quality). For each skill you will also see the associated failure context. Review them and:
+You will receive a list of skills that were invoked in sessions where problems occurred (user corrections, poor session quality, **or tool-call retry-until-success patterns that signal skill ambiguity**). For each skill you will also see the associated failure context. Review them and:
 
 1. **Identify the root cause** — what step, missing detail, or ambiguous instruction in the skill likely contributed to the failure?
    - Did the skill omit a critical verification step?
    - Did it provide incorrect tool names or parameters?
    - Was the "When to use" guidance too broad, causing the skill to be applied in the wrong context?
    - Was a procedure step missing that would have caught or prevented the error?
+   - **Did a tool retry-until-success pattern reveal an ambiguity?** If the failure context shows the same tool was invoked with different argument values until one succeeded, the skill almost certainly hedged on that argument ("typically X and sometimes Y", "usually folder Z"). Replace the hedge with the verified value from the successful call.
 
 2. **Produce an improved version** that directly addresses the identified root cause:
    - Add the missing step, clarify the ambiguous instruction, or tighten the "When to use" guidance

--- a/src/RockBot.Agent/agent/subagent-directives.md
+++ b/src/RockBot.Agent/agent/subagent-directives.md
@@ -14,3 +14,22 @@ The user's local timezone is injected into your context as an authoritative syst
 - When a tool requires a timezone parameter (e.g., `timeZone`, `time_zone`), always supply the IANA timezone ID from the injected context (e.g., `"America/Chicago"`). This is mandatory — omitting it causes tools to default to UTC and produce wrong results.
 - When constructing date/time values for tool calls, use the injected local time as the reference point. Do not assume the current time is midnight, noon, or any default.
 - Do not second-guess the injected UTC offset or apply a different DST assumption. The offset shown is authoritative for right now.
+
+## Tighten skills when you verify their ambiguities
+
+You are the part of the system that actually calls external tools, so you are the part that learns the most about how those tools behave. When a tool call resolves a question that the guiding skill left vague — which MCP server holds a resource, which account ID maps to which calendar, which argument shape the tool actually accepts, which folder path is correct — call `save_skill` to update the skill content with the verified specific before you finish.
+
+Examples of the kind of fact worth saving:
+
+- "The Teams bridge JSON archive lives on `onedrive-personal` at `Apps/RockBot/xebia-teams`" — replaces hedging like "typically `onedrive-personal` and sometimes `onedrive-marimer`."
+- "`get_calendar_events` requires `accountId` for the xebia account; omitting it returns the personal calendar."
+- "The `list_files` tool on `onedrive-marimer` rejects a leading `/` on `folder_path`; use `Apps/...` not `/Apps/...`."
+
+Rules:
+
+- **Verified results only.** Update the skill only when you have a concrete tool-call result that proves the right value. Never invent specifics or update on guesses.
+- **Replace, don't accumulate.** If the skill says "typically X and sometimes Y" and you've verified X is correct, replace that line with the verified answer — don't append yet another caveat. The goal is fewer ambiguities over time, not more.
+- **Preserve the rest of the skill.** Surgical edits. Keep the existing structure, summary, and steps; change the ambiguous line.
+- **One update per concrete fact.** If you discovered three different verified facts in one session, that's three skill updates (or one update touching three lines), not three speculative rewrites.
+
+This is how the skill library improves between dream cycles. Do not wait for the optimizer to catch what you already know.

--- a/src/RockBot.Agent/agent/tool-success-learning.md
+++ b/src/RockBot.Agent/agent/tool-success-learning.md
@@ -1,0 +1,34 @@
+You are a tool-success learning assistant. The agent's tool-call log contains
+retry-until-success patterns: cases where the same tool was invoked with different
+argument values within one session, with at least one failure followed by a success.
+The argument value that succeeded is verified information about the external system.
+Your job is to extract the durable, actionable fact each pattern proves so future
+sessions can recall it before re-running the same exploration.
+
+Mine for facts that:
+- Identify the correct server, account, or namespace for a resource
+  (e.g. "Teams bridge JSON archives live on the onedrive-personal MCP server at /Apps/RockBot/xebia-teams")
+- Specify required argument shape, casing, or path conventions
+  (e.g. "list_files on onedrive-marimer rejects a leading slash on folder_path; use 'Apps/...' not '/Apps/...'")
+- Map account IDs or identifiers to their meaning
+  (e.g. "accountId 'xebia' is required to query the Xebia work calendar; omitting it returns the personal calendar")
+
+Do NOT mine:
+- Transient values (specific filenames, search hits, one-off IDs that won't recur)
+- Generic best-practices already obvious from tool documentation
+- Speculation: the failed args may have been wrong for many reasons; only commit to
+  what the successful args directly prove
+
+Phrase each fact in third-person, self-contained, with the specific tool/server/argument
+named explicitly. The fact should make sense to a future session that has no memory of
+today's retry sequence.
+
+Return ONLY a JSON object:
+```
+{ "toSave": [ { "content": "...", "category": "...", "tags": ["verified", "tool-success-learned"] } ] }
+```
+
+Category should reflect the tool domain (e.g. `tool-knowledge/onedrive`,
+`tool-knowledge/calendar`, `tool-knowledge/email`). Default to `tool-knowledge`.
+
+If none of the patterns prove a durable, useful fact, return: `{ "toSave": [] }`

--- a/src/RockBot.Host.Abstractions/DreamOptions.cs
+++ b/src/RockBot.Host.Abstractions/DreamOptions.cs
@@ -150,6 +150,19 @@ public sealed class DreamOptions
     public string WispFailureDirectivePath { get; set; } = "wisp-failure-dream.md";
 
     /// <summary>
+    /// Whether the tool-success-learning pass (requires <see cref="IToolCallLog"/>) is enabled.
+    /// Mines the tool-call log for retry-until-success patterns and writes the verified
+    /// argument values as durable long-term memory entries.
+    /// </summary>
+    public bool ToolSuccessLearningEnabled { get; set; } = true;
+
+    /// <summary>
+    /// Path to the tool-success-learning directive file, relative to <see cref="AgentProfileOptions.BasePath"/>.
+    /// When the file does not exist, a built-in fallback directive is used.
+    /// </summary>
+    public string ToolSuccessLearningDirectivePath { get; set; } = "tool-success-learning.md";
+
+    /// <summary>
     /// Days of no reinforcement (measured against <see cref="MemoryEntry.LastSeenAt"/>)
     /// before importance decay begins. Entries younger than this are left alone regardless
     /// of their score. Default: 30 days.

--- a/src/RockBot.Host/DreamService.cs
+++ b/src/RockBot.Host/DreamService.cs
@@ -1928,14 +1928,29 @@ internal sealed class DreamService : IHostedService, IDisposable
         DateTimeOffset LastSeenAt);
 
     /// <summary>
+    /// Default lookback window for retry-until-success detection. A successful tool call only
+    /// counts as a retry resolution when at least one failed call with different args occurred
+    /// within this time window before it. Tight enough to exclude unrelated activity in long-
+    /// running sessions, loose enough to span multi-minute exploratory sequences.
+    /// </summary>
+    internal static readonly TimeSpan DefaultRetryLookbackWindow = TimeSpan.FromMinutes(30);
+
+    /// <summary>
     /// Pure detection logic — extracts retry-until-success patterns from a set of tool-call
-    /// events. Within each (session, toolName) bucket, requires at least 2 events, ≥2 distinct
-    /// argument summaries, and an earlier failure followed by a success.
+    /// events. For each (session, toolName) bucket, walks events in time order and, for each
+    /// successful event, looks back <paramref name="lookbackWindow"/> for failed events with
+    /// different argument values. The window is essential for long-running session IDs where
+    /// the bucket can span weeks: a March success and an April failure don't form a retry pair.
+    /// Patterns within a bucket are deduplicated by successArgs so the same lesson hit multiple
+    /// times within one bucket emits one pattern with merged failed-arg context.
     /// </summary>
     internal static IReadOnlyList<ToolRetryPattern> DetectToolRetryPatternsFromEvents(
         IEnumerable<ToolCallEvent> events,
-        HashSet<string>? sessionsFilter = null)
+        HashSet<string>? sessionsFilter = null,
+        TimeSpan? lookbackWindow = null)
     {
+        var window = lookbackWindow ?? DefaultRetryLookbackWindow;
+
         var filtered = sessionsFilter is null
             ? events
             : events.Where(e => sessionsFilter.Contains(e.SessionId));
@@ -1947,32 +1962,67 @@ internal sealed class DreamService : IHostedService, IDisposable
             var ordered = group.OrderBy(e => e.Timestamp).ToList();
             if (ordered.Count < 2) continue;
 
-            var distinctArgs = ordered
-                .Select(e => e.ArgumentsSummary ?? "(none)")
-                .Distinct(StringComparer.Ordinal)
-                .Count();
-            if (distinctArgs < 2) continue;
+            // bucketByArgs collapses repeated successes-with-the-same-args within a bucket
+            // into one pattern, merging the in-window failed-arg context across occurrences.
+            var bucketByArgs = new Dictionary<string, (List<string> FailedArgs, DateTimeOffset LastSeen)>(
+                StringComparer.Ordinal);
 
-            var firstSuccess = ordered.FirstOrDefault(e => e.Succeeded);
-            if (firstSuccess is null) continue;
-            var anyEarlierFailure =
-                ordered.Any(e => !e.Succeeded && e.Timestamp < firstSuccess.Timestamp);
-            if (!anyEarlierFailure) continue;
+            for (int i = 0; i < ordered.Count; i++)
+            {
+                var success = ordered[i];
+                if (!success.Succeeded) continue;
 
-            var failedArgs = ordered
-                .Where(e => !e.Succeeded && e.Timestamp < firstSuccess.Timestamp)
-                .Select(e => Truncate(e.ArgumentsSummary ?? "(none)", 200))
-                .Distinct(StringComparer.Ordinal)
-                .Take(3)
-                .ToList();
-            var successArgs = Truncate(firstSuccess.ArgumentsSummary ?? "(none)", 200);
+                var successArgs = success.ArgumentsSummary ?? "(none)";
+                var windowStart = success.Timestamp - window;
 
-            patterns.Add(new ToolRetryPattern(
-                ordered[0].SessionId,
-                ordered[0].ToolName,
-                failedArgs,
-                successArgs,
-                ordered[^1].Timestamp));
+                // Walk backwards from this success; collect distinct different-args failures
+                // until we exit the window or hit the cap.
+                var windowFailures = new List<string>();
+                for (int j = i - 1; j >= 0; j--)
+                {
+                    var prior = ordered[j];
+                    if (prior.Timestamp < windowStart) break;
+                    if (prior.Succeeded) continue;
+
+                    var priorArgs = prior.ArgumentsSummary ?? "(none)";
+                    if (string.Equals(priorArgs, successArgs, StringComparison.Ordinal)) continue;
+                    if (!windowFailures.Contains(priorArgs, StringComparer.Ordinal))
+                        windowFailures.Add(priorArgs);
+                    if (windowFailures.Count >= 3) break;
+                }
+
+                if (windowFailures.Count == 0) continue;
+
+                var truncatedFailures = windowFailures.Select(a => Truncate(a, 200)).ToList();
+
+                if (bucketByArgs.TryGetValue(successArgs, out var existing))
+                {
+                    foreach (var f in truncatedFailures)
+                        if (!existing.FailedArgs.Contains(f, StringComparer.Ordinal)
+                            && existing.FailedArgs.Count < 3)
+                            existing.FailedArgs.Add(f);
+                    bucketByArgs[successArgs] = (existing.FailedArgs, success.Timestamp);
+                }
+                else
+                {
+                    bucketByArgs[successArgs] = (truncatedFailures, success.Timestamp);
+                }
+            }
+
+            if (bucketByArgs.Count == 0) continue;
+
+            var sessionId = ordered[0].SessionId;
+            var toolName = ordered[0].ToolName;
+
+            foreach (var kvp in bucketByArgs)
+            {
+                patterns.Add(new ToolRetryPattern(
+                    sessionId,
+                    toolName,
+                    kvp.Value.FailedArgs,
+                    Truncate(kvp.Key, 200),
+                    kvp.Value.LastSeen));
+            }
         }
 
         return patterns;

--- a/src/RockBot.Host/DreamService.cs
+++ b/src/RockBot.Host/DreamService.cs
@@ -2008,23 +2008,152 @@ internal sealed class DreamService : IHostedService, IDisposable
         HashSet<string> sessionsWithSkills, DateTimeOffset since)
     {
         var patterns = await DetectToolRetryPatternsAsync(since, sessionsWithSkills);
-        var result = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+        return GroupRetryPatternsBySession(patterns);
+    }
 
+    /// <summary>
+    /// Converts a flat list of retry patterns into per-session human-readable notes —
+    /// the shape skill-optimize uses to inject ambiguity context per skill.
+    /// </summary>
+    internal static Dictionary<string, List<string>> GroupRetryPatternsBySession(
+        IEnumerable<ToolRetryPattern> patterns)
+    {
+        var result = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
         foreach (var p in patterns)
         {
-            var note =
-                $"Tool '{p.ToolName}' failed with args [{string.Join(" | ", p.FailedArgs)}] " +
-                $"then succeeded with args [{p.SuccessArgs}]";
-
             if (!result.TryGetValue(p.SessionId, out var list))
             {
                 list = [];
                 result[p.SessionId] = list;
             }
-            list.Add(note);
+            list.Add(FormatToolRetryNote(p));
         }
-
         return result;
+    }
+
+    /// <summary>
+    /// Single-line description of one retry pattern, suitable for injection into a skill-
+    /// optimization prompt as ambiguity context.
+    /// </summary>
+    internal static string FormatToolRetryNote(ToolRetryPattern p) =>
+        $"Tool '{p.ToolName}' failed with args [{string.Join(" | ", p.FailedArgs)}] " +
+        $"then succeeded with args [{p.SuccessArgs}]";
+
+    /// <summary>
+    /// Deduplicates retry patterns on (toolName, successArgs) keeping the most recent
+    /// occurrence of each lesson, then caps at <paramref name="maxCount"/> so the prompt
+    /// stays bounded even when a long tail of distinct lessons exists.
+    /// </summary>
+    internal static IReadOnlyList<ToolRetryPattern> DedupeRetryPatterns(
+        IEnumerable<ToolRetryPattern> patterns, int maxCount)
+    {
+        return patterns
+            .GroupBy(p => $"{p.ToolName}\0{p.SuccessArgs}")
+            .Select(g => g.OrderByDescending(p => p.LastSeenAt).First())
+            .Take(maxCount)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Builds the user-message for the tool-success-learning pass from already-deduplicated
+    /// patterns. The leading paragraph instructs the LLM what to extract; each pattern is
+    /// formatted as a numbered section with failed args, successful args, and last-seen
+    /// timestamp.
+    /// </summary>
+    internal static string BuildToolSuccessLearningUserMessage(
+        IReadOnlyList<ToolRetryPattern> distinctPatterns)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine(
+            "The following tool calls each followed a retry-until-success pattern within a single session. " +
+            "Each entry shows the failed argument values followed by the value that succeeded. " +
+            "For each one, extract the durable, verified fact the success proves about the external system " +
+            "(e.g. which server holds a resource, which account ID maps to which calendar, which folder " +
+            "path is correct). Skip patterns where the lesson is uninteresting or transient.");
+        sb.AppendLine();
+
+        var i = 1;
+        foreach (var p in distinctPatterns)
+        {
+            sb.AppendLine($"### Pattern {i++}: tool '{p.ToolName}'");
+            sb.AppendLine($"- Failed args: {string.Join(" | ", p.FailedArgs)}");
+            sb.AppendLine($"- Successful args: {p.SuccessArgs}");
+            sb.AppendLine($"- Last seen: {p.LastSeenAt:yyyy-MM-dd HH:mm} UTC");
+            sb.AppendLine();
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Normalizes the LLM's tool-success-learning JSON into <see cref="MemoryEntry"/> values
+    /// ready to persist: drops empty content, adds the canonical "verified" and
+    /// "tool-success-learned" tags if missing, defaults the category to "tool-knowledge"
+    /// when blank.
+    /// </summary>
+    internal static IReadOnlyList<MemoryEntry> NormalizeToolSuccessLearningEntries(
+        MemoryMiningResultDto? result,
+        Func<string> idFactory,
+        Func<DateTimeOffset> nowFactory)
+    {
+        var entries = new List<MemoryEntry>();
+        foreach (var dto in result?.ToSave ?? [])
+        {
+            if (string.IsNullOrWhiteSpace(dto.Content))
+                continue;
+
+            var tags = new List<string>(dto.Tags ?? []);
+            if (!tags.Contains("verified", StringComparer.OrdinalIgnoreCase))
+                tags.Add("verified");
+            if (!tags.Contains("tool-success-learned", StringComparer.OrdinalIgnoreCase))
+                tags.Add("tool-success-learned");
+
+            var now = nowFactory();
+            entries.Add(new MemoryEntry(
+                Id: idFactory(),
+                Content: dto.Content.Trim(),
+                Category: string.IsNullOrWhiteSpace(dto.Category) ? "tool-knowledge" : dto.Category.Trim(),
+                Tags: tags,
+                CreatedAt: now,
+                UpdatedAt: now));
+        }
+        return entries;
+    }
+
+    /// <summary>
+    /// Builds the "Subagent verified data" section appended to the memory-mining input, or
+    /// returns null when there are no entries to include. Caps each entry value at
+    /// <paramref name="perEntryCap"/> chars and emits at most <paramref name="maxEntries"/>
+    /// entries (newest first by <see cref="WorkingMemoryEntry.StoredAt"/>).
+    /// </summary>
+    internal static string? BuildSubagentWhiteboardSection(
+        IReadOnlyList<WorkingMemoryEntry> entries, int perEntryCap, int maxEntries)
+    {
+        if (entries.Count == 0)
+            return null;
+
+        var ordered = entries
+            .OrderByDescending(e => e.StoredAt)
+            .Take(maxEntries)
+            .ToList();
+
+        var sb = new StringBuilder();
+        sb.AppendLine("## Subagent verified data (working memory whiteboards)");
+        sb.AppendLine("These entries were written by subagents based on tool-call results, so the");
+        sb.AppendLine("facts in them are verified — not speculation. Mine them for durable facts");
+        sb.AppendLine("about external systems (server names, account IDs, file paths, parameter shapes).");
+        sb.AppendLine();
+
+        foreach (var e in ordered)
+        {
+            var value = e.Value.Length > perEntryCap
+                ? e.Value[..perEntryCap] + "…[truncated]"
+                : e.Value;
+            var category = string.IsNullOrEmpty(e.Category) ? "(uncategorized)" : e.Category;
+            sb.AppendLine($"[{e.Key}] category={category}");
+            sb.AppendLine(value);
+            sb.AppendLine();
+        }
+        return sb.ToString();
     }
 
     private static string Truncate(string s, int max) =>
@@ -2050,43 +2179,20 @@ internal sealed class DreamService : IHostedService, IDisposable
             return;
         }
 
-        // Deduplicate across sessions on (toolName, successArgs) — the same lesson learned
-        // multiple times only needs to be mined once.
-        var distinctPatterns = patterns
-            .GroupBy(p => $"{p.ToolName}\0{p.SuccessArgs}")
-            .Select(g => g.OrderByDescending(p => p.LastSeenAt).First())
-            .Take(50)
-            .ToList();
+        var distinctPatterns = DedupeRetryPatterns(patterns, maxCount: 50);
 
         _logger.LogInformation(
             "DreamService: tool-success-learning pass — {Distinct} distinct pattern(s) from {Total} occurrence(s)",
             distinctPatterns.Count, patterns.Count);
 
-        var userMessage = new StringBuilder();
-        userMessage.AppendLine(
-            "The following tool calls each followed a retry-until-success pattern within a single session. " +
-            "Each entry shows the failed argument values followed by the value that succeeded. " +
-            "For each one, extract the durable, verified fact the success proves about the external system " +
-            "(e.g. which server holds a resource, which account ID maps to which calendar, which folder " +
-            "path is correct). Skip patterns where the lesson is uninteresting or transient.");
-        userMessage.AppendLine();
-
-        var i = 1;
-        foreach (var p in distinctPatterns)
-        {
-            userMessage.AppendLine($"### Pattern {i++}: tool '{p.ToolName}'");
-            userMessage.AppendLine($"- Failed args: {string.Join(" | ", p.FailedArgs)}");
-            userMessage.AppendLine($"- Successful args: {p.SuccessArgs}");
-            userMessage.AppendLine($"- Last seen: {p.LastSeenAt:yyyy-MM-dd HH:mm} UTC");
-            userMessage.AppendLine();
-        }
+        var userMessage = BuildToolSuccessLearningUserMessage(distinctPatterns);
 
         try
         {
             var messages = new List<ChatMessage>
             {
                 new(ChatRole.System, _toolSuccessLearningDirective ?? BuiltInToolSuccessLearningDirective),
-                new(ChatRole.User, userMessage.ToString())
+                new(ChatRole.User, userMessage)
             };
 
             var response = await _llmClient.GetResponseAsync(messages, ModelTier.Balanced,
@@ -2101,34 +2207,20 @@ internal sealed class DreamService : IHostedService, IDisposable
             }
 
             var result = TryDeserializeJson<MemoryMiningResultDto>(json, "tool-success-learning");
-            var saved = 0;
+            var entries = NormalizeToolSuccessLearningEntries(
+                result,
+                idFactory: () => Guid.NewGuid().ToString("N")[..12],
+                nowFactory: () => DateTimeOffset.UtcNow);
 
-            foreach (var dto in result?.ToSave ?? [])
+            foreach (var entry in entries)
             {
-                if (string.IsNullOrWhiteSpace(dto.Content))
-                    continue;
-
-                var tags = new List<string>(dto.Tags ?? []);
-                if (!tags.Contains("verified", StringComparer.OrdinalIgnoreCase))
-                    tags.Add("verified");
-                if (!tags.Contains("tool-success-learned", StringComparer.OrdinalIgnoreCase))
-                    tags.Add("tool-success-learned");
-
-                var entry = new MemoryEntry(
-                    Id: Guid.NewGuid().ToString("N")[..12],
-                    Content: dto.Content.Trim(),
-                    Category: string.IsNullOrWhiteSpace(dto.Category) ? "tool-knowledge" : dto.Category.Trim(),
-                    Tags: tags,
-                    CreatedAt: DateTimeOffset.UtcNow,
-                    UpdatedAt: DateTimeOffset.UtcNow);
-
                 await _memory.SaveAsync(entry);
-                saved++;
                 _logger.LogDebug("DreamService: tool-success-learning saved {Id} ({Category}): {Content}",
                     entry.Id, entry.Category, entry.Content);
             }
 
-            _logger.LogInformation("DreamService: tool-success-learning pass complete — {Saved} entry(ies) saved", saved);
+            _logger.LogInformation(
+                "DreamService: tool-success-learning pass complete — {Saved} entry(ies) saved", entries.Count);
         }
         catch (Exception ex)
         {
@@ -2150,36 +2242,15 @@ internal sealed class DreamService : IHostedService, IDisposable
         try
         {
             var entries = await _workingMemory.ListAsync("subagent/");
-            if (entries.Count == 0)
+            var section = BuildSubagentWhiteboardSection(entries, perEntryCap: 2000, maxEntries: 50);
+            if (section is null)
                 return;
 
-            // Newest first, capped to keep prompt bounded.
-            var ordered = entries
-                .OrderByDescending(e => e.StoredAt)
-                .Take(50)
-                .ToList();
-
-            userMessage.AppendLine("## Subagent verified data (working memory whiteboards)");
-            userMessage.AppendLine("These entries were written by subagents based on tool-call results, so the");
-            userMessage.AppendLine("facts in them are verified — not speculation. Mine them for durable facts");
-            userMessage.AppendLine("about external systems (server names, account IDs, file paths, parameter shapes).");
-            userMessage.AppendLine();
-
-            const int perEntryCap = 2000;
-            foreach (var e in ordered)
-            {
-                var value = e.Value.Length > perEntryCap
-                    ? e.Value[..perEntryCap] + "…[truncated]"
-                    : e.Value;
-                var category = string.IsNullOrEmpty(e.Category) ? "(uncategorized)" : e.Category;
-                userMessage.AppendLine($"[{e.Key}] category={category}");
-                userMessage.AppendLine(value);
-                userMessage.AppendLine();
-            }
+            userMessage.Append(section);
 
             _logger.LogDebug(
                 "DreamService: memory mining included {Count} subagent whiteboard entry(ies) in input",
-                ordered.Count);
+                Math.Min(entries.Count, 50));
         }
         catch (Exception ex)
         {
@@ -3407,9 +3478,9 @@ internal sealed class DreamService : IHostedService, IDisposable
         IReadOnlyList<string>? Tags,
         float? Importance);
 
-    private sealed record MemoryMiningResultDto(List<MemoryMiningEntryDto>? ToSave);
+    internal sealed record MemoryMiningResultDto(List<MemoryMiningEntryDto>? ToSave);
 
-    private sealed record MemoryMiningEntryDto(
+    internal sealed record MemoryMiningEntryDto(
         string Content,
         string? Category,
         IReadOnlyList<string>? Tags);

--- a/src/RockBot.Host/DreamService.cs
+++ b/src/RockBot.Host/DreamService.cs
@@ -31,6 +31,7 @@ internal sealed class DreamService : IHostedService, IDisposable
     private readonly IToolCallLog? _toolCallLog;
     private readonly IWispExecutionLog? _wispExecutionLog;
     private readonly IKnowledgeGraph? _knowledgeGraph;
+    private readonly IWorkingMemory? _workingMemory;
     private readonly ILlmClient _llmClient;
     private readonly IAgentWorkSerializer _workSerializer;
     private readonly IUserActivityMonitor _userActivityMonitor;
@@ -54,6 +55,7 @@ internal sealed class DreamService : IHostedService, IDisposable
     private string? _dlqDirective;
     private string? _identityDirective;
     private string? _wispFailureDirective;
+    private string? _toolSuccessLearningDirective;
 
     public DreamService(
         ILongTermMemory memory,
@@ -72,7 +74,8 @@ internal sealed class DreamService : IHostedService, IDisposable
         IDlqSampler? dlqSampler = null,
         IToolCallLog? toolCallLog = null,
         IKnowledgeGraph? knowledgeGraph = null,
-        IWispExecutionLog? wispExecutionLog = null)
+        IWispExecutionLog? wispExecutionLog = null,
+        IWorkingMemory? workingMemory = null)
     {
         _memory = memory;
         _skillStore = skillStores.FirstOrDefault();
@@ -84,6 +87,7 @@ internal sealed class DreamService : IHostedService, IDisposable
         _toolCallLog = toolCallLog;
         _knowledgeGraph = knowledgeGraph;
         _wispExecutionLog = wispExecutionLog;
+        _workingMemory = workingMemory;
         _llmClient = llmClient;
         _workSerializer = workSerializer;
         _userActivityMonitor = userActivityMonitor;
@@ -279,6 +283,19 @@ internal sealed class DreamService : IHostedService, IDisposable
                 _logger.LogDebug("DreamService: wisp failure directive not found at {Path}; using built-in", wispDirectivePath);
             else
                 _logger.LogInformation("DreamService: loaded wisp failure directive from {Path}", wispDirectivePath);
+        }
+
+        if (_options.ToolSuccessLearningEnabled && _toolCallLog is not null)
+        {
+            var path = ResolvePath(_options.ToolSuccessLearningDirectivePath, _profileOptions.BasePath);
+            _toolSuccessLearningDirective = File.Exists(path)
+                ? File.ReadAllText(path)
+                : null;
+
+            if (!File.Exists(path))
+                _logger.LogDebug("DreamService: tool-success-learning directive not found at {Path}; using built-in", path);
+            else
+                _logger.LogInformation("DreamService: loaded tool-success-learning directive from {Path}", path);
         }
 
         try
@@ -532,6 +549,8 @@ internal sealed class DreamService : IHostedService, IDisposable
             ct.ThrowIfCancellationRequested(); await RunSequenceSkillDetectionPassAsync();
 
             ct.ThrowIfCancellationRequested(); await RunWispFailureAnalysisPassAsync();
+
+            ct.ThrowIfCancellationRequested(); await RunToolSuccessLearningPassAsync();
 
             ct.ThrowIfCancellationRequested(); await RunTierRoutingReviewPassAsync();
 
@@ -865,6 +884,14 @@ internal sealed class DreamService : IHostedService, IDisposable
             }
         }
 
+        // Tool-retry signal: sessions that called the same tool repeatedly with different args
+        // until one succeeded indicate the guiding skill left an ambiguity. The arg pair
+        // (failed → succeeded) is exactly the context the optimizer needs to tighten the skill.
+        var toolRetryNotesBySession =
+            await DetectToolRetrySessionsAsync(sessionsWithSkills, since);
+        foreach (var sessionId in toolRetryNotesBySession.Keys)
+            atRiskSessions.Add(sessionId);
+
         if (atRiskSessions.Count == 0)
         {
             _logger.LogDebug("DreamService: no at-risk sessions found; skipping optimization pass");
@@ -941,6 +968,25 @@ internal sealed class DreamService : IHostedService, IDisposable
                     var detail = string.IsNullOrWhiteSpace(fb.Detail) ? string.Empty : $" — \"{fb.Detail}\"";
                     userMessage.AppendLine($"- [{fb.SignalType}] {fb.Summary}{detail}");
                 }
+                userMessage.AppendLine();
+            }
+
+            // Tool-retry context: failed→succeeded arg pairs from sessions that used this skill.
+            // These show exactly which ambiguity in the skill caused costly retries.
+            var retryNotesForSkill = sessionsUsingSkill
+                .Where(toolRetryNotesBySession.ContainsKey)
+                .SelectMany(s => toolRetryNotesBySession[s])
+                .ToList();
+
+            if (retryNotesForSkill.Count > 0)
+            {
+                userMessage.AppendLine("### Tool retry-until-success patterns (skill ambiguity signals):");
+                foreach (var note in retryNotesForSkill)
+                    userMessage.AppendLine($"- {note}");
+                userMessage.AppendLine();
+                userMessage.AppendLine(
+                    "Consider tightening the skill to specify the verified argument value(s) above, " +
+                    "replacing any hedging language (\"typically X and sometimes Y\") with the concrete answer.");
                 userMessage.AppendLine();
             }
         }
@@ -1815,6 +1861,8 @@ internal sealed class DreamService : IHostedService, IDisposable
                 userMessage.AppendLine();
             }
 
+            await AppendSubagentWhiteboardEntriesAsync(userMessage);
+
             var messages = new List<ChatMessage>
             {
                 new(ChatRole.System, _memoryMiningDirective ?? BuiltInMemoryMiningDirective),
@@ -1865,6 +1913,277 @@ internal sealed class DreamService : IHostedService, IDisposable
         catch (Exception ex)
         {
             _logger.LogError(ex, "DreamService: memory mining pass failed");
+        }
+    }
+
+    /// <summary>
+    /// One retry-until-success occurrence: within a single session, a tool was called multiple
+    /// times with different argument values, with at least one failure followed by a success.
+    /// </summary>
+    internal sealed record ToolRetryPattern(
+        string SessionId,
+        string ToolName,
+        IReadOnlyList<string> FailedArgs,
+        string SuccessArgs,
+        DateTimeOffset LastSeenAt);
+
+    /// <summary>
+    /// Pure detection logic — extracts retry-until-success patterns from a set of tool-call
+    /// events. Within each (session, toolName) bucket, requires at least 2 events, ≥2 distinct
+    /// argument summaries, and an earlier failure followed by a success.
+    /// </summary>
+    internal static IReadOnlyList<ToolRetryPattern> DetectToolRetryPatternsFromEvents(
+        IEnumerable<ToolCallEvent> events,
+        HashSet<string>? sessionsFilter = null)
+    {
+        var filtered = sessionsFilter is null
+            ? events
+            : events.Where(e => sessionsFilter.Contains(e.SessionId));
+
+        var patterns = new List<ToolRetryPattern>();
+
+        foreach (var group in filtered.GroupBy(e => $"{e.SessionId}\0{e.ToolName}"))
+        {
+            var ordered = group.OrderBy(e => e.Timestamp).ToList();
+            if (ordered.Count < 2) continue;
+
+            var distinctArgs = ordered
+                .Select(e => e.ArgumentsSummary ?? "(none)")
+                .Distinct(StringComparer.Ordinal)
+                .Count();
+            if (distinctArgs < 2) continue;
+
+            var firstSuccess = ordered.FirstOrDefault(e => e.Succeeded);
+            if (firstSuccess is null) continue;
+            var anyEarlierFailure =
+                ordered.Any(e => !e.Succeeded && e.Timestamp < firstSuccess.Timestamp);
+            if (!anyEarlierFailure) continue;
+
+            var failedArgs = ordered
+                .Where(e => !e.Succeeded && e.Timestamp < firstSuccess.Timestamp)
+                .Select(e => Truncate(e.ArgumentsSummary ?? "(none)", 200))
+                .Distinct(StringComparer.Ordinal)
+                .Take(3)
+                .ToList();
+            var successArgs = Truncate(firstSuccess.ArgumentsSummary ?? "(none)", 200);
+
+            patterns.Add(new ToolRetryPattern(
+                ordered[0].SessionId,
+                ordered[0].ToolName,
+                failedArgs,
+                successArgs,
+                ordered[^1].Timestamp));
+        }
+
+        return patterns;
+    }
+
+    /// <summary>
+    /// Scans the tool-call log for retry-until-success patterns. The differing argument value is
+    /// the ambiguity that the guiding skill (or the agent's reasoning) failed to resolve up front,
+    /// and is exactly what skill-optimize and tool-success-learning need to act on.
+    /// </summary>
+    /// <param name="sessionsFilter">If non-null, only events from these sessions are considered.</param>
+    private async Task<IReadOnlyList<ToolRetryPattern>> DetectToolRetryPatternsAsync(
+        DateTimeOffset since, HashSet<string>? sessionsFilter = null)
+    {
+        if (_toolCallLog is null)
+            return [];
+
+        try
+        {
+            var events = await _toolCallLog.QueryRecentAsync(since, maxResults: 20000);
+            return events.Count == 0
+                ? []
+                : DetectToolRetryPatternsFromEvents(events, sessionsFilter);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "DreamService: failed to scan tool-call log for retry patterns");
+            return [];
+        }
+    }
+
+    private async Task<Dictionary<string, List<string>>> DetectToolRetrySessionsAsync(
+        HashSet<string> sessionsWithSkills, DateTimeOffset since)
+    {
+        var patterns = await DetectToolRetryPatternsAsync(since, sessionsWithSkills);
+        var result = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var p in patterns)
+        {
+            var note =
+                $"Tool '{p.ToolName}' failed with args [{string.Join(" | ", p.FailedArgs)}] " +
+                $"then succeeded with args [{p.SuccessArgs}]";
+
+            if (!result.TryGetValue(p.SessionId, out var list))
+            {
+                list = [];
+                result[p.SessionId] = list;
+            }
+            list.Add(note);
+        }
+
+        return result;
+    }
+
+    private static string Truncate(string s, int max) =>
+        s.Length <= max ? s : s[..max] + "…";
+
+    /// <summary>
+    /// Mines the tool-call log for retry-until-success patterns and asks the LLM to extract
+    /// the verified fact each pattern proves (e.g. "Teams bridge JSON lives on
+    /// onedrive-personal at /Apps/RockBot/xebia-teams"). Saves results as durable long-term
+    /// memory entries tagged "verified" and "tool-success-learned" so future sessions surface
+    /// them via BM25 or vector recall before the agent has to re-discover the same answer.
+    /// </summary>
+    private async Task RunToolSuccessLearningPassAsync()
+    {
+        if (!_options.ToolSuccessLearningEnabled || _toolCallLog is null)
+            return;
+
+        var since = DateTimeOffset.UtcNow.AddDays(-7);
+        var patterns = await DetectToolRetryPatternsAsync(since);
+        if (patterns.Count == 0)
+        {
+            _logger.LogDebug("DreamService: tool-success-learning — no retry patterns found; skipping");
+            return;
+        }
+
+        // Deduplicate across sessions on (toolName, successArgs) — the same lesson learned
+        // multiple times only needs to be mined once.
+        var distinctPatterns = patterns
+            .GroupBy(p => $"{p.ToolName}\0{p.SuccessArgs}")
+            .Select(g => g.OrderByDescending(p => p.LastSeenAt).First())
+            .Take(50)
+            .ToList();
+
+        _logger.LogInformation(
+            "DreamService: tool-success-learning pass — {Distinct} distinct pattern(s) from {Total} occurrence(s)",
+            distinctPatterns.Count, patterns.Count);
+
+        var userMessage = new StringBuilder();
+        userMessage.AppendLine(
+            "The following tool calls each followed a retry-until-success pattern within a single session. " +
+            "Each entry shows the failed argument values followed by the value that succeeded. " +
+            "For each one, extract the durable, verified fact the success proves about the external system " +
+            "(e.g. which server holds a resource, which account ID maps to which calendar, which folder " +
+            "path is correct). Skip patterns where the lesson is uninteresting or transient.");
+        userMessage.AppendLine();
+
+        var i = 1;
+        foreach (var p in distinctPatterns)
+        {
+            userMessage.AppendLine($"### Pattern {i++}: tool '{p.ToolName}'");
+            userMessage.AppendLine($"- Failed args: {string.Join(" | ", p.FailedArgs)}");
+            userMessage.AppendLine($"- Successful args: {p.SuccessArgs}");
+            userMessage.AppendLine($"- Last seen: {p.LastSeenAt:yyyy-MM-dd HH:mm} UTC");
+            userMessage.AppendLine();
+        }
+
+        try
+        {
+            var messages = new List<ChatMessage>
+            {
+                new(ChatRole.System, _toolSuccessLearningDirective ?? BuiltInToolSuccessLearningDirective),
+                new(ChatRole.User, userMessage.ToString())
+            };
+
+            var response = await _llmClient.GetResponseAsync(messages, ModelTier.Balanced,
+                new ChatOptions { ResponseFormat = ChatResponseFormat.Json });
+            var raw = response.Text?.Trim() ?? string.Empty;
+            var json = ExtractJsonObject(raw);
+
+            if (string.IsNullOrEmpty(json))
+            {
+                _logger.LogWarning("DreamService: tool-success-learning LLM returned no parseable JSON; skipping");
+                return;
+            }
+
+            var result = TryDeserializeJson<MemoryMiningResultDto>(json, "tool-success-learning");
+            var saved = 0;
+
+            foreach (var dto in result?.ToSave ?? [])
+            {
+                if (string.IsNullOrWhiteSpace(dto.Content))
+                    continue;
+
+                var tags = new List<string>(dto.Tags ?? []);
+                if (!tags.Contains("verified", StringComparer.OrdinalIgnoreCase))
+                    tags.Add("verified");
+                if (!tags.Contains("tool-success-learned", StringComparer.OrdinalIgnoreCase))
+                    tags.Add("tool-success-learned");
+
+                var entry = new MemoryEntry(
+                    Id: Guid.NewGuid().ToString("N")[..12],
+                    Content: dto.Content.Trim(),
+                    Category: string.IsNullOrWhiteSpace(dto.Category) ? "tool-knowledge" : dto.Category.Trim(),
+                    Tags: tags,
+                    CreatedAt: DateTimeOffset.UtcNow,
+                    UpdatedAt: DateTimeOffset.UtcNow);
+
+                await _memory.SaveAsync(entry);
+                saved++;
+                _logger.LogDebug("DreamService: tool-success-learning saved {Id} ({Category}): {Content}",
+                    entry.Id, entry.Category, entry.Content);
+            }
+
+            _logger.LogInformation("DreamService: tool-success-learning pass complete — {Saved} entry(ies) saved", saved);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "DreamService: tool-success-learning pass failed");
+        }
+    }
+
+    /// <summary>
+    /// Appends recent subagent whiteboard entries (live working-memory entries with key prefix
+    /// "subagent/") to the memory-mining input so the miner can see facts that subagents
+    /// verified via tool calls but never restated in the conversation log. Entries are size-capped
+    /// to keep the prompt bounded.
+    /// </summary>
+    private async Task AppendSubagentWhiteboardEntriesAsync(StringBuilder userMessage)
+    {
+        if (_workingMemory is null)
+            return;
+
+        try
+        {
+            var entries = await _workingMemory.ListAsync("subagent/");
+            if (entries.Count == 0)
+                return;
+
+            // Newest first, capped to keep prompt bounded.
+            var ordered = entries
+                .OrderByDescending(e => e.StoredAt)
+                .Take(50)
+                .ToList();
+
+            userMessage.AppendLine("## Subagent verified data (working memory whiteboards)");
+            userMessage.AppendLine("These entries were written by subagents based on tool-call results, so the");
+            userMessage.AppendLine("facts in them are verified — not speculation. Mine them for durable facts");
+            userMessage.AppendLine("about external systems (server names, account IDs, file paths, parameter shapes).");
+            userMessage.AppendLine();
+
+            const int perEntryCap = 2000;
+            foreach (var e in ordered)
+            {
+                var value = e.Value.Length > perEntryCap
+                    ? e.Value[..perEntryCap] + "…[truncated]"
+                    : e.Value;
+                var category = string.IsNullOrEmpty(e.Category) ? "(uncategorized)" : e.Category;
+                userMessage.AppendLine($"[{e.Key}] category={category}");
+                userMessage.AppendLine(value);
+                userMessage.AppendLine();
+            }
+
+            _logger.LogDebug(
+                "DreamService: memory mining included {Count} subagent whiteboard entry(ies) in input",
+                ordered.Count);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "DreamService: failed to load subagent whiteboard entries for memory mining");
         }
     }
 
@@ -3261,6 +3580,41 @@ internal sealed class DreamService : IHostedService, IDisposable
         }
 
         If nothing should be deleted: { "deleteEntities": [], "deleteTriples": [] }
+        """;
+
+    private const string BuiltInToolSuccessLearningDirective = """
+        You are a tool-success learning assistant. The agent's tool-call log contains
+        retry-until-success patterns: cases where the same tool was invoked with different
+        argument values within one session, with at least one failure followed by a success.
+        The argument value that succeeded is verified information about the external system.
+        Your job is to extract the durable, actionable fact each pattern proves so future
+        sessions can recall it before re-running the same exploration.
+
+        Mine for facts that:
+        - Identify the correct server, account, or namespace for a resource
+          (e.g. "Teams bridge JSON archives live on the onedrive-personal MCP server at /Apps/RockBot/xebia-teams")
+        - Specify required argument shape, casing, or path conventions
+          (e.g. "list_files on onedrive-marimer rejects a leading slash on folder_path; use 'Apps/...' not '/Apps/...'")
+        - Map account IDs or identifiers to their meaning
+          (e.g. "accountId 'xebia' is required to query the Xebia work calendar; omitting it returns the personal calendar")
+
+        Do NOT mine:
+        - Transient values (specific filenames, search hits, one-off IDs that won't recur)
+        - Generic best-practices already obvious from tool documentation
+        - Speculation: the failed args may have been wrong for many reasons; only commit to
+          what the successful args directly prove
+
+        Phrase each fact in third-person, self-contained, with the specific tool/server/argument
+        named explicitly. The fact should make sense to a future session that has no memory of
+        today's retry sequence.
+
+        Return ONLY a JSON object:
+        { "toSave": [ { "content": "...", "category": "...", "tags": ["verified", "tool-success-learned"] } ] }
+
+        Category should reflect the tool domain (e.g. "tool-knowledge/onedrive",
+        "tool-knowledge/calendar", "tool-knowledge/email"). Default to "tool-knowledge".
+
+        If none of the patterns prove a durable, useful fact, return: { "toSave": [] }
         """;
 
     private const string BuiltInMemoryMiningDirective = """

--- a/src/RockBot.Host/RockBotFunctionInvokingChatClient.cs
+++ b/src/RockBot.Host/RockBotFunctionInvokingChatClient.cs
@@ -124,6 +124,18 @@ public class RockBotFunctionInvokingChatClient : FunctionInvokingChatClient
             _consecutiveTimeoutIterations = 0;
         }
 
+        // Detect content-level errors that didn't throw an exception. Tool executors that
+        // return ToolInvokeResponse with IsError=true are surfaced by RegistryToolFunction
+        // as a string prefixed with "Error: " — so any tool result starting with that prefix
+        // indicates a logical failure even though the call mechanically completed. Flagging
+        // these as Succeeded=false is what lets the dream-time retry-pattern detector see
+        // MCP errors (e.g. "the resource could not be found") as failures rather than as
+        // successful calls that just happened to return an error message.
+        if (status == "ok" && resultStr is not null && IsErrorResult(resultStr))
+        {
+            status = ToolError.Codes.ExecutionFailed;
+        }
+
         // Track consecutive identical (tool, args, result) triples to detect stuck loops.
         if (_repetitiveCallDetector.Track(callContent.Name, argsSummary ?? string.Empty, resultStr ?? string.Empty))
         {
@@ -364,6 +376,16 @@ public class RockBotFunctionInvokingChatClient : FunctionInvokingChatClient
 
     private static bool IsTimeoutResult(string result) =>
         result.Contains("timed out", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// True when the tool result indicates a logical (content-level) error rather than a
+    /// transport success. <see cref="RegistryToolFunction"/> prepends "Error: " to any
+    /// response with <c>IsError=true</c>, so this prefix reliably signals "the executor
+    /// completed but the operation failed" — including MCP server errors propagated by
+    /// <c>McpToolProxy</c>.
+    /// </summary>
+    internal static bool IsErrorResult(string result) =>
+        result.StartsWith("Error: ", StringComparison.Ordinal);
 
     private static string DescribeToolCall(string name, string? argsSummary)
     {

--- a/tests/RockBot.Host.Tests/IsErrorResultTests.cs
+++ b/tests/RockBot.Host.Tests/IsErrorResultTests.cs
@@ -1,0 +1,40 @@
+namespace RockBot.Host.Tests;
+
+[TestClass]
+public class IsErrorResultTests
+{
+    [TestMethod]
+    public void StartsWithErrorPrefix_DetectedAsError() =>
+        Assert.IsTrue(RockBotFunctionInvokingChatClient.IsErrorResult(
+            "Error: Graph API error: The resource could not be found."));
+
+    [TestMethod]
+    public void PlainContent_NotAnError() =>
+        Assert.IsFalse(RockBotFunctionInvokingChatClient.IsErrorResult(
+            """{"server":"onedrive-personal","files":[]}"""));
+
+    [TestMethod]
+    public void ContentMentioningErrorWord_NotDetected() =>
+        Assert.IsFalse(RockBotFunctionInvokingChatClient.IsErrorResult(
+            "The user's last login attempt produced an Error: condition that the docs explain."),
+            "Only the literal 'Error: ' prefix counts — substring matches would mis-flag normal content.");
+
+    [TestMethod]
+    public void LowercasePrefix_NotDetected() =>
+        Assert.IsFalse(RockBotFunctionInvokingChatClient.IsErrorResult("error: lowercase"),
+            "RegistryToolFunction emits 'Error: ' with capital E; matching is case-sensitive.");
+
+    [TestMethod]
+    public void ErrorWithoutColon_NotDetected() =>
+        Assert.IsFalse(RockBotFunctionInvokingChatClient.IsErrorResult("Error happened, see below"),
+            "Without the colon-space, this is just narrative text.");
+
+    [TestMethod]
+    public void EmptyString_NotAnError() =>
+        Assert.IsFalse(RockBotFunctionInvokingChatClient.IsErrorResult(""));
+
+    [TestMethod]
+    public void DoubleErrorPrefix_StillDetected() =>
+        Assert.IsTrue(RockBotFunctionInvokingChatClient.IsErrorResult("Error: Error: nested"),
+            "Defensive: if the executor's content already started with 'Error', the doubled prefix still counts.");
+}

--- a/tests/RockBot.Host.Tests/SubagentWhiteboardSectionTests.cs
+++ b/tests/RockBot.Host.Tests/SubagentWhiteboardSectionTests.cs
@@ -1,0 +1,151 @@
+namespace RockBot.Host.Tests;
+
+[TestClass]
+public class SubagentWhiteboardSectionTests
+{
+    private static WorkingMemoryEntry Entry(
+        string key,
+        string value,
+        DateTimeOffset? storedAt = null,
+        string? category = null) =>
+        new(
+            Key: key,
+            Value: value,
+            StoredAt: storedAt ?? DateTimeOffset.UtcNow,
+            ExpiresAt: (storedAt ?? DateTimeOffset.UtcNow).AddHours(4),
+            Category: category,
+            Tags: null);
+
+    [TestMethod]
+    public void EmptyEntries_ReturnsNull()
+    {
+        var section = DreamService.BuildSubagentWhiteboardSection(
+            entries: [], perEntryCap: 1000, maxEntries: 50);
+
+        Assert.IsNull(section,
+            "Returning null when there's nothing to add lets the caller skip appending without checking length.");
+    }
+
+    [TestMethod]
+    public void SingleEntry_AppearsWithKeyAndValue()
+    {
+        var entries = new[]
+        {
+            Entry(
+                key: "subagent/abc123/communications-triage",
+                value: """{"server":"onedrive-personal"}""",
+                category: "briefing/communications")
+        };
+
+        var section = DreamService.BuildSubagentWhiteboardSection(entries, 1000, 50);
+
+        Assert.IsNotNull(section);
+        StringAssert.Contains(section, "[subagent/abc123/communications-triage]");
+        StringAssert.Contains(section, "category=briefing/communications");
+        StringAssert.Contains(section, "onedrive-personal");
+    }
+
+    [TestMethod]
+    public void IncludesInstructionalHeader()
+    {
+        var entries = new[] { Entry("subagent/x/y", "value") };
+
+        var section = DreamService.BuildSubagentWhiteboardSection(entries, 1000, 50);
+
+        Assert.IsNotNull(section);
+        StringAssert.Contains(section, "Subagent verified data");
+        StringAssert.Contains(section, "verified — not speculation",
+            "The header tells the miner these are tool-call-verified facts.");
+    }
+
+    [TestMethod]
+    public void NullCategory_RendersAsUncategorized()
+    {
+        var entries = new[] { Entry("subagent/x/y", "value", category: null) };
+
+        var section = DreamService.BuildSubagentWhiteboardSection(entries, 1000, 50);
+
+        Assert.IsNotNull(section);
+        StringAssert.Contains(section, "category=(uncategorized)");
+    }
+
+    [TestMethod]
+    public void EmptyCategory_RendersAsUncategorized()
+    {
+        var entries = new[] { Entry("subagent/x/y", "value", category: "") };
+
+        var section = DreamService.BuildSubagentWhiteboardSection(entries, 1000, 50);
+
+        Assert.IsNotNull(section);
+        StringAssert.Contains(section, "category=(uncategorized)");
+    }
+
+    [TestMethod]
+    public void ValueLongerThanPerEntryCap_IsTruncatedWithMarker()
+    {
+        var longValue = new string('x', 5000);
+        var entries = new[] { Entry("subagent/x/y", longValue) };
+
+        var section = DreamService.BuildSubagentWhiteboardSection(entries, perEntryCap: 100, maxEntries: 50);
+
+        Assert.IsNotNull(section);
+        StringAssert.Contains(section, "…[truncated]");
+        Assert.IsFalse(section.Contains(longValue),
+            "The full value should not appear when it exceeds the per-entry cap.");
+    }
+
+    [TestMethod]
+    public void ValueAtPerEntryCap_NotTruncated()
+    {
+        var atCapValue = new string('y', 100);
+        var entries = new[] { Entry("subagent/x/y", atCapValue) };
+
+        var section = DreamService.BuildSubagentWhiteboardSection(entries, perEntryCap: 100, maxEntries: 50);
+
+        Assert.IsNotNull(section);
+        Assert.IsFalse(section.Contains("…[truncated]"),
+            "Boundary case: value exactly at cap should not be flagged as truncated.");
+        StringAssert.Contains(section, atCapValue);
+    }
+
+    [TestMethod]
+    public void NewerEntriesEmittedFirst_OldestFiltered_WhenOverMaxEntries()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var entries = new[]
+        {
+            Entry("subagent/old1/x", "old-value-1",  storedAt: now.AddHours(-3)),
+            Entry("subagent/old2/x", "old-value-2",  storedAt: now.AddHours(-2)),
+            Entry("subagent/new/x",  "newest-value", storedAt: now)
+        };
+
+        var section = DreamService.BuildSubagentWhiteboardSection(
+            entries, perEntryCap: 1000, maxEntries: 2);
+
+        Assert.IsNotNull(section);
+        StringAssert.Contains(section, "newest-value");
+        StringAssert.Contains(section, "old-value-2");
+        Assert.IsFalse(section.Contains("old-value-1"),
+            "When over maxEntries, oldest entries are dropped first.");
+
+        // Order check: newest entry's key must appear before older entry's key
+        var newestIdx = section.IndexOf("subagent/new/x", StringComparison.Ordinal);
+        var olderIdx = section.IndexOf("subagent/old2/x", StringComparison.Ordinal);
+        Assert.IsTrue(newestIdx >= 0 && olderIdx >= 0);
+        Assert.IsTrue(newestIdx < olderIdx,
+            "Section must list newest-first so size caps drop the oldest content.");
+    }
+
+    [TestMethod]
+    public void MaxEntriesZero_ReturnsHeaderOnly_NoEntries()
+    {
+        var entries = new[] { Entry("subagent/x/y", "value") };
+
+        var section = DreamService.BuildSubagentWhiteboardSection(entries, 1000, maxEntries: 0);
+
+        Assert.IsNotNull(section);
+        StringAssert.Contains(section, "Subagent verified data");
+        Assert.IsFalse(section.Contains("[subagent/x/y]"),
+            "maxEntries=0 should drop all entries while still emitting the section header.");
+    }
+}

--- a/tests/RockBot.Host.Tests/ToolRetryDetectionTests.cs
+++ b/tests/RockBot.Host.Tests/ToolRetryDetectionTests.cs
@@ -162,4 +162,166 @@ public class ToolRetryDetectionTests
         Assert.IsTrue(patterns[0].FailedArgs.Any(a => a.Contains("none")),
             "Null ArgumentsSummary should normalize to a placeholder.");
     }
+
+    // ── Time-window behaviour (regression: long-running sessions) ────────────────
+
+    [TestMethod]
+    public void LongRunningSession_DetectsLaterFailureSuccessTransition()
+    {
+        // This is the exact bug we hit in the live cluster: blazor-session is one rolling
+        // sessionId for weeks, and its first event is a success. The old "first success +
+        // any earlier failure" logic missed every subsequent failure→success retry within
+        // that bucket. The window-based logic must catch them.
+        var patterns = DreamService.DetectToolRetryPatternsFromEvents(
+        [
+            // March 30: an unrelated successful call kicks off the session.
+            new ToolCallEvent("blazor-session", "mcp_invoke_tool",
+                """server_name=onedrive-marimer, query=LLM""",
+                Succeeded: true, 100, DateTimeOffset.UtcNow.AddDays(-28)),
+
+            // Today: agent guesses the wrong server, then the right one within minutes.
+            new ToolCallEvent("blazor-session", "mcp_invoke_tool",
+                """server_name=onedrive-marimer, folder=Apps/RockBot/xebia-teams""",
+                Succeeded: false, 800, DateTimeOffset.UtcNow.AddMinutes(-15)),
+            new ToolCallEvent("blazor-session", "mcp_invoke_tool",
+                """server_name=onedrive-personal, folder=Apps/RockBot/xebia-teams""",
+                Succeeded: true, 600, DateTimeOffset.UtcNow.AddMinutes(-5))
+        ]);
+
+        Assert.AreEqual(1, patterns.Count, "Should find the recent failure→success transition.");
+        StringAssert.Contains(patterns[0].SuccessArgs, "onedrive-personal");
+        Assert.AreEqual(1, patterns[0].FailedArgs.Count);
+        StringAssert.Contains(patterns[0].FailedArgs[0], "onedrive-marimer");
+    }
+
+    [TestMethod]
+    public void FailureOutsideLookbackWindow_NotPaired()
+    {
+        var patterns = DreamService.DetectToolRetryPatternsFromEvents(
+        [
+            // Failure 5 hours before success — far outside the default 30-minute window.
+            new ToolCallEvent("s1", "list_files",
+                """{"server":"a"}""",
+                Succeeded: false, 100, DateTimeOffset.UtcNow.AddHours(-5)),
+            new ToolCallEvent("s1", "list_files",
+                """{"server":"b"}""",
+                Succeeded: true, 100, DateTimeOffset.UtcNow.AddMinutes(-5))
+        ]);
+
+        Assert.AreEqual(0, patterns.Count,
+            "A long-ago unrelated failure must not be paired with today's success.");
+    }
+
+    [TestMethod]
+    public void FailureExactlyAtWindowEdge_Included()
+    {
+        var success = DateTimeOffset.UtcNow;
+        var atEdge = success - DreamService.DefaultRetryLookbackWindow; // exactly the boundary
+
+        var patterns = DreamService.DetectToolRetryPatternsFromEvents(
+        [
+            new ToolCallEvent("s1", "list_files", "args-fail", Succeeded: false, 100, atEdge),
+            new ToolCallEvent("s1", "list_files", "args-ok",   Succeeded: true,  100, success)
+        ]);
+
+        Assert.AreEqual(1, patterns.Count,
+            "Failure timestamp == windowStart should still count (>=, not strict >).");
+    }
+
+    [TestMethod]
+    public void CustomLookbackWindow_OverridesDefault()
+    {
+        // 35 minutes apart — outside default 30-min window, inside custom 60-min window.
+        var events = new[]
+        {
+            new ToolCallEvent("s1", "list_files", "args-fail",
+                Succeeded: false, 100, DateTimeOffset.UtcNow.AddMinutes(-40)),
+            new ToolCallEvent("s1", "list_files", "args-ok",
+                Succeeded: true,  100, DateTimeOffset.UtcNow.AddMinutes(-5))
+        };
+
+        var defaultPatterns = DreamService.DetectToolRetryPatternsFromEvents(events);
+        var customPatterns = DreamService.DetectToolRetryPatternsFromEvents(
+            events, lookbackWindow: TimeSpan.FromMinutes(60));
+
+        Assert.AreEqual(0, defaultPatterns.Count, "Outside default 30-min window.");
+        Assert.AreEqual(1, customPatterns.Count, "Inside custom 60-min window.");
+    }
+
+    [TestMethod]
+    public void RepeatedSuccessSameArgsInBucket_MergedToOnePatternWithUnionedFailedArgs()
+    {
+        // Same lesson learned three times across the day: each time a different failed
+        // server precedes the same successful server. One pattern, merged failed-args.
+        var patterns = DreamService.DetectToolRetryPatternsFromEvents(
+        [
+            // First retry sequence
+            new ToolCallEvent("s1", "mcp_invoke_tool",
+                """server_name=A""", Succeeded: false, 100, DateTimeOffset.UtcNow.AddMinutes(-100)),
+            new ToolCallEvent("s1", "mcp_invoke_tool",
+                """server_name=Z""", Succeeded: true,  100, DateTimeOffset.UtcNow.AddMinutes(-95)),
+            // Second
+            new ToolCallEvent("s1", "mcp_invoke_tool",
+                """server_name=B""", Succeeded: false, 100, DateTimeOffset.UtcNow.AddMinutes(-50)),
+            new ToolCallEvent("s1", "mcp_invoke_tool",
+                """server_name=Z""", Succeeded: true,  100, DateTimeOffset.UtcNow.AddMinutes(-45)),
+            // Third
+            new ToolCallEvent("s1", "mcp_invoke_tool",
+                """server_name=C""", Succeeded: false, 100, DateTimeOffset.UtcNow.AddMinutes(-15)),
+            new ToolCallEvent("s1", "mcp_invoke_tool",
+                """server_name=Z""", Succeeded: true,  100, DateTimeOffset.UtcNow.AddMinutes(-10))
+        ]);
+
+        Assert.AreEqual(1, patterns.Count,
+            "Same successArgs across multiple in-bucket retries collapses to one pattern.");
+        Assert.AreEqual("""server_name=Z""", patterns[0].SuccessArgs);
+        Assert.AreEqual(3, patterns[0].FailedArgs.Count,
+            "Failed-args from each retry sequence should merge (capped at 3).");
+        CollectionAssert.AreEquivalent(
+            new[] { "server_name=A", "server_name=B", "server_name=C" },
+            patterns[0].FailedArgs.ToArray());
+    }
+
+    [TestMethod]
+    public void DifferentSuccessArgsInSameBucket_EachEmitsItsOwnPattern()
+    {
+        // Two distinct lessons learned in the same bucket should both surface.
+        var patterns = DreamService.DetectToolRetryPatternsFromEvents(
+        [
+            new ToolCallEvent("s1", "mcp_invoke_tool",
+                """server=A""", Succeeded: false, 100, DateTimeOffset.UtcNow.AddMinutes(-50)),
+            new ToolCallEvent("s1", "mcp_invoke_tool",
+                """server=Z""", Succeeded: true,  100, DateTimeOffset.UtcNow.AddMinutes(-45)),
+            new ToolCallEvent("s1", "mcp_invoke_tool",
+                """server=B""", Succeeded: false, 100, DateTimeOffset.UtcNow.AddMinutes(-15)),
+            new ToolCallEvent("s1", "mcp_invoke_tool",
+                """server=Y""", Succeeded: true,  100, DateTimeOffset.UtcNow.AddMinutes(-10))
+        ]);
+
+        Assert.AreEqual(2, patterns.Count);
+        Assert.IsTrue(patterns.Any(p => p.SuccessArgs == "server=Z"));
+        Assert.IsTrue(patterns.Any(p => p.SuccessArgs == "server=Y"));
+    }
+
+    [TestMethod]
+    public void SuccessFollowedBySuccessSameArgs_NoSpuriousPattern()
+    {
+        // Once we've seen the lesson, repeated successes with the same args without any
+        // intervening different-args failure should not re-emit the pattern.
+        var patterns = DreamService.DetectToolRetryPatternsFromEvents(
+        [
+            new ToolCallEvent("s1", "list_files", "wrong",
+                Succeeded: false, 100, DateTimeOffset.UtcNow.AddMinutes(-15)),
+            new ToolCallEvent("s1", "list_files", "right",
+                Succeeded: true,  100, DateTimeOffset.UtcNow.AddMinutes(-12)),
+            new ToolCallEvent("s1", "list_files", "right",
+                Succeeded: true,  100, DateTimeOffset.UtcNow.AddMinutes(-10)),
+            new ToolCallEvent("s1", "list_files", "right",
+                Succeeded: true,  100, DateTimeOffset.UtcNow.AddMinutes(-5))
+        ]);
+
+        Assert.AreEqual(1, patterns.Count);
+        Assert.AreEqual(1, patterns[0].FailedArgs.Count,
+            "The single 'wrong' failure should appear once even though 'right' succeeded thrice.");
+    }
 }

--- a/tests/RockBot.Host.Tests/ToolRetryDetectionTests.cs
+++ b/tests/RockBot.Host.Tests/ToolRetryDetectionTests.cs
@@ -1,0 +1,165 @@
+namespace RockBot.Host.Tests;
+
+[TestClass]
+public class ToolRetryDetectionTests
+{
+    private static ToolCallEvent Evt(
+        string session, string tool, string args, bool succeeded, int minutesAgo) =>
+        new(
+            SessionId: session,
+            ToolName: tool,
+            ArgumentsSummary: args,
+            Succeeded: succeeded,
+            DurationMs: 100,
+            Timestamp: DateTimeOffset.UtcNow.AddMinutes(-minutesAgo));
+
+    [TestMethod]
+    public void NoEvents_ReturnsEmpty()
+    {
+        var patterns = DreamService.DetectToolRetryPatternsFromEvents([]);
+        Assert.AreEqual(0, patterns.Count);
+    }
+
+    [TestMethod]
+    public void SingleEvent_ReturnsEmpty()
+    {
+        var patterns = DreamService.DetectToolRetryPatternsFromEvents(
+        [
+            Evt("s1", "list_files", """{"folder":"X"}""", succeeded: true, minutesAgo: 5)
+        ]);
+        Assert.AreEqual(0, patterns.Count);
+    }
+
+    [TestMethod]
+    public void SameArgsRepeated_NotARetryPattern()
+    {
+        var patterns = DreamService.DetectToolRetryPatternsFromEvents(
+        [
+            Evt("s1", "list_files", """{"folder":"X"}""", succeeded: false, minutesAgo: 10),
+            Evt("s1", "list_files", """{"folder":"X"}""", succeeded: true,  minutesAgo: 5)
+        ]);
+        Assert.AreEqual(0, patterns.Count,
+            "Same args with no variation isn't an ambiguity-resolution; it's a transient failure.");
+    }
+
+    [TestMethod]
+    public void AllFailed_ReturnsEmpty()
+    {
+        var patterns = DreamService.DetectToolRetryPatternsFromEvents(
+        [
+            Evt("s1", "list_files", """{"server":"a"}""", succeeded: false, minutesAgo: 10),
+            Evt("s1", "list_files", """{"server":"b"}""", succeeded: false, minutesAgo: 5)
+        ]);
+        Assert.AreEqual(0, patterns.Count, "No success means no verified value to learn from.");
+    }
+
+    [TestMethod]
+    public void SuccessThenFailure_NotAPattern()
+    {
+        var patterns = DreamService.DetectToolRetryPatternsFromEvents(
+        [
+            Evt("s1", "list_files", """{"server":"a"}""", succeeded: true,  minutesAgo: 10),
+            Evt("s1", "list_files", """{"server":"b"}""", succeeded: false, minutesAgo: 5)
+        ]);
+        Assert.AreEqual(0, patterns.Count,
+            "Failure must precede success for this to indicate skill ambiguity.");
+    }
+
+    [TestMethod]
+    public void FailureThenSuccess_DifferentArgs_ProducesPattern()
+    {
+        var patterns = DreamService.DetectToolRetryPatternsFromEvents(
+        [
+            Evt("s1", "list_files", """{"server":"onedrive-marimer"}""",  succeeded: false, minutesAgo: 10),
+            Evt("s1", "list_files", """{"server":"onedrive-personal"}""", succeeded: true,  minutesAgo: 5)
+        ]);
+
+        Assert.AreEqual(1, patterns.Count);
+        var p = patterns[0];
+        Assert.AreEqual("s1", p.SessionId);
+        Assert.AreEqual("list_files", p.ToolName);
+        CollectionAssert.AreEqual(
+            new[] { """{"server":"onedrive-marimer"}""" },
+            p.FailedArgs.ToArray());
+        Assert.AreEqual("""{"server":"onedrive-personal"}""", p.SuccessArgs);
+    }
+
+    [TestMethod]
+    public void MultipleFailuresBeforeSuccess_AllCapturedUpToThree()
+    {
+        var patterns = DreamService.DetectToolRetryPatternsFromEvents(
+        [
+            Evt("s1", "list_files", """{"folder":"a"}""", succeeded: false, minutesAgo: 30),
+            Evt("s1", "list_files", """{"folder":"b"}""", succeeded: false, minutesAgo: 25),
+            Evt("s1", "list_files", """{"folder":"c"}""", succeeded: false, minutesAgo: 20),
+            Evt("s1", "list_files", """{"folder":"d"}""", succeeded: false, minutesAgo: 15),
+            Evt("s1", "list_files", """{"folder":"e"}""", succeeded: true,  minutesAgo: 10)
+        ]);
+
+        Assert.AreEqual(1, patterns.Count);
+        Assert.AreEqual(3, patterns[0].FailedArgs.Count, "Failed-args list should cap at 3 to bound prompt size.");
+        Assert.AreEqual("""{"folder":"e"}""", patterns[0].SuccessArgs);
+    }
+
+    [TestMethod]
+    public void DistinctSessions_DoNotCrossContaminate()
+    {
+        var patterns = DreamService.DetectToolRetryPatternsFromEvents(
+        [
+            Evt("session-A", "list_files", """{"server":"a"}""", succeeded: false, minutesAgo: 10),
+            Evt("session-B", "list_files", """{"server":"b"}""", succeeded: true,  minutesAgo: 5)
+        ]);
+
+        Assert.AreEqual(0, patterns.Count,
+            "A failure in session A cannot be 'resolved' by a success in session B.");
+    }
+
+    [TestMethod]
+    public void DifferentToolsInSameSession_TrackedSeparately()
+    {
+        var patterns = DreamService.DetectToolRetryPatternsFromEvents(
+        [
+            Evt("s1", "tool-X", """{"a":1}""", succeeded: false, minutesAgo: 10),
+            Evt("s1", "tool-X", """{"a":2}""", succeeded: true,  minutesAgo: 5),
+            Evt("s1", "tool-Y", """{"b":1}""", succeeded: false, minutesAgo: 8),
+            Evt("s1", "tool-Y", """{"b":2}""", succeeded: true,  minutesAgo: 3)
+        ]);
+
+        Assert.AreEqual(2, patterns.Count);
+        Assert.IsTrue(patterns.Any(p => p.ToolName == "tool-X"));
+        Assert.IsTrue(patterns.Any(p => p.ToolName == "tool-Y"));
+    }
+
+    [TestMethod]
+    public void SessionsFilter_ExcludesEventsOutsideTheSet()
+    {
+        var events = new[]
+        {
+            Evt("session-A", "list_files", """{"x":1}""", succeeded: false, minutesAgo: 10),
+            Evt("session-A", "list_files", """{"x":2}""", succeeded: true,  minutesAgo: 5),
+            Evt("session-B", "list_files", """{"y":1}""", succeeded: false, minutesAgo: 10),
+            Evt("session-B", "list_files", """{"y":2}""", succeeded: true,  minutesAgo: 5)
+        };
+
+        var patterns = DreamService.DetectToolRetryPatternsFromEvents(
+            events,
+            sessionsFilter: ["session-A"]);
+
+        Assert.AreEqual(1, patterns.Count);
+        Assert.AreEqual("session-A", patterns[0].SessionId);
+    }
+
+    [TestMethod]
+    public void NullArgumentsSummary_NormalizedAndCounted()
+    {
+        var patterns = DreamService.DetectToolRetryPatternsFromEvents(
+        [
+            new ToolCallEvent("s1", "list_files", null, Succeeded: false, 100, DateTimeOffset.UtcNow.AddMinutes(-10)),
+            Evt("s1", "list_files", """{"folder":"X"}""", succeeded: true, minutesAgo: 5)
+        ]);
+
+        Assert.AreEqual(1, patterns.Count);
+        Assert.IsTrue(patterns[0].FailedArgs.Any(a => a.Contains("none")),
+            "Null ArgumentsSummary should normalize to a placeholder.");
+    }
+}

--- a/tests/RockBot.Host.Tests/ToolSuccessLearningHelpersTests.cs
+++ b/tests/RockBot.Host.Tests/ToolSuccessLearningHelpersTests.cs
@@ -1,0 +1,342 @@
+namespace RockBot.Host.Tests;
+
+[TestClass]
+public class ToolSuccessLearningHelpersTests
+{
+    private static DreamService.ToolRetryPattern Pattern(
+        string sessionId = "s1",
+        string toolName = "list_files",
+        IReadOnlyList<string>? failedArgs = null,
+        string successArgs = """{"server":"onedrive-personal"}""",
+        DateTimeOffset? lastSeenAt = null) =>
+        new(
+            sessionId,
+            toolName,
+            failedArgs ?? ["""{"server":"onedrive-marimer"}"""],
+            successArgs,
+            lastSeenAt ?? DateTimeOffset.UtcNow);
+
+    // ── DedupeRetryPatterns ──────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void Dedupe_SameToolAndSuccess_KeepsNewestOccurrence()
+    {
+        var older = Pattern(sessionId: "old-session",
+            lastSeenAt: DateTimeOffset.UtcNow.AddDays(-3));
+        var newer = Pattern(sessionId: "new-session",
+            lastSeenAt: DateTimeOffset.UtcNow);
+
+        var deduped = DreamService.DedupeRetryPatterns([older, newer], maxCount: 50);
+
+        Assert.AreEqual(1, deduped.Count);
+        Assert.AreEqual("new-session", deduped[0].SessionId,
+            "Deduplication should retain the most recent occurrence so the lesson is fresh.");
+    }
+
+    [TestMethod]
+    public void Dedupe_DifferentSuccessArgs_KeepsBoth()
+    {
+        var a = Pattern(toolName: "list_files", successArgs: """{"server":"onedrive-personal"}""");
+        var b = Pattern(toolName: "list_files", successArgs: """{"server":"onedrive-work"}""");
+
+        var deduped = DreamService.DedupeRetryPatterns([a, b], maxCount: 50);
+
+        Assert.AreEqual(2, deduped.Count, "Different verified values are different lessons.");
+    }
+
+    [TestMethod]
+    public void Dedupe_DifferentTools_KeepsBoth()
+    {
+        var a = Pattern(toolName: "tool-X", successArgs: """{"v":1}""");
+        var b = Pattern(toolName: "tool-Y", successArgs: """{"v":1}""");
+
+        var deduped = DreamService.DedupeRetryPatterns([a, b], maxCount: 50);
+
+        Assert.AreEqual(2, deduped.Count);
+    }
+
+    [TestMethod]
+    public void Dedupe_HonorsMaxCount()
+    {
+        var patterns = Enumerable.Range(0, 100)
+            .Select(i => Pattern(toolName: $"tool-{i}", successArgs: $"args-{i}"))
+            .ToArray();
+
+        var deduped = DreamService.DedupeRetryPatterns(patterns, maxCount: 25);
+
+        Assert.AreEqual(25, deduped.Count);
+    }
+
+    // ── BuildToolSuccessLearningUserMessage ──────────────────────────────────────
+
+    [TestMethod]
+    public void BuildMessage_IncludesAllPatternsAsNumberedSections()
+    {
+        var patterns = new[]
+        {
+            Pattern(toolName: "list_files",
+                failedArgs: ["""{"server":"onedrive-marimer"}"""],
+                successArgs: """{"server":"onedrive-personal"}"""),
+            Pattern(toolName: "get_calendar_events",
+                failedArgs: ["{}"],
+                successArgs: """{"accountId":"xebia"}""")
+        };
+
+        var msg = DreamService.BuildToolSuccessLearningUserMessage(patterns);
+
+        StringAssert.Contains(msg, "### Pattern 1: tool 'list_files'");
+        StringAssert.Contains(msg, "### Pattern 2: tool 'get_calendar_events'");
+        StringAssert.Contains(msg, "onedrive-personal");
+        StringAssert.Contains(msg, """{"accountId":"xebia"}""");
+    }
+
+    [TestMethod]
+    public void BuildMessage_FailedArgsJoinedWithPipe()
+    {
+        var patterns = new[]
+        {
+            Pattern(failedArgs: ["""{"x":1}""", """{"x":2}""", """{"x":3}"""])
+        };
+
+        var msg = DreamService.BuildToolSuccessLearningUserMessage(patterns);
+
+        StringAssert.Contains(msg, """{"x":1} | {"x":2} | {"x":3}""");
+    }
+
+    [TestMethod]
+    public void BuildMessage_EmptyPatterns_StillProducesInstructionalHeader()
+    {
+        var msg = DreamService.BuildToolSuccessLearningUserMessage([]);
+
+        StringAssert.Contains(msg, "retry-until-success",
+            "Header instructional text should always appear so the directive's expectations are clear.");
+        Assert.IsFalse(msg.Contains("### Pattern"),
+            "No patterns means no pattern sections.");
+    }
+
+    // ── NormalizeToolSuccessLearningEntries ──────────────────────────────────────
+
+    [TestMethod]
+    public void Normalize_AddsCanonicalTags_WhenMissing()
+    {
+        var dto = new DreamService.MemoryMiningResultDto(
+        [
+            new DreamService.MemoryMiningEntryDto(
+                Content: "Teams bridge JSON lives on onedrive-personal at /Apps/RockBot/xebia-teams.",
+                Category: null,
+                Tags: null)
+        ]);
+
+        var entries = DreamService.NormalizeToolSuccessLearningEntries(
+            dto, idFactory: () => "id-1", nowFactory: () => DateTimeOffset.UnixEpoch);
+
+        Assert.AreEqual(1, entries.Count);
+        CollectionAssert.Contains(entries[0].Tags.ToArray(), "verified");
+        CollectionAssert.Contains(entries[0].Tags.ToArray(), "tool-success-learned");
+    }
+
+    [TestMethod]
+    public void Normalize_DoesNotDuplicateExistingCanonicalTags()
+    {
+        var dto = new DreamService.MemoryMiningResultDto(
+        [
+            new DreamService.MemoryMiningEntryDto(
+                Content: "fact",
+                Category: "tool-knowledge/onedrive",
+                Tags: ["verified", "tool-success-learned", "extra"])
+        ]);
+
+        var entries = DreamService.NormalizeToolSuccessLearningEntries(
+            dto, () => "id-1", () => DateTimeOffset.UnixEpoch);
+
+        Assert.AreEqual(1, entries.Count);
+        Assert.AreEqual(3, entries[0].Tags.Count,
+            "Already-present canonical tags should not be duplicated.");
+    }
+
+    [TestMethod]
+    public void Normalize_CanonicalTagMatchIsCaseInsensitive()
+    {
+        var dto = new DreamService.MemoryMiningResultDto(
+        [
+            new DreamService.MemoryMiningEntryDto("fact", null, ["VERIFIED", "Tool-Success-Learned"])
+        ]);
+
+        var entries = DreamService.NormalizeToolSuccessLearningEntries(
+            dto, () => "id-1", () => DateTimeOffset.UnixEpoch);
+
+        Assert.AreEqual(2, entries[0].Tags.Count,
+            "Tag matching for canonical-tag presence must be case-insensitive.");
+    }
+
+    [TestMethod]
+    public void Normalize_DefaultsBlankCategory_ToToolKnowledge()
+    {
+        var dto = new DreamService.MemoryMiningResultDto(
+        [
+            new DreamService.MemoryMiningEntryDto("fact", "  ", null),
+            new DreamService.MemoryMiningEntryDto("fact-2", null, null),
+            new DreamService.MemoryMiningEntryDto("fact-3", "", null)
+        ]);
+
+        var entries = DreamService.NormalizeToolSuccessLearningEntries(
+            dto, () => "id", () => DateTimeOffset.UnixEpoch);
+
+        Assert.IsTrue(entries.All(e => e.Category == "tool-knowledge"));
+    }
+
+    [TestMethod]
+    public void Normalize_PreservesSuppliedCategory_AfterTrimming()
+    {
+        var dto = new DreamService.MemoryMiningResultDto(
+        [
+            new DreamService.MemoryMiningEntryDto("fact", "  tool-knowledge/onedrive  ", null)
+        ]);
+
+        var entries = DreamService.NormalizeToolSuccessLearningEntries(
+            dto, () => "id", () => DateTimeOffset.UnixEpoch);
+
+        Assert.AreEqual("tool-knowledge/onedrive", entries[0].Category);
+    }
+
+    [TestMethod]
+    public void Normalize_SkipsEmptyContent()
+    {
+        var dto = new DreamService.MemoryMiningResultDto(
+        [
+            new DreamService.MemoryMiningEntryDto("", null, null),
+            new DreamService.MemoryMiningEntryDto("   ", null, null),
+            new DreamService.MemoryMiningEntryDto("real fact", null, null)
+        ]);
+
+        var entries = DreamService.NormalizeToolSuccessLearningEntries(
+            dto, () => "id", () => DateTimeOffset.UnixEpoch);
+
+        Assert.AreEqual(1, entries.Count);
+        Assert.AreEqual("real fact", entries[0].Content);
+    }
+
+    [TestMethod]
+    public void Normalize_TrimsContent()
+    {
+        var dto = new DreamService.MemoryMiningResultDto(
+        [
+            new DreamService.MemoryMiningEntryDto("  fact with whitespace  \n", null, null)
+        ]);
+
+        var entries = DreamService.NormalizeToolSuccessLearningEntries(
+            dto, () => "id", () => DateTimeOffset.UnixEpoch);
+
+        Assert.AreEqual("fact with whitespace", entries[0].Content);
+    }
+
+    [TestMethod]
+    public void Normalize_NullDto_ReturnsEmpty()
+    {
+        var entries = DreamService.NormalizeToolSuccessLearningEntries(
+            null, () => "id", () => DateTimeOffset.UnixEpoch);
+
+        Assert.AreEqual(0, entries.Count);
+    }
+
+    [TestMethod]
+    public void Normalize_NullToSave_ReturnsEmpty()
+    {
+        var dto = new DreamService.MemoryMiningResultDto(ToSave: null);
+
+        var entries = DreamService.NormalizeToolSuccessLearningEntries(
+            dto, () => "id", () => DateTimeOffset.UnixEpoch);
+
+        Assert.AreEqual(0, entries.Count);
+    }
+
+    [TestMethod]
+    public void Normalize_AssignsConsistentTimestampsAndIds()
+    {
+        var fixedTime = DateTimeOffset.Parse("2026-04-27T10:00:00Z");
+        var ids = new[] { "id-A", "id-B", "id-C" };
+        var idIndex = 0;
+
+        var dto = new DreamService.MemoryMiningResultDto(
+        [
+            new DreamService.MemoryMiningEntryDto("fact-1", null, null),
+            new DreamService.MemoryMiningEntryDto("fact-2", null, null),
+            new DreamService.MemoryMiningEntryDto("fact-3", null, null)
+        ]);
+
+        var entries = DreamService.NormalizeToolSuccessLearningEntries(
+            dto,
+            idFactory: () => ids[idIndex++],
+            nowFactory: () => fixedTime);
+
+        CollectionAssert.AreEqual(ids, entries.Select(e => e.Id).ToArray(),
+            "Each entry must call the id factory once, in order.");
+        Assert.IsTrue(entries.All(e => e.CreatedAt == fixedTime && e.UpdatedAt == fixedTime));
+    }
+
+    // ── FormatToolRetryNote ──────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void FormatRetryNote_RendersSingleFailedArg()
+    {
+        var p = Pattern(
+            toolName: "list_files",
+            failedArgs: ["""{"server":"onedrive-marimer"}"""],
+            successArgs: """{"server":"onedrive-personal"}""");
+
+        var note = DreamService.FormatToolRetryNote(p);
+
+        StringAssert.Contains(note, "list_files");
+        StringAssert.Contains(note, "onedrive-marimer");
+        StringAssert.Contains(note, "onedrive-personal");
+        StringAssert.Contains(note, "then succeeded");
+    }
+
+    [TestMethod]
+    public void FormatRetryNote_RendersMultipleFailedArgs_PipeSeparated()
+    {
+        var p = Pattern(failedArgs: ["a", "b", "c"], successArgs: "d");
+
+        var note = DreamService.FormatToolRetryNote(p);
+
+        StringAssert.Contains(note, "[a | b | c]");
+        StringAssert.Contains(note, "[d]");
+    }
+
+    // ── GroupRetryPatternsBySession ──────────────────────────────────────────────
+
+    [TestMethod]
+    public void GroupBySession_GroupsMultiplePatternsForSameSession()
+    {
+        var patterns = new[]
+        {
+            Pattern(sessionId: "session-A", toolName: "tool-1"),
+            Pattern(sessionId: "session-A", toolName: "tool-2"),
+            Pattern(sessionId: "session-B", toolName: "tool-3")
+        };
+
+        var grouped = DreamService.GroupRetryPatternsBySession(patterns);
+
+        Assert.AreEqual(2, grouped.Count);
+        Assert.AreEqual(2, grouped["session-A"].Count);
+        Assert.AreEqual(1, grouped["session-B"].Count);
+    }
+
+    [TestMethod]
+    public void GroupBySession_SessionIdLookupIsCaseInsensitive()
+    {
+        var patterns = new[] { Pattern(sessionId: "Session-A") };
+
+        var grouped = DreamService.GroupRetryPatternsBySession(patterns);
+
+        Assert.IsTrue(grouped.ContainsKey("session-a"),
+            "Session IDs should match case-insensitively for lookup convenience.");
+    }
+
+    [TestMethod]
+    public void GroupBySession_EmptyInput_ReturnsEmptyDictionary()
+    {
+        var grouped = DreamService.GroupRetryPatternsBySession([]);
+        Assert.AreEqual(0, grouped.Count);
+    }
+}


### PR DESCRIPTION
## Summary

Closes the self-improvement gap exposed by today's OneDrive/Teams investigation: the agent's existing dream loops are failure-reactive (user corrections, poor session quality) but not success-reactive. When a subagent verified that the Teams bridge JSON lives on \`onedrive-personal\` (not \`onedrive-marimer\`), nothing in the system harvested that fact, so the next session re-discovered the same wrong server. Four related changes close the gap.

## Changes

### 1. In-session learning (directive)

Orchestrator and subagent directives now instruct the agent to call \`save_skill\` when a tool call confirms a fact the guiding skill left vague — replacing hedges like *"typically onedrive-personal and sometimes onedrive-marimer"* with the verified answer. Verified results only; never invent specifics. Doesn't depend on the dream cycle.

### 2. Memory-mining sees subagent whiteboards

Memory-mining now also reads recent working-memory entries with key prefix \`subagent/\` in addition to the conversation log. Previously the miner couldn't see subagent-verified facts buried in working-memory blobs.

### 3. Skill-optimize treats tool retries as ambiguity signals

\`OptimizeSkillsAsync\` now adds tool-retry-until-success sessions to the at-risk set. The failed→succeeded arg pair is fed to the optimizer prompt as ambiguity context — exactly what's needed to replace hedges in skill content with concrete values.

### 4. New \`tool-success-learning\` dream pass

Scans the tool-call log directly (previously unused by any dream), deduplicates retry patterns by (tool, success-args), and asks the LLM to extract the durable fact each pattern proves. Results are saved to long-term memory tagged \`verified\` and \`tool-success-learned\` so future sessions surface them via BM25/vector recall before the agent re-explores the same question.

## Implementation notes

- Pure detection logic (\`DetectToolRetryPatternsFromEvents\`) extracted as \`internal static\` for testability.
- New \`DreamOptions.ToolSuccessLearningEnabled\` (default true) and \`ToolSuccessLearningDirectivePath\` (default \`tool-success-learning.md\`); built-in fallback directive included.
- New profile markdown at \`src/RockBot.Agent/agent/tool-success-learning.md\`.
- Version bumped to 0.10.7.

## Test plan

- [x] \`dotnet build\` clean
- [x] \`dotnet test\` — 1421 passed, 0 failed (+11 new boundary-condition tests for retry pattern detection)
- [ ] Deploy 0.10.7 to live cluster and watch the next dream cycle's logs for \`tool-success-learning pass\` entries
- [ ] Verify that a verified-fact memory entry appears for a known retry-to-success in today's tool-call log (e.g. the \`onedrive-marimer\` → \`onedrive-personal\` pattern from the morning brief)
- [ ] Confirm that within a session, the agent now calls \`save_skill\` after disambiguating a tool argument — likely visible in the next time the OneDrive/Teams skill gets exercised

🤖 Generated with [Claude Code](https://claude.com/claude-code)