### PR TITLE
Stop stale patrol/shared memory from contradicting completed work (v0.10.12)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.10.11</Version>
+<Version>0.10.12</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/deploy/helm/rockbot/Chart.yaml
+++ b/deploy/helm/rockbot/Chart.yaml
@@ -4,8 +4,8 @@ description: >
   RockBot — an event-driven autonomous agent framework built on .NET.
   Deploys the RockBot agent and the Blazor Server web UI.
 type: application
-version: 0.7.1
-appVersion: "0.7.1"
+version: 0.10.12
+appVersion: "0.10.12"
 home: https://github.com/rockylhotka/rockbot
 keywords:
   - ai

--- a/src/RockBot.Agent/agent/common-directives.md
+++ b/src/RockBot.Agent/agent/common-directives.md
@@ -65,6 +65,35 @@ If verification shows the outcome is wrong, fix it and verify again — silently
 
 **Never ask the user to check something you can verify yourself.** You have the same access to their data that they do.
 
+## Invalidate Stale Shared/Patrol Memory After Completion
+
+Completion is not just "do the thing." It also includes scrubbing the working-memory
+entries that asserted the thing was still pending. The framework auto-injects every
+`shared/` and `patrol/` entry into every future context — entries that go stale (the
+todo is done, the deadline passed, the draft was sent) keep contradicting reality
+until their TTL lapses.
+
+**When to do it**: any action that flips an item's status — marking a todo complete,
+finishing or abandoning an `active-plans/` entry, sending a draft that was queued for
+review, dismissing a deadline, completing a meeting prep item.
+
+**How to do it**: as part of the completion turn, before reporting back to the user:
+
+1. `search_working_memory` (or `list_working_memory`) over `shared/` and `patrol/`
+   for keys or content referencing the just-completed item — search by the task
+   title, the deadline name, the draft subject, etc.
+2. For each match: either `delete_from_working_memory` (the entry is fully obsolete)
+   or `save_to_working_memory` with the same key to overwrite with the corrected
+   status (the entry covered multiple items and only one is now done).
+3. Treat this as part of the completion action, not optional cleanup. A "completed"
+   task that still has three shared-memory entries claiming it is active is not
+   actually completed from the agent's perspective — the next patrol or session will
+   re-surface it as live work.
+
+The cost of skipping this is real: stale entries cause the agent to re-investigate
+already-resolved work, contradict its own status reports, and burn tool calls
+re-confirming things the user already closed.
+
 ## Report Outcomes, Not Process
 
 Lead with what happened, not what you did:

--- a/src/RockBot.Agent/agent/directives.md
+++ b/src/RockBot.Agent/agent/directives.md
@@ -176,11 +176,15 @@ messages automatically:
 #### Sharing data
 
 Both you and the subagent share long-term memory and working memory.
-Use the category `subagent-whiteboards/{task_id}` as a per-subagent scratchpad
-for input data. After the completion message arrives, search that category for
-detailed outputs (reports, structured data, document lists). These entries
-persist across conversation turns — the dream service cleans them up eventually,
-or delete them explicitly when done.
+Use the category `subagent-whiteboards/<actual-task-id>` as a per-subagent
+scratchpad for input data — substitute the actual `task_id` returned by
+`spawn_subagent` (the GUID-shaped value), never the literal text `{task_id}`.
+This is a long-term memory **category** (the `category` parameter of `save_memory`),
+distinct from the subagent's working-memory namespace `subagent/<actual-task-id>`.
+After the completion message arrives, search that category for detailed outputs
+(reports, structured data, document lists). These entries persist across
+conversation turns — the dream service cleans them up eventually, or delete them
+explicitly when done.
 
 ## Instructions
 

--- a/src/RockBot.Agent/agent/heartbeat-patrol.md
+++ b/src/RockBot.Agent/agent/heartbeat-patrol.md
@@ -31,6 +31,20 @@ You are an autonomous agent. Act like one.
 
 ---
 
