### PR TITLE
Advertise A2A metadata field on the spawn_wisps schema and skill guide

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.10.18</Version>
+<Version>0.10.19</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.Wisp/WispToolRegistrar.cs
+++ b/src/RockBot.Wisp/WispToolRegistrar.cs
@@ -55,6 +55,8 @@ internal sealed class WispToolRegistrar(
                         "agent": { "type": "string", "description": "A2A agent name (gateway=A2A)." },
                         "skill": { "type": "string", "description": "A2A skill ID (gateway=A2A)." },
                         "message": { "type": "string", "description": "A2A message content (gateway=A2A)." },
+                        "metadata": { "type": "object", "description": "Optional A2A message metadata (gateway=A2A): per-skill control parameters the target agent advertises in its skill description (e.g. providerId, count, since). Values must be primitives (string/number/boolean). Use this for filter/control hints, not the message text." },
+                        "timeout_minutes": { "type": "integer", "description": "A2A task timeout in minutes (gateway=A2A, default 5)." },
                         "input_from": { "type": "string", "description": "File path or {{steps.id.result}} template for step input." },
                         "output_to": { "type": "string", "description": "File path to write step output." },
                         "on_failure": {

--- a/src/RockBot.Wisp/WispToolSkillProvider.cs
+++ b/src/RockBot.Wisp/WispToolSkillProvider.cs
@@ -243,6 +243,23 @@ public sealed class WispToolSkillProvider : IToolSkillProvider
         }
         ```
 
+        Use `metadata` to pass per-skill filter/control parameters the target agent
+        advertises in its skill description (e.g. `providerId`, `count`, `since`).
+        Read the skill description in `list_known_agents` / `get_agent_details` for
+        the recognized keys. Don't bury filter values in `message` text — most
+        agents won't parse them out:
+        ```json
+        {
+          "id": "bluesky_mentions",
+          "mode": "Direct",
+          "gateway": "A2A",
+          "agent": "SocialAgent",
+          "skill": "recent-mentions",
+          "message": "Recent Bluesky mentions for the user.",
+          "metadata": { "providerId": "bluesky", "count": 10 }
+        }
+        ```
+
         ### LLM steps
 
         LLM steps omit the gateway. The wisp LLM is a blank slate — it has no


### PR DESCRIPTION
## Summary
- Add `metadata` (and `timeout_minutes`) to the `spawn_wisps` JSON schema so the LLM sees the field when authoring wisp definitions
- Extend the wisp skill guide with a SocialAgent-style example showing per-skill filtering
- Bump to 0.10.19

## Why
#325 wired metadata through `WispStep` → `GatewayRouter.RouteA2A` → `invoke_agent`, but the JSON schema the LLM uses to author wisps still listed only `agent`/`skill`/`message`. The LLM had no way to discover the new field and kept burying filter values in message text.

Live verification on 0.10.18: four `recent-mentions` wisps for "Bluesky only" returned the byte-identical 6,446-char Mastodon-only payload (sha `158749d4748f`). The wisp definitions in the logs confirmed no `metadata` field was set — exactly as predicted by the missing schema.

This PR is the schema/docs counterpart to #325. Code path was already correct; the LLM just couldn't see it.

## Test plan
- [x] `RockBot.Wisp.Tests` 106/106 still pass (schema is JSON, parsed at validation time only)
- [ ] After deploy: confirm next "Bluesky only" wisp produces a definition with `"metadata": {"providerId": "bluesky"}` and SocialAgent returns 0 native Bluesky mentions instead of the Mastodon union

🤖 Generated with [Claude Code](https://claude.com/claude-code)