### PR TITLE
Fix A2A well-known enrichment for v1 agent cards

### DIFF
--- a/src/RockBot.A2A/AgentDirectory.cs
+++ b/src/RockBot.A2A/AgentDirectory.cs
@@ -138,7 +138,18 @@ internal sealed class AgentDirectory(
                 httpClient.DefaultRequestHeaders.TryAddWithoutValidation(seed.AuthHeaderName, headerValue);
             }
 
-            var url = $"{seed.Url!.TrimEnd('/')}/.well-known/agent-card.json";
+            // Well-known is host-relative per RFC 8615 — resolve against the URL's
+            // authority, not the (possibly path-prefixed) seed URL. Seeds like
+            // "http://host/a2a/" must still fetch "http://host/.well-known/agent-card.json".
+            if (!Uri.TryCreate(seed.Url, UriKind.Absolute, out var baseUri))
+            {
+                logger.LogWarning(
+                    "Skipping enrichment for well-known peer '{AgentName}': invalid URL '{Url}'",
+                    seed.AgentName, seed.Url);
+                return;
+            }
+
+            var url = new Uri(baseUri, "/.well-known/agent-card.json").ToString();
             var response = await httpClient.GetAsync(url, ct);
             if (!response.IsSuccessStatusCode)
             {
@@ -149,14 +160,12 @@ internal sealed class AgentDirectory(
             }
 
             var json = await response.Content.ReadAsStringAsync(ct);
-            var remote = JsonSerializer.Deserialize<AgentCard>(json, JsonOptions);
-            if (remote is null)
-            {
-                logger.LogWarning(
-                    "Empty agent-card response for well-known peer '{AgentName}' from {Url}",
-                    seed.AgentName, url);
-                return;
-            }
+
+            // Extract via JsonDocument rather than deserializing as AgentCard — a v1
+            // card uses "name" instead of "agentName" and would fail the required-field
+            // check. The agent-card schema also varies between v0.3 and v1; pulling
+            // fields explicitly keeps both paths working.
+            var remote = ExtractRemoteFields(json);
 
             // Merge remote fields into the seeded card while preserving locally-configured
             // coordinates (Url, AuthHeader*) and the AgentName key.
@@ -173,8 +182,9 @@ internal sealed class AgentDirectory(
             {
                 _agents[seed.AgentName] = existing with { Card = merged };
                 logger.LogInformation(
-                    "Enriched well-known agent '{AgentName}' from {Url} ({SkillCount} skill(s))",
-                    seed.AgentName, url, merged.Skills?.Count ?? 0);
+                    "Enriched well-known agent '{AgentName}' from {Url} (protocol={Protocol}, streaming={Streaming}, {SkillCount} skill(s))",
+                    seed.AgentName, url, merged.ProtocolVersion ?? "(unset)",
+                    merged.SupportsStreaming, merged.Skills?.Count ?? 0);
             }
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
@@ -188,6 +198,88 @@ internal sealed class AgentDirectory(
                 seed.AgentName, seed.Url);
         }
     }