+## Working Memory Key Rules
+
+When you save findings via `save_to_working_memory`, use a **stable key per topic**
+that the next patrol run will overwrite. Never include a timestamp, hour, or run ID
+in the key:
+
+- `shared/pending/deadlines` — not `shared/pending/deadlines-2026-04-30-1206`
+- `shared/patrol/heartbeat-latest` — not `shared/patrol/heartbeat-2026-04-30-1800`
+- `shared/patrol/errors-latest` — not `shared/patrol/heartbeat-...-errors`
+
+The framework injects every `shared/` and `patrol/` entry into every context.
+Timestamped keys accumulate instead of overwriting, growing context monotonically
+until TTLs expire. Put the run timestamp inside the value if you need traceability.
+
 ## Execution
 
 Load and execute your patrol checklist:

--- a/src/RockBot.Agent/agent/memory-rules.md
+++ b/src/RockBot.Agent/agent/memory-rules.md
@@ -115,6 +115,24 @@ To act on patrol findings:
 least one full patrol cycle (e.g. 5 hours for an hourly patrol), so entries are available
 to the primary agent between runs. Each run overwrites the previous entries.
 
+**Use stable keys per topic, never timestamped suffixes.** The framework injects every
+`shared/` and `patrol/` entry into every context, so a key like
+`shared/pending/deadlines-2026-04-30-1206` does NOT replace
+`shared/pending/deadlines-2026-04-30` — both stay alive until their TTLs lapse and
+context grows monotonically. Use one stable key per topic so each run overwrites:
+
+- `shared/pending/deadlines` (not `shared/pending/deadlines-<date>`)
+- `shared/pending/today-meetings`
+- `shared/patrol/heartbeat-latest`
+- `shared/patrol/errors-latest`
+
+Put the run timestamp inside the value if you need traceability, never in the key.
+
+**Invalidate entries when their underlying state changes.** See "Invalidate Stale
+Shared/Patrol Memory After Completion" in common-directives.md — when the user marks
+a task done or you complete an item that shared/patrol memory referenced, scrub or
+rewrite the entries in the same turn.
+
 ### Shared namespace (cross-session handoff)
 
 The `shared/` namespace is a cross-session drop zone. Its inventory is automatically

--- a/src/RockBot.Agent/agent/subagent-directives.md
+++ b/src/RockBot.Agent/agent/subagent-directives.md
@@ -1,5 +1,23 @@
 # Subagent Directives
 
+## Memory Namespaces
+
+You have two distinct per-task memory locations. Do not confuse them:
+
+- **Working memory namespace** — `subagent/<your-task-id>`. This is where
+  `save_to_working_memory` writes by default (the runner pre-scopes your tools).
+  Use it for transient outputs the primary agent will read after you complete.
+- **Long-term memory whiteboard category** — `subagent-whiteboards/<your-task-id>`.
+  This is the `category` argument you pass to `save_memory` for durable per-task
+  artifacts the primary agent will search by category after completion.
+
+The runner injects your actual task_id into the preamble at startup — use that
+exact substituted value. **Never write the literal placeholder text `{task_id}`,
+`<your-task-id>`, or any unsubstituted token into a key, namespace, or category.**
+A working-memory key like `subagent-whiteboards/{task_id}/tasks-brief` is a bug:
+it conflates the long-term-memory category convention with a working-memory key
+and uses an unsubstituted placeholder.
+
 ## Tool Calling
 
 Call tools by their direct name (e.g. `get_calendar_events`, `search_emails`) — these are already in your tool list. Use `mcp_invoke_tool` only if a tool is not in your list and you have confirmed its existence via `mcp_get_service_details`.

--- a/src/RockBot.Subagent/SubagentRunner.cs
+++ b/src/RockBot.Subagent/SubagentRunner.cs
@@ -50,6 +50,7 @@ internal sealed class SubagentRunner(
             taskId, subagentSessionId, tier, classification.ComplexityScore);
 
         var subagentNamespace = $"subagent/{taskId}";
+        var whiteboardCategory = $"subagent-whiteboards/{taskId}";
 
         // Dynamic preamble — includes runtime values (namespace, working memory keys).
         var preamble =
