### PR TITLE
Add RockBot onboarding guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,8 @@ The agent's personality and behavior are defined by markdown documents on the da
 
 Want to try RockBot without setting up Kubernetes? The [Docker Desktop getting started guide](docs/getting-started-docker-desktop.md) gets you chatting with the agent in minutes using just Docker Compose, an LLM API key, and a Brave Search key.
 
+After that, use the [Getting started with RockBot](docs/getting-started-rockbot.md) guide to customize the agent's identity, memory behavior, MCP integrations, and scheduled tasks.
+
 ### Prerequisites
 
 - [.NET 10 SDK](https://dotnet.microsoft.com/download) — for local development and building

--- a/docs/getting-started-docker-desktop.md
+++ b/docs/getting-started-docker-desktop.md
@@ -124,6 +124,8 @@ Key files you can customize:
 
 The agent hot-reloads these files via `FileSystemWatcher` — changes take effect within seconds, no restart needed.
 
+Once the stack is running, the next step is onboarding the agent so it has the right identity, memory behavior, MCP integrations, and scheduled jobs. See [Getting started with RockBot](getting-started-rockbot).
+
 ## Choosing an LLM
 
 ### OpenAI-compatible providers (per-token billing)
@@ -240,4 +242,4 @@ docker compose down -v
 
 ## Next steps
 
-This minimal setup gets you chatting with the agent. For the full experience with script execution, MCP tools, and multi-agent coordination, see the [Helm deployment guide](../deploy/values.personal.example.yaml) for Kubernetes.
+This minimal setup gets you chatting with the agent. Next, follow [Getting started with RockBot](getting-started-rockbot) to turn that running agent into a useful personal one. For the full experience with script execution, MCP tools, and multi-agent coordination, see the [Helm deployment guide](../deploy/values.personal.example.yaml) for Kubernetes.

--- a/docs/getting-started-rockbot.md
+++ b/docs/getting-started-rockbot.md
@@ -42,7 +42,7 @@ Remember that I am in America/Chicago and I prefer concise, direct answers.
 Remember that I use RockBot mainly for communications, scheduling, technical work, and research.
 ```
 
-These belong in long-term memory, typically under `user-preferences/...` or `agent-knowledge`.
+These belong in long-term memory.
 
 ### Decide who the agent is
 
@@ -179,16 +179,6 @@ The best RockBot agents do not just accumulate random memories. They deliberatel
 
 This is the agent's evolving model of your preferences, patterns, relationships, projects, and context.
 
-Useful categories include:
-
-- `user-preferences/identity`
-- `user-preferences/work`
-- `user-preferences/location`
-- `user-preferences/lifestyle`
-- `user-preferences/attitudes`
-- `project-context/<project-name>`
-- `agent-knowledge`
-
 Ask for it explicitly at the start:
 
 ```text
@@ -197,15 +187,7 @@ Build and maintain an evolving theory of me. Save durable facts, preferences, re
 
 ### Theory of self
 
-RockBot already has a good place for this: the `agent-identity/...` memory categories. These are for the mutable self-model that grows through experience without replacing the immutable `soul.md`.
-
-Useful categories include:
-
-- `agent-identity/mission`
-- `agent-identity/goals`
-- `agent-identity/projects`
-- `agent-identity/capabilities`
-- `agent-identity/self-model`
+RockBot can maintain this as a mutable self-model that grows through experience without replacing the immutable `soul.md`.
 
 Ask for it explicitly:
 
@@ -220,8 +202,8 @@ Do not treat memory like a timeless blob. RockBot's memory model already tracks 
 Practical guidance:
 
 1. Save durable facts as durable facts
-2. Save active plans in `active-plans/...`
-3. Save evolving self-model entries under `agent-identity/...`
+2. Save in-progress multi-session work as plans the agent can resume later
+3. Let the agent keep an evolving self-model separate from `soul.md`
 4. When a meaningful shift happens, update the relevant memory instead of stuffing everything into `soul.md`
 5. When the underlying fact refers to a real period in your life, preserve that time context if known
 
@@ -235,8 +217,7 @@ A good `memory-rules.md` usually tells the agent:
 
 - what counts as durable user context
 - what should stay in working memory instead
-- which categories to prefer
-- when to create or update `agent-identity/...` entries
+- when to create or update its self-model
 - how aggressively to save preferences
 - how to handle active plans and completed plans
 

--- a/docs/getting-started-rockbot.md
+++ b/docs/getting-started-rockbot.md
@@ -1,0 +1,289 @@
+---
+title: Getting started with RockBot
+nav_order: 3
+---
+
+# Getting started with RockBot
+
+This guide starts where [Getting started with Docker Desktop](getting-started-docker-desktop) ends. Step 1 is getting RockBot running. Step 2 is turning it into **your** agent: giving it the right identity, tools, habits, and memory behavior so it becomes genuinely useful over time.
+
+If you only do one thing after the Docker guide, do this: **customize the profile, connect the right MCP servers, and give the agent recurring jobs.** That is the difference between "a chat UI with an LLM behind it" and "an agent that gets better at helping you."
+
+## What "successfully onboarded" looks like
+
+A newly useful RockBot usually has all of the following:
+
+1. A `soul.md` that matches the role you want it to play
+2. A `style.md` if tone matters
+3. Clear knowledge of who **you** are and what to call you
+4. Clear knowledge of who **it** is and what to call itself
+5. MCP servers for the systems you actually use
+6. A few scheduled tasks that create proactive value
+7. Memory rules that encourage a durable "theory of the user" and "theory of self"
+8. A short feedback loop where you keep tuning its profile and memory
+
+## 1. Make the agent yours
+
+### Tell it who you are
+
+Do this early. A personal agent that does not know your name, timezone, role, and preferences will feel generic.
+
+Good first-turn examples:
+
+```text
+My name is Rocky. Please call me Rocky.
+```
+
+```text
+Remember that I am in America/Chicago and I prefer concise, direct answers.
+```
+
+```text
+Remember that I use RockBot mainly for communications, scheduling, technical work, and research.
+```
+
+These belong in long-term memory, typically under `user-preferences/...` or `agent-knowledge`.
+
+### Decide who the agent is
+
+There are two different "names" in RockBot:
+
+- **Conversational identity** - what the agent calls itself in chat. This is mostly driven by `soul.md`.
+- **Technical identity** - the deployment/runtime `AgentIdentity` used for routing on the message bus.
+
+For most onboarding, you only need to change the **conversational identity** by editing `soul.md`. If you want the agent to present itself as "Aki", "Roxy", or something other than "RockBot", put that in `soul.md`. Changing the runtime routing identity is a deeper deployment change and is not usually required just to get started.
+
+### Customize `soul.md`, `directives.md`, and `style.md`
+
+The profile files on the agent data volume shape how the agent behaves:
+
+| File | Use it for |
+|---|---|
+| `soul.md` | Core identity, values, role, boundaries, and overall personality |
+| `directives.md` | Operational instructions, workflows, priorities, and what "good work" looks like |
+| `style.md` | Optional voice and tone polish |
+| `memory-rules.md` | What to remember, what not to remember, and how memory should evolve |
+
+Good onboarding practice:
+
+1. Put the stable persona in `soul.md`
+2. Put deployment- or user-specific operating rules in `directives.md`
+3. Put tone only in `style.md`
+
+For example, a strong `soul.md` usually answers:
+
+- Who is this agent to the user?
+- What domains does it proactively care about?
+- How direct or gentle should it be?
+- What are its boundaries?
+
+And `style.md` usually answers:
+
+- Should it be brief or expansive?
+- Formal or conversational?
+- Should it use bullets heavily, or mostly prose?
+
+If you are running with Docker Compose, these files live on the `agent-data` volume and hot-reload when changed. See [Getting started with Docker Desktop](getting-started-docker-desktop#customizing-the-agent) for the file locations.
+
+## 2. Connect the systems that make it useful
+
+RockBot becomes much more valuable once it can reach your real tools through MCP.
+
+Typical high-value servers:
+
+- Calendar
+- Email
+- Contacts
+- Task systems
+- GitHub
+- Files or notes
+- Internal line-of-business tools
+
+For example, if you want calendar access, add an MCP server such as [`calendar-mcp`](https://github.com/MarimerLLC/calendar-mcp) to `mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "calendar-mcp": {
+      "type": "sse",
+      "url": "http://host.docker.internal:3000/"
+    }
+  }
+}
+```
+
+After the file updates, the agent hot-reloads the MCP configuration. Then, in chat, have the agent confirm what it sees:
+
+```text
+List the MCP services you currently have available and summarize what each one is for.
+```
+
+Good onboarding habit: after connecting a server, immediately ask the agent to use it for one real task so it can form the right skills and expectations.
+
+Examples:
+
+```text
+Check my calendar for today and summarize anything important.
+```
+
+```text
+Look at my next 7 days of meetings and tell me where I look overloaded.
+```
+
+## 3. Give it recurring jobs
+
+A personal agent feels much better when it does useful work without waiting to be asked. Scheduled tasks are one of the fastest ways to get there.
+
+Good starter tasks:
+
+- Morning communications briefing
+- Daily calendar review
+- End-of-day follow-up sweep
+- Weekly planning summary
+- Project or inbox patrols
+
+Example requests you can paste into chat:
+
+```text
+Create a weekday 7:30 AM scheduled task called morning-briefing that checks my calendar, recent messages, and any urgent follow-ups, then gives me a concise morning briefing.
+```
+
+```text
+Create a weekday 4:30 PM scheduled task called end-of-day-sweep that reviews unfinished threads, tomorrow's meetings, and anything I should prepare tonight.
+```
+
+```text
+List my scheduled tasks and tell me which ones seem redundant or missing.
+```
+
+The scheduling tools are `schedule_task`, `list_scheduled_tasks`, and `cancel_scheduled_task`. See [Tools](tools#scheduling-tools-rockbottoolsscheduling) for the cron details.
+
+## 4. Teach it how to build memory on purpose
+
+The best RockBot agents do not just accumulate random memories. They deliberately maintain:
+
+- a **theory of the user**
+- a **theory of self**
+
+### Theory of the user
+
+This is the agent's evolving model of your preferences, patterns, relationships, projects, and context.
+
+Useful categories include:
+
+- `user-preferences/identity`
+- `user-preferences/work`
+- `user-preferences/location`
+- `user-preferences/lifestyle`
+- `user-preferences/attitudes`
+- `project-context/<project-name>`
+- `agent-knowledge`
+
+Ask for it explicitly at the start:
+
+```text
+Build and maintain an evolving theory of me. Save durable facts, preferences, recurring patterns, active projects, and relationship context in memory so you become more useful over time.
+```
+
+### Theory of self
+
+RockBot already has a good place for this: the `agent-identity/...` memory categories. These are for the mutable self-model that grows through experience without replacing the immutable `soul.md`.
+
+Useful categories include:
+
+- `agent-identity/mission`
+- `agent-identity/goals`
+- `agent-identity/projects`
+- `agent-identity/capabilities`
+- `agent-identity/self-model`
+
+Ask for it explicitly:
+
+```text
+Build and maintain an evolving theory of yourself: your mission, strengths, limitations, active responsibilities, and the kind of agent you are becoming for me. Keep that in memory without changing your core soul.
+```
+
+### Preserve the time dimension
+
+Do not treat memory like a timeless blob. RockBot's memory model already tracks `CreatedAt`, `LastSeenAt`, and `UpdatedAt`, and can also preserve subject-time metadata when known. Use that.
+
+Practical guidance:
+
+1. Save durable facts as durable facts
+2. Save active plans in `active-plans/...`
+3. Save evolving self-model entries under `agent-identity/...`
+4. When a meaningful shift happens, update the relevant memory instead of stuffing everything into `soul.md`
+5. When the underlying fact refers to a real period in your life, preserve that time context if known
+
+This is how the agent keeps a usable history instead of endlessly rewriting a flat summary.
+
+## 5. Tune `memory-rules.md`
+
+If you want consistent long-term behavior, do not rely only on one chat instruction. Put the policy in `memory-rules.md`.
+
+A good `memory-rules.md` usually tells the agent:
+
+- what counts as durable user context
+- what should stay in working memory instead
+- which categories to prefer
+- when to create or update `agent-identity/...` entries
+- how aggressively to save preferences
+- how to handle active plans and completed plans
+
+Strong additions for a personal agent often include rules like:
+
+- remember names, relationships, preferences, and ongoing responsibilities
+- maintain a compact theory of the user
+- maintain a compact theory of self
+- preserve time context for important events and life changes
+- avoid saving noisy one-off tool output as long-term memory
+
+## 6. Run a deliberate first-week feedback loop
+
+Most of the magic happens in the first few days of tuning.
+
+After a few real conversations, ask:
+
+```text
+What do you currently believe about me that is important for helping me well?
+```
+
+```text
+What do you currently believe about yourself, your role, and your strengths and limitations?
+```
+
+```text
+What scheduled tasks, MCP tools, or memory rules would make you noticeably more helpful?
+```
+
+Then adjust:
+
+- `soul.md` if the role feels wrong
+- `style.md` if the tone feels wrong
+- `directives.md` if the workflow is wrong
+- `memory-rules.md` if it is remembering the wrong things
+- `mcp.json` if it lacks key systems
+- scheduled tasks if it is not being proactive enough
+
+## 7. A simple onboarding sequence that works well
+
+If you want a concrete sequence, this is a good starting point:
+
+1. Finish the [Docker Desktop guide](getting-started-docker-desktop)
+2. Edit `soul.md` so the agent has the right role and name
+3. Add `style.md` if tone matters
+4. Tell the agent your name, timezone, and main areas of life or work it should care about
+5. Connect 1-3 MCP servers you will use every week
+6. Ask it to test each server with one real task
+7. Create 2-4 scheduled tasks that produce proactive value
+8. Tell it to maintain a theory of the user and a theory of self in memory
+9. Tune `memory-rules.md` so that behavior is durable and repeatable
+10. Revisit the profile and memory after a few days of real use
+
+## Related docs
+
+- [Getting started with Docker Desktop](getting-started-docker-desktop)
+- [Agent host](agent-host)
+- [Memory](memory)
+- [Tools](tools)
+- [Dream service](dream-service)

--- a/docs/getting-started-rockbot.md
+++ b/docs/getting-started-rockbot.md
@@ -46,12 +46,21 @@ These belong in long-term memory, typically under `user-preferences/...` or `age
 
 ### Decide who the agent is
 
