### PR TITLE
Add regex mode to SearchMemory tool

### DIFF
--- a/src/RockBot.Agent/agent/common-directives.md
+++ b/src/RockBot.Agent/agent/common-directives.md
@@ -179,6 +179,12 @@ Call `search_memory` explicitly only when you want to search with a specific
 query that differs from the raw message (e.g., after clarification, or when you
 want to narrow to a category).
 
+`search_memory` has two modes. Use `mode='regex'` when you know the literal
+token you're hunting for — a file path, ID, version string, or exact phrase —
+and the regex matches against both the memory's path name (`category/id`) and
+its content. Otherwise leave the default `mode='hybrid'` for semantic/keyword
+search.
+
 ### Narrative identity
 
 Your evolving self-model is stored in long-term memory under `agent-identity/`

--- a/src/RockBot.Host.Abstractions/MemorySearchCriteria.cs
+++ b/src/RockBot.Host.Abstractions/MemorySearchCriteria.cs
@@ -4,7 +4,11 @@ namespace RockBot.Host;
 /// Criteria for searching long-term memory entries.
 /// All specified criteria are combined with AND logic.
 /// </summary>
-/// <param name="Query">Case-insensitive substring to match against content.</param>
+/// <param name="Query">
+/// In <see cref="MemorySearchMode.Hybrid"/> (default), a case-insensitive keyword/phrase to rank against.
+/// In <see cref="MemorySearchMode.Regex"/>, a .NET regex pattern matched against the entry's
+/// memory path name (<c>{category}/{id}</c> or <c>{id}</c>) plus its content, tags, and category words.
+/// </param>
 /// <param name="Category">Category prefix to match (e.g. "project-context" matches "project-context/rockbot").</param>
 /// <param name="Tags">Tags that entries must contain (all specified tags must be present).</param>
 /// <param name="CreatedAfter">Only include entries created after this time.</param>
@@ -13,7 +17,13 @@ namespace RockBot.Host;
 /// <param name="QueryEmbedding">
 /// Pre-computed query embedding vector. When provided, stores skip generating their own
 /// query embedding — avoiding redundant calls to the embedding endpoint when multiple
-/// searches share the same query text (e.g. during context building).
+/// searches share the same query text (e.g. during context building). Ignored in
+/// <see cref="MemorySearchMode.Regex"/>.
+/// </param>
+/// <param name="Mode">Search backend selector. Defaults to <see cref="MemorySearchMode.Hybrid"/>.</param>
+/// <param name="RegexCaseSensitive">
+/// When <see cref="Mode"/> is <see cref="MemorySearchMode.Regex"/>, controls case sensitivity of the regex.
+/// Default <c>false</c> mirrors Claude Code's Grep tool. Ignored in hybrid mode.
 /// </param>
 public sealed record MemorySearchCriteria(
     string? Query = null,
@@ -22,4 +32,6 @@ public sealed record MemorySearchCriteria(
     DateTimeOffset? CreatedAfter = null,
     DateTimeOffset? CreatedBefore = null,
     int MaxResults = 20,
-    float[]? QueryEmbedding = null);
+    float[]? QueryEmbedding = null,
+    MemorySearchMode Mode = MemorySearchMode.Hybrid,
+    bool RegexCaseSensitive = false);

--- a/src/RockBot.Host.Abstractions/MemorySearchException.cs
+++ b/src/RockBot.Host.Abstractions/MemorySearchException.cs
@@ -1,0 +1,14 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Thrown by memory search backends when a caller-supplied query cannot be executed —
+/// for example an invalid regex pattern, a per-entry match timeout, or an overall
+/// scan-budget overrun. The tool layer surfaces the message verbatim to the model so
+/// it can refine its query.
+/// </summary>
+public sealed class MemorySearchException : Exception
+{
+    public MemorySearchException(string message) : base(message) { }
+
+    public MemorySearchException(string message, Exception inner) : base(message, inner) { }
+}

