### PR TITLE
Bump version to 0.10.30

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.10.29</Version>
+<Version>0.10.30</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->


### PR DESCRIPTION
## Summary

- Bumps `Directory.Build.props` from `0.10.29` to `0.10.30`.

## Why

The agent image running in the cluster is already on `0.10.30` (deployed during PR #341 validation to confirm the OCE/`RunPassAsync` log-noise cleanup). This brings `main` in line with the deployed tag.

## Test plan

- [x] One-line version bump; build/test unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)