### PR TITLE
Refresh well-known A2A agent cards periodically and on demand (#322)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.10.20</Version>
+<Version>0.10.21</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.10.21</Version>
+<Version>0.10.22</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.A2A/A2ACallerToolRegistrar.cs
+++ b/src/RockBot.A2A/A2ACallerToolRegistrar.cs
@@ -212,10 +212,16 @@ internal sealed class A2ACallerToolRegistrar(
         {
             Name = "refresh_agent_card",
             Description = """
-                Re-fetch a known agent's /.well-known/agent-card.json so its skills, metadata,
-                and description reflect the current published state. Use this when an invoke_agent
-                call returns an unexpected error (e.g. unknown skill or metadata key), when the
-                user asks "what can X do now?", or when you suspect cached capabilities are stale.
+                FORCES a fresh HTTP re-fetch of an A2A agent's /.well-known/agent-card.json so
+                the local directory reflects its CURRENT published skills and metadata.
+                Distinct from get_agent_details, which only returns the locally-cached card
+                (potentially hours stale). Call this — before get_agent_details / invoke_agent —
+                whenever: (a) invoke_agent fails with 'unknown skill' or 'unknown metadata key',
+                (b) the user asks "what can X do now?", "is X up to date?", or mentions a new
+                feature/skill the agent should support, (c) you otherwise suspect the cached
+                capabilities are stale. Note: this is for A2A agents (use list_known_agents),
+                NOT MCP servers. Returns a status summary; read the refreshed card via
+                get_agent_details.
                 """,
             ParametersSchema = RefreshAgentCardSchema,
             Source = "a2a"

--- a/src/RockBot.A2A/A2ACallerToolRegistrar.cs
+++ b/src/RockBot.A2A/A2ACallerToolRegistrar.cs
@@ -19,6 +19,7 @@ internal sealed class A2ACallerToolRegistrar(
     AgentIdentity identity,
     IHttpClientFactory httpClientFactory,
     InputRequiredHandler inputRequiredHandler,
+    AgentCardSummarizer summarizer,
     ILoggerFactory loggerFactory) : IHostedService
 {
     private const string InvokeAgentSchema = """
@@ -138,6 +139,19 @@ internal sealed class A2ACallerToolRegistrar(
         }
         """;
 
+    private const string RefreshAgentCardSchema = """
+        {
+          "type": "object",
+          "properties": {
+            "agent_name": {
+              "type": "string",
+              "description": "The name of the agent whose /.well-known/agent-card.json should be re-fetched."
+            }
+          },
+          "required": ["agent_name"]
+        }
+        """;
+
     public Task StartAsync(CancellationToken cancellationToken)
     {
         var invokeLogger = loggerFactory.CreateLogger<InvokeAgentExecutor>();
@@ -193,6 +207,20 @@ internal sealed class A2ACallerToolRegistrar(
             Source = "a2a"
         }, new UnregisterAgentExecutor(directory, loggerFactory.CreateLogger<UnregisterAgentExecutor>()));
         registrarLogger.LogInformation("Registered tool: unregister_agent");
+
+        registry.Register(new ToolRegistration
+        {
+            Name = "refresh_agent_card",
+            Description = """
+                Re-fetch a known agent's /.well-known/agent-card.json so its skills, metadata,
+                and description reflect the current published state. Use this when an invoke_agent
+                call returns an unexpected error (e.g. unknown skill or metadata key), when the
+                user asks "what can X do now?", or when you suspect cached capabilities are stale.
+                """,
+            ParametersSchema = RefreshAgentCardSchema,
+            Source = "a2a"
+        }, new RefreshAgentCardExecutor(directory, summarizer, loggerFactory.CreateLogger<RefreshAgentCardExecutor>()));
+        registrarLogger.LogInformation("Registered tool: refresh_agent_card");
 
         return Task.CompletedTask;
     }

--- a/src/RockBot.A2A/A2AOptions.cs
+++ b/src/RockBot.A2A/A2AOptions.cs
@@ -44,6 +44,13 @@ public sealed class A2AOptions
     /// </summary>
     public List<AgentCard> WellKnownAgents { get; set; } = [];
 
+    /// <summary>
+    /// How often to re-fetch well-known peers' <c>/.well-known/agent-card.json</c>
+    /// so changes to a peer's skills/metadata become visible without restarting.
+    /// <see cref="TimeSpan.Zero"/> disables the periodic refresh. Default: 4 hours.
+    /// </summary>
+    public TimeSpan WellKnownRefreshInterval { get; set; } = TimeSpan.FromHours(4);
+
     // ── Long-running task polling ───────────────────────────────────────────
 
     /// <summary>Initial polling delay for long-running HTTP tasks (exponential backoff start).</summary>

--- a/src/RockBot.A2A/A2AServiceCollectionExtensions.cs
+++ b/src/RockBot.A2A/A2AServiceCollectionExtensions.cs
@@ -61,6 +61,12 @@ public static class A2AServiceCollectionExtensions
         builder.Services.AddSingleton<Microsoft.Extensions.Hosting.IHostedService>(
             sp => sp.GetRequiredService<AgentDiscoveryService>());
 
+        // Periodic well-known refresh — re-fetches /.well-known/agent-card.json
+        // so peer skill/metadata changes become visible without a pod restart.
+        builder.Services.AddSingleton<WellKnownRefreshService>();
+        builder.Services.AddSingleton<Microsoft.Extensions.Hosting.IHostedService>(
+            sp => sp.GetRequiredService<WellKnownRefreshService>());
+
         // Task request handler on agent.task.{agentName}
         var agentName = builder.Identity.Name;
 

--- a/src/RockBot.A2A/AgentDirectory.cs
+++ b/src/RockBot.A2A/AgentDirectory.cs
@@ -109,22 +109,47 @@ internal sealed class AgentDirectory(
         await EnrichWellKnownFromRemoteAsync(cancellationToken);
     }
 
-    private async Task EnrichWellKnownFromRemoteAsync(CancellationToken cancellationToken)
-    {
-        if (httpClientFactory is null) return;
+    private Task EnrichWellKnownFromRemoteAsync(CancellationToken cancellationToken) =>
+        RefreshAllWellKnownAsync(cancellationToken);
 
-        var toEnrich = options.WellKnownAgents
+    public async Task<IReadOnlyList<AgentCardRefreshResult>> RefreshAllWellKnownAsync(CancellationToken ct)
+    {
+        if (httpClientFactory is null) return Array.Empty<AgentCardRefreshResult>();
+
+        var toRefresh = options.WellKnownAgents
             .Where(c => !string.IsNullOrWhiteSpace(c.Url) && (c.Skills is null || c.Skills.Count == 0))
             .ToList();
 
-        if (toEnrich.Count == 0) return;
+        if (toRefresh.Count == 0) return Array.Empty<AgentCardRefreshResult>();
 
-        var tasks = toEnrich.Select(seed => FetchAndMergeAsync(seed, cancellationToken));
-        await Task.WhenAll(tasks);
+        var tasks = toRefresh.Select(seed => FetchAndMergeAsync(seed, ct));
+        var results = await Task.WhenAll(tasks);
+        return results;
     }
 
-    private async Task FetchAndMergeAsync(AgentCard seed, CancellationToken ct)
+    public async Task<AgentCardRefreshResult> RefreshAgentCardAsync(string agentName, CancellationToken ct)
     {
+        if (!_agents.TryGetValue(agentName, out var entry))
+            return new AgentCardRefreshResult(agentName, false, false, "agent not found");
+
+        var seed = options.WellKnownAgents.FirstOrDefault(
+            c => string.Equals(c.AgentName, agentName, StringComparison.OrdinalIgnoreCase));
+        if (seed is not null && seed.Skills is { Count: > 0 })
+            return new AgentCardRefreshResult(agentName, false, false, "offline override");
+
+        if (httpClientFactory is null)
+            return new AgentCardRefreshResult(agentName, false, false, "http client factory unavailable");
+
+        if (string.IsNullOrWhiteSpace(entry.Card.Url))
+            return new AgentCardRefreshResult(agentName, false, false, "agent has no URL");
+
+        return await FetchAndMergeAsync(entry.Card, ct);
+    }
+
+    private async Task<AgentCardRefreshResult> FetchAndMergeAsync(AgentCard seed, CancellationToken ct)
+    {
+        var prevSkills = _agents.TryGetValue(seed.AgentName, out var prev) ? prev.Card.Skills : null;
+
         try
         {
             using var httpClient = httpClientFactory!.CreateClient();
@@ -146,7 +171,7 @@ internal sealed class AgentDirectory(
                 logger.LogWarning(
                     "Skipping enrichment for well-known peer '{AgentName}': invalid URL '{Url}'",
                     seed.AgentName, seed.Url);
-                return;
+                return new AgentCardRefreshResult(seed.AgentName, false, false, "invalid URL");
             }
 
             var url = new Uri(baseUri, "/.well-known/agent-card.json").ToString();
@@ -156,7 +181,7 @@ internal sealed class AgentDirectory(
                 logger.LogWarning(
                     "Could not fetch agent-card for well-known peer '{AgentName}' from {Url}: HTTP {Status}",
                     seed.AgentName, url, (int)response.StatusCode);
-                return;
+                return new AgentCardRefreshResult(seed.AgentName, false, false, $"HTTP {(int)response.StatusCode}");
             }
 
             var json = await response.Content.ReadAsStringAsync(ct);
@@ -178,14 +203,22 @@ internal sealed class AgentDirectory(
                 SupportsStreaming = remote.SupportsStreaming ?? seed.SupportsStreaming
             };
 
+            var skillsChanged = !SkillIdsEqual(prevSkills, merged.Skills);
+
             if (_agents.TryGetValue(seed.AgentName, out var existing))
             {
-                _agents[seed.AgentName] = existing with { Card = merged };
+                _agents[seed.AgentName] = existing with
+                {
+                    Card = merged,
+                    LlmSummary = skillsChanged ? null : existing.LlmSummary
+                };
                 logger.LogInformation(
-                    "Enriched well-known agent '{AgentName}' from {Url} (protocol={Protocol}, streaming={Streaming}, {SkillCount} skill(s))",
+                    "Refreshed well-known agent '{AgentName}' from {Url} (protocol={Protocol}, streaming={Streaming}, {SkillCount} skill(s), skillsChanged={Changed})",
                     seed.AgentName, url, merged.ProtocolVersion ?? "(unset)",
-                    merged.SupportsStreaming, merged.Skills?.Count ?? 0);
+                    merged.SupportsStreaming, merged.Skills?.Count ?? 0, skillsChanged);
             }
+
+            return new AgentCardRefreshResult(seed.AgentName, true, skillsChanged, null);
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
@@ -194,9 +227,21 @@ internal sealed class AgentDirectory(
         catch (Exception ex)
         {
             logger.LogWarning(ex,
-                "Failed to enrich well-known agent '{AgentName}' from {Url} — entry kept without remote data",
+                "Failed to refresh well-known agent '{AgentName}' from {Url} — entry kept without remote data",
                 seed.AgentName, seed.Url);
+            return new AgentCardRefreshResult(seed.AgentName, false, false, ex.Message);
         }
+    }
+
+    private static bool SkillIdsEqual(IReadOnlyList<AgentSkill>? a, IReadOnlyList<AgentSkill>? b)
+    {
+        var aSet = new HashSet<string>(
+            (a ?? []).Select(s => s.Id ?? string.Empty),
+            StringComparer.OrdinalIgnoreCase);
+        var bSet = new HashSet<string>(
+            (b ?? []).Select(s => s.Id ?? string.Empty),
+            StringComparer.OrdinalIgnoreCase);
+        return aSet.SetEquals(bSet);
     }
 
     internal sealed record RemoteFields(

--- a/src/RockBot.A2A/IAgentDirectory.cs
+++ b/src/RockBot.A2A/IAgentDirectory.cs
@@ -24,4 +24,36 @@ public interface IAgentDirectory
     /// Removes an agent from the directory. Well-known agents are not removed.
     /// </summary>
     void Remove(string agentName);
+
+    /// <summary>
+    /// Updates the LLM-generated summary for an agent. No-op if the agent is unknown.
+    /// </summary>
+    void SetSummary(string agentName, string summary);
+
+    /// <summary>
+    /// Re-fetches every well-known peer's <c>/.well-known/agent-card.json</c> and merges
+    /// the result into the directory. Seeds with an explicit <see cref="AgentCard.Skills"/>
+    /// array are treated as offline overrides and skipped.
+    /// </summary>
+    Task<IReadOnlyList<AgentCardRefreshResult>> RefreshAllWellKnownAsync(CancellationToken ct);
+
+    /// <summary>
+    /// Re-fetches a single agent's <c>/.well-known/agent-card.json</c>. Returns a result
+    /// describing what happened (refreshed / skipped / not-found / error) so the caller
+    /// can decide whether to regenerate the cached LLM summary.
+    /// </summary>
+    Task<AgentCardRefreshResult> RefreshAgentCardAsync(string agentName, CancellationToken ct);
 }
+
+/// <summary>
+/// Outcome of a single agent-card refresh attempt.
+/// </summary>
+/// <param name="AgentName">Agent the refresh targeted.</param>
+/// <param name="Refreshed">True when a remote fetch happened and merged successfully.</param>
+/// <param name="SkillsChanged">True when the skill-id set differs from the pre-refresh entry.</param>
+/// <param name="Reason">Human-readable note for skipped/not-found/error cases.</param>
+public sealed record AgentCardRefreshResult(
+    string AgentName,
+    bool Refreshed,
+    bool SkillsChanged,
+    string? Reason);

--- a/src/RockBot.A2A/RefreshAgentCardExecutor.cs
+++ b/src/RockBot.A2A/RefreshAgentCardExecutor.cs
@@ -1,0 +1,99 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using RockBot.Tools;
+
+namespace RockBot.A2A;
+
+/// <summary>
+/// On-demand <c>refresh_agent_card</c> tool: re-fetches a peer's
+/// <c>/.well-known/agent-card.json</c> so an LLM can recover from stale
+/// capability data without waiting for the periodic refresh cycle.
+/// </summary>
+internal sealed class RefreshAgentCardExecutor(
+    IAgentDirectory directory,
+    AgentCardSummarizer summarizer,
+    ILogger<RefreshAgentCardExecutor> logger) : IToolExecutor
+{
+    public async Task<ToolInvokeResponse> ExecuteAsync(ToolInvokeRequest request, CancellationToken ct)
+    {
+        Dictionary<string, JsonElement> args;
+        try
+        {
+            args = string.IsNullOrWhiteSpace(request.Arguments)
+                ? []
+                : JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(request.Arguments) ?? [];
+        }
+        catch
+        {
+            return Error(request, "Invalid arguments JSON.");
+        }
+
+        if (!args.TryGetValue("agent_name", out var nameEl) || nameEl.ValueKind != JsonValueKind.String)
+            return Error(request, "Missing required parameter: agent_name");
+
+        var agentName = nameEl.GetString()!;
+
+        var result = await directory.RefreshAgentCardAsync(agentName, ct);
+
+        if (result.SkillsChanged)
+        {
+            var card = directory.GetAgent(result.AgentName);
+            if (card is not null)
+            {
+                _ = Task.Run(async () =>
+                {
+                    try
+                    {
+                        var summary = await summarizer.SummarizeAsync(card, CancellationToken.None);
+                        directory.SetSummary(result.AgentName, summary);
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.LogWarning(ex,
+                            "Failed to regenerate LLM summary for '{AgentName}' after refresh",
+                            result.AgentName);
+                    }
+                }, CancellationToken.None);
+            }
+        }
+
+        var refreshedCard = directory.GetAgent(result.AgentName);
+        var skillCount = refreshedCard?.Skills?.Count ?? 0;
+
+        var status = (result.Refreshed, result.Reason) switch
+        {
+            (true, _) => result.SkillsChanged ? "refreshed (skills changed)" : "refreshed (no changes)",
+            (false, "agent not found") => "not found",
+            (false, "offline override") => "skipped (offline override)",
+            (false, _) => "skipped",
+        };
+
+        var payload = new
+        {
+            agentName = result.AgentName,
+            status,
+            refreshed = result.Refreshed,
+            skillsChanged = result.SkillsChanged,
+            reason = result.Reason,
+            skillCount,
+        };
+
+        var json = JsonSerializer.Serialize(payload, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = true,
+            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+        });
+
+        return new ToolInvokeResponse
+        {
+            ToolCallId = request.ToolCallId,
+            ToolName = request.ToolName,
+            Content = json,
+            IsError = false,
+        };
+    }
+
+    private static ToolInvokeResponse Error(ToolInvokeRequest req, string msg) =>
+        new() { ToolCallId = req.ToolCallId, ToolName = req.ToolName, Content = msg, IsError = true };
+}

--- a/src/RockBot.A2A/WellKnownRefreshService.cs
+++ b/src/RockBot.A2A/WellKnownRefreshService.cs
@@ -1,0 +1,93 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace RockBot.A2A;
+
+/// <summary>
+/// Periodically re-fetches every well-known peer's <c>/.well-known/agent-card.json</c>
+/// so changes to a peer's skills/metadata become visible without restarting. When a
+/// peer's skill set changes, the cached <see cref="AgentDirectoryEntry.LlmSummary"/>
+/// is regenerated.
+/// </summary>
+internal sealed class WellKnownRefreshService(
+    AgentDirectory directory,
+    AgentCardSummarizer summarizer,
+    A2AOptions options,
+    ILogger<WellKnownRefreshService> logger) : IHostedService
+{
+    private CancellationTokenSource? _loopCts;
+    private Task? _loopTask;
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (options.WellKnownRefreshInterval <= TimeSpan.Zero)
+        {
+            logger.LogInformation("Periodic well-known refresh disabled (interval is zero or negative)");
+            return Task.CompletedTask;
+        }
+
+        _loopCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        _loopTask = Task.Run(() => RefreshLoopAsync(_loopCts.Token));
+        logger.LogInformation(
+            "Started periodic well-known refresh loop (interval={Interval})",
+            options.WellKnownRefreshInterval);
+        return Task.CompletedTask;
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        _loopCts?.Cancel();
+        if (_loopTask is not null)
+        {
+            try { await _loopTask; }
+            catch (OperationCanceledException) { /* normal shutdown */ }
+        }
+        _loopCts?.Dispose();
+    }
+
+    private async Task RefreshLoopAsync(CancellationToken ct)
+    {
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                await Task.Delay(options.WellKnownRefreshInterval, ct);
+                await RunRefreshPassAsync(ct);
+            }
+        }
+        catch (OperationCanceledException) { /* normal shutdown */ }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Well-known refresh loop terminated unexpectedly");
+        }
+    }
+
+    private async Task RunRefreshPassAsync(CancellationToken ct)
+    {
+        try
+        {
+            var results = await directory.RefreshAllWellKnownAsync(ct);
+            foreach (var result in results)
+            {
+                if (!result.SkillsChanged) continue;
+
+                var card = directory.GetAgent(result.AgentName);
+                if (card is null) continue;
+
+                var summary = await summarizer.SummarizeAsync(card, ct);
+                directory.SetSummary(result.AgentName, summary);
+                logger.LogInformation(
+                    "Regenerated LLM summary for '{AgentName}' after skill changes",
+                    result.AgentName);
+            }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Well-known refresh pass failed");
+        }
+    }
+}