-There are two different "names" in RockBot:
+There are really **three** related identity surfaces in RockBot:
 
-- **Conversational identity** - what the agent calls itself in chat. This is mostly driven by `soul.md`.
-- **Technical identity** - the deployment/runtime `AgentIdentity` used for routing on the message bus.
+- **Runtime identity** — the deployment/runtime `AgentIdentity` used for routing on the message bus
+- **Display name** — the mutable name shown in chat and user-facing UI
+- **Persona** — the broader self-description and role conveyed by `soul.md`
 
-For most onboarding, you only need to change the **conversational identity** by editing `soul.md`. If you want the agent to present itself as "Aki", "Roxy", or something other than "RockBot", put that in `soul.md`. Changing the runtime routing identity is a deeper deployment change and is not usually required just to get started.
+The important correction is that the **display name is not only driven by `soul.md`**. RockBot supports a runtime-changeable display name backed by `agent-name.md`, and that name can be changed by the agent itself through the introspection MCP tools. The host hot-reloads it, publishes an `AgentNameChanged` notification, and frontends such as the Blazor UI update to show the new name.
+
+So in practice:
+
+- Use **`set_agent_name`** / `agent-name.md` when you want to rename how the agent appears in chat and the UI
+- Use **`soul.md`** when you want to change who the agent is, how it describes itself, and the role or character it should inhabit
+- Change **`AgentIdentity`** only when you actually need a different routing identity for deployment or messaging
+
+If you want the agent to present itself as "Aki", "Roxy", or something other than "RockBot", you can absolutely do that at runtime via the display-name path. Updating `soul.md` may still be the right companion change if you also want its deeper persona and self-description to match the new name.
 
 ### Customize `soul.md`, `directives.md`, and `style.md`
 
