### PR TITLE
Forward per-skill metadata through invoke_agent and wisp A2A steps

### DIFF
--- a/src/RockBot.A2A/A2ACallerSkillProvider.cs
+++ b/src/RockBot.A2A/A2ACallerSkillProvider.cs
@@ -45,9 +45,22 @@ public sealed class A2ACallerSkillProvider : IToolSkillProvider
         - agent_name (required): The name of the target agent (from list_known_agents)
         - skill (required): The skill ID to invoke on the target agent
         - message (required): The instruction or question for the agent
+        - data (optional): Structured payload sent as a DataPart (use for nested objects/arrays)
+        - metadata (optional): Per-skill control parameters that the target agent advertises
+          (e.g. providerId, count, since). Look for "metadata parameters" or "metadata keys"
+          in the skill description. Values must be primitives (string, number, boolean) — use
+          'data' for anything nested.
         - timeout_minutes (optional): How long to wait (default 5 minutes)
 
         Returns: task_id for tracking
+
+        Example: filter recent-mentions to a single platform
+            invoke_agent(
+              agent_name="SocialAgent",
+              skill="recent-mentions",
+              message="Recent mentions for Bluesky.",
+              metadata={"providerId": "bluesky", "count": 10}
+            )
 
         ## register_agent
         Register or update an HTTP-based A2A agent in the directory. The agent

--- a/src/RockBot.A2A/A2ACallerToolRegistrar.cs
+++ b/src/RockBot.A2A/A2ACallerToolRegistrar.cs
@@ -41,6 +41,10 @@ internal sealed class A2ACallerToolRegistrar(
               "type": "object",
               "description": "Optional structured data payload sent alongside the text message as an A2A DataPart. Include it whenever the request has structured inputs — identifiers, records, parameters, filters, coordinates, enums, etc. — rather than stuffing them into the message text. Inspect the target skill's description, tags, and examples (via get_agent_details) for field hints. If the skill doesn't document structured fields, send the values in message text instead — don't fabricate field names. Must be a JSON object."
             },
