### PR TITLE
Suppress pip cache warning in Python sandbox pods

### DIFF
--- a/src/RockBot.Scripts.Container/ContainerScriptHandler.cs
+++ b/src/RockBot.Scripts.Container/ContainerScriptHandler.cs
@@ -151,7 +151,8 @@ internal sealed class ContainerScriptHandler(
                         Env =
                         [
                             new V1EnvVar { Name = "ROCKBOT_SCRIPT", Value = request.Script },
-                            new V1EnvVar { Name = "ROCKBOT_INPUT", Value = request.InputData }
+                            new V1EnvVar { Name = "ROCKBOT_INPUT", Value = request.InputData },
+                            new V1EnvVar { Name = "PIP_NO_CACHE_DIR", Value = "1" }
                         ],
                         Resources = new V1ResourceRequirements
                         {

--- a/src/RockBot.Scripts.Container/ContainerScriptRunner.cs
+++ b/src/RockBot.Scripts.Container/ContainerScriptRunner.cs
@@ -109,7 +109,8 @@ internal sealed class ContainerScriptRunner(
                         Env =
                         [
                             new V1EnvVar { Name = "ROCKBOT_SCRIPT", Value = request.Script },
-                            new V1EnvVar { Name = "ROCKBOT_INPUT", Value = request.InputData }
+                            new V1EnvVar { Name = "ROCKBOT_INPUT", Value = request.InputData },
+                            new V1EnvVar { Name = "PIP_NO_CACHE_DIR", Value = "1" }
                         ],
                         Resources = new V1ResourceRequirements
                         {


### PR DESCRIPTION
## Summary
- Inject `PIP_NO_CACHE_DIR=1` into every Python sandbox pod spawned by `rockbot-scripts-manager`
- Updates both `ContainerScriptHandler` and `ContainerScriptRunner` (parallel code paths)

## Why
The sandbox pod runs as UID 1000 with no `HOME` set, so pip falls back to `/.cache/pip` which the non-root user can't write to. Pip detects this on every invocation, disables the cache, and emits:

> WARNING: The directory '/.cache/pip' or its parent directory is not owned or is not writable by the current user. The cache has been disabled.

The warning is harmless but shows up in tool output for every `execute_python_script` call. Telling pip not to cache at all eliminates the noise — and the cache had no value anyway since each pod is one-shot (`RestartPolicy=Never`).

## Deployment status
The fix has already been built and deployed live as `rockylhotka/rockbot-scripts-manager:0.10.12`. This PR brings `main` in sync with what's running.

## Test plan
- [x] `dotnet build` passes
- [x] Image rebuilt and rolled out to cluster
- [ ] Next `execute_python_script` invocation runs without the pip cache warning in agent logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)