### PR TITLE
Route unsolicited non-final replies to DisplayStatusAsync (#331)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.10.24</Version>
+<Version>0.10.25</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.UserProxy.Abstractions/IUserFrontend.cs
+++ b/src/RockBot.UserProxy.Abstractions/IUserFrontend.cs
@@ -9,6 +9,21 @@ public interface IUserFrontend
     Task DisplayErrorAsync(string message, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Displays a non-final, ephemeral progress update from an agent (e.g. subagent
+    /// progress notes, A2A task status). These are unsolicited <see cref="AgentReply"/>
+    /// envelopes that arrived without a matching pending request and have
+    /// <see cref="AgentReply.IsFinal"/> = false. Frontends should render them as
+    /// transient activity (e.g. an activity log line, a dim status row) rather than
+    /// as a separate chat bubble per message, so progress does not stack as apparent
+    /// duplicate output before the final reply arrives.
+    ///
+    /// The default implementation delegates to <see cref="DisplayReplyAsync"/> so
+    /// existing custom frontends keep their previous behavior until they opt in.
+    /// </summary>
+    Task DisplayStatusAsync(AgentReply reply, CancellationToken cancellationToken = default) =>
+        DisplayReplyAsync(reply, cancellationToken);
+
+    /// <summary>
     /// Called when the agent's display name changes. Frontends should update
     /// their UI (titles, headers, etc.) accordingly.
     /// </summary>

--- a/src/RockBot.UserProxy.Blazor/Services/BlazorUserFrontend.cs
+++ b/src/RockBot.UserProxy.Blazor/Services/BlazorUserFrontend.cs
@@ -20,21 +20,22 @@ public sealed class BlazorUserFrontend(ChatStateService chatState) : IUserFronte
 
         var category = CategorizeReply(reply);
 
-        if (reply.IsFinal)
-        {
-            // Final result — add as a permanent chat bubble and clear the progress indicator
-            chatState.SetThinkingMessage(null);
-            chatState.AddAgentReply(reply, category);
-        }
-        else
-        {
-            // Non-final progress — append to the source's activity log bubble
-            // instead of creating a separate bubble per message.
-            // IsCompletion signals the source has finished (e.g. subagent result Phase 1) —
-            // close the activity log so the spinner and header indicator disappear.
-            chatState.AppendActivityLogEntry(reply.Content, category, reply.AgentName,
-                close: reply.IsCompletion);
-        }
+        // Final result — add as a permanent chat bubble and clear the progress indicator
+        chatState.SetThinkingMessage(null);
+        chatState.AddAgentReply(reply, category);
+        return Task.CompletedTask;
+    }
+
+    public Task DisplayStatusAsync(AgentReply reply, CancellationToken cancellationToken = default)
+    {
+        var category = CategorizeReply(reply);
+
+        // Non-final progress — append to the source's activity log bubble
+        // instead of creating a separate bubble per message.
+        // IsCompletion signals the source has finished (e.g. subagent result Phase 1) —
+        // close the activity log so the spinner and header indicator disappear.
+        chatState.AppendActivityLogEntry(reply.Content, category, reply.AgentName,
+            close: reply.IsCompletion);
         return Task.CompletedTask;
     }
 

--- a/src/RockBot.UserProxy.Cli/SpectreConsoleFrontend.cs
+++ b/src/RockBot.UserProxy.Cli/SpectreConsoleFrontend.cs
@@ -21,6 +21,15 @@ internal sealed class SpectreConsoleFrontend : IUserFrontend
         return Task.CompletedTask;
     }
 
+    public Task DisplayStatusAsync(AgentReply reply, CancellationToken cancellationToken = default)
+    {
+        // Render ephemeral progress as a single dim line rather than a panel,
+        // so unsolicited subagent / A2A progress doesn't stack as bubbles.
+        AnsiConsole.MarkupLine(
+            $"[dim italic]{Markup.Escape(reply.AgentName)}: {Markup.Escape(reply.Content)}[/]");
+        return Task.CompletedTask;
+    }
+
     public Task DisplayErrorAsync(string message, CancellationToken cancellationToken = default)
     {
         AnsiConsole.MarkupLine($"[red]Error:[/] {Markup.Escape(message)}");

--- a/src/RockBot.UserProxy/UserProxyService.cs
+++ b/src/RockBot.UserProxy/UserProxyService.cs
@@ -417,11 +417,18 @@ public sealed class UserProxyService(
                     envelope.CorrelationId, reply.AgentName);
             }
         }