+            "metadata": {
+              "type": "object",
+              "description": "Optional A2A message metadata — per-skill control parameters that the target agent advertises in its skill description (e.g. 'providerId', 'count', 'since'). Send filter/control values here when the skill description documents them as 'metadata parameters' or 'metadata keys'. Values must be primitives (string, number, boolean) or ISO-8601 strings — no nested objects or arrays. Distinct from 'data': metadata is for routing/filter hints; data is for the request body. Must be a JSON object."
+            },
             "timeout_minutes": {
               "type": "integer",
               "description": "Optional timeout in minutes (default: 5)."

--- a/src/RockBot.A2A/InvokeAgentExecutor.cs
+++ b/src/RockBot.A2A/InvokeAgentExecutor.cs
@@ -84,6 +84,43 @@ internal sealed class InvokeAgentExecutor(
             dataJson = dataEl.GetRawText();
         }
 
+        // Optional A2A message metadata — per-skill control parameters that some
+        // agents advertise (e.g. SocialAgent's providerId/count/since). Only
+        // primitives are allowed; objects/arrays would push outside the v1 metadata
+        // contract and most receiving handlers can't interpret them. Values are
+        // serialized to strings — receivers coerce to int/date/etc as needed.
+        Dictionary<string, string>? metadata = null;
+        if (args.TryGetValue("metadata", out var metaEl) && metaEl.ValueKind != JsonValueKind.Null &&
+            metaEl.ValueKind != JsonValueKind.Undefined)
+        {
+            if (metaEl.ValueKind != JsonValueKind.Object)
+                return Error(request, "Argument 'metadata' must be a JSON object.");
+
+            metadata = new Dictionary<string, string>(StringComparer.Ordinal);
+            foreach (var prop in metaEl.EnumerateObject())
+            {
+                var v = prop.Value;
+                string? str = v.ValueKind switch
+                {
+                    JsonValueKind.String => v.GetString(),
+                    JsonValueKind.Number => v.GetRawText(),
+                    JsonValueKind.True => "true",
+                    JsonValueKind.False => "false",
+                    _ => null
+                };
+                if (str is null)
+                    return Error(request,
+                        $"Argument 'metadata.{prop.Name}' must be a string, number, or boolean. " +
+                        "Use 'data' for nested objects/arrays.");
+
+                metadata[prop.Name] = str;
+            }
+
+            if (metadata.ContainsKey("skill"))
+                return Error(request,
+                    "Argument 'metadata.skill' is reserved — it's set automatically from the 'skill' parameter.");
+        }
+
         // Reject self-invocation — the LLM sometimes uses its own identity name
         // instead of the target agent's name from the directory.
         if (agentName.Equals(identity.Name, StringComparison.OrdinalIgnoreCase))
@@ -123,7 +160,8 @@ internal sealed class InvokeAgentExecutor(
             Message = new AgentMessage
             {
                 Role = "user",
-                Parts = parts
+                Parts = parts,
+                Metadata = metadata
             }
         };
 
@@ -372,7 +410,7 @@ internal sealed class InvokeAgentExecutor(
         var repetitionDetector = new InputRequiredRepetitionDetector(options.InputRequiredRepetitionThreshold);
 
         // Initial send
-        var sendParams = BuildV03SendParams(taskId, initialParts, contextId, taskRequest.Skill);
+        var sendParams = BuildV03SendParams(taskId, initialParts, contextId, taskRequest.Skill, taskRequest.Message.Metadata);
         var a2aResponse = await a2aClient.SendMessageAsync(sendParams, ct);
         var result = MapV03Response(a2aResponse, taskId);
 
@@ -441,7 +479,7 @@ internal sealed class InvokeAgentExecutor(
                     taskId, pending.InputRequiredRound, followUp.WasAutonomous);
 
                 // Send follow-up with contextId
-                sendParams = BuildV03SendParams(taskId, TextOnlyParts(followUp.ResponseText), contextId, taskRequest.Skill);
+                sendParams = BuildV03SendParams(taskId, TextOnlyParts(followUp.ResponseText), contextId, taskRequest.Skill, taskRequest.Message.Metadata);
                 a2aResponse = await a2aClient.SendMessageAsync(sendParams, ct);
                 result = MapV03Response(a2aResponse, taskId);
                 continue;
@@ -454,7 +492,8 @@ internal sealed class InvokeAgentExecutor(
     }
 
     private static A2AV03.MessageSendParams BuildV03SendParams(
-        string taskId, IReadOnlyList<AgentMessagePart> parts, string? contextId, string skill)
+        string taskId, IReadOnlyList<AgentMessagePart> parts, string? contextId, string skill,
+        IReadOnlyDictionary<string, string>? extraMetadata = null)
     {
         return new A2AV03.MessageSendParams
         {
@@ -465,10 +504,7 @@ internal sealed class InvokeAgentExecutor(
                 ContextId = contextId,
                 Parts = parts.Select(MapOutboundV03Part).ToList()
             },
-            Metadata = new Dictionary<string, JsonElement>
-            {
-                ["skill"] = JsonSerializer.SerializeToElement(skill)
-            }
+            Metadata = BuildOutboundMetadata(skill, extraMetadata)
         };
     }
 
@@ -616,7 +652,7 @@ internal sealed class InvokeAgentExecutor(
         var repetitionDetector = new InputRequiredRepetitionDetector(options.InputRequiredRepetitionThreshold);
 
         // Initial send
-        var sendRequest = BuildV1SendRequest(taskId, initialParts, contextId, taskRequest.Skill);
+        var sendRequest = BuildV1SendRequest(taskId, initialParts, contextId, taskRequest.Skill, taskRequest.Message.Metadata);
         var a2aResponse = await a2aClient.SendMessageAsync(sendRequest, ct);
         var result = MapV1Response(a2aResponse, taskId);
 
@@ -685,7 +721,7 @@ internal sealed class InvokeAgentExecutor(
                     taskId, pending.InputRequiredRound, followUp.WasAutonomous);
 
                 // Send follow-up with contextId
-                sendRequest = BuildV1SendRequest(taskId, TextOnlyParts(followUp.ResponseText), contextId, taskRequest.Skill);
+                sendRequest = BuildV1SendRequest(taskId, TextOnlyParts(followUp.ResponseText), contextId, taskRequest.Skill, taskRequest.Message.Metadata);
                 a2aResponse = await a2aClient.SendMessageAsync(sendRequest, ct);
                 result = MapV1Response(a2aResponse, taskId);
                 continue;
@@ -719,7 +755,7 @@ internal sealed class InvokeAgentExecutor(
 
         string? contextId = null;
         var repetitionDetector = new InputRequiredRepetitionDetector(options.InputRequiredRepetitionThreshold);
-        var sendRequest = BuildV1SendRequest(taskId, initialParts, contextId, taskRequest.Skill);
+        var sendRequest = BuildV1SendRequest(taskId, initialParts, contextId, taskRequest.Skill, taskRequest.Message.Metadata);
 
         while (!ct.IsCancellationRequested)
         {
@@ -838,7 +874,7 @@ internal sealed class InvokeAgentExecutor(
                     taskId, pending.InputRequiredRound, followUp.WasAutonomous);
 
                 // Send follow-up with contextId — continue streaming
-                sendRequest = BuildV1SendRequest(taskId, TextOnlyParts(followUp.ResponseText), contextId, taskRequest.Skill);
+                sendRequest = BuildV1SendRequest(taskId, TextOnlyParts(followUp.ResponseText), contextId, taskRequest.Skill, taskRequest.Message.Metadata);
                 continue;
             }
 
@@ -877,7 +913,8 @@ internal sealed class InvokeAgentExecutor(
     }
 
     private static A2AV1.SendMessageRequest BuildV1SendRequest(
-        string taskId, IReadOnlyList<AgentMessagePart> parts, string? contextId, string skill)
+        string taskId, IReadOnlyList<AgentMessagePart> parts, string? contextId, string skill,
+        IReadOnlyDictionary<string, string>? extraMetadata = null)
     {
         return new A2AV1.SendMessageRequest
         {
@@ -888,11 +925,34 @@ internal sealed class InvokeAgentExecutor(
                 ContextId = contextId,
                 Parts = parts.Select(MapOutboundV1Part).ToList()
             },
-            Metadata = new Dictionary<string, JsonElement>
-            {
-                ["skill"] = JsonSerializer.SerializeToElement(skill)
-            }
+            Metadata = BuildOutboundMetadata(skill, extraMetadata)
         };
+    }
+
+    /// <summary>
+    /// Builds the outbound A2A <c>Message.metadata</c> dict. Always includes
+    /// <c>skill</c> (set from the tool argument). Caller-supplied metadata is
+    /// serialized as JSON strings — receivers coerce to int/date/bool as needed.
+    /// </summary>
+    internal static Dictionary<string, JsonElement> BuildOutboundMetadata(
+        string skill, IReadOnlyDictionary<string, string>? extraMetadata)
+    {
+        var dict = new Dictionary<string, JsonElement>(StringComparer.Ordinal)
+        {
+            ["skill"] = JsonSerializer.SerializeToElement(skill)
+        };
+
+        if (extraMetadata is null) return dict;
+
+        foreach (var kvp in extraMetadata)
+        {
+            // Reserve "skill" — the executor already rejects this at the input
+            // boundary, but defend in depth in case a future caller bypasses it.
+            if (kvp.Key == "skill") continue;
+            dict[kvp.Key] = JsonSerializer.SerializeToElement(kvp.Value);
+        }
+
+        return dict;
     }
 
     internal static A2AV1.Part MapOutboundV1Part(AgentMessagePart part)

--- a/src/RockBot.Wisp/GatewayRouter.cs
+++ b/src/RockBot.Wisp/GatewayRouter.cs
@@ -96,6 +96,9 @@ internal static partial class GatewayRouter
         if (step.TimeoutMinutes is not null)
             args["timeout_minutes"] = step.TimeoutMinutes;
 
+        if (step.Metadata is JsonElement md && md.ValueKind == JsonValueKind.Object)
+            args["metadata"] = md;
+
         return ToolRouteResult.Success("invoke_agent", JsonSerializer.Serialize(args, JsonOptions));
     }
 

--- a/src/RockBot.Wisp/WispStep.cs
+++ b/src/RockBot.Wisp/WispStep.cs
@@ -105,6 +105,15 @@ public sealed record WispStep
     public string? Message { get; init; }
 
     /// <summary>
+    /// Optional A2A message metadata (gateway=a2a only) — per-skill control parameters
+    /// that the target agent advertises in its skill description (e.g. <c>providerId</c>,
+    /// <c>count</c>, <c>since</c>). Forwarded into <c>invoke_agent</c>'s <c>metadata</c>
+    /// argument. Values must be primitives (string/number/boolean).
+    /// </summary>
+    [JsonPropertyName("metadata")]
+    public JsonElement? Metadata { get; init; }
+
+    /// <summary>
     /// Timeout in minutes for A2A steps. Defaults to 5.
     /// </summary>
     [JsonPropertyName("timeout_minutes")]

--- a/tests/RockBot.A2A.Tests/A2ACallerTests.cs
+++ b/tests/RockBot.A2A.Tests/A2ACallerTests.cs
@@ -234,6 +234,150 @@ public class A2ACallerTests
     }
 
     [TestMethod]