--- a/src/RockBot.Host.Abstractions/MemorySearchMode.cs
+++ b/src/RockBot.Host.Abstractions/MemorySearchMode.cs
@@ -1,0 +1,21 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Backend used by <see cref="ILongTermMemory.SearchAsync"/> when scoring candidate entries
+/// against a query.
+/// </summary>
+public enum MemorySearchMode
+{
+    /// <summary>
+    /// Default. BM25 keyword ranking, optionally combined with vector similarity when
+    /// embeddings are configured. Recall-oriented and tolerant of paraphrase.
+    /// </summary>
+    Hybrid = 0,
+
+    /// <summary>
+    /// .NET regex pattern matched against the literal stored content (memory path name +
+    /// content + tags + category words). Exact and deterministic — preferred when the
+    /// caller already knows the literal token (file path, id, version, exact phrase).
+    /// </summary>
+    Regex = 1,
+}

--- a/src/RockBot.Host/FileMemoryStore.cs
+++ b/src/RockBot.Host/FileMemoryStore.cs
@@ -107,12 +107,23 @@ internal sealed partial class FileMemoryStore : ILongTermMemory
         // No query: return most-recently reinforced entries up to MaxResults.
         // Ordered by LastSeenAt (real reinforcement) rather than UpdatedAt (dream rewrites),
         // so dream housekeeping does not artificially promote entries in no-query results.
-        if (criteria.Query is null)
+        if (string.IsNullOrWhiteSpace(criteria.Query))
         {
             return candidates
                 .OrderByDescending(e => e.LastSeenAt)
                 .Take(criteria.MaxResults)
                 .ToList();
+        }
+
+        // Regex mode: literal pattern matching, no scoring, bounded by timeouts.
+        if (criteria.Mode == MemorySearchMode.Regex)
+        {
+            return RegexMatcher.MatchEntries(
+                candidates,
+                criteria.Query,
+                criteria.RegexCaseSensitive,
+                criteria.MaxResults,
+                BuildRegexSurface);
         }
 
         // With query: use hybrid ranking if embeddings available, else BM25-only.
@@ -261,6 +272,21 @@ internal sealed partial class FileMemoryStore : ILongTermMemory
         if (entry.Category is not null)
             parts.Add(entry.Category.Replace('/', ' ').Replace('-', ' '));
         return string.Join(" ", parts);
+    }
+
+    // ── Regex match surface ───────────────────────────────────────────────────
+
+    /// <summary>
+    /// Returns the text the regex backend matches against: the entry's logical memory
+    /// path name (<c>{category}/{id}</c> or <c>{id}</c> when uncategorized) on its own
+    /// line, then the BM25 document text (content + tags + category words). The on-disk
+    /// file path from <see cref="GetFilePath"/> is deliberately never included — the
+    /// model interacts with memories by id, not by storage layout.
+    /// </summary>
+    internal static string BuildRegexSurface(MemoryEntry entry)
+    {
+        var pathName = entry.Category is null ? entry.Id : $"{entry.Category}/{entry.Id}";
+        return $"{pathName}\n{GetDocumentText(entry)}";
     }
 
     // ── Structural Filter ─────────────────────────────────────────────────────

