### PR TITLE
Add gpt-5.5 support and fix orphan tool_call protocol bugs

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.10.15</Version>
+<Version>0.10.16</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/deploy/helm/rockbot/Chart.yaml
+++ b/deploy/helm/rockbot/Chart.yaml
@@ -4,8 +4,8 @@ description: >
   RockBot — an event-driven autonomous agent framework built on .NET.
   Deploys the RockBot agent and the Blazor Server web UI.
 type: application
-version: 0.10.12
-appVersion: "0.10.12"
+version: 0.10.15
+appVersion: "0.10.15"
 home: https://github.com/rockylhotka/rockbot
 keywords:
   - ai

--- a/src/RockBot.Agent/agent/llm-pricing.json
+++ b/src/RockBot.Agent/agent/llm-pricing.json
@@ -1,4 +1,6 @@
 [
+  { "prefix": "gpt-5.5-pro",      "inputPerM": 30.00, "outputPerM": 180.00 },
+  { "prefix": "gpt-5.5",          "inputPerM":  5.00, "outputPerM":  30.00 },
   { "prefix": "gpt-5.4-pro",      "inputPerM": 30.00, "outputPerM": 180.00 },
   { "prefix": "gpt-5.4-mini",     "inputPerM":  0.75, "outputPerM":   4.50 },
   { "prefix": "gpt-5.4",          "inputPerM":  2.50, "outputPerM":  15.00 },

--- a/src/RockBot.Host/AgentLoopRunner.cs
+++ b/src/RockBot.Host/AgentLoopRunner.cs
@@ -1230,7 +1230,9 @@ public sealed partial class AgentLoopRunner(
     /// <summary>
     /// Removes conversation history (user and assistant messages that aren't the current request)
     /// from the chat message list. Keeps system messages, tool messages, and the last user message.
-    /// Returns the number of messages removed.
+    /// Then sweeps for orphaned tool messages whose paired assistant FunctionCallContent was just
+    /// removed — leaving them in would trigger the same OpenAI 400 we get from the summary path.
+    /// Returns the number of history messages removed (orphan sweep is logged separately).
     /// </summary>
     internal static int StripConversationHistory(List<ChatMessage> chatMessages)
     {
@@ -1260,6 +1262,8 @@ public sealed partial class AgentLoopRunner(
                 if (i < lastUserIdx) lastUserIdx--;
             }
         }
+
+        RockBotFunctionInvokingChatClient.StripOrphanedToolCalls(chatMessages);
 
         return removed;
     }

--- a/src/RockBot.Host/RockBotFunctionInvokingChatClient.cs
+++ b/src/RockBot.Host/RockBotFunctionInvokingChatClient.cs
@@ -235,6 +235,13 @@ public class RockBotFunctionInvokingChatClient : FunctionInvokingChatClient
 
                 var summaryMessages = new List<ChatMessage>(messageList);
                 summaryMessages.AddRange(response.Messages);
+                var (orphanedCalls, orphanedResults) = StripOrphanedToolCalls(summaryMessages);
+                if (orphanedCalls > 0 || orphanedResults > 0)
+                {
+                    _logger.LogWarning(
+                        "Stripped {Calls} orphaned tool call(s) and {Results} orphaned tool result(s) before summary follow-up",
+                        orphanedCalls, orphanedResults);
+                }
                 summaryMessages.Add(new ChatMessage(ChatRole.User,
                     "The task loop has ended. Write a concise summary of what was accomplished. " +
                     "Report only what was completed — do not describe intentions or future actions."));
@@ -339,6 +346,68 @@ public class RockBotFunctionInvokingChatClient : FunctionInvokingChatClient
                 "Trimmed tool result for call {CallId}: {Before:N0} → {After:N0} chars",
                 old.CallId, bestLen, trimmed.Length);
         }
+    }
+
+    /// <summary>
+    /// Removes <see cref="FunctionCallContent"/> entries whose CallId has no matching
+    /// <see cref="FunctionResultContent"/>, and vice versa. The OpenAI-compatible API
+    /// rejects requests where an assistant tool_calls message lacks a corresponding tool
+    /// response (or where a tool message references an unknown call_id). This pairing
+    /// can break when the tool loop hits its iteration limit mid-call, leaving an
+    /// unanswered FunctionCallContent in the response we then reuse for a follow-up.
+    /// Returns the number of orphans removed in each direction.
+    /// </summary>
+    internal static (int orphanedCalls, int orphanedResults) StripOrphanedToolCalls(
+        List<ChatMessage> messages)
+    {
+        var resultIds = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var msg in messages)
+            foreach (var c in msg.Contents)
+                if (c is FunctionResultContent frc && !string.IsNullOrEmpty(frc.CallId))
+                    resultIds.Add(frc.CallId);
+
+        var orphanedCalls = 0;
+        foreach (var msg in messages)
+        {
+            for (var i = msg.Contents.Count - 1; i >= 0; i--)
+            {
+                if (msg.Contents[i] is FunctionCallContent fcc &&
+                    !string.IsNullOrEmpty(fcc.CallId) &&
+                    !resultIds.Contains(fcc.CallId))
+                {
+                    msg.Contents.RemoveAt(i);
+                    orphanedCalls++;
+                }
+            }
+        }
+
+        var callIds = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var msg in messages)
+            foreach (var c in msg.Contents)
+                if (c is FunctionCallContent fcc && !string.IsNullOrEmpty(fcc.CallId))
+                    callIds.Add(fcc.CallId);
+
+        var orphanedResults = 0;
+        foreach (var msg in messages)
+        {
+            for (var i = msg.Contents.Count - 1; i >= 0; i--)
+            {
+                if (msg.Contents[i] is FunctionResultContent frc &&
+                    (string.IsNullOrEmpty(frc.CallId) || !callIds.Contains(frc.CallId)))
+                {
+                    msg.Contents.RemoveAt(i);
+                    orphanedResults++;
+                }
+            }
+        }
+
+        for (var i = messages.Count - 1; i >= 0; i--)
+        {
+            if (messages[i].Contents.Count == 0)
+                messages.RemoveAt(i);
+        }
+
+        return (orphanedCalls, orphanedResults);
     }
 
     private static int EstimateMessageChars(ChatMessage m) =>