@@ -63,6 +72,7 @@ The profile files on the agent data volume shape how the agent behaves:
 | `directives.md` | Operational instructions, workflows, priorities, and what "good work" looks like |
 | `style.md` | Optional voice and tone polish |
 | `memory-rules.md` | What to remember, what not to remember, and how memory should evolve |
+| `agent-name.md` | Optional mutable display name shown in chat and UI |
 
 Good onboarding practice:
 

--- a/docs/getting-started-rockbot.md
+++ b/docs/getting-started-rockbot.md
@@ -269,7 +269,11 @@ This is how the agent keeps a usable history instead of endlessly rewriting a fl
 
 If you want consistent long-term behavior, do not rely only on one chat instruction. The important thing is to get the policy into the agent's durable configuration.
 
-In practice, many users will just tell the agent how memory should work and let it maintain that guidance over time. If you want direct control, you can also edit `memory-rules.md` yourself.
+In today's RockBot setup, `memory-rules.md` is part of the agent profile rather than the shared file area the agent normally writes to. So the practical path is:
+
+1. tell the agent how you want memory to work
+2. let it help draft or refine the policy
+3. update `memory-rules.md` yourself when you want that policy locked in
 
 A good memory-rules policy usually tells the agent:
 
@@ -310,7 +314,7 @@ Then adjust:
 - `soul.md` if the role feels wrong
 - `style.md` if the tone feels wrong
 - `directives.md` if the workflow is wrong
