### PR TITLE
Replace save-response emoji with SVG so it renders on mobile (v0.10.14)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.10.12</Version>
+<Version>0.10.14</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.10.14</Version>
+<Version>0.10.15</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.UserProxy.Blazor/Pages/Chat.razor
+++ b/src/RockBot.UserProxy.Blazor/Pages/Chat.razor
@@ -190,7 +190,10 @@
                                 {
                                     <button class="btn-feedback" title="Save this response"
                                             @onclick="() => StartSaveFlow(message)">
-                                        💾
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
+                                            <path d="M11 2H9v3h2z"/>
+                                            <path d="M1.5 0h11.586a1.5 1.5 0 0 1 1.06.44l1.415 1.414A1.5 1.5 0 0 1 16 2.914V14.5a1.5 1.5 0 0 1-1.5 1.5h-13A1.5 1.5 0 0 1 0 14.5v-13A1.5 1.5 0 0 1 1.5 0M1 1.5v13a.5.5 0 0 0 .5.5H2v-4.5A1.5 1.5 0 0 1 3.5 9h9a1.5 1.5 0 0 1 1.5 1.5V15h.5a.5.5 0 0 0 .5-.5V2.914a.5.5 0 0 0-.146-.353l-1.415-1.415A.5.5 0 0 0 13.086 1H13v4.5A1.5 1.5 0 0 1 11.5 7h-7A1.5 1.5 0 0 1 3 5.5V1H1.5a.5.5 0 0 0-.5.5m3 0V5a.5.5 0 0 0 .5.5h7a.5.5 0 0 0 .5-.5V1zM3 15h10v-4.5a.5.5 0 0 0-.5-.5h-9a.5.5 0 0 0-.5.5z"/>
+                                        </svg>
                                     </button>
                                 }
                             </div>

--- a/src/RockBot.UserProxy.Blazor/wwwroot/css/app.css
+++ b/src/RockBot.UserProxy.Blazor/wwwroot/css/app.css
@@ -320,6 +320,11 @@ body.dark-mode .form-control:focus {
     cursor: default;
 }
 
+/* Monochrome SVG icons need more opacity than colored emoji to read at the same weight */
+.btn-feedback:has(svg) {
+    opacity: 0.7;
+}
+
 body.dark-mode .feedback-bar {
     border-top-color: rgba(255, 255, 255, 0.1);
 }

--- a/src/RockBot.UserProxy.Blazor/wwwroot/css/app.css
+++ b/src/RockBot.UserProxy.Blazor/wwwroot/css/app.css
@@ -325,6 +325,11 @@ body.dark-mode .form-control:focus {
     opacity: 0.7;
 }
 
+/* In dark mode, tint the SVG orange so it stands out against the dark bubble */
+body.dark-mode .btn-feedback svg {
+    color: #fb923c;
+}
+
 body.dark-mode .feedback-bar {
     border-top-color: rgba(255, 255, 255, 0.1);
 }


### PR DESCRIPTION
## Summary
- The 💾 emoji on the per-message feedback bar was missing on some mobile fonts, so the "save this response" button was invisible on phones while the thumbs up/down (more common emoji) still rendered.
- Swapped to an inline floppy-disk SVG using `currentColor` so it inherits the bubble's text color across light/dark mode and is independent of the device emoji font.
- Bumped opacity for SVG-bearing feedback buttons to 0.7 (vs. the 0.35 default for emoji), since a monochrome white glyph on a dark bubble at 35% opacity was nearly invisible.
- Bumped version to 0.10.14.

## Test plan
- [x] Verify save icon now renders on mobile alongside thumbs up/down
- [x] Verify icon contrast is acceptable in dark mode
- [ ] Verify icon contrast in light mode
- [ ] Verify hover/disabled states still feel right

🤖 Generated with [Claude Code](https://claude.com/claude-code)