--- a/tests/RockBot.A2A.Tests/RefreshAgentCardExecutorTests.cs
+++ b/tests/RockBot.A2A.Tests/RefreshAgentCardExecutorTests.cs
@@ -1,0 +1,154 @@
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using RockBot.Tools;
+
+namespace RockBot.A2A.Tests;
+
+[TestClass]
+public class RefreshAgentCardExecutorTests
+{
+    private static AgentCardSummarizer CreateSummarizer() =>
+        new(new ServiceCollection().BuildServiceProvider(), NullLogger<AgentCardSummarizer>.Instance);
+
+    private static ToolInvokeRequest Request(string? args) =>
+        new()
+        {
+            ToolCallId = "call-1",
+            ToolName = "refresh_agent_card",
+            Arguments = args
+        };
+
+    [TestMethod]
+    public async Task ReturnsError_WhenAgentNameMissing()
+    {
+        var directory = new FakeDirectory();
+        var executor = new RefreshAgentCardExecutor(
+            directory, CreateSummarizer(), NullLogger<RefreshAgentCardExecutor>.Instance);
+
+        var response = await executor.ExecuteAsync(Request("""{}"""), CancellationToken.None);
+
+        Assert.IsTrue(response.IsError);
+        StringAssert.Contains(response.Content!, "agent_name");
+        Assert.AreEqual(0, directory.RefreshCallCount,
+            "Directory should not be touched when agent_name is missing.");
+    }
+
+    [TestMethod]
+    public async Task ReturnsError_OnInvalidJson()
+    {
+        var directory = new FakeDirectory();
+        var executor = new RefreshAgentCardExecutor(
+            directory, CreateSummarizer(), NullLogger<RefreshAgentCardExecutor>.Instance);
+
+        var response = await executor.ExecuteAsync(Request("not json"), CancellationToken.None);
+
+        Assert.IsTrue(response.IsError);
+    }
+
+    [TestMethod]
+    public async Task ReturnsSuccessJson_WhenAgentRefreshed()
+    {
+        var directory = new FakeDirectory
+        {
+            NextResult = new AgentCardRefreshResult("Bob", Refreshed: true, SkillsChanged: true, Reason: null)
+        };
+        directory.AddOrUpdate(new AgentCard
+        {
+            AgentName = "Bob",
+            Skills = [new AgentSkill { Id = "s1", Name = "S1", Description = "x" }]
+        });
+        var executor = new RefreshAgentCardExecutor(
+            directory, CreateSummarizer(), NullLogger<RefreshAgentCardExecutor>.Instance);
+
+        var response = await executor.ExecuteAsync(
+            Request("""{"agent_name":"Bob"}"""), CancellationToken.None);
+
+        Assert.IsFalse(response.IsError);
+        using var doc = JsonDocument.Parse(response.Content!);
+        Assert.AreEqual("Bob", doc.RootElement.GetProperty("agentName").GetString());
+        Assert.IsTrue(doc.RootElement.GetProperty("refreshed").GetBoolean());
+        Assert.IsTrue(doc.RootElement.GetProperty("skillsChanged").GetBoolean());
+        StringAssert.Contains(doc.RootElement.GetProperty("status").GetString()!, "refreshed");
+    }
+
+    [TestMethod]
+    public async Task ReturnsNotFoundStatus_WhenDirectoryReportsNotFound()
+    {
+        var directory = new FakeDirectory
+        {
+            NextResult = new AgentCardRefreshResult("Ghost", false, false, "agent not found")
+        };
+        var executor = new RefreshAgentCardExecutor(
+            directory, CreateSummarizer(), NullLogger<RefreshAgentCardExecutor>.Instance);
+
+        var response = await executor.ExecuteAsync(
+            Request("""{"agent_name":"Ghost"}"""), CancellationToken.None);
+
+        Assert.IsFalse(response.IsError);
+        using var doc = JsonDocument.Parse(response.Content!);
+        Assert.AreEqual("not found", doc.RootElement.GetProperty("status").GetString());
+        Assert.IsFalse(doc.RootElement.GetProperty("refreshed").GetBoolean());
+    }
+
+    [TestMethod]
+    public async Task ReturnsSkippedStatus_WhenOfflineOverride()
+    {
+        var directory = new FakeDirectory
+        {
+            NextResult = new AgentCardRefreshResult("Bob", false, false, "offline override")
+        };
+        var executor = new RefreshAgentCardExecutor(
+            directory, CreateSummarizer(), NullLogger<RefreshAgentCardExecutor>.Instance);
+
+        var response = await executor.ExecuteAsync(
+            Request("""{"agent_name":"Bob"}"""), CancellationToken.None);
+
+        Assert.IsFalse(response.IsError);
+        using var doc = JsonDocument.Parse(response.Content!);
+        StringAssert.Contains(doc.RootElement.GetProperty("status").GetString()!, "offline override");
+    }
+
+    private sealed class FakeDirectory : IAgentDirectory
+    {
+        private readonly Dictionary<string, AgentDirectoryEntry> _entries = new(StringComparer.OrdinalIgnoreCase);
+
+        public AgentCardRefreshResult NextResult { get; set; } =
+            new("", false, false, "no result configured");
+        public int RefreshCallCount { get; private set; }
+
+        public AgentCard? GetAgent(string agentName) =>
+            _entries.TryGetValue(agentName, out var e) ? e.Card : null;
+
+        public IReadOnlyList<AgentCard> GetAllAgents() =>
+            _entries.Values.Select(e => e.Card).ToList();
+
+        public IReadOnlyList<AgentCard> FindBySkill(string skillId) => Array.Empty<AgentCard>();
+
+        public IReadOnlyList<AgentDirectoryEntry> GetAllEntries() => _entries.Values.ToList();
+
+        public void AddOrUpdate(AgentCard card) =>
+            _entries[card.AgentName] = new AgentDirectoryEntry
+            {
+                Card = card,
+                LastSeenAt = DateTimeOffset.UtcNow
+            };
+
+        public void Remove(string agentName) => _entries.Remove(agentName);
+
+        public void SetSummary(string agentName, string summary)
+        {
+            if (_entries.TryGetValue(agentName, out var e))
+                _entries[agentName] = e with { LlmSummary = summary };
+        }
+
+        public Task<IReadOnlyList<AgentCardRefreshResult>> RefreshAllWellKnownAsync(CancellationToken ct) =>
+            Task.FromResult<IReadOnlyList<AgentCardRefreshResult>>(Array.Empty<AgentCardRefreshResult>());
+
+        public Task<AgentCardRefreshResult> RefreshAgentCardAsync(string agentName, CancellationToken ct)
+        {
+            RefreshCallCount++;
+            return Task.FromResult(NextResult);
+        }
+    }
+}