+    public async Task InvokeAgentExecutor_AttachesMetadata_ToAgentMessage()
+    {
+        var publisher = new TrackingPublisher();
+        var tracker = new A2ATaskTracker();
+        var executor = BuildExecutor(publisher, tracker);
+
+        var request = BuildToolRequest("""
+            {
+              "agent_name": "SocialAgent",
+              "skill": "recent-mentions",
+              "message": "Recent mentions only.",
+              "metadata": { "providerId": "bluesky", "count": 10, "active": true }
+            }
+            """);
+
+        await executor.ExecuteAsync(request, CancellationToken.None);
+
+        var taskReq = publisher.Published[0].Envelope.GetPayload<AgentTaskRequest>()!;
+        Assert.IsNotNull(taskReq.Message.Metadata);
+        Assert.AreEqual("bluesky", taskReq.Message.Metadata["providerId"]);
+        Assert.AreEqual("10",      taskReq.Message.Metadata["count"]);
+        Assert.AreEqual("true",    taskReq.Message.Metadata["active"]);
+    }
+
+    [TestMethod]
+    public async Task InvokeAgentExecutor_RejectsMetadata_WithNestedObject()
+    {
+        var publisher = new TrackingPublisher();
+        var tracker = new A2ATaskTracker();
+        var executor = BuildExecutor(publisher, tracker);
+
+        // Nested objects belong in 'data', not 'metadata'.
+        var request = BuildToolRequest("""
+            {
+              "agent_name": "TargetAgent",
+              "skill": "chat",
+              "message": "x",
+              "metadata": { "filter": { "platform": "bluesky" } }
+            }
+            """);
+
+        var response = await executor.ExecuteAsync(request, CancellationToken.None);
+
+        Assert.IsTrue(response.IsError);
+        StringAssert.Contains(response.Content, "metadata");
+        Assert.AreEqual(0, publisher.Published.Count);
+    }
+
+    [TestMethod]
+    public async Task InvokeAgentExecutor_RejectsMetadata_WithArrayValue()
+    {
+        var publisher = new TrackingPublisher();
+        var tracker = new A2ATaskTracker();
+        var executor = BuildExecutor(publisher, tracker);
+
+        var request = BuildToolRequest("""
+            {
+              "agent_name": "TargetAgent",
+              "skill": "chat",
+              "message": "x",
+              "metadata": { "providers": ["bluesky", "mastodon"] }
+            }
+            """);
+
+        var response = await executor.ExecuteAsync(request, CancellationToken.None);
+
+        Assert.IsTrue(response.IsError);
+        StringAssert.Contains(response.Content, "providers");
+        Assert.AreEqual(0, publisher.Published.Count);
+    }
+
+    [TestMethod]
+    public async Task InvokeAgentExecutor_RejectsMetadata_WhenSkillKeyReserved()
+    {
+        var publisher = new TrackingPublisher();
+        var tracker = new A2ATaskTracker();
+        var executor = BuildExecutor(publisher, tracker);
+
+        // 'skill' is auto-set from the top-level argument; allowing it in metadata
+        // would create an ambiguity about which value wins on the wire.
+        var request = BuildToolRequest("""
+            {
+              "agent_name": "TargetAgent",
+              "skill": "chat",
+              "message": "x",
+              "metadata": { "skill": "something-else" }
+            }
+            """);
+
+        var response = await executor.ExecuteAsync(request, CancellationToken.None);
+
+        Assert.IsTrue(response.IsError);
+        StringAssert.Contains(response.Content, "skill");
+        Assert.AreEqual(0, publisher.Published.Count);
+    }
+
+    [TestMethod]
+    public async Task InvokeAgentExecutor_AcceptsNullMetadata_AsMissing()
+    {
+        var publisher = new TrackingPublisher();
+        var tracker = new A2ATaskTracker();
+        var executor = BuildExecutor(publisher, tracker);
+
+        var request = BuildToolRequest("""
+            { "agent_name": "TargetAgent", "skill": "chat", "message": "Hi.", "metadata": null }
+            """);
+
+        var response = await executor.ExecuteAsync(request, CancellationToken.None);
+
+        Assert.IsFalse(response.IsError);
+        var taskReq = publisher.Published[0].Envelope.GetPayload<AgentTaskRequest>()!;
+        Assert.IsNull(taskReq.Message.Metadata);
+    }
+
+    [TestMethod]
+    public void BuildOutboundMetadata_AlwaysIncludesSkill()
+    {
+        var dict = InvokeAgentExecutor.BuildOutboundMetadata("recent-mentions", null);
+        Assert.IsTrue(dict.ContainsKey("skill"));
+        Assert.AreEqual("recent-mentions", dict["skill"].GetString());
+    }
+
+    [TestMethod]
+    public void BuildOutboundMetadata_MergesExtras_AlongsideSkill()
+    {
+        var extras = new Dictionary<string, string> { ["providerId"] = "bluesky", ["count"] = "10" };
+        var dict = InvokeAgentExecutor.BuildOutboundMetadata("recent-mentions", extras);
+
+        Assert.AreEqual("recent-mentions", dict["skill"].GetString());
+        Assert.AreEqual("bluesky", dict["providerId"].GetString());
+        Assert.AreEqual("10",      dict["count"].GetString());
+    }
+
+    [TestMethod]
+    public void BuildOutboundMetadata_IgnoresExtraSkillKey_DefenseInDepth()
+    {
+        // The executor blocks "skill" at input, but the helper should also
+        // refuse to overwrite the auto-set value if a caller ever bypasses that.
+        var extras = new Dictionary<string, string> { ["skill"] = "evil" };
+        var dict = InvokeAgentExecutor.BuildOutboundMetadata("recent-mentions", extras);
+        Assert.AreEqual("recent-mentions", dict["skill"].GetString());
+    }
+
+    [TestMethod]
     public void MapOutboundV03Part_TextPart_MapsToV03TextPart()
     {
         var part = new AgentMessagePart { Kind = "text", Text = "hello" };

--- a/tests/RockBot.Wisp.Tests/GatewayRouterTests.cs
+++ b/tests/RockBot.Wisp.Tests/GatewayRouterTests.cs
@@ -151,6 +151,50 @@ public class GatewayRouterTests
     }
 
     [TestMethod]
