### PR TITLE
Load LLM pricing from PVC file with hot-reload

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.10.10</Version>
+<Version>0.10.11</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/deploy/helm/rockbot/templates/agent/deployment.yaml
+++ b/deploy/helm/rockbot/templates/agent/deployment.yaml
@@ -63,6 +63,13 @@ spec:
                 cp /app/mcp.json /data/agent/mcp.json
               fi
 
+              # llm-pricing.json — operator-editable pricing table consumed by LlmCostEstimator.
+              # Copy no-clobber so manual price tweaks survive image upgrades.
+              if [ -f /app/agent/llm-pricing.json ] && [ ! -s /data/agent/llm-pricing.json ]; then
+                echo "  Copying default llm-pricing.json"
+                cp /app/agent/llm-pricing.json /data/agent/llm-pricing.json
+              fi
+
               # Per-model behavior prompt files — copy per-file so users can customise
               # individual prompts without losing others on upgrade
               for model_dir in /app/model-behaviors/*/; do

--- a/deploy/helm/rockbot/templates/configmap.yaml
+++ b/deploy/helm/rockbot/templates/configmap.yaml
@@ -28,6 +28,7 @@ data:
   Memory__BasePath: "/data/agent/memory"
   Skill__BasePath: "/data/agent/skills"
   McpBridge__ConfigPath: "/data/agent/mcp.json"
+  LlmPricing__ConfigPath: "/data/agent/llm-pricing.json"
 
   # ── Default MCP servers (auto-seeded into mcp.json on startup) ────────────
   # The agent skips seeding an entry when an existing mcp.json entry already points

--- a/src/McpServer.Introspection/Program.cs
+++ b/src/McpServer.Introspection/Program.cs
@@ -6,7 +6,8 @@ builder.Services.AddHealthChecks();
 builder.Services.AddMcpServer()
     .WithHttpTransport()
     .WithTools<AgentNameTools>()
-    .WithTools<CopilotUsageTools>();
+    .WithTools<CopilotUsageTools>()
+    .WithTools<LlmPricingTools>();
 
 var app = builder.Build();
 

--- a/src/McpServer.Introspection/Tools/LlmPricingTools.cs
+++ b/src/McpServer.Introspection/Tools/LlmPricingTools.cs
@@ -1,0 +1,27 @@
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+
+namespace McpServer.Introspection.Tools;
+
+[McpServerToolType]
+public sealed class LlmPricingTools(IConfiguration configuration)
+{
+    private string PricingFilePath =>
+        configuration["LlmPricing:Path"] ?? "/data/agent/llm-pricing.json";
+
+    [McpServerTool(Name = "get_llm_pricing")]
+    [Description(
+        "Returns the agent's LLM pricing table as JSON: an array of " +
+        "{prefix, inputPerM, outputPerM} entries giving USD cost per million tokens " +
+        "for each model prefix. Cost = (inputTokens * inputPerM + outputTokens * outputPerM) / 1_000_000. " +
+        "The first entry whose prefix is contained in the model ID wins (longest-prefix-first ordering). " +
+        "Use this to estimate the cost of an LLM call before making it, or to explain pricing to the user.")]
+    public async Task<string> GetLlmPricingAsync()
+    {
+        if (!File.Exists(PricingFilePath))
+            return "Pricing file not found at " + PricingFilePath +
+                   ". The agent is using its built-in fallback table.";
+
+        return await File.ReadAllTextAsync(PricingFilePath);
+    }
+}

--- a/src/RockBot.Agent/Program.cs
+++ b/src/RockBot.Agent/Program.cs
@@ -363,6 +363,10 @@ builder.Services.Configure<AgentProfileOptions>(builder.Configuration.GetSection
 // Allow MaxToolIterations and other AgentHostOptions to be overridden via appsettings.json or env vars.
 builder.Services.Configure<AgentHostOptions>(builder.Configuration.GetSection("AgentHost"));
 
+// LLM pricing — loaded from a JSON file on the agent PVC so prices can be refreshed
+// without rebuilding the image. LlmPricing__ConfigPath in the ConfigMap overrides the default.
+builder.Services.Configure<LlmPricingOptions>(builder.Configuration.GetSection("LlmPricing"));
+
 // MCP bridge (replaces external RockBot.Tools.Mcp.Bridge process)
 builder.Services.Configure<McpBridgeOptions>(builder.Configuration.GetSection("McpBridge"));
 builder.Services.AddHostedService<McpBridgeService>();

--- a/src/RockBot.Agent/RockBot.Agent.csproj
+++ b/src/RockBot.Agent/RockBot.Agent.csproj
@@ -29,6 +29,9 @@
   <ItemGroup>
     <None Include="mcp.json" CopyToOutputDirectory="PreserveNewest" />
     <None Include="appsettings.json" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="agent\llm-pricing.json" CopyToOutputDirectory="PreserveNewest">
+      <Link>agent\llm-pricing.json</Link>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/RockBot.Agent/agent/llm-pricing.json
+++ b/src/RockBot.Agent/agent/llm-pricing.json
@@ -1,0 +1,32 @@
+[
+  { "prefix": "gpt-5.4-pro",      "inputPerM": 30.00, "outputPerM": 180.00 },
+  { "prefix": "gpt-5.4-mini",     "inputPerM":  0.75, "outputPerM":   4.50 },
+  { "prefix": "gpt-5.4",          "inputPerM":  2.50, "outputPerM":  15.00 },
+
+  { "prefix": "claude-opus-4",    "inputPerM": 15.00, "outputPerM":  75.00 },
+  { "prefix": "claude-sonnet-4",  "inputPerM":  3.00, "outputPerM":  15.00 },
+  { "prefix": "claude-haiku-4",   "inputPerM":  0.80, "outputPerM":   4.00 },
+  { "prefix": "claude-3-opus",    "inputPerM": 15.00, "outputPerM":  75.00 },
+  { "prefix": "claude-3-5-sonnet","inputPerM":  3.00, "outputPerM":  15.00 },
+  { "prefix": "claude-3-5-haiku", "inputPerM":  0.80, "outputPerM":   4.00 },
+  { "prefix": "claude-3-haiku",   "inputPerM":  0.25, "outputPerM":   1.25 },
+
+  { "prefix": "gpt-5.3",          "inputPerM":  1.75, "outputPerM":  14.00 },
+  { "prefix": "gpt-4o-mini",      "inputPerM":  0.15, "outputPerM":   0.60 },
+  { "prefix": "gpt-4o",           "inputPerM":  2.50, "outputPerM":  10.00 },
+  { "prefix": "gpt-4-turbo",      "inputPerM": 10.00, "outputPerM":  30.00 },
+  { "prefix": "o1-mini",          "inputPerM":  1.10, "outputPerM":   4.40 },
+  { "prefix": "o1",               "inputPerM": 15.00, "outputPerM":  60.00 },
+  { "prefix": "o3-mini",          "inputPerM":  1.10, "outputPerM":   4.40 },
+
+  { "prefix": "gemini-3.1-pro",   "inputPerM":  2.00, "outputPerM":  12.00 },
+  { "prefix": "gemini-3-flash",   "inputPerM":  0.50, "outputPerM":   3.00 },
+  { "prefix": "gemini-2.5-pro",   "inputPerM":  1.25, "outputPerM":  10.00 },
+  { "prefix": "gemini-2.5-flash", "inputPerM":  0.15, "outputPerM":   0.60 },
+  { "prefix": "gemini-2.0-flash", "inputPerM":  0.10, "outputPerM":   0.40 },
+  { "prefix": "gemini-1.5-pro",   "inputPerM":  1.25, "outputPerM":   5.00 },
+  { "prefix": "gemini-1.5-flash", "inputPerM":  0.075,"outputPerM":   0.30 },
+
+  { "prefix": "deepseek-chat",    "inputPerM":  0.14, "outputPerM":   0.28 },
+  { "prefix": "deepseek-r1",      "inputPerM":  0.55, "outputPerM":   2.19 }
+]

--- a/src/RockBot.Host/LlmClient.cs
+++ b/src/RockBot.Host/LlmClient.cs
@@ -14,6 +14,7 @@ namespace RockBot.Host;
 /// </summary>
 internal sealed class LlmClient(
     TieredChatClientRegistry registry,
+    LlmCostEstimator costEstimator,
     ILogger<LlmClient> logger) : ILlmClient
 {
     /// <summary>Calls the LLM using the Balanced tier.</summary>
@@ -81,7 +82,7 @@ internal sealed class LlmClient(
                 if (usage.OutputTokenCount.HasValue)
                     HostDiagnostics.LlmTokenOutput.Add(outputTokens, tierTag, modelTag);
 
-                var costUsd = LlmCostEstimator.EstimateCost(modelId, inputTokens, outputTokens);
+                var costUsd = costEstimator.EstimateCost(modelId, inputTokens, outputTokens);
                 if (costUsd > 0)
                 {
                     HostDiagnostics.LlmCostUsd.Add(costUsd, tierTag, modelTag);

--- a/src/RockBot.Host/LlmCostEstimator.cs
+++ b/src/RockBot.Host/LlmCostEstimator.cs
@@ -1,58 +1,173 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
 namespace RockBot.Host;
 
 /// <summary>
 /// Estimates LLM call cost in USD from token counts and model ID.
-/// Uses a static lookup of well-known models; unknown models return 0.
-/// Update this table as pricing changes or new models are added.
+/// Pricing is loaded from a JSON file on the agent PVC (see <see cref="LlmPricingOptions"/>),
+/// hot-reloaded on file change. When the file is missing or invalid, a small built-in
+/// fallback table is used so cost metrics keep flowing rather than collapsing to zero.
 /// </summary>
-internal static class LlmCostEstimator
+public sealed class LlmCostEstimator : IDisposable
 {
-    /// <summary>Cost per million tokens (input, output) in USD.</summary>
-    private static readonly (string Prefix, double InputPerM, double OutputPerM)[] Table =
+    private static readonly LlmPricingEntry[] BuiltInDefaults =
     [
-        // Claude models (Anthropic / OpenRouter)
-        ("claude-opus-4",        15.00, 75.00),
-        ("claude-sonnet-4",       3.00, 15.00),
-        ("claude-haiku-4",        0.80,  4.00),
-        ("claude-3-opus",        15.00, 75.00),
-        ("claude-3-5-sonnet",     3.00, 15.00),
-        ("claude-3-5-haiku",      0.80,  4.00),
-        ("claude-3-haiku",        0.25,  1.25),
+        // Azure OpenAI / OpenAI gpt-5.4 family — currently deployed via Azure
+        new("gpt-5.4-pro",        30.00, 180.00),
+        new("gpt-5.4-mini",        0.75,   4.50),
+        new("gpt-5.4",             2.50,  15.00),
 
-        // OpenAI models
-        ("gpt-5.3",               1.75, 14.00),
-        ("gpt-4o-mini",           0.15,  0.60),
-        ("gpt-4o",                2.50, 10.00),
-        ("gpt-4-turbo",          10.00, 30.00),
-        ("o1-mini",               1.10,  4.40),
-        ("o1",                   15.00, 60.00),
-        ("o3-mini",               1.10,  4.40),
+        // Claude (Anthropic / OpenRouter)
+        new("claude-opus-4",      15.00,  75.00),
+        new("claude-sonnet-4",     3.00,  15.00),
+        new("claude-haiku-4",      0.80,   4.00),
+        new("claude-3-opus",      15.00,  75.00),
+        new("claude-3-5-sonnet",   3.00,  15.00),
+        new("claude-3-5-haiku",    0.80,   4.00),
+        new("claude-3-haiku",      0.25,   1.25),
 
-        // Google models
-        ("gemini-3.1-pro",        2.00, 12.00),
-        ("gemini-3-flash",        0.50,  3.00),
-        ("gemini-2.0-flash",      0.10,  0.40),
-        ("gemini-2.5-flash",      0.15,  0.60),
-        ("gemini-1.5-flash",      0.075, 0.30),
-        ("gemini-1.5-pro",        1.25,  5.00),
-        ("gemini-2.5-pro",        1.25,  10.00),
+        // OpenAI legacy
+        new("gpt-5.3",             1.75,  14.00),
+        new("gpt-4o-mini",         0.15,   0.60),
+        new("gpt-4o",              2.50,  10.00),
+        new("gpt-4-turbo",        10.00,  30.00),
+        new("o1-mini",             1.10,   4.40),
+        new("o1",                 15.00,  60.00),
+        new("o3-mini",             1.10,   4.40),
 
-        // DeepSeek models
-        ("deepseek-chat",         0.14,  0.28),
-        ("deepseek-r1",           0.55,  2.19),
+        // Google
+        new("gemini-3.1-pro",      2.00,  12.00),
+        new("gemini-3-flash",      0.50,   3.00),
+        new("gemini-2.5-pro",      1.25,  10.00),
+        new("gemini-2.5-flash",    0.15,   0.60),
+        new("gemini-2.0-flash",    0.10,   0.40),
+        new("gemini-1.5-pro",      1.25,   5.00),
+        new("gemini-1.5-flash",    0.075,  0.30),
+
+        // DeepSeek
+        new("deepseek-chat",       0.14,   0.28),
+        new("deepseek-r1",         0.55,   2.19),
     ];
 
-    /// <summary>
-    /// Estimates cost in USD for a single LLM call.
-    /// Returns 0 if the model is not in the lookup table.
-    /// </summary>
-    public static double EstimateCost(string modelId, long inputTokens, long outputTokens)
+    private readonly LlmPricingOptions _options;
+    private readonly ILogger<LlmCostEstimator> _logger;
+    private FileSystemWatcher? _watcher;
+    private Timer? _debounce;
+    private int _reloadPending;
+
+    // Sorted longest-prefix-first so "gpt-5.4-pro" wins over "gpt-5.4".
+    private LlmPricingEntry[] _table = SortLongestFirst(BuiltInDefaults);
+
+    public LlmCostEstimator(IOptions<LlmPricingOptions> options, ILogger<LlmCostEstimator> logger)
     {
-        foreach (var (prefix, inputPerM, outputPerM) in Table)
+        _options = options.Value;
+        _logger = logger;
+        Reload();
+        StartWatching();
+    }
+
+    /// <summary>Estimates cost in USD. Returns 0 when no prefix matches.</summary>
+    public double EstimateCost(string modelId, long inputTokens, long outputTokens)
+    {
+        var table = _table;
+        foreach (var entry in table)
         {
-            if (modelId.Contains(prefix, StringComparison.OrdinalIgnoreCase))
-                return (inputTokens * inputPerM + outputTokens * outputPerM) / 1_000_000.0;
+            if (modelId.Contains(entry.Prefix, StringComparison.OrdinalIgnoreCase))
+                return (inputTokens * entry.InputPerM + outputTokens * entry.OutputPerM) / 1_000_000.0;
         }
         return 0.0;
     }
+
+    private void Reload()
+    {
+        try
+        {
+            if (!File.Exists(_options.ConfigPath))
+            {
+                _logger.LogInformation("LLM pricing file {Path} not found, using built-in defaults", _options.ConfigPath);
+                _table = SortLongestFirst(BuiltInDefaults);
+                return;
+            }
+
+            var json = File.ReadAllText(_options.ConfigPath);
+            var entries = JsonSerializer.Deserialize<LlmPricingEntry[]>(json, JsonOpts);
+            if (entries is null || entries.Length == 0)
+            {
+                _logger.LogWarning("LLM pricing file {Path} parsed as empty, using built-in defaults", _options.ConfigPath);
+                _table = SortLongestFirst(BuiltInDefaults);
+                return;
+            }
+
+            _table = SortLongestFirst(entries);
+            _logger.LogInformation("Loaded {Count} LLM pricing entries from {Path}", entries.Length, _options.ConfigPath);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load LLM pricing from {Path}, keeping previous table", _options.ConfigPath);
+        }
+    }
+
+    private void StartWatching()
+    {
+        var dir = Path.GetDirectoryName(_options.ConfigPath);
+        var file = Path.GetFileName(_options.ConfigPath);
+        if (string.IsNullOrEmpty(dir) || !Directory.Exists(dir))
+        {
+            _logger.LogDebug("LLM pricing directory {Dir} does not exist, file watching disabled", dir);
+            return;
+        }
+
+        _watcher = new FileSystemWatcher(dir, file)
+        {
+            NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.Size | NotifyFilters.FileName,
+            IncludeSubdirectories = false,
+            EnableRaisingEvents = true,
+        };
+        _watcher.Changed += OnFileChanged;
+        _watcher.Created += OnFileChanged;
+        _watcher.Renamed += OnFileChanged;
+    }
+
+    private void OnFileChanged(object sender, FileSystemEventArgs e)
+    {
+        if (Interlocked.Exchange(ref _reloadPending, 1) == 0)
+        {
+            _debounce?.Dispose();
+            _debounce = new Timer(_ =>
+            {
+                try { Reload(); }
+                finally { Interlocked.Exchange(ref _reloadPending, 0); }
+            }, null, TimeSpan.FromMilliseconds(500), Timeout.InfiniteTimeSpan);
+        }
+    }
+
+    private static LlmPricingEntry[] SortLongestFirst(IEnumerable<LlmPricingEntry> entries)
+        => entries.OrderByDescending(e => e.Prefix.Length).ToArray();
+
+    private static readonly JsonSerializerOptions JsonOpts = new(JsonSerializerDefaults.Web)
+    {
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        AllowTrailingCommas = true,
+    };
+
+    public void Dispose()
+    {
+        if (_watcher is not null)
+        {
+            _watcher.EnableRaisingEvents = false;
+            _watcher.Dispose();
+            _watcher = null;
+        }
+        _debounce?.Dispose();
+        _debounce = null;
+    }
 }
+
+/// <summary>Single pricing entry: a model ID prefix and per-million-token rates in USD.</summary>
+public sealed record LlmPricingEntry(
+    [property: JsonPropertyName("prefix")] string Prefix,
+    [property: JsonPropertyName("inputPerM")] double InputPerM,
+    [property: JsonPropertyName("outputPerM")] double OutputPerM);

--- a/src/RockBot.Host/LlmPricingOptions.cs
+++ b/src/RockBot.Host/LlmPricingOptions.cs
@@ -1,0 +1,14 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Options for <see cref="LlmCostEstimator"/>. Pricing is loaded from a JSON file
+/// on the agent PVC so prices can be refreshed without rebuilding the image.
+/// </summary>
+public sealed class LlmPricingOptions
+{
+    /// <summary>
+    /// Absolute path to the pricing JSON file. When the file is missing or fails to
+    /// parse, the estimator falls back to a small built-in table.
+    /// </summary>
+    public string ConfigPath { get; set; } = "/data/agent/llm-pricing.json";
+}

--- a/src/RockBot.Host/RockBotFunctionInvokingChatClient.cs
+++ b/src/RockBot.Host/RockBotFunctionInvokingChatClient.cs
@@ -22,6 +22,7 @@ public class RockBotFunctionInvokingChatClient : FunctionInvokingChatClient
     private readonly IToolProgressNotifier? _progressNotifier;
     private readonly IToolCallLog? _toolCallLog;
     private readonly ModelBehavior _modelBehavior;
+    private readonly LlmCostEstimator _costEstimator;
     private readonly ILogger _logger;
 
     private int _consecutiveTimeoutIterations;
@@ -33,12 +34,14 @@ public class RockBotFunctionInvokingChatClient : FunctionInvokingChatClient
         IToolProgressNotifier? progressNotifier,
         IToolCallLog? toolCallLog,
         ModelBehavior modelBehavior,
+        LlmCostEstimator costEstimator,
         IOptions<AgentHostOptions> hostOptions,
         ILogger logger) : base(innerClient)
     {
         _progressNotifier = progressNotifier;
         _toolCallLog = toolCallLog;
         _modelBehavior = modelBehavior;
+        _costEstimator = costEstimator;
         _logger = logger;
 
         MaximumIterationsPerRequest = modelBehavior.MaxToolIterationsOverride ?? hostOptions.Value.MaxToolIterations;
@@ -271,7 +274,7 @@ public class RockBotFunctionInvokingChatClient : FunctionInvokingChatClient
                         HostDiagnostics.LlmTokenInput.Add(inputTokens, modelTag);
                     if (summaryUsage.OutputTokenCount.HasValue)
                         HostDiagnostics.LlmTokenOutput.Add(outputTokens, modelTag);
-                    var costUsd = LlmCostEstimator.EstimateCost(summaryModelId, inputTokens, outputTokens);
+                    var costUsd = _costEstimator.EstimateCost(summaryModelId, inputTokens, outputTokens);
                     if (costUsd > 0)
                     {
                         HostDiagnostics.LlmCostUsd.Add(costUsd, modelTag);

--- a/src/RockBot.Host/ServiceCollectionExtensions.cs
+++ b/src/RockBot.Host/ServiceCollectionExtensions.cs
@@ -32,6 +32,8 @@ public static class ServiceCollectionExtensions
         configure(builder);
         builder.Build();
 
+        services.AddSingleton<LlmCostEstimator>();
+        services.Configure<LlmPricingOptions>(_ => { });
         services.AddTransient<ILlmClient, LlmClient>();
         services.AddSingleton<IToolProgressNotifier, ToolProgressNotifier>();
         services.AddTransient<AgentLoopRunner>();
@@ -94,6 +96,7 @@ public static class ServiceCollectionExtensions
                 sp.GetService<IToolProgressNotifier>(),
                 sp.GetService<IToolCallLog>(),
                 behavior,
+                sp.GetRequiredService<LlmCostEstimator>(),
                 sp.GetRequiredService<IOptions<AgentHostOptions>>(),
                 sp.GetRequiredService<ILogger<RockBotFunctionInvokingChatClient>>());
         });

--- a/src/RockBot.Llm/ServiceCollectionExtensions.cs
+++ b/src/RockBot.Llm/ServiceCollectionExtensions.cs
@@ -83,12 +83,13 @@ public static class LlmServiceCollectionExtensions
             var logger = sp.GetRequiredService<ILogger<RockBotFunctionInvokingChatClient>>();
             var progressNotifier = sp.GetService<IToolProgressNotifier>();
             var toolCallLog = sp.GetService<IToolCallLog>();
+            var costEstimator = sp.GetRequiredService<LlmCostEstimator>();
 
             IChatClient Wrap(IChatClient raw) =>
                 behavior.UseTextBasedToolCalling
                     ? raw
                     : new RockBotFunctionInvokingChatClient(raw, progressNotifier, toolCallLog, behavior,
-                        sp.GetRequiredService<IOptions<AgentHostOptions>>(), logger);
+                        costEstimator, sp.GetRequiredService<IOptions<AgentHostOptions>>(), logger);
 
             return new TieredChatClientRegistry(
                 Wrap(lowInnerClient), Wrap(balancedInnerClient), Wrap(highInnerClient));

--- a/tests/RockBot.Host.Tests/LlmCostEstimatorTests.cs
+++ b/tests/RockBot.Host.Tests/LlmCostEstimatorTests.cs
@@ -1,0 +1,69 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace RockBot.Host.Tests;
+
+[TestClass]
+public class LlmCostEstimatorTests
+{
+    private static LlmCostEstimator NewEstimator(string configPath)
+    {
+        var opts = Options.Create(new LlmPricingOptions { ConfigPath = configPath });
+        return new LlmCostEstimator(opts, NullLogger<LlmCostEstimator>.Instance);
+    }
+
+    [TestMethod]
+    public void EstimateCost_UsesBuiltInDefaults_WhenFileMissing()
+    {
+        using var estimator = NewEstimator(Path.Combine(Path.GetTempPath(), $"missing-{Guid.NewGuid():N}.json"));
+
+        // gpt-5.4 is in built-in defaults at $2.50/M input, $15.00/M output.
+        var cost = estimator.EstimateCost("gpt-5.4", 1_000_000, 1_000_000);
+
+        Assert.AreEqual(17.50, cost, 0.0001);
+    }
+
+    [TestMethod]
+    public void EstimateCost_LongestPrefixWins()
+    {
+        // gpt-5.4-pro must match before gpt-5.4 even though both contain "gpt-5.4".
+        using var estimator = NewEstimator(Path.Combine(Path.GetTempPath(), $"missing-{Guid.NewGuid():N}.json"));
+
+        var cost = estimator.EstimateCost("gpt-5.4-pro", 1_000_000, 0);
+
+        Assert.AreEqual(30.00, cost, 0.0001);
+    }
+
+    [TestMethod]
+    public void EstimateCost_ReturnsZero_ForUnknownModel()
+    {
+        using var estimator = NewEstimator(Path.Combine(Path.GetTempPath(), $"missing-{Guid.NewGuid():N}.json"));
+
+        Assert.AreEqual(0.0, estimator.EstimateCost("totally-unknown-model", 1_000_000, 1_000_000));
+    }
+
+    [TestMethod]
+    public void EstimateCost_LoadsFromFile_OverridingDefaults()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"pricing-{Guid.NewGuid():N}.json");
+        File.WriteAllText(path, """
+            [
+              { "prefix": "my-model", "inputPerM": 100.0, "outputPerM": 200.0 }
+            ]
+            """);
+        try
+        {
+            using var estimator = NewEstimator(path);
+
+            // From file: my-model = $100/M input, $200/M output.
+            Assert.AreEqual(0.30, estimator.EstimateCost("my-model-v1", 1_000, 1_000), 0.0001);
+
+            // gpt-5.4 was in built-in defaults but the file fully replaces them, so it returns 0.
+            Assert.AreEqual(0.0, estimator.EstimateCost("gpt-5.4", 1_000_000, 1_000_000));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Cost estimator pricing was hardcoded — when the live agent switched to `gpt-5.4`, no prefix matched and `rockbot_llm_cost_usd_total` recorded $0, breaking the rockbot-economics Grafana dashboard.
- Pricing now loads from `/data/agent/llm-pricing.json` on the agent PVC with ~500ms hot-reload via `FileSystemWatcher`, falling back to a built-in table when the file is missing or invalid.
- Adds `gpt-5.4` / `gpt-5.4-pro` / `gpt-5.4-mini` entries to both the built-in defaults and the seed file copied to the PVC by the helm init container (no-clobber, so manual edits survive image upgrades).
- Entries are sorted longest-prefix-first so `gpt-5.4-pro` correctly beats `gpt-5.4`.

## Test plan
- [x] `dotnet build RockBot.slnx` clean
- [x] `dotnet test RockBot.slnx` — 593 host tests pass, full suite green
- [x] New `LlmCostEstimatorTests` cover built-in fallback, longest-prefix-first, unknown model, file override
- [ ] After deploy, edit `/data/agent/llm-pricing.json` on a running pod and confirm reload log line appears within ~1s
- [ ] After deploy, confirm `rockbot_llm_cost_usd_total{rockbot_llm_model=~"gpt-5.4.*"}` series shows non-zero values in Grafana

## Pricing caveat
`gpt-5.4-mini` rate ($0.75/$4.50) sourced from MS Q&A and pricepertoken — the azure.microsoft.com pricing page timed out during fetch. Worth spot-checking in the Azure pricing UI before relying on it for billing-critical decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)