### PR TITLE
Bump version to 0.10.17

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.10.16</Version>
+<Version>0.10.17</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->


### PR DESCRIPTION
## Summary
- Bump `<Version>` to 0.10.17 to ship the A2A v1 agent-card enrichment fix from #321

## Test plan
- [x] CI build-and-test passes