--- a/tests/RockBot.A2A.Tests/WellKnownAgentEnrichmentTests.cs
+++ b/tests/RockBot.A2A.Tests/WellKnownAgentEnrichmentTests.cs
@@ -278,28 +278,245 @@ public class WellKnownAgentEnrichmentTests
         Assert.IsNull(card.Skills);
     }
 
+    [TestMethod]
+    public async Task RefreshAllWellKnownAsync_RefetchesAndUpdatesSkills()
+    {
+        var initial = new AgentCard
+        {
+            AgentName = "Bob",
+            Description = "Bob's agent",
+            Version = "1.0",
+            Skills = [new AgentSkill { Id = "old-skill", Name = "Old", Description = "x" }]
+        };
+        var handler = new RecordingHandler(JsonSerializer.Serialize(initial, CamelCase));
+        var options = new A2AOptions
+        {
+            DirectoryPersistencePath = string.Empty,
+            WellKnownAgents = [new AgentCard { AgentName = "Bob", Url = "http://gateway-bob:5200" }]
+        };
+        var directory = new AgentDirectory(options, NullLogger<AgentDirectory>.Instance, new StubFactory(handler));
+        await directory.StartAsync(CancellationToken.None);
+
+        var updated = new AgentCard
+        {
+            AgentName = "Bob",
+            Description = "Bob's agent v2",
+            Version = "1.1",
+            Skills =
+            [
+                new AgentSkill { Id = "old-skill", Name = "Old", Description = "x" },
+                new AgentSkill { Id = "new-skill", Name = "New", Description = "y" }
+            ]
+        };
+        handler.Body = JsonSerializer.Serialize(updated, CamelCase);
+
+        var results = await directory.RefreshAllWellKnownAsync(CancellationToken.None);
+
+        Assert.AreEqual(1, results.Count);
+        Assert.AreEqual("Bob", results[0].AgentName);
+        Assert.IsTrue(results[0].Refreshed);
+        Assert.IsTrue(results[0].SkillsChanged);
+
+        var card = directory.GetAgent("Bob");
+        Assert.IsNotNull(card?.Skills);
+        Assert.AreEqual(2, card.Skills.Count);
+        Assert.IsTrue(card.Skills.Any(s => s.Id == "new-skill"));
+    }
+
+    [TestMethod]
+    public async Task RefreshAllWellKnownAsync_PreservesOfflineOverride()
+    {
+        var handler = new RecordingHandler("""{"agentName":"Bob","skills":[{"id":"remote"}]}""");
+        var options = new A2AOptions
+        {
+            DirectoryPersistencePath = string.Empty,
+            WellKnownAgents =
+            [
+                new AgentCard
+                {
+                    AgentName = "Bob",
+                    Url = "http://gateway-bob:5200",
+                    Skills = [new AgentSkill { Id = "override", Name = "O", Description = "x" }]
+                }
+            ]
+        };
+        var directory = new AgentDirectory(options, NullLogger<AgentDirectory>.Instance, new StubFactory(handler));
+        await directory.StartAsync(CancellationToken.None);
+
+        var startCount = handler.RequestCount;
+        var results = await directory.RefreshAllWellKnownAsync(CancellationToken.None);
+
+        Assert.AreEqual(0, results.Count, "Offline overrides should not be refreshed.");
+        Assert.AreEqual(startCount, handler.RequestCount, "No HTTP request should have been made.");
+
+        var card = directory.GetAgent("Bob");
+        Assert.AreEqual("override", card?.Skills?.Single().Id);
+    }
+
+    [TestMethod]
+    public async Task RefreshAllWellKnownAsync_ClearsLlmSummary_WhenSkillsChange()
+    {
+        var initial = new AgentCard
+        {
+            AgentName = "Bob",
+            Skills = [new AgentSkill { Id = "old", Name = "Old", Description = "x" }]
+        };
+        var handler = new RecordingHandler(JsonSerializer.Serialize(initial, CamelCase));
+        var options = new A2AOptions
+        {
+            DirectoryPersistencePath = string.Empty,
+            WellKnownAgents = [new AgentCard { AgentName = "Bob", Url = "http://gateway-bob:5200" }]
+        };
+        var directory = new AgentDirectory(options, NullLogger<AgentDirectory>.Instance, new StubFactory(handler));
+        await directory.StartAsync(CancellationToken.None);
+        directory.SetSummary("Bob", "An agent that does old things.");
+        Assert.AreEqual("An agent that does old things.", directory.GetAllEntries().Single().LlmSummary);
+
+        var updated = new AgentCard
+        {
+            AgentName = "Bob",
+            Skills = [new AgentSkill { Id = "new", Name = "New", Description = "y" }]
+        };
+        handler.Body = JsonSerializer.Serialize(updated, CamelCase);
+
+        var results = await directory.RefreshAllWellKnownAsync(CancellationToken.None);
+
+        Assert.IsTrue(results.Single().SkillsChanged);
+        Assert.IsNull(directory.GetAllEntries().Single().LlmSummary,
+            "LlmSummary must be cleared when skills change so a fresh summary is regenerated.");
+    }
+
+    [TestMethod]
+    public async Task RefreshAllWellKnownAsync_PreservesLlmSummary_WhenSkillsUnchanged()
+    {
+        var card = new AgentCard
+        {
+            AgentName = "Bob",
+            Description = "v1",
+            Skills = [new AgentSkill { Id = "same-skill", Name = "Same", Description = "x" }]
+        };
+        var handler = new RecordingHandler(JsonSerializer.Serialize(card, CamelCase));
+        var options = new A2AOptions
+        {
+            DirectoryPersistencePath = string.Empty,
+            WellKnownAgents = [new AgentCard { AgentName = "Bob", Url = "http://gateway-bob:5200" }]
+        };
+        var directory = new AgentDirectory(options, NullLogger<AgentDirectory>.Instance, new StubFactory(handler));
+        await directory.StartAsync(CancellationToken.None);
+        directory.SetSummary("Bob", "Bob does things.");
+
+        // Same skill set, just a bumped description — skills unchanged should preserve summary.
+        var same = card with { Description = "v2" };
+        handler.Body = JsonSerializer.Serialize(same, CamelCase);
+
+        var results = await directory.RefreshAllWellKnownAsync(CancellationToken.None);
+
+        Assert.IsTrue(results.Single().Refreshed);
+        Assert.IsFalse(results.Single().SkillsChanged);
+        Assert.AreEqual("Bob does things.", directory.GetAllEntries().Single().LlmSummary);
+    }
+
+    [TestMethod]
+    public async Task RefreshAgentCardAsync_ReturnsNotFound_ForUnknownAgent()
+    {
+        var handler = new RecordingHandler("");
+        var options = new A2AOptions { DirectoryPersistencePath = string.Empty };
+        var directory = new AgentDirectory(options, NullLogger<AgentDirectory>.Instance, new StubFactory(handler));
+        await directory.StartAsync(CancellationToken.None);
+
+        var result = await directory.RefreshAgentCardAsync("nobody", CancellationToken.None);
+
+        Assert.IsFalse(result.Refreshed);
+        Assert.IsFalse(result.SkillsChanged);
+        Assert.AreEqual("agent not found", result.Reason);
+    }
+
+    [TestMethod]
+    public async Task RefreshAgentCardAsync_ReturnsSkipped_ForOfflineOverride()
+    {
+        var handler = new RecordingHandler("""{"agentName":"Bob","skills":[{"id":"remote"}]}""");
+        var options = new A2AOptions
+        {
+            DirectoryPersistencePath = string.Empty,
+            WellKnownAgents =
+            [
+                new AgentCard
+                {
+                    AgentName = "Bob",
+                    Url = "http://gateway-bob:5200",
+                    Skills = [new AgentSkill { Id = "override", Name = "O", Description = "x" }]
+                }
+            ]
+        };
+        var directory = new AgentDirectory(options, NullLogger<AgentDirectory>.Instance, new StubFactory(handler));
+        await directory.StartAsync(CancellationToken.None);
+
+        var beforeCount = handler.RequestCount;
+        var result = await directory.RefreshAgentCardAsync("Bob", CancellationToken.None);
+
+        Assert.IsFalse(result.Refreshed);
+        Assert.AreEqual("offline override", result.Reason);
+        Assert.AreEqual(beforeCount, handler.RequestCount);
+    }
+
+    [TestMethod]
+    public async Task RefreshAgentCardAsync_RefetchesByName()
+    {
+        var initial = new AgentCard
+        {
+            AgentName = "Bob",
+            Skills = [new AgentSkill { Id = "v1", Name = "V1", Description = "x" }]
+        };
+        var handler = new RecordingHandler(JsonSerializer.Serialize(initial, CamelCase));
+        var options = new A2AOptions
+        {
+            DirectoryPersistencePath = string.Empty,
+            WellKnownAgents = [new AgentCard { AgentName = "Bob", Url = "http://gateway-bob:5200" }]
+        };
+        var directory = new AgentDirectory(options, NullLogger<AgentDirectory>.Instance, new StubFactory(handler));
+        await directory.StartAsync(CancellationToken.None);
+
+        var updated = initial with
+        {
+            Skills = [new AgentSkill { Id = "v2", Name = "V2", Description = "y" }]
+        };
+        handler.Body = JsonSerializer.Serialize(updated, CamelCase);
+
+        var beforeCount = handler.RequestCount;
+        var result = await directory.RefreshAgentCardAsync("Bob", CancellationToken.None);
+
+        Assert.IsTrue(result.Refreshed);
+        Assert.IsTrue(result.SkillsChanged);
+        Assert.AreEqual(beforeCount + 1, handler.RequestCount);
+        Assert.AreEqual("v2", directory.GetAgent("Bob")?.Skills?.Single().Id);
+    }
+
     private sealed class RecordingHandler : HttpMessageHandler
     {
-        private readonly string _body;
-        private readonly HttpStatusCode _status;
+        private HttpStatusCode _status;
 
         public RecordingHandler(string body = "", HttpStatusCode status = HttpStatusCode.OK)
         {
-            _body = body;
+            Body = body;
             _status = status;
         }
 
+        public string Body { get; set; }
         public Uri? LastRequestUri { get; private set; }
         public System.Net.Http.Headers.HttpRequestHeaders? LastRequestHeaders { get; private set; }
+        public int RequestCount { get; private set; }
+
+        public void SetStatus(HttpStatusCode status) => _status = status;
 
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request, CancellationToken cancellationToken)
         {
             LastRequestUri = request.RequestUri;
             LastRequestHeaders = request.Headers;
+            RequestCount++;
             return Task.FromResult(new HttpResponseMessage(_status)
             {
-                Content = new StringContent(_body, Encoding.UTF8, "application/json")
+                Content = new StringContent(Body, Encoding.UTF8, "application/json")
             });
         }
     }