-        else
+        else if (reply.IsFinal)
         {
-            // Unsolicited reply — display via frontend
+            // Unsolicited final reply — display as a chat bubble
             logger.LogDebug("Unsolicited reply from {Agent}, displaying via frontend", reply.AgentName);
             _ = frontend.DisplayReplyAsync(reply, ct);
+        }
+        else
+        {
+            // Unsolicited non-final reply (subagent progress, A2A status) — render as
+            // ephemeral status so progress doesn't stack as separate chat bubbles.
+            logger.LogDebug("Unsolicited progress from {Agent}, displaying as status", reply.AgentName);
+            _ = frontend.DisplayStatusAsync(reply, ct);
         }
 
         return Task.FromResult(MessageResult.Ack);

--- a/tests/RockBot.UserProxy.Blazor.Tests/BlazorUserFrontendTests.cs
+++ b/tests/RockBot.UserProxy.Blazor.Tests/BlazorUserFrontendTests.cs
@@ -81,7 +81,7 @@ public class BlazorUserFrontendTests
             IsFinal = false
         };
 
-        await _frontend.DisplayReplyAsync(reply);
+        await _frontend.DisplayStatusAsync(reply);
 
         var msg = GetLastMessage();
         Assert.AreEqual(MessageCategory.A2AActivity, msg.Category);
@@ -100,7 +100,7 @@ public class BlazorUserFrontendTests
             IsFinal = false
         };
 
-        await _frontend.DisplayReplyAsync(reply);
+        await _frontend.DisplayStatusAsync(reply);
 
         var msg = GetLastMessage();
         Assert.AreEqual(MessageCategory.SubagentActivity, msg.Category);
@@ -147,7 +147,7 @@ public class BlazorUserFrontendTests
             IsFinal = false
         };
 
-        await _frontend.DisplayReplyAsync(externalReply);
+        await _frontend.DisplayStatusAsync(externalReply);
 
         var msg = GetLastMessage();
         Assert.AreEqual(MessageCategory.A2AActivity, msg.Category);
@@ -174,7 +174,7 @@ public class BlazorUserFrontendTests
             IsFinal = false
         };
 
-        await _frontend.DisplayReplyAsync(reply);
+        await _frontend.DisplayStatusAsync(reply);
 
         var msg = GetLastMessage();
         Assert.AreEqual(MessageCategory.PrimaryProgress, msg.Category);
@@ -192,7 +192,7 @@ public class BlazorUserFrontendTests
             IsFinal = false
         };
 
-        await _frontend.DisplayReplyAsync(reply);
+        await _frontend.DisplayStatusAsync(reply);
 
         var msg = GetLastMessage();
         Assert.AreEqual(MessageCategory.PrimaryProgress, msg.Category);
@@ -211,7 +211,7 @@ public class BlazorUserFrontendTests
             IsFinal = false
         };
 
-        await _frontend.DisplayReplyAsync(reply);
+        await _frontend.DisplayStatusAsync(reply);
 
         var msg = GetLastMessage();
         Assert.AreEqual(MessageCategory.PrimaryProgress, msg.Category);