--- a/tests/RockBot.Host.Tests/ContentFilterRecoveryTests.cs
+++ b/tests/RockBot.Host.Tests/ContentFilterRecoveryTests.cs
@@ -111,6 +111,50 @@ public class ContentFilterRecoveryTests
     }
 
     [TestMethod]
+    public void StripConversationHistory_DropsToolResultsOrphanedByAssistantRemoval()
+    {
+        // The previous assistant turn invoked a tool — when that assistant message is
+        // stripped as "history", the tool-result message it paired with is left orphaned.
+        // The orphan would re-trigger HTTP 400 on the recovery retry, so it must go too.
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.System, "system prompt"),
+            new(ChatRole.User, "what's the weather?"),
+            new(ChatRole.Assistant, [new FunctionCallContent("c1", "get_weather")]),
+            new(ChatRole.Tool, [new FunctionResultContent("c1", "72F sunny")]),
+            new(ChatRole.Assistant, "It's 72 and sunny."),
+            new(ChatRole.User, "current request"),
+        };
+
+        var removed = AgentLoopRunner.StripConversationHistory(messages);
+
+        Assert.AreEqual(3, removed, "Two assistant messages and one user history message removed");
+        Assert.AreEqual(2, messages.Count, "Orphan tool result should be swept too, leaving system + current user");
+        Assert.AreEqual(ChatRole.System, messages[0].Role);
+        Assert.AreEqual("current request", messages[1].Text);
+    }
+
+    [TestMethod]
+    public void StripConversationHistory_KeepsToolMessageWithPlainText()
+    {
+        // Tool messages that don't contain FunctionResultContent (e.g. plain text contents)
+        // shouldn't be touched by the orphan sweep — they're not part of a tool_call pairing.
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.System, "system"),
+            new(ChatRole.User, "old"),
+            new(ChatRole.Tool, "free-form tool note"),
+            new(ChatRole.User, "current"),
+        };
+
+        var removed = AgentLoopRunner.StripConversationHistory(messages);
+
+        Assert.AreEqual(1, removed);
+        Assert.AreEqual(3, messages.Count);
+        Assert.AreEqual(ChatRole.Tool, messages[1].Role);
+    }
+
+    [TestMethod]
     public void StripConversationHistory_MultipleSystemInterleavedWithHistory()
     {
         // Simulates real context: system messages interspersed with history

--- a/tests/RockBot.Host.Tests/StripOrphanedToolCallsTests.cs
+++ b/tests/RockBot.Host.Tests/StripOrphanedToolCallsTests.cs
@@ -1,0 +1,131 @@
+using Microsoft.Extensions.AI;
+
+namespace RockBot.Host.Tests;
+
+[TestClass]
+public class StripOrphanedToolCallsTests
+{
+    private static ChatMessage AssistantWithCalls(params (string callId, string name)[] calls)
+    {
+        var msg = new ChatMessage(ChatRole.Assistant, []);
+        foreach (var (callId, name) in calls)
+            msg.Contents.Add(new FunctionCallContent(callId, name));
+        return msg;
+    }
+
+    private static ChatMessage ToolResult(string callId, string result) =>
+        new(ChatRole.Tool, [new FunctionResultContent(callId, result)]);
+
+    [TestMethod]
+    public void NoOrphans_LeavesMessagesUntouched()
+    {
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.System, "system"),
+            new(ChatRole.User, "do thing"),
+            AssistantWithCalls(("c1", "search")),
+            ToolResult("c1", "found 3"),
+            new(ChatRole.Assistant, "done"),
+        };
+        var initialCount = messages.Count;
+
+        var (calls, results) = RockBotFunctionInvokingChatClient.StripOrphanedToolCalls(messages);
+
+        Assert.AreEqual(0, calls);
+        Assert.AreEqual(0, results);
+        Assert.AreEqual(initialCount, messages.Count);
+    }
+
+    [TestMethod]
+    public void OrphanedFunctionCall_RemovedFromAssistantMessage()
+    {
+        // Reproduces the production failure: assistant emitted a tool_call that the loop
+        // ran out of iterations to execute, leaving an orphan FunctionCallContent.
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.User, "do thing"),
+            AssistantWithCalls(("orphan-1", "search")),
+        };
+
+        var (calls, results) = RockBotFunctionInvokingChatClient.StripOrphanedToolCalls(messages);
+
+        Assert.AreEqual(1, calls);
+        Assert.AreEqual(0, results);
+        // The assistant message had only the orphan call → message should be dropped.
+        Assert.AreEqual(1, messages.Count);
+        Assert.AreEqual(ChatRole.User, messages[0].Role);
+    }
+
+    [TestMethod]
+    public void OrphanedFunctionCall_KeepsOtherContentInSameMessage()
+    {
+        var assistantMsg = new ChatMessage(ChatRole.Assistant, [
+            new TextContent("here is what I'll do"),
+            new FunctionCallContent("orphan-1", "search"),
+        ]);
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.User, "do thing"),
+            assistantMsg,
+        };
+
+        var (calls, results) = RockBotFunctionInvokingChatClient.StripOrphanedToolCalls(messages);
+
+        Assert.AreEqual(1, calls);
+        Assert.AreEqual(0, results);
+        Assert.AreEqual(2, messages.Count);
+        Assert.AreEqual(1, messages[1].Contents.Count);
+        Assert.IsInstanceOfType<TextContent>(messages[1].Contents[0]);
+    }
+
+    [TestMethod]
+    public void OrphanedToolResult_RemovedFromToolMessage()
+    {
+        // Symmetric case: tool result with no preceding assistant FunctionCallContent.
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.User, "do thing"),
+            ToolResult("ghost-call", "result with no parent"),
+        };
+
+        var (calls, results) = RockBotFunctionInvokingChatClient.StripOrphanedToolCalls(messages);
+
+        Assert.AreEqual(0, calls);
+        Assert.AreEqual(1, results);
+        Assert.AreEqual(1, messages.Count);
+    }
+
+    [TestMethod]
+    public void MixedPairedAndOrphaned_KeepsPairedRemovesOrphan()
+    {
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.User, "task"),
+            AssistantWithCalls(("c1", "search"), ("c2-orphan", "spawn_wisp")),
+            ToolResult("c1", "search results"),
+            new(ChatRole.Assistant, "incomplete"),
+        };
+
+        var (calls, results) = RockBotFunctionInvokingChatClient.StripOrphanedToolCalls(messages);
+
+        Assert.AreEqual(1, calls);
+        Assert.AreEqual(0, results);
+        Assert.AreEqual(4, messages.Count);
+        // Assistant tool_calls message should keep the paired call only.
+        var remaining = messages[1].Contents.OfType<FunctionCallContent>().ToList();
+        Assert.AreEqual(1, remaining.Count);
+        Assert.AreEqual("c1", remaining[0].CallId);
+    }
+
+    [TestMethod]
+    public void EmptyMessageList_NoChange()
+    {
+        var messages = new List<ChatMessage>();
+
+        var (calls, results) = RockBotFunctionInvokingChatClient.StripOrphanedToolCalls(messages);
+
+        Assert.AreEqual(0, calls);
+        Assert.AreEqual(0, results);
+        Assert.AreEqual(0, messages.Count);
+    }
+}


### PR DESCRIPTION
## Summary
Three changes uncovered while moving balanced + high LLM tiers to Azure Foundry's new `gpt-5.5`:

1. **Pricing table** — added `gpt-5.5` (\$5 / \$30 per 1M) and `gpt-5.5-pro` (\$30 / \$180 per 1M) to `src/RockBot.Agent/agent/llm-pricing.json`, longest-prefix-first so `-pro` matches before the bare prefix.
2. **Helm chart bump** — `version` and `appVersion` 0.10.12 → 0.10.15 to match `Directory.Build.props`.
3. **Two orphan-tool_call fixes** — Azure 400'd in production with `tool_calls must be followed by tool messages responding to each tool_call_id`. Two code paths can produce orphans:
   - `RockBotFunctionInvokingChatClient`'s "incomplete response → request summary" follow-up appended `response.Messages` (which can include an unexecuted `FunctionCallContent` if the iteration limit was hit mid-call) directly into the next call.
   - `AgentLoopRunner.StripConversationHistory` (content-filter recovery) removed user/assistant messages but kept tool messages, leaving orphan `FunctionResultContent` whenever the removed assistant had paired tool_calls.

   Added `StripOrphanedToolCalls` static helper in `RockBotFunctionInvokingChatClient` that scans both directions (orphan `FunctionCallContent` and orphan `FunctionResultContent`), removes them, and drops any messages whose `Contents` collection becomes empty. Both code paths now call it.

## Test plan
- [x] All 601 `RockBot.Host.Tests` pass (8 new tests covering both orphan paths).
- [ ] Verify the agent pod hot-reloads the new pricing file (`/data/agent/llm-pricing.json`) and reports correct cost for a gpt-5.5 call.
- [ ] After deploying, confirm no new HTTP 400 `tool_call_id did not have response messages` errors in agent logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)