### PR DESCRIPTION
## Summary

Closes #322. Today `AgentDirectory` only fetches well-known peers' `/.well-known/agent-card.json` once at startup — when a peer (e.g. SocialAgent) ships new skills or per-skill metadata, RockBot keeps using the snapshot from boot until the pod restarts. This PR adds two complementary refresh paths.

- **Periodic refresh** — new `WellKnownRefreshService` (`IHostedService`) re-fetches every well-known peer on a configurable cadence. Controlled by `A2AOptions.WellKnownRefreshInterval`; default 4h, `TimeSpan.Zero` disables.
- **On-demand `refresh_agent_card` tool** — lets the LLM force a fresh re-fetch when an `invoke_agent` call returns an unexpected error, when the user asks "what can X do now?", or when the cache is otherwise suspect. The tool description leads with **"FORCES a fresh HTTP re-fetch"** and explicitly contrasts with `get_agent_details` so the LLM doesn't conflate them (verified live — without that contrast the LLM kept choosing `get_agent_details` instead).

Both paths preserve the existing offline-override semantic: well-known seeds with an explicit `skills` array are treated as authoritative and never re-fetched. When a refresh detects skill-id changes, the cached `LlmSummary` is cleared and (in the periodic service / tool paths) regenerated against the new capabilities so we never serve stale agent summaries.