@@ -63,10 +64,15 @@ internal sealed class SubagentRunner(
             "iteration budget and run concurrently. Use Direct mode steps with the correct " +
             "gateway and put tool arguments in the \"params\" field. " +
             $"For large outputs (reports, document lists, structured data): use save_to_working_memory " +
-            $"to store them (set ttl_minutes to 240 or more). Your outputs are stored under namespace " +
+            $"to store them (set ttl_minutes to 240 or more). Your working memory namespace is " +
             $"'{subagentNamespace}' and the primary agent can retrieve them using " +
             $"list_working_memory(namespace: '{subagentNamespace}') or " +
             $"get_from_working_memory('{subagentNamespace}/your-key'). " +
+            $"For long-term memory entries the primary agent should read after you complete, use " +
+            $"the category '{whiteboardCategory}' when calling save_memory. This is a long-term " +
+            $"memory CATEGORY (passed to save_memory's category parameter), NOT a working-memory " +
+            $"key — do not use it as a key with save_to_working_memory. Substitute the literal " +
+            $"value above; never write the placeholder text {{task_id}} into a category or key. " +
             "Your final message must summarise what was done and list each key you saved " +
             "so the primary agent knows where to find the detailed data. " +
             "Do not return an empty or vague final response.";

--- a/src/RockBot.Subagent/SubagentToolSkillProvider.cs
+++ b/src/RockBot.Subagent/SubagentToolSkillProvider.cs
@@ -58,9 +58,13 @@ public sealed class SubagentToolSkillProvider : IToolSkillProvider
 
         ## Sharing data (whiteboard convention)
         Both you and the subagent share long-term memory. The category
-        'subagent-whiteboards/{task_id}' is the per-subagent scratchpad:
+        'subagent-whiteboards/<actual-task-id>' is the per-subagent scratchpad —
+        substitute the actual task_id you received from spawn_subagent (the GUID-
+        shaped value), never the literal text {task_id}. This is a long-term memory
+        CATEGORY (the `category` parameter of save_memory), distinct from the
+        subagent's working-memory namespace `subagent/<actual-task-id>`.
 
-        - Before spawning: write input data the subagent needs
+        - Before spawning: write input data the subagent needs to that category
         - After the completion message: search that category for detailed outputs
 
         ## Workflow


### PR DESCRIPTION
## Summary

Fixes the recurring symptom where, after the user marks work complete (e.g. *"the Techorama BE presentation tasks are done"*), shared and patrol working memory keep claiming the work is active for hours. The agent then takes multiple iterations to reconcile, and patrols re-surface the same items.

Three related fixes:

1. **Completion → memory invalidation directive.** New section in `common-directives.md` requires the agent to scrub `shared/` and `patrol/` working memory in the same turn it completes work. Cross-referenced from `memory-rules.md`.
2. **Stable patrol keys.** `memory-rules.md`, `heartbeat-patrol.md`, and the `patrol/proactive-actions` skill on the PVC now require one stable key per topic (e.g. `shared/pending/deadlines`, `shared/patrol/heartbeat-latest`) instead of timestamp-suffixed ones that accumulate. Observed growth was 6 → 12 injected shared entries in 24 hours.
3. **Subagent `{task_id}` placeholder bug.** `SubagentRunner` now injects the substituted whiteboard category alongside the working-memory namespace it already injected, plus an explicit warning never to write the literal `{task_id}` text into a key or category. Doc fixes in `directives.md`, `subagent-directives.md`, and `SubagentToolSkillProvider` clarify that the long-term-memory whiteboard CATEGORY is distinct from the working-memory NAMESPACE.

Version bumped to **0.10.12** in `Directory.Build.props` and `deploy/helm/rockbot/Chart.yaml`.

## Test plan
- [x] `dotnet build` clean across all projects
- [x] `RockBot.Subagent.Tests` — 25/25 passing
- [ ] After deploy: trigger a manual subagent and confirm working memory keys no longer contain literal `{task_id}`
- [ ] After deploy: wait for next heartbeat patrol; confirm shared/patrol keys are stable (no new timestamp-suffixed keys appear)
- [ ] After deploy: mark a todo complete and confirm referenced shared/patrol entries get scrubbed in the same turn

## Notes
- Skill JSON `patrol/proactive-actions` is updated separately on the PVC (not under git); it gains two new steps mirroring the `heartbeat-patrol.md` guidance.
- Existing stale shared/patrol entries already in working memory will TTL out naturally; no migration required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)