--- a/tests/RockBot.UserProxy.Tests/TestHelpers.cs
+++ b/tests/RockBot.UserProxy.Tests/TestHelpers.cs
@@ -70,11 +70,20 @@ internal sealed class StubSubscription(string topic, string subscriptionName) : 
 internal sealed class StubUserFrontend : IUserFrontend
 {
     public List<AgentReply> DisplayedReplies { get; } = [];
+    public List<AgentReply> DisplayedStatusReplies { get; } = [];
     public List<string> DisplayedErrors { get; } = [];
 
     public Task DisplayReplyAsync(AgentReply reply, CancellationToken cancellationToken = default)
     {
         DisplayedReplies.Add(reply);
+        return Task.CompletedTask;
+    }
+
+    // Override so the default interface implementation (which delegates to
+    // DisplayReplyAsync) doesn't fold status replies back into DisplayedReplies.
+    public Task DisplayStatusAsync(AgentReply reply, CancellationToken cancellationToken = default)
+    {
+        DisplayedStatusReplies.Add(reply);
         return Task.CompletedTask;
     }
 

--- a/tests/RockBot.UserProxy.Tests/UserProxyServiceTests.cs
+++ b/tests/RockBot.UserProxy.Tests/UserProxyServiceTests.cs
@@ -168,7 +168,8 @@ public sealed class UserProxyServiceTests
         {
             Content = "Unsolicited hello",
             SessionId = "s1",
-            AgentName = "agent-x"
+            AgentName = "agent-x",
+            IsFinal = true
         };
         var envelope = TestEnvelopeHelper.CreateEnvelope(reply,
             source: "agent-x",
@@ -179,6 +180,53 @@ public sealed class UserProxyServiceTests
         Assert.AreEqual(MessageResult.Ack, result);
         Assert.AreEqual(1, _frontend.DisplayedReplies.Count);
         Assert.AreEqual("Unsolicited hello", _frontend.DisplayedReplies[0].Content);
+    }
+
+    [TestMethod]
+    public async Task HandleResponse_UnsolicitedNonFinal_RoutesToDisplayStatus()
+    {
+        // Unsolicited progress (subagent / A2A status) — IsFinal=false should land
+        // in DisplayStatusAsync, not DisplayReplyAsync, so it doesn't stack as a bubble.
+        var reply = new AgentReply
+        {
+            Content = "Searching the web...",
+            SessionId = "s1",
+            AgentName = "subagent-research",
+            IsFinal = false
+        };
+        var envelope = TestEnvelopeHelper.CreateEnvelope(reply,
+            source: "subagent-research",
+            correlationId: "no-match");
+
+        var result = await _subscriber.CapturedHandler!(envelope, CancellationToken.None);
+
+        Assert.AreEqual(MessageResult.Ack, result);
+        Assert.AreEqual(0, _frontend.DisplayedReplies.Count,
+            "Non-final unsolicited reply must not be displayed as a chat bubble");
+        Assert.AreEqual(1, _frontend.DisplayedStatusReplies.Count);
+        Assert.AreEqual("Searching the web...", _frontend.DisplayedStatusReplies[0].Content);
+    }
+
+    [TestMethod]
+    public async Task HandleResponse_UnsolicitedFinal_RoutesToDisplayReply()
+    {
+        var reply = new AgentReply
+        {
+            Content = "Final answer",
+            SessionId = "s1",
+            AgentName = "agent-x",
+            IsFinal = true
+        };
+        var envelope = TestEnvelopeHelper.CreateEnvelope(reply,
+            source: "agent-x",
+            correlationId: "no-match");
+
+        var result = await _subscriber.CapturedHandler!(envelope, CancellationToken.None);
+
+        Assert.AreEqual(MessageResult.Ack, result);
+        Assert.AreEqual(1, _frontend.DisplayedReplies.Count);
+        Assert.AreEqual(0, _frontend.DisplayedStatusReplies.Count,
+            "Final unsolicited reply must not be routed to DisplayStatusAsync");
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary
- Adds `IUserFrontend.DisplayStatusAsync` for ephemeral progress so subagent / A2A status updates no longer stack as separate chat bubbles next to the final synthesis (issue #331).
- `UserProxyService.HandleResponseAsync` now branches the unsolicited path on `IsFinal`: final → `DisplayReplyAsync`, non-final → `DisplayStatusAsync`. Blazor renders status via the activity log; the CLI renders a dim italic single line.
- Bumps version to 0.10.25.

Closes #331.

## Test plan
- [x] `dotnet build RockBot.slnx` clean.
- [x] `dotnet test RockBot.slnx` — 1,412 passed, 0 failed (unit suite; RabbitMQ/script integration tests skipped without their dependencies).
- [x] New `HandleResponse_UnsolicitedNonFinal_RoutesToDisplayStatus` and `HandleResponse_UnsolicitedFinal_RoutesToDisplayReply` cover the routing branch.
- [x] Blazor non-final tests flipped to `DisplayStatusAsync`; categorization assertions still hold.
- [ ] Smoke test on k8s: trigger a subagent task and confirm one final chat bubble plus an activity log for the subagent (no duplicate bubble).
- [ ] Confirm A2A status updates render the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)