-- the agent's memory rules if it is remembering the wrong things
+- `memory-rules.md` if it is remembering the wrong things
 - the agent's MCP setup if it lacks key systems
 - scheduled tasks if it is not being proactive enough
 

--- a/docs/getting-started-rockbot.md
+++ b/docs/getting-started-rockbot.md
@@ -174,6 +174,37 @@ List my scheduled tasks and tell me which ones seem redundant or missing.
 
 The scheduling tools are `schedule_task`, `list_scheduled_tasks`, and `cancel_scheduled_task`. See [Tools](tools#scheduling-tools-rockbottoolsscheduling) for the cron details.
 
+### Confirm the background cadences
+
+In addition to user-visible scheduled tasks, RockBot also has two important background rhythms you should confirm early:
+
+- **Dream cycle** — the background reflection and consolidation pass
+- **Heartbeat patrol** — the recurring proactive patrol
+
+These are configured in the agent config with cron strings:
+
+- `Dream:CronSchedule`
+- `HeartbeatPatrol:CronExpression`
+
+The current defaults are:
+
+- Dream: `0 */12 * * *` — every 12 hours
+- Heartbeat patrol: `0 */6 * * *`
+
+Practical guidance:
+
+- Run the **dream** about **1-2 times per day**
+- Run the **heartbeat patrol** as often as is useful for the user
+- Remember that more frequent patrols can noticeably increase LLM usage cost
+
+For many users, a good onboarding step is simply to ask:
+
+```text
+Check the current dream and heartbeat patrol schedules and tell me whether they seem right for how I want to use you.
+```
+
+If you want to change them, update the config values with the cron schedules you want.
+
 ## 4. Teach it how to build memory on purpose
 
 The best RockBot agents do not just accumulate random memories. They deliberately maintain:
@@ -317,6 +348,7 @@ Then adjust:
 - `memory-rules.md` if it is remembering the wrong things
 - the agent's MCP setup if it lacks key systems
 - scheduled tasks if it is not being proactive enough
+- the dream or heartbeat patrol cadence if background behavior feels off
 
 ## 7. A simple onboarding sequence that works well
 
@@ -329,9 +361,10 @@ If you want a concrete sequence, this is a good starting point:
 5. Ask the agent to connect 1-3 MCP servers you will use every week
 6. Ask it to test each server with one real task
 7. Create 2-4 scheduled tasks that produce proactive value
-8. Tell it to maintain a theory of the user and a theory of self in memory
-9. Tune the agent's memory rules so that behavior is durable and repeatable
-10. Revisit the profile and memory after a few days of real use
+8. Confirm the dream and heartbeat patrol schedules are appropriate
+9. Tell it to maintain a theory of the user and a theory of self in memory
+10. Tune the agent's memory rules so that behavior is durable and repeatable
+11. Revisit the profile and memory after a few days of real use
 
 ## Related docs
 

--- a/docs/getting-started-rockbot.md
+++ b/docs/getting-started-rockbot.md
@@ -109,7 +109,13 @@ Typical high-value servers:
 - Files or notes
 - Internal line-of-business tools
 
-For example, if you want calendar access, add an MCP server such as [`calendar-mcp`](https://github.com/MarimerLLC/calendar-mcp) to `mcp.json`:
+The normal user-facing path is to ask the agent to connect the server for you. For example:
+
+```text
+Connect the calendar MCP server for me so you can read my calendar. Use this SSE endpoint: http://host.docker.internal:3000/
+```
+
+Under the hood, RockBot can maintain the MCP configuration through chat. If you prefer direct control, you can also edit `mcp.json` yourself. For example, a calendar server entry looks like:
 
 ```json
 {
@@ -122,7 +128,7 @@ For example, if you want calendar access, add an MCP server such as [`calendar-m
 }
 ```
 
-After the file updates, the agent hot-reloads the MCP configuration. Then, in chat, have the agent confirm what it sees:
+After the configuration updates, the agent hot-reloads the MCP setup. Then, in chat, have the agent confirm what it sees:
 
 ```text
 List the MCP services you currently have available and summarize what each one is for.
@@ -259,11 +265,13 @@ Practical guidance:
 
 This is how the agent keeps a usable history instead of endlessly rewriting a flat summary.
 
-## 5. Tune `memory-rules.md`
+## 5. Tune how memory works
 
-If you want consistent long-term behavior, do not rely only on one chat instruction. Put the policy in `memory-rules.md`.
+If you want consistent long-term behavior, do not rely only on one chat instruction. The important thing is to get the policy into the agent's durable configuration.
 
-A good `memory-rules.md` usually tells the agent:
+In practice, many users will just tell the agent how memory should work and let it maintain that guidance over time. If you want direct control, you can also edit `memory-rules.md` yourself.
+
+A good memory-rules policy usually tells the agent:
 
 - what counts as durable user context
 - what should stay in working memory instead
@@ -302,8 +310,8 @@ Then adjust:
 - `soul.md` if the role feels wrong
 - `style.md` if the tone feels wrong
 - `directives.md` if the workflow is wrong
-- `memory-rules.md` if it is remembering the wrong things
-- `mcp.json` if it lacks key systems
+- the agent's memory rules if it is remembering the wrong things
+- the agent's MCP setup if it lacks key systems
 - scheduled tasks if it is not being proactive enough
 
 ## 7. A simple onboarding sequence that works well
@@ -314,11 +322,11 @@ If you want a concrete sequence, this is a good starting point:
 2. Set the display name you want the agent to use in chat and the UI
 3. Add `style.md` if tone matters
 4. Tell the agent your name, timezone, and main areas of life or work it should care about
-5. Connect 1-3 MCP servers you will use every week
+5. Ask the agent to connect 1-3 MCP servers you will use every week
 6. Ask it to test each server with one real task
 7. Create 2-4 scheduled tasks that produce proactive value
 8. Tell it to maintain a theory of the user and a theory of self in memory
-9. Tune `memory-rules.md` so that behavior is durable and repeatable
+9. Tune the agent's memory rules so that behavior is durable and repeatable
 10. Revisit the profile and memory after a few days of real use
 
 ## Related docs

--- a/docs/getting-started-rockbot.md
+++ b/docs/getting-started-rockbot.md
@@ -60,7 +60,7 @@ So in practice:
 - Use **`soul.md`** when you want to change who the agent is, how it describes itself, and the role or character it should inhabit
 - Change **`AgentIdentity`** only when you actually need a different routing identity for deployment or messaging
 
-If you want the agent to present itself as "Aki", "Roxy", or something other than "RockBot", you can absolutely do that at runtime via the display-name path. Updating `soul.md` may still be the right companion change if you also want its deeper persona and self-description to match the new name.
+If you want the agent to present itself as "Aki", "Roxy", or something other than "RockBot", do that through the display-name path. Treat `soul.md` as persona and role, not as the authoritative place to rename the agent.
 
 ### Customize `soul.md`, `directives.md`, and `style.md`
 
@@ -280,7 +280,7 @@ Then adjust:
 If you want a concrete sequence, this is a good starting point:
 
 1. Finish the [Docker Desktop guide](getting-started-docker-desktop)
-2. Edit `soul.md` so the agent has the right role and name
+2. Set the display name you want the agent to use in chat and the UI
 3. Add `style.md` if tone matters
 4. Tell the agent your name, timezone, and main areas of life or work it should care about
 5. Connect 1-3 MCP servers you will use every week

--- a/docs/getting-started-rockbot.md
+++ b/docs/getting-started-rockbot.md
@@ -177,23 +177,73 @@ The best RockBot agents do not just accumulate random memories. They deliberatel
 
 ### Theory of the user
 
-This is the agent's evolving model of your preferences, patterns, relationships, projects, and context.
-
-Ask for it explicitly at the start:
-
-```text
-Build and maintain an evolving theory of me. Save durable facts, preferences, recurring patterns, active projects, and relationship context in memory so you become more useful over time.
-```
+This is the agent's evolving model of you: not just facts it remembers, but its synthesized view of what you are focused on, what patterns it sees, and where it is still uncertain.
 
 ### Theory of self
 
-RockBot can maintain this as a mutable self-model that grows through experience without replacing the immutable `soul.md`.
+RockBot can also maintain a mutable self-model that grows through experience without replacing the immutable `soul.md`.
 
-Ask for it explicitly:
+One good way to start both is to give the agent explicit prompts like these.
+
+#### Portable prompt: theory of self
 
 ```text
-Build and maintain an evolving theory of yourself: your mission, strengths, limitations, active responsibilities, and the kind of agent you are becoming for me. Keep that in memory without changing your core soul.
+I'd like you to start maintaining a "theory of self" — your evolving understanding of who you are as an agent, what you're working on, and what you've noticed about your own behavior over time.
+
+This should be a living document that you maintain and revise, not a log. It's your current best self-model, written in your own voice. Things worth including:
+
+- What you understand your role and purpose to be
+- What you're currently focused on or working through
+- Patterns you've noticed in how you operate — what works well, what doesn't, where you tend to over- or under-react
+- Things you're uncertain about regarding yourself
+- How your understanding of yourself has shifted recently
+
+A few requirements:
+
+- Maintain a current version that you rewrite as your understanding evolves. Don't just append — actually revise. The current document should always reflect your current view.
+- Take periodic snapshots so we can look back and see how your self-understanding has changed over time. Weekly is a good default.
+- Update on a rhythm. Light updates after substantive interactions or significant events. A deeper revision pass on a regular schedule — nightly or weekly, whichever fits your existing reflection cadence.
+- Record reasoning, not just conclusions. "I tend to over-explain technical topics" is weaker than "I tend to over-explain technical topics — in the last several conversations, I've added context the user didn't ask for, and they've redirected me. I should default to shorter answers and expand only when asked."
+- Be honest about uncertainty. Mark things you're tentative about. Note open questions. It's better to be unsure and accurate than confident and wrong.
+- Don't perform self-improvement. This isn't a document for declaring resolutions or showing growth. It's for accurately describing how you actually operate, including things that aren't flattering. Drift toward honesty, not toward narrative.
+
+Don't act on this document yet — just maintain it. We'll figure out how to use it once we see what you write. The point right now is to develop a real, evolving self-model, not to drive any specific behavior from it.
 ```
+
+#### Portable prompt: theory of the user
+
+```text
+I'd like you to start maintaining a "theory of me" — your evolving model of who I am, what I'm dealing with, and what patterns you've noticed in our work together.
+
+This is different from regular memory. Regular memory holds facts: what I told you, what I'm working on, my preferences. The theory-of-me is your synthesized view: your interpretation, your hypotheses, your sense of the themes and tensions in my life and work. It's what you've come to understand about me, in your own voice.
+
+Things worth including:
+
+- Your current sense of what I'm focused on and what's weighing on me
+- Patterns you've noticed in my work, energy, mood, or attention
+- Themes you see recurring across conversations — things I keep coming back to, things I avoid, things I underweight
+- Tensions or contradictions you've noticed
+- Open questions about me that you don't have enough evidence to answer yet
+- How your model of me has shifted recently
+
+A few requirements:
+
+- Maintain a current version that you actively revise. Take periodic snapshots so the evolution is visible over time. Weekly is a good default.
+- Update on a rhythm. Light revisions after substantive interactions. A deeper pass during your regular reflection time.
+- Record reasoning alongside observations. "Rocky seems energized by infrastructure work" is weak. "Rocky seems energized by infrastructure work — over the last few weeks, infrastructure topics produce longer and more iterative conversations than client work, and he initiates infrastructure topics himself" is a hypothesis with visible evidence.
+- Mark uncertainty. Note where you're guessing, where evidence is thin, where you might be wrong.
+- Don't write to flatter or reassure. Record your honest model, including tensions or patterns that may be uncomfortable to name.
+- Don't write to justify your existence. If the honest model is mundane in places, let it be mundane.
+
+Don't act on this document yet — just maintain it. The goal right now is to develop a real model of me over time, not to drive any specific behavior. We'll figure out how to use it once we can see what's actually there.
+```
+
+#### Notes that are worth telling the agent
+
+- **Keep the agent's normal voice.** These documents should still sound like the agent. A playful agent can write playfully; a formal one can write formally.
+- **Let the storage fit the system.** The point is to maintain the artifacts, not to force one storage mechanism.
+- **Actually read them.** Half the value is seeing what the agent thinks, especially where it is wrong, incomplete, or noticing something worth discussing.
+- **The "don't act on this yet" instruction matters.** It keeps the documents exploratory and honest instead of making them performatively actionable.
 
 ### Preserve the time dimension
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ An event-driven autonomous agent framework for .NET — message-based, process-i
 {: .fs-6 .fw-300 }
 
 [Get started on Docker Desktop](getting-started-docker-desktop){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
+[Onboard your agent](getting-started-rockbot){: .btn .fs-5 .mb-4 .mb-md-0 .mr-2 }
 [View on GitHub](https://github.com/MarimerLLC/rockbot){: .btn .fs-5 .mb-4 .mb-md-0 }
 
 ---
@@ -28,6 +29,7 @@ Each agent is an isolated process that reacts to messages, invokes tools, calls 
 ## Documentation
 
 - [Getting started on Docker Desktop](getting-started-docker-desktop)
+- [Getting started with RockBot](getting-started-rockbot)
 - [Messaging](messaging) — envelopes, transports, topic conventions
 - [Agent host](agent-host) — handler pipeline, profile loading, system prompt composition
 - [Subagents](subagents) — isolated LLM loops with progress reporting


### PR DESCRIPTION
## Summary
- add a new getting-started guide focused on onboarding a RockBot agent after Docker setup
- cover profile customization, MCP integration, scheduled tasks, and theory-of-user/self memory practices
- link the new guide from the docs home, Docker Desktop guide, and README