+    public void Route_A2A_ForwardsMetadata_WhenStepProvidesIt()
+    {
+        var step = new WispStep
+        {
+            Id = "filter-mentions",
+            Mode = StepMode.Direct,
+            Gateway = GatewayType.A2A,
+            Agent = "SocialAgent",
+            Skill = "recent-mentions",
+            Message = "Bluesky only.",
+            Metadata = JsonDocument.Parse("""{"providerId":"bluesky","count":10}""").RootElement
+        };
+
+        var result = GatewayRouter.Route(step, "wisp-123", EmptyResults);
+
+        Assert.IsTrue(result.IsSuccess);
+        var args = JsonDocument.Parse(result.Arguments!).RootElement;
+        Assert.IsTrue(args.TryGetProperty("metadata", out var md));
+        Assert.AreEqual("bluesky", md.GetProperty("providerId").GetString());
+        Assert.AreEqual(10, md.GetProperty("count").GetInt32());
+    }
+
+    [TestMethod]
+    public void Route_A2A_OmitsMetadata_WhenStepHasNone()
+    {
+        var step = new WispStep
+        {
+            Id = "no-md",
+            Mode = StepMode.Direct,
+            Gateway = GatewayType.A2A,
+            Agent = "TargetAgent",
+            Skill = "summarize",
+            Message = "x"
+        };
+
+        var result = GatewayRouter.Route(step, "wisp-123", EmptyResults);
+
+        Assert.IsTrue(result.IsSuccess);
+        var args = JsonDocument.Parse(result.Arguments!).RootElement;
+        Assert.IsFalse(args.TryGetProperty("metadata", out _),
+            "metadata key must not appear when the wisp step doesn't supply it.");
+    }
+
+    [TestMethod]
     public void Route_A2A_MissingAgent_ReturnsStructuralError()
     {
         var step = new WispStep


### PR DESCRIPTION
## Summary
- `invoke_agent` accepts an optional `metadata` object (string/number/boolean primitives) that's merged into the outbound A2A `Message.metadata` alongside the auto-set `skill` key
- `WispStep` gains a `metadata` field for `gateway=a2a` steps; `GatewayRouter.RouteA2A` forwards it into the `invoke_agent` invocation
- The A2A tool guide picks up a short example showing per-skill filtering

## Why
A2A peers like SocialAgent 1.3.3 advertise per-skill control parameters (`providerId`, `count`, `since`, …) in their card and read them from `message.metadata`. Until now there was no way for the LLM (or a wisp step) to set those — `invoke_agent` only put `skill` in the metadata dict, and `WispStep` had no metadata field at all. The receiving agent fell back to its unfiltered default, so calls intended to be platform-scoped silently returned the union.

Verified on the live cluster: four `recent-mentions` calls (default, ""Mastodon only"", ""Bluesky only"", retry) all returned the byte-identical 6446-char payload (sha `158749d4748f`) with the same 4 Mastodon items. Only `provider-status` differed. The filter literally couldn't reach SocialAgent.

## Validation rules on `metadata`
- Must be a JSON object (rejects strings/arrays/etc)
- Each value must be a primitive: string, number, or boolean (numbers and bools are stringified for transport)
- Nested objects/arrays → use `data` instead
- The `skill` key is reserved (auto-set from the top-level argument)

## Test plan
- [x] `RockBot.A2A.Tests` — 8 new tests covering happy-path attach, nested-object rejection, array rejection, reserved-skill rejection, null-as-missing, and `BuildOutboundMetadata` invariants. 135/135 pass.
- [x] `RockBot.Wisp.Tests` — 2 new tests covering `RouteA2A` forwarding metadata when present and omitting it when absent. 106/106 pass.
- [x] Full solution build clean (warnings only on pre-existing CA1416)

## Follow-up
- #324 — extract the duplicated InputRequired loop from the three Dispatch methods. Surfaced while threading metadata through the call sites; not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)