`AgentDirectory.FetchAndMergeAsync` is refactored to return an `AgentCardRefreshResult` (refreshed / skills-changed / reason). `IAgentDirectory` gains `RefreshAllWellKnownAsync`, `RefreshAgentCardAsync`, and `SetSummary`. The existing startup `EnrichWellKnownFromRemoteAsync` becomes a thin wrapper over `RefreshAllWellKnownAsync` so the original first-startup behavior is unchanged.

Live-tested on cluster with v0.10.22: at startup the directory enriches 7 SocialAgent skills, the periodic loop logs `Started periodic well-known refresh loop (interval=04:00:00)`, and the LLM successfully invokes `refresh_agent_card` end-to-end (HTTP fetch → merge → structured JSON response).

## Test plan

- [x] `dotnet build RockBot.slnx` clean
- [x] `dotnet test RockBot.slnx` — full suite passes (149 in RockBot.A2A.Tests after the additions, all other test assemblies green)
- [x] 7 new tests in `WellKnownAgentEnrichmentTests.cs` covering `RefreshAllWellKnownAsync` (refetch, offline-override, summary clear/preserve) and `RefreshAgentCardAsync` (not-found, offline-override, refetch-by-name)
- [x] 5 new tests in `RefreshAgentCardExecutorTests.cs` covering missing/invalid args, success path, not-found and offline-override responses
- [x] Deployed to k8s as `rockbot-agent:0.10.22`; verified pod startup logs (`Registered tool: refresh_agent_card`, `Started periodic well-known refresh loop`, `Refreshed well-known agent 'SocialAgent' ... 7 skill(s)`)
- [x] Tool invoked end-to-end via blazor session — HTTP GET to peer's `/.well-known/agent-card.json` confirmed in logs, structured JSON returned to the LLM

🤖 Generated with [Claude Code](https://claude.com/claude-code)