### PR TITLE
Put A2A metadata on Message, not on the request envelope

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.10.19</Version>
+<Version>0.10.20</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.A2A/InvokeAgentExecutor.cs
+++ b/src/RockBot.A2A/InvokeAgentExecutor.cs
@@ -491,7 +491,7 @@ internal sealed class InvokeAgentExecutor(
         return result;
     }
 
-    private static A2AV03.MessageSendParams BuildV03SendParams(
+    internal static A2AV03.MessageSendParams BuildV03SendParams(
         string taskId, IReadOnlyList<AgentMessagePart> parts, string? contextId, string skill,
         IReadOnlyDictionary<string, string>? extraMetadata = null)
     {
@@ -502,9 +502,9 @@ internal sealed class InvokeAgentExecutor(
                 Role = A2AV03.MessageRole.User,
                 MessageId = taskId,
                 ContextId = contextId,
-                Parts = parts.Select(MapOutboundV03Part).ToList()
-            },
-            Metadata = BuildOutboundMetadata(skill, extraMetadata)
+                Parts = parts.Select(MapOutboundV03Part).ToList(),
+                Metadata = BuildOutboundMetadata(skill, extraMetadata)
+            }
         };
     }
 
@@ -912,10 +912,14 @@ internal sealed class InvokeAgentExecutor(
         };
     }
 
-    private static A2AV1.SendMessageRequest BuildV1SendRequest(
+    internal static A2AV1.SendMessageRequest BuildV1SendRequest(
         string taskId, IReadOnlyList<AgentMessagePart> parts, string? contextId, string skill,
         IReadOnlyDictionary<string, string>? extraMetadata = null)
     {
+        // Per A2A spec, per-message metadata (skill, providerId, count, …) belongs
+        // on Message.metadata, not SendMessageRequest.metadata. Receivers like
+        // SocialAgent read Message.metadata for skill dispatch and per-skill params;
+        // request-level metadata is at most a fallback for the skill key.
         return new A2AV1.SendMessageRequest
         {
             Message = new A2AV1.Message
@@ -923,9 +927,9 @@ internal sealed class InvokeAgentExecutor(
                 Role = A2AV1.Role.User,
                 MessageId = taskId,
                 ContextId = contextId,
-                Parts = parts.Select(MapOutboundV1Part).ToList()
-            },
-            Metadata = BuildOutboundMetadata(skill, extraMetadata)
+                Parts = parts.Select(MapOutboundV1Part).ToList(),
+                Metadata = BuildOutboundMetadata(skill, extraMetadata)
+            }
         };
     }
 

--- a/tests/RockBot.A2A.Tests/A2ACallerTests.cs
+++ b/tests/RockBot.A2A.Tests/A2ACallerTests.cs
@@ -349,6 +349,43 @@ public class A2ACallerTests
     }
 
     [TestMethod]
+    public void BuildV1SendRequest_PutsMetadata_OnMessage_NotOnRequest()
+    {
+        // Per A2A v1 spec, per-message metadata (skill + per-skill params)
+        // belongs on Message.metadata. Receivers like SocialAgent dispatch
+        // skills and read filter parameters from Message.metadata. Putting it
+        // on SendMessageRequest.metadata makes the values invisible to them.
+        var extras = new Dictionary<string, string> { ["providerId"] = "bluesky" };
+        var req = InvokeAgentExecutor.BuildV1SendRequest(
+            taskId: "t1", parts: [new AgentMessagePart { Kind = "text", Text = "hi" }],
+            contextId: null, skill: "recent-mentions", extraMetadata: extras);
+
+        Assert.IsNotNull(req.Message.Metadata,
+            "Message.metadata must carry the skill + per-skill keys.");
+        Assert.AreEqual("recent-mentions", req.Message.Metadata["skill"].GetString());
+        Assert.AreEqual("bluesky", req.Message.Metadata["providerId"].GetString());
+
+        Assert.IsNull(req.Metadata,
+            "SendMessageRequest.metadata must remain unset — receivers read Message.metadata.");
+    }
+
+    [TestMethod]
+    public void BuildV03SendParams_PutsMetadata_OnMessage_NotOnParams()
+    {
+        var extras = new Dictionary<string, string> { ["providerId"] = "bluesky" };
+        var p = InvokeAgentExecutor.BuildV03SendParams(
+            taskId: "t1", parts: [new AgentMessagePart { Kind = "text", Text = "hi" }],
+            contextId: null, skill: "recent-mentions", extraMetadata: extras);
+
+        Assert.IsNotNull(p.Message.Metadata);
+        Assert.AreEqual("recent-mentions", p.Message.Metadata["skill"].GetString());
+        Assert.AreEqual("bluesky", p.Message.Metadata["providerId"].GetString());
+
+        Assert.IsNull(p.Metadata,
+            "MessageSendParams.metadata must remain unset — receivers read Message.metadata.");
+    }
+
+    [TestMethod]
     public void BuildOutboundMetadata_AlwaysIncludesSkill()
     {
         var dict = InvokeAgentExecutor.BuildOutboundMetadata("recent-mentions", null);


### PR DESCRIPTION
## Summary
- Move A2A `metadata` from `SendMessageRequest`/`MessageSendParams` to `Message.metadata` for both v1 and v0.3
- Add two regression tests that pin metadata to `Message.metadata` and assert the request envelope stays empty
- Bump to 0.10.20

## Why
Per A2A spec, per-message metadata — `skill` and per-skill control params (`providerId`, `count`, `since`, …) — belongs on `Message.metadata`. The original `BuildV1SendRequest` / `BuildV03SendParams` wrote it to the request envelope (`SendMessageRequest.metadata` / `MessageSendParams.metadata`) instead. That worked for `skill` only because SocialAgent's dispatcher falls back to request-level metadata for that one key. Per-skill keys had no fallback and silently dropped.

Confirmed live on 0.10.19: even when the LLM correctly authored the wisp with `metadata.providerId=bluesky`, SocialAgent logged
```
Dispatching skill recent-mentions (from request metadata) parameters={}
```
…and returned the unfiltered Mastodon union. RockBot's metadata was being placed where SocialAgent (and any spec-conformant receiver) wouldn't look.

## Test plan
- [x] `BuildV1SendRequest_PutsMetadata_OnMessage_NotOnRequest` — locks v1 location
- [x] `BuildV03SendParams_PutsMetadata_OnMessage_NotOnParams` — locks v0.3 location
- [x] All 137 `RockBot.A2A.Tests` pass
- [ ] Live: after deploy, expect `parameters={providerId=bluesky, count=10}` in SocialAgent's log and `0 items` returned for a Bluesky-only filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)