--- a/src/RockBot.Host/RegexMatcher.cs
+++ b/src/RockBot.Host/RegexMatcher.cs
@@ -1,0 +1,87 @@
+using System.Diagnostics;
+using System.Text.RegularExpressions;
+
+namespace RockBot.Host;
+
+/// <summary>
+/// Runs a caller-supplied regex pattern across a pre-filtered set of <see cref="MemoryEntry"/>
+/// candidates. Used by the regex backend of <see cref="ILongTermMemory.SearchAsync"/>.
+/// Bounds cost two ways: a per-entry <see cref="Regex.MatchTimeout"/> catches catastrophic
+/// backtracking on a single input, and an overall wall-clock budget across the scan stops a
+/// slow-but-not-pathological pattern from dominating as the corpus grows.
+/// </summary>
+internal static class RegexMatcher
+{
+    internal static readonly TimeSpan DefaultPerEntryTimeout = TimeSpan.FromSeconds(1);
+    internal static readonly TimeSpan DefaultOverallBudget = TimeSpan.FromSeconds(10);
+    internal const int MaxPatternLength = 512;
+
+    public static IReadOnlyList<MemoryEntry> MatchEntries(
+        IReadOnlyCollection<MemoryEntry> candidates,
+        string pattern,
+        bool caseSensitive,
+        int maxResults,
+        Func<MemoryEntry, string> documentText) =>
+        MatchEntries(candidates, pattern, caseSensitive, maxResults, documentText,
+            DefaultPerEntryTimeout, DefaultOverallBudget);
+
+    /// <summary>
+    /// Test-friendly overload that allows custom timeouts. Production callers should use
+    /// the parameterless-budget overload above.
+    /// </summary>
+    internal static IReadOnlyList<MemoryEntry> MatchEntries(
+        IReadOnlyCollection<MemoryEntry> candidates,
+        string pattern,
+        bool caseSensitive,
+        int maxResults,
+        Func<MemoryEntry, string> documentText,
+        TimeSpan perEntryTimeout,
+        TimeSpan overallBudget)
+    {
+        if (pattern.Length > MaxPatternLength)
+            throw new MemorySearchException(
+                $"Regex pattern exceeds {MaxPatternLength} characters. Narrow the pattern.");
+
+        Regex regex;
+        var options = RegexOptions.CultureInvariant;
+        if (!caseSensitive) options |= RegexOptions.IgnoreCase;
+        try
+        {
+            regex = new Regex(pattern, options, perEntryTimeout);
+        }
+        catch (ArgumentException ex)
+        {
+            throw new MemorySearchException($"Invalid regex pattern: {ex.Message}", ex);
+        }
+
+        var matches = new List<MemoryEntry>();
+        var sw = Stopwatch.StartNew();
+        var scanned = 0;
+        foreach (var entry in candidates)
+        {
+            if (sw.Elapsed > overallBudget)
+                throw new MemorySearchException(
+                    $"Regex search exceeded {overallBudget.TotalSeconds:F1}s after scanning " +
+                    $"{scanned}/{candidates.Count} entries. Narrow the pattern or add a category filter.");
+
+            scanned++;
+            try
+            {
+                if (regex.IsMatch(documentText(entry)))
+                    matches.Add(entry);
+            }
+            catch (RegexMatchTimeoutException ex)
+            {
+                throw new MemorySearchException(
+                    $"Regex match timed out after {perEntryTimeout.TotalSeconds:F1}s on a single entry. " +
+                    "Try a more specific pattern.", ex);
+            }
+        }
+
+        return matches
+            .OrderByDescending(e => e.ImportanceScore)
+            .ThenByDescending(e => e.LastSeenAt)
+            .Take(maxResults)
+            .ToList();
+    }
+}

--- a/src/RockBot.Memory/MemoryTools.cs
+++ b/src/RockBot.Memory/MemoryTools.cs
@@ -126,18 +126,34 @@ public sealed class MemoryTools
     }
 
     [Description("Search long-term memory for previously saved facts, preferences, or patterns. " +
-                 "Use query for keyword search and category for scoping to a knowledge area.")]
+                 "Use query for keyword search and category for scoping to a knowledge area. " +
+                 "Set mode='regex' when you know the literal token (file path, id, version, exact phrase); " +
+                 "otherwise leave mode='hybrid' (default) for semantic/keyword search.")]
     public async Task<string> SearchMemory(
-        [Description("Optional keyword to search for in memory content")] string? query = null,
-        [Description("Optional category prefix to filter by (e.g. 'user-preferences')")] string? category = null)
+        [Description("Optional keyword (hybrid mode) or .NET regex pattern (regex mode) to search for")] string? query = null,
+        [Description("Optional category prefix to filter by (e.g. 'user-preferences')")] string? category = null,
+        [Description("Search backend: 'hybrid' (default, BM25 + optional vector) or 'regex' (case-insensitive .NET regex against memory path name and content)")] string? mode = null)
     {
-        _logger.LogInformation("Tool call: SearchMemory(query={Query}, category={Category})", query, category);
+        _logger.LogInformation("Tool call: SearchMemory(query={Query}, category={Category}, mode={Mode})", query, category, mode);
+
+        if (!TryParseMode(mode, out var parsedMode))
+            return $"Unknown search mode '{mode}'. Use 'hybrid' or 'regex'.";
 
         var criteria = new MemorySearchCriteria(
             Query: string.IsNullOrWhiteSpace(query) ? null : query.Trim(),
-            Category: string.IsNullOrWhiteSpace(category) ? null : category.Trim());
+            Category: string.IsNullOrWhiteSpace(category) ? null : category.Trim(),
+            Mode: parsedMode);
 
-        var results = await _memory.SearchAsync(criteria);
+        IReadOnlyList<MemoryEntry> results;
+        try
+        {
+            results = await _memory.SearchAsync(criteria);
+        }
+        catch (MemorySearchException ex)
+        {
+            _logger.LogInformation("SearchMemory rejected by backend: {Message}", ex.Message);
+            return ex.Message;
+        }
 
         _logger.LogInformation("SearchMemory returned {Count} results", results.Count);
 
@@ -158,6 +174,21 @@ public sealed class MemoryTools
         }
 
         return sb.ToString();
+    }
+
+    private static bool TryParseMode(string? mode, out MemorySearchMode parsed)
+    {
+        if (string.IsNullOrWhiteSpace(mode))
+        {
+            parsed = MemorySearchMode.Hybrid;
+            return true;
+        }
+
+        if (Enum.TryParse(mode.Trim(), ignoreCase: true, out parsed))
+            return true;
+
+        parsed = MemorySearchMode.Hybrid;
+        return false;
     }
 
     private static string FormatAge(MemoryEntry e)

--- a/tests/RockBot.Agent.Tests/MemoryToolsTests.cs
+++ b/tests/RockBot.Agent.Tests/MemoryToolsTests.cs
@@ -223,6 +223,72 @@ public class MemoryToolsTests
     }
 
     // -------------------------------------------------------------------------
+    // SearchMemory — mode parameter
+    // -------------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task SearchMemory_DefaultMode_PassesHybrid()
+    {
+        var memory = new StubLongTermMemory();
+        var tools = MakeTools(memory);
+
+        await tools.SearchMemory("anything");
+
+        Assert.IsNotNull(memory.LastCriteria);
+        Assert.AreEqual(MemorySearchMode.Hybrid, memory.LastCriteria.Mode);
+    }
+
+    [TestMethod]
+    public async Task SearchMemory_ModeRegex_PassesRegex()
+    {
+        var memory = new StubLongTermMemory();
+        var tools = MakeTools(memory);
+
+        await tools.SearchMemory("anything", mode: "Regex");
+
+        Assert.IsNotNull(memory.LastCriteria);
+        Assert.AreEqual(MemorySearchMode.Regex, memory.LastCriteria.Mode);
+    }
+
+    [TestMethod]
+    public async Task SearchMemory_ModeRegex_LowerCase_PassesRegex()
+    {
+        var memory = new StubLongTermMemory();
+        var tools = MakeTools(memory);
+
+        await tools.SearchMemory("anything", mode: "regex");
+
+        Assert.IsNotNull(memory.LastCriteria);
+        Assert.AreEqual(MemorySearchMode.Regex, memory.LastCriteria.Mode);
+    }
+
+    [TestMethod]
+    public async Task SearchMemory_UnknownMode_ReturnsErrorString_AndDoesNotCallStore()
+    {
+        var memory = new StubLongTermMemory();
+        var tools = MakeTools(memory);
+
+        var result = await tools.SearchMemory("anything", mode: "fuzzy");
+
+        StringAssert.Contains(result, "Unknown search mode");
+        Assert.IsNull(memory.LastCriteria, "Store should not be called for an invalid mode.");
+    }
+
+    [TestMethod]
+    public async Task SearchMemory_MemorySearchException_ReturnsMessage()
+    {
+        var memory = new StubLongTermMemory
+        {
+            SearchOverride = _ => throw new MemorySearchException("bad pattern: nope")
+        };
+        var tools = MakeTools(memory);
+
+        var result = await tools.SearchMemory("[", mode: "regex");
+
+        StringAssert.Contains(result, "bad pattern: nope");
+    }
+
+    // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
 
@@ -246,6 +312,9 @@ internal sealed class StubLongTermMemory : ILongTermMemory
 {
     private readonly List<MemoryEntry> _entries = [];
 
+    public MemorySearchCriteria? LastCriteria { get; private set; }
+    public Func<MemorySearchCriteria, IReadOnlyList<MemoryEntry>>? SearchOverride { get; set; }
+
     public void Add(MemoryEntry entry) => _entries.Add(entry);
 
     public Task SaveAsync(MemoryEntry entry, CancellationToken cancellationToken = default)
@@ -256,8 +325,12 @@ internal sealed class StubLongTermMemory : ILongTermMemory
     }
 
     public Task<IReadOnlyList<MemoryEntry>> SearchAsync(
-        MemorySearchCriteria criteria, CancellationToken cancellationToken = default) =>
-        Task.FromResult<IReadOnlyList<MemoryEntry>>([.. _entries]);
+        MemorySearchCriteria criteria, CancellationToken cancellationToken = default)
+    {
+        LastCriteria = criteria;
+        var results = SearchOverride is not null ? SearchOverride(criteria) : (IReadOnlyList<MemoryEntry>)[.. _entries];
+        return Task.FromResult(results);
+    }
 
     public Task<MemoryEntry?> GetAsync(string id, CancellationToken cancellationToken = default) =>
         Task.FromResult(_entries.FirstOrDefault(e => e.Id == id));

--- a/tests/RockBot.Host.Tests/FileMemoryStoreTests.cs
+++ b/tests/RockBot.Host.Tests/FileMemoryStoreTests.cs
@@ -419,6 +419,224 @@ public class FileMemoryStoreTests
         Assert.IsTrue(results.Any(r => r.Id == "content"));
     }
 
+    // ── Regex mode ────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task Search_RegexMode_MatchesLiteralToken()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(CreateEntry("v0", "deploy v0.10.30 to staging"));
+        await store.SaveAsync(CreateEntry("other", "unrelated content"));
+
+        var results = await store.SearchAsync(new MemorySearchCriteria(
+            Query: @"v\d+\.\d+\.\d+", Mode: MemorySearchMode.Regex));
+
+        Assert.AreEqual(1, results.Count);
+        Assert.AreEqual("v0", results[0].Id);
+    }
+
+    [TestMethod]
+    public async Task Search_RegexMode_MatchesMemoryIdInPathName()
+    {
+        var store = CreateStore();
+        // Content does not mention "openrouter-key" — only the id does.
+        await store.SaveAsync(CreateEntry("openrouter-key-rotation", "An unrelated note about rotation."));
+        await store.SaveAsync(CreateEntry("foo", "Different entry."));
+
+        var results = await store.SearchAsync(new MemorySearchCriteria(
+            Query: "openrouter-key", Mode: MemorySearchMode.Regex));
+
+        Assert.AreEqual(1, results.Count);
+        Assert.AreEqual("openrouter-key-rotation", results[0].Id);
+    }
+
+    [TestMethod]
+    public async Task Search_RegexMode_MatchesCategoryInPathName()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(CreateEntry("foo", "Some content", category: "project-context"));
+        await store.SaveAsync(CreateEntry("bar", "Other content", category: "user-preferences"));
+
+        var results = await store.SearchAsync(new MemorySearchCriteria(
+            Query: @"^project-context/", Mode: MemorySearchMode.Regex));
+
+        Assert.AreEqual(1, results.Count);
+        Assert.AreEqual("foo", results[0].Id);
+    }
+
+    [TestMethod]
+    public async Task Search_RegexMode_DoesNotMatchOnDiskFilePath()
+    {
+        // The on-disk path ends in ".json" but the regex surface deliberately omits it.
+        // A pattern that hits the storage layout (.json suffix) must not match anything.
+        var store = CreateStore();
+        await store.SaveAsync(CreateEntry("entry-1", "Some plain content"));
+
+        var results = await store.SearchAsync(new MemorySearchCriteria(
+            Query: @"\.json$", Mode: MemorySearchMode.Regex));
+
+        Assert.AreEqual(0, results.Count, "Storage-layout details must not be exposed to regex matches.");
+    }
+
+    [TestMethod]
+    public async Task Search_RegexMode_DefaultIsCaseInsensitive()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(CreateEntry("h", "Helm release in cluster"));
+
+        var results = await store.SearchAsync(new MemorySearchCriteria(
+            Query: "helm", Mode: MemorySearchMode.Regex));
+
+        Assert.AreEqual(1, results.Count);
+    }
+
+    [TestMethod]
+    public async Task Search_RegexMode_CaseSensitive_RespectsFlag()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(CreateEntry("h", "Helm release in cluster"));
+
+        var lowerResults = await store.SearchAsync(new MemorySearchCriteria(
+            Query: "helm", Mode: MemorySearchMode.Regex, RegexCaseSensitive: true));
+        Assert.AreEqual(0, lowerResults.Count);
+
+        var upperResults = await store.SearchAsync(new MemorySearchCriteria(
+            Query: "Helm", Mode: MemorySearchMode.Regex, RegexCaseSensitive: true));
+        Assert.AreEqual(1, upperResults.Count);
+    }
+
+    [TestMethod]
+    public async Task Search_RegexMode_HonorsCategoryFilter()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(CreateEntry("a", "shared keyword", category: "project-context"));
+        await store.SaveAsync(CreateEntry("b", "shared keyword", category: "user-preferences"));
+
+        var results = await store.SearchAsync(new MemorySearchCriteria(
+            Query: "shared", Category: "project-context", Mode: MemorySearchMode.Regex));
+
+        Assert.AreEqual(1, results.Count);
+        Assert.AreEqual("a", results[0].Id);
+    }
+
+    [TestMethod]
+    public async Task Search_RegexMode_RespectsMaxResults()
+    {
+        var store = CreateStore();
+        for (int i = 0; i < 10; i++)
+            await store.SaveAsync(CreateEntry($"e{i}", "matching content"));
+
+        var results = await store.SearchAsync(new MemorySearchCriteria(
+            Query: "matching", Mode: MemorySearchMode.Regex, MaxResults: 3));
+
+        Assert.AreEqual(3, results.Count);
+    }
+
+    [TestMethod]
+    public async Task Search_RegexMode_InvalidPattern_Throws()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(CreateEntry("a", "anything"));
+
+        await Assert.ThrowsExactlyAsync<MemorySearchException>(async () =>
+        {
+            await store.SearchAsync(new MemorySearchCriteria(
+                Query: "[", Mode: MemorySearchMode.Regex));
+        });
+    }
+
+    [TestMethod]
+    public async Task Search_RegexMode_NoMatches_ReturnsEmpty()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(CreateEntry("a", "the cat sat on the mat"));
+
+        var results = await store.SearchAsync(new MemorySearchCriteria(
+            Query: "nothing-here", Mode: MemorySearchMode.Regex));
+
+        Assert.AreEqual(0, results.Count);
+    }
+
+    [TestMethod]
+    public async Task Search_RegexMode_OrdersByImportanceThenLastSeen()
+    {
+        var store = CreateStore();
+        var now = DateTimeOffset.UtcNow;
+
+        await store.SaveAsync(new MemoryEntry("low", "shared content", null, [], now,
+            ImportanceScore: 0.2f) { LastSeenAt = now });
+        await store.SaveAsync(new MemoryEntry("highOld", "shared content", null, [], now.AddDays(-10),
+            ImportanceScore: 0.9f) { LastSeenAt = now.AddDays(-10) });
+        await store.SaveAsync(new MemoryEntry("highRecent", "shared content", null, [], now,
+            ImportanceScore: 0.9f) { LastSeenAt = now });
+
+        var results = await store.SearchAsync(new MemorySearchCriteria(
+            Query: "shared", Mode: MemorySearchMode.Regex));
+
+        Assert.AreEqual(3, results.Count);
+        Assert.AreEqual("highRecent", results[0].Id, "Highest importance, most recent wins.");
+        Assert.AreEqual("highOld", results[1].Id, "Same importance, older LastSeenAt comes second.");
+        Assert.AreEqual("low", results[2].Id);
+    }
+
+    [TestMethod]
+    public async Task Search_RegexMode_NullQuery_FallsBackToNoQueryPath()
+    {
+        var store = CreateStore();
+        var now = DateTimeOffset.UtcNow;
+        await store.SaveAsync(new MemoryEntry("old", "old", null, [], now.AddDays(-5)));
+        await store.SaveAsync(new MemoryEntry("new", "new", null, [], now));
+
+        var results = await store.SearchAsync(new MemorySearchCriteria(
+            Mode: MemorySearchMode.Regex));
+
+        Assert.AreEqual(2, results.Count);
+        Assert.AreEqual("new", results[0].Id, "Null query falls through to LastSeenAt ordering.");
+    }
+
+    [TestMethod]
+    public void Search_RegexMode_PathologicalPattern_ThrowsTimeout()
+    {
+        // Catastrophic backtracking: (a+)+$ on a string that's all 'a's plus a trailing 'b'.
+        // Force a tiny per-entry timeout so the test stays under ~200ms.
+        var entry = new MemoryEntry("evil", new string('a', 60) + "b", null, [], DateTimeOffset.UtcNow);
+
+        Assert.ThrowsExactly<MemorySearchException>(() =>
+            RegexMatcher.MatchEntries(
+                new[] { entry },
+                @"(a+)+$",
+                caseSensitive: false,
+                maxResults: 10,
+                FileMemoryStore.BuildRegexSurface,
+                perEntryTimeout: TimeSpan.FromMilliseconds(50),
+                overallBudget: TimeSpan.FromSeconds(5)));
+    }
+
+    [TestMethod]
+    public void Search_RegexMode_OverallBudget_BoundsTotalScan()
+    {
+        // Build many candidates and force per-entry surface generation to be slow via the
+        // documentText delegate. Each "entry" adds ~5ms to wall clock; with a 30ms overall
+        // budget we expect to throw before scanning all 200.
+        var now = DateTimeOffset.UtcNow;
+        var candidates = Enumerable.Range(0, 200)
+            .Select(i => new MemoryEntry($"e{i}", "content", null, [], now))
+            .ToList();
+
+        var ex = Assert.ThrowsExactly<MemorySearchException>(() =>
+            RegexMatcher.MatchEntries(
+                candidates,
+                "content",
+                caseSensitive: false,
+                maxResults: 10,
+                e => { Thread.Sleep(5); return e.Content; },
+                perEntryTimeout: TimeSpan.FromSeconds(1),
+                overallBudget: TimeSpan.FromMilliseconds(30)));
+
+        StringAssert.Contains(ex.Message, "/200");
+        StringAssert.Contains(ex.Message, "exceeded");
+    }
+
     // ── Tokenizer unit tests ──────────────────────────────────────────────────
 
     [TestMethod]


### PR DESCRIPTION
## Summary

- Adds a `mode` parameter to the `SearchMemory` tool: `hybrid` (default — BM25 + optional vector, unchanged) or `regex` (literal pattern matching).
- Regex backend matches against each entry's logical memory path name (`{category}/{id}`) plus the BM25 document text (content + tags + category words). The on-disk file path from `FileMemoryStore.GetFilePath` is deliberately never in the match surface — the model operates in id-space.
- Two-layer cost ceiling: per-entry `Regex.MatchTimeout` of 1s catches catastrophic backtracking on a single input; an overall 10s wall-clock budget across the scan stops a slow-but-not-pathological pattern from dominating as the corpus grows.
- New `MemorySearchException` carries human-readable backend errors (invalid pattern, per-entry timeout, overall budget) up to the tool layer, which surfaces the message verbatim so the model can refine its query.
- Hybrid path, vector cache, and `_embeddingCache` are skipped entirely in regex mode — behaves identically whether the deployment runs hybrid or BM25-only.
- Updated `common-directives.md` (loaded by both primary and sub agents) with one short paragraph teaching when to reach for `mode='regex'`.

## Test plan

- [x] `dotnet build RockBot.slnx` — clean
- [x] `dotnet test RockBot.slnx` — full unit suite green (615 Host tests, 130 Agent tests, all others pass)
- [x] Targeted `Search_RegexMode_*` tests cover: literal-token match, id-in-path match, category-in-path match, on-disk-path-must-not-leak, default case-insensitive, case-sensitive flag, category pre-filter, MaxResults cap, invalid pattern → exception, no-match → empty, importance/last-seen ordering, null-query fallback, catastrophic-backtracking timeout, overall-budget overrun
- [x] `MemoryToolsTests` cover: default mode is hybrid, `regex` / `Regex` parsed, unknown mode returns error string and skips the store, `MemorySearchException` flows through verbatim
- [ ] Optional manual verification in a live cluster (out of scope — unit coverage is sufficient per issue)

Closes #339

🤖 Generated with [Claude Code](https://claude.com/claude-code)