+
+    internal sealed record RemoteFields(
+        string? Description,
+        string? Version,
+        IReadOnlyList<AgentSkill>? Skills,
+        string? ProtocolVersion,
+        bool? SupportsStreaming);
+
+    /// <summary>
+    /// Extracts the subset of agent-card fields we merge during enrichment, accepting
+    /// both A2A v0.3 and v1 layouts. v1 collapses <c>protocolVersion</c>/<c>url</c>/
+    /// <c>preferredTransport</c> into <c>supportedInterfaces[]</c> and stream support
+    /// into <c>capabilities.streaming</c>; v0.3 keeps them at the top level. Using
+    /// JsonDocument (rather than <c>JsonSerializer.Deserialize&lt;AgentCard&gt;</c>)
+    /// avoids tripping on the v1 <c>name</c>-vs-<c>agentName</c> rename.
+    /// </summary>
+    internal static RemoteFields ExtractRemoteFields(string cardJson)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(cardJson);
+            var root = doc.RootElement;
+            if (root.ValueKind != JsonValueKind.Object) return new(null, null, null, null, null);
+
+            string? description = TryGetString(root, "description");
+            string? version = TryGetString(root, "version");
+
+            IReadOnlyList<AgentSkill>? skills = null;
+            if (root.TryGetProperty("skills", out var skillsEl) &&
+                skillsEl.ValueKind == JsonValueKind.Array)
+            {
+                try
+                {
+                    skills = JsonSerializer.Deserialize<List<AgentSkill>>(skillsEl.GetRawText(), JsonOptions);
+                }
+                catch (JsonException) { /* leave skills null — partial enrichment is fine */ }
+            }
+
+            // protocolVersion: v0.3 uses top-level; v1 uses supportedInterfaces[].protocolVersion.
+            string? protocolVersion = TryGetString(root, "protocolVersion");
+            if (protocolVersion is null &&
+                root.TryGetProperty("supportedInterfaces", out var interfaces) &&
+                interfaces.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var iface in interfaces.EnumerateArray())
+                {
+                    if (iface.ValueKind == JsonValueKind.Object)
+                    {
+                        var pv = TryGetString(iface, "protocolVersion");
+                        if (pv is not null) { protocolVersion = pv; break; }
+                    }
+                }
+            }
+
+            // SupportsStreaming: v0.3 emits as a top-level bool; v1 nests under capabilities.
+            bool? streaming = null;
+            if (root.TryGetProperty("supportsStreaming", out var topStream))
+            {
+                if (topStream.ValueKind == JsonValueKind.True) streaming = true;
+                else if (topStream.ValueKind == JsonValueKind.False) streaming = false;
+            }
+            if (streaming is null &&
+                root.TryGetProperty("capabilities", out var caps) &&
+                caps.ValueKind == JsonValueKind.Object &&
+                caps.TryGetProperty("streaming", out var nested))
+            {
+                if (nested.ValueKind == JsonValueKind.True) streaming = true;
+                else if (nested.ValueKind == JsonValueKind.False) streaming = false;
+            }
+
+            return new RemoteFields(description, version, skills, protocolVersion, streaming);
+        }
+        catch (JsonException)
+        {
+            return new RemoteFields(null, null, null, null, null);
+        }
+    }
+
+    private static string? TryGetString(JsonElement obj, string name) =>
+        obj.TryGetProperty(name, out var el) && el.ValueKind == JsonValueKind.String
+            ? el.GetString()
+            : null;
 
     public Task StopAsync(CancellationToken cancellationToken) =>
         FlushAsync(cancellationToken);

--- a/tests/RockBot.A2A.Tests/WellKnownAgentEnrichmentTests.cs
+++ b/tests/RockBot.A2A.Tests/WellKnownAgentEnrichmentTests.cs
@@ -155,6 +155,108 @@ public class WellKnownAgentEnrichmentTests
     }
 
     [TestMethod]
+    public async Task StartAsync_FetchesWellKnown_AtHostRoot_WhenSeedUrlHasPath()
+    {
+        // Seed URL with a path prefix (e.g. SocialAgent at "http://host/a2a/").
+        // Well-known is host-relative per RFC 8615 — must hit "http://host/.well-known/agent-card.json",
+        // not "http://host/a2a/.well-known/agent-card.json".
+        var handler = new RecordingHandler("""{"agentName":"Bob","description":"x"}""");
+        var options = new A2AOptions
+        {
+            DirectoryPersistencePath = string.Empty,
+            WellKnownAgents =
+            [
+                new AgentCard { AgentName = "Bob", Url = "http://gateway-bob:5200/a2a/" }
+            ]
+        };
+
+        var directory = new AgentDirectory(options, NullLogger<AgentDirectory>.Instance, new StubFactory(handler));
+
+        await directory.StartAsync(CancellationToken.None);
+
+        Assert.AreEqual("http://gateway-bob:5200/.well-known/agent-card.json",
+            handler.LastRequestUri?.ToString(),
+            "Well-known must be fetched from the URL authority, not the seed path.");
+    }
+
+    [TestMethod]
+    public async Task StartAsync_ExtractsProtocolVersion_FromV1SupportedInterfaces()
+    {
+        // A2A v1 card: protocolVersion lives inside supportedInterfaces[], not at the top.
+        const string v1Card = """
+        {
+          "name": "SocialAgent",
+          "description": "Social media agent",
+          "version": "1.3.0.0",
+          "supportedInterfaces": [
+            { "url": "/a2a", "protocolBinding": "JSONRPC",  "protocolVersion": "1.0" },
+            { "url": "/a2a", "protocolBinding": "HTTPJSON", "protocolVersion": "1.0" }
+          ],
+          "capabilities": { "streaming": true },
+          "skills": [{ "id": "engagement-summary", "name": "Engagement", "description": "x" }]
+        }
+        """;
+        var handler = new RecordingHandler(v1Card);
+        var options = new A2AOptions
+        {
+            DirectoryPersistencePath = string.Empty,
+            WellKnownAgents =
+            [
+                new AgentCard { AgentName = "SocialAgent", Url = "http://social-agent/a2a/" }
+            ]
+        };
+
+        var directory = new AgentDirectory(options, NullLogger<AgentDirectory>.Instance, new StubFactory(handler));
+
+        await directory.StartAsync(CancellationToken.None);
+
+        var card = directory.GetAgent("SocialAgent");
+        Assert.IsNotNull(card);
+        Assert.AreEqual("1.0", card.ProtocolVersion,
+            "v1 card protocolVersion must be extracted from supportedInterfaces[0].");
+        Assert.AreEqual(true, card.SupportsStreaming,
+            "v1 card streaming capability must be extracted from capabilities.streaming.");
+        Assert.AreEqual("Social media agent", card.Description);
+        Assert.IsNotNull(card.Skills);
+        Assert.AreEqual(1, card.Skills.Count);
+    }
+
+    [TestMethod]
+    public void ExtractRemoteFields_ReturnsNulls_ForMalformedJson()
+    {
+        var fields = AgentDirectory.ExtractRemoteFields("not json");
+        Assert.IsNull(fields.ProtocolVersion);
+        Assert.IsNull(fields.SupportsStreaming);
+    }
+
+    [TestMethod]
+    public void ExtractRemoteFields_ReturnsNulls_WhenFieldsAbsent()
+    {
+        var fields = AgentDirectory.ExtractRemoteFields("""{"agentName":"x"}""");
+        Assert.IsNull(fields.ProtocolVersion);
+        Assert.IsNull(fields.SupportsStreaming);
+    }
+
+    [TestMethod]
+    public void ExtractRemoteFields_HandlesNullStreaming()
+    {
+        // SocialAgent emits capabilities.streaming: null — must round-trip as null,
+        // not as false (which would be a meaningful "no streaming" signal).
+        var fields = AgentDirectory.ExtractRemoteFields(
+            """{"capabilities":{"streaming":null}}""");
+        Assert.IsNull(fields.SupportsStreaming);
+    }
+
+    [TestMethod]
+    public void ExtractRemoteFields_PrefersTopLevelProtocolVersion_OverInterfaces()
+    {
+        // If both layouts are present, the explicit top-level wins (v0.3-style).
+        var fields = AgentDirectory.ExtractRemoteFields(
+            """{"protocolVersion":"0.3","supportedInterfaces":[{"protocolVersion":"1.0"}]}""");
+        Assert.AreEqual("0.3", fields.ProtocolVersion);
+    }
+
+    [TestMethod]
     public async Task StartAsync_NoEnrichment_WhenHttpFactoryNotProvided()
     {
         var options = new A2AOptions


### PR DESCRIPTION
## Summary
- Resolve `/.well-known/agent-card.json` against the URL authority instead of appending to the (possibly path-prefixed) seed URL — fixes 404s for peers registered at e.g. `http://host/a2a/`
- Accept A2A v1 card layout: pull `protocolVersion` from `supportedInterfaces[].protocolVersion` and streaming support from `capabilities.streaming` when the v0.3 top-level fields are absent
- Extract via `JsonDocument` so the v1 `name`-vs-`agentName` rename doesn't trip the strict `AgentCard` deserializer

## Why
SocialAgent went live with an A2A v1.0 spec-compliant agent card. Two bugs in `AgentDirectory.FetchAndMergeAsync` prevented RockBot from picking up the new layout:
1. The well-known URL was being built as `{seed.Url}/.well-known/agent-card.json`, which for `http://social-agent.../a2a/` resolves to `.../a2a/.well-known/agent-card.json` → 404.
2. Even if the fetch had worked, deserializing as `AgentCard` only reads top-level `protocolVersion`. v1 collapses `protocolVersion`/`url`/`preferredTransport` into `supportedInterfaces[]` and moves streaming under `capabilities.streaming`, neither of which round-trip through RockBot's `AgentCard` record.

Without these fixes, v1 peers register with `protocolVersion: null` and `InvokeAgentExecutor.IsV1` returns false → dispatch silently falls back to the v0.3 SDK and fails against v1-only servers.

## Test plan
- [x] `WellKnownAgentEnrichmentTests` — 11 tests, all passing
  - New: `StartAsync_FetchesWellKnown_AtHostRoot_WhenSeedUrlHasPath`
  - New: `StartAsync_ExtractsProtocolVersion_FromV1SupportedInterfaces`
  - New: `ExtractRemoteFields_*` covering malformed JSON, absent fields, null streaming, and top-level-wins precedence
- [x] Full `RockBot.A2A.Tests` suite passes (127/127)
- [x] Manually verified on the live cluster: SocialAgent's directory entry now reports `protocolVersion: "1.0"` after applying the seed override (belt-and-suspenders for the live deployment, independent of the code fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)