### PR TITLE
Add observation framework and LLM gateway design docs

### DIFF
--- a/design/llm-gateway.md
+++ b/design/llm-gateway.md
@@ -1,0 +1,154 @@
+# LLM Gateway
+
+## Problem
+
+LLM calls in RockBot today are made directly from many call sites — handlers, the dream service, subagent runners, A2A handlers — each going through `ILlmClient` to the underlying SDK. There is no global throttling and no centralized retry policy. Three problems result:
+
+1. **Rate limiting is ad-hoc.** When the provider returns 429, behavior depends on whatever the SDK does by default. Call sites do not coordinate. Bursty work (especially planned parallel dream phases) can overwhelm a tier and produce cascades of failures.
+2. **Cross-cutting concerns are scattered.** Retry, backoff, metrics, cost recording — all of these belong in one place but currently are not anywhere.
+3. **No clean way for user work to outrun background work.** A user message arriving while the dream cycle is mid-flight needs to get LLM capacity. Today this works only because the work-serializer cancels the dream cycle outright; LLM-level coordination is implicit.
+
+The trigger for this design is the [observation framework](observation-framework.md), whose parallelism makes the rate-limit story untenable without coordination. But the gateway is independently valuable.
+
+## Goals
+
+- Single chokepoint for every LLM call, regardless of caller.
+- Per-tier concurrency caps (Low / Balanced / High treated independently).
+- Honor `Retry-After` on 429s, with exponential backoff as fallback.
+- Cancellation propagates end-to-end: pending and in-flight calls abort when their `ct` fires.
+- User-facing calls effectively preempt background calls without a priority queue.
+- Centralized observability: token counts, latency, retry counts, queue depth, cost.
+- Bounded queue depth: the system fails fast under sustained rate limiting rather than piling up indefinitely.
+
+## Non-goals
+
+- Priority queues / priority lanes. User-priority semantics are achieved via cancellation (see "User priority"). Lanes were considered and rejected as unneeded complexity.
+- Replacing the SDK. The gateway wraps the SDK; it does not reimplement provider clients.
+- Per-call routing across providers. Tier selection remains the caller's concern; the gateway only mediates calls within whatever tier the caller chose.
+- Solving observation-framework parallelism by itself. The gateway is a prerequisite, not a replacement.
+
+## Architecture
+
+Every LLM call passes through the gateway. The gateway holds per-tier `SemaphoreSlim` instances and applies retry middleware on the way through.
+
+```
+   Caller (handler / dream phase / subagent)
+        │  ILlmClient.GetResponseAsync(request, ct)
+        ▼
+   ┌─────────────────────────────────────────────────┐
+   │  LlmGateway                                     │
+   │                                                 │
+   │   await _tierSemaphores[tier].WaitAsync(ct);    │
+   │   try {                                         │
+   │     // retry middleware:                        │
+   │     //   on 429 -> honor Retry-After or         │
+   │     //   exponential backoff (ct-aware sleep)   │
+   │     //   max attempts capped                    │
+   │     // metrics: tokens, latency, retries, $$    │
+   │   } finally {                                   │
+   │     _tierSemaphores[tier].Release();            │
+   │   }                                             │
+   └────────────────────┬────────────────────────────┘
+                        │
+                        ▼
+                Provider SDK (with built-in retry disabled)
+```
+
+The gateway is the only direct consumer of the provider SDK. `ILlmClient` implementations that bypass it must be removed.
+
+## Cancellation, not priority lanes
+
+User-priority semantics emerge from cancellation. A priority queue was considered and rejected.
+
+The reasoning: the work-serializer already cancels the dream when a user message arrives (`DreamService.DreamAsync` acquires via `TryAcquireForScheduledAsync`, which yields a CT that fires on preemption). When dream's `ct` fires:
+
+- `SemaphoreSlim.WaitAsync(ct)` causes every dream LLM call currently waiting in the queue to throw `OperationCanceledException` and exit, freeing slots.
+- In-flight LLM calls inside dream phases see `ct` cancelled and the SDK request aborts.
+- The user-facing call's `WaitAsync` then succeeds promptly.
+
+This gives the same outcome as priority lanes — user calls do not wait behind dream calls — without any of the complexity that priority brings: no ambient priority context, no envelope priority field on cross-bus calls, no subagent priority inheritance question, no priority-aware retry semantics.
+
+The one behavioral difference: priority lanes would let dream continue running its non-contending calls during a brief user turn, whereas cancellation drops the dream's queued work entirely. Since the work-serializer already cancels the entire dream cycle on user preemption, this is not a regression — it matches the existing architecture.
+
+## Retry policy
+
+On 429:
+
+1. If the response carries a `Retry-After` header (Anthropic and OpenAI both do), wait that long. The wait is `ct`-aware (`Task.Delay(retryAfter, ct)`).
+2. If no `Retry-After`, fall back to exponential backoff: 1s, 2s, 4s, 8s, capped at some configurable maximum (16s suggested).
+3. After a configurable maximum number of retries (default 5), surface the failure to the caller. The caller decides what to do.
+
+The slot is held during the retry wait. Releasing the slot during the wait does not help: rate limits are per-tier, so any other call in that tier will hit the same limit. Holding the slot also keeps priority semantics simple: a retried call does not jump ahead of a newly-arrived call (or vice versa) because there is no priority to think about.
+
+The provider SDK's built-in retry MUST be disabled. Gateway and SDK both retrying causes them to fight: the SDK retries silently, gateway sees success, then the same call hits the limit again. The gateway owns retry; the SDK does not.
+
+Other error classes (5xx, network errors) get their own short retry policy (1 retry with brief backoff) for transient failures, but are not the primary concern. 401/403 and 4xx-other are non-retryable and surface immediately.
+
+## Cancellation discipline
+
+This is the load-bearing implementation requirement. Every LLM call site must accept and flow `ct` through to the gateway, and the gateway must flow `ct` through to the SDK. Any path that uses `CancellationToken.None` is a black hole: user preemption stops working for that path, and the cancellation-as-priority story breaks.
+
+Concrete enforcement options:
+
+- **Mandatory `ct` parameter at the gateway boundary.** No overload accepting `default`. Call sites must explicitly pass a token; the analyzer/compiler catches missed propagation.
+- **Audit pass on existing call sites.** Every existing `ILlmClient` consumer needs review to confirm `ct` is passed.
+- **Test coverage.** A test that cancels a CT during a simulated long LLM call and asserts the call aborts within a bounded time. Run for each tier.
+
+## Bounded queue depth
+
+`SemaphoreSlim`'s implicit waiter queue is unbounded. Under sustained rate limiting, callers pile up and a dream cycle that should run for 5 minutes runs for an hour. Two options for bounding:
+
+- **Fail-fast**: `MaxPendingPerTier` config; once exceeded, new calls fail immediately with a "gateway saturated" error. Caller decides whether to retry, defer, or skip. Simplest.
+- **Shed-oldest**: cancel the oldest pending waiter when a new call arrives at the cap. More complex, but means "freshness" wins under load.
+
+Recommendation: start with fail-fast. It is much simpler and the dream cycle can choose to skip a phase rather than block. Shed-oldest is only worth it if a real workload demands it.
+
+## Tier configuration
+
+Each tier has an independent `SemaphoreSlim`. Initial caps (configurable):
+
+- **Low**: higher concurrency cap (e.g. 8). Cheap calls, used heavily by extraction in observation phases and similar batch work.
+- **Balanced**: moderate (e.g. 4).
+- **High**: lower (e.g. 2). Expensive calls, used for judgment work.
+
+Caps are per-process. Across multiple agent processes against the same provider account, total concurrency is the sum. Per-account rate limits ultimately bound the system; the gateway is a per-process governor, not a global one.
+
+## Metrics
+
+Recorded at the gateway, per call:
+
+- Tier
+- Latency (semaphore wait, in-flight, total)
+- Token counts (input, output, cached if available)
+- Cost (computed from tokens × tier price)
+- Retry count (and whether it terminated in success or failure)
+- Outcome (success, retry-exhausted, cancelled, network-failure, non-retryable-error)
+
+Aggregated per tier:
+
+- Current queue depth
+- In-flight count
+- Slots free
+- Rolling RPM and TPM
+
+Surface via the existing telemetry pipeline (logs at minimum; metrics endpoint if one exists).
+
+## Implementation phases
+
+1. **Wrap, don't replace.** The gateway is a thin layer in front of `ILlmClient` (or whatever the existing abstraction is). Existing call sites already go through that abstraction; the gateway is plumbed in behind it without touching call sites.
+2. **Disable SDK retry.** Configure the underlying SDK clients to not retry. Confirm via test.
+3. **Add per-tier semaphores + retry middleware.** Honor `Retry-After`, exponential fallback, ct-aware sleeps.
+4. **Audit ct propagation.** Walk every existing LLM call site, confirm ct flows. Fix any that pass `None`.
+5. **Add metrics.** Wire tokens / latency / retries through the existing telemetry pipeline.
+6. **Add bounded queue.** Start with fail-fast.
+7. **Test cancellation contract.** Per-tier test that asserts cancellation aborts pending and in-flight calls promptly.
+
+Step 4 is the one that has follow-on work elsewhere in the codebase. Each violation is small but they have to all be fixed before the cancellation guarantee holds.
+
+## Open questions
+
+- **Cap defaults.** The 8/4/2 split above is a guess. Real workload will inform tuning. Should be config-overridable.
+- **Cross-process coordination.** If multiple agent processes run against the same provider account, per-process caps undercount real concurrency. Out of scope for v1, but worth noting as a future concern (Redis-backed gateway? provider-side rate-limit tracking?).
+- **Streaming responses.** Do any current call sites use streaming? If so, "in-flight" measurement and cancellation behave differently. Confirm during the audit pass.
+- **Subagent message-bus boundary.** Subagent calls are dispatched via `IMessagePublisher`, which means `ct` does not naturally cross the bus. The receiving handler establishes a fresh `ct` from its own work-serializer slot, which is the right behavior — but worth confirming that no LLM calls inside a subagent handler accidentally fall back to `None` because the original ct didn't survive the boundary.
+- **Retry budget per call vs. per cycle.** Should there be a global budget on retries-per-dream-cycle so that a degraded provider doesn't burn the whole cycle on a single phase's retries? Probably premature, but record as a thought.

--- a/design/observation-framework.md
+++ b/design/observation-framework.md
@@ -1,0 +1,232 @@
+# Observation Framework
+
+## Problem
+
+The agent maintains "theory of self" and "theory of user" markdown files that are intended to evolve over time as the agent observes its own behavior and the user's. In practice, they only evolve when the user explicitly asks the agent to update them — there is no recurring process driving accumulation, so the files stagnate and never reflect actual ongoing observation.
+
+More broadly: the agent has no general mechanism for *accumulating evidence-based observations over time about anything*. Skills are recallable knowledge, memory is recallable facts, but neither serves the role of "observations that compound across many interactions, get reinforced or fade, and graduate into stable knowledge." That is the gap this design fills.
+
+The two theory-of files are the first concrete consumers, but the framework is intended to be reused for additional observational domains as they emerge.
+
+## Goals
+
+- Theories (and other observational artifacts) evolve continuously, not on-demand.
+- Observations are grounded in concrete evidence (quotes, conversation references), not generative LLM confabulation.
+- The mechanism is general: new observational domains can be added by configuration, not by code.
+- Single observations never become facts. Evidence must accumulate across multiple dreams before promotion.
+- Stale observations age out without manual intervention.
+- Cost-tiered: cheap LLM for high-recall extraction, expensive LLM only for judgment.
+- Parallelizable from day one. Dream cycle runtime is already a concern; new phases must not make it worse.
+
+## Non-goals
+
+- Eliminating the LLM. Extraction and evaluation are LLM tasks; only bookkeeping is deterministic.
+- Real-time observation. This is dream-cycle work, not per-turn.
+- Self-editing of always-loaded directives. The framework owns regeneration; the agent does not edit its own theory files.
+- Solving broader dream-cycle parallelism. That is a separate effort. The new phase introduced here parallelizes *within itself*.
+
+## Background: why not just edit directives?
+
+An earlier proposal was a "learned-directives.md" file the agent could self-edit, always loaded into context. That was rejected because the always-loaded + self-editable + unbounded combination violates "nothing trusts the LLM" more than skills do — skills are scoped recall-on-demand, while a self-authored directive file becomes the agent's own constitution. For habits the designer can name today, editing the human-authored `directives.md` is the cleaner answer. The observation framework is for habits and traits the agent *discovers* through evidence, where the framework — not the LLM — owns the data and the promotion logic.
+
+## Architecture overview
+
+```
+       Dream cycle
+       │
+       ▼
+ ┌────────────────────────────────────────────────────────────┐
+ │  ObservationPhase  (one phase in DreamService)             │
+ │                                                            │
+ │  parallel(targets):                                        │
+ │    ┌──────────────────────────────────────────────────┐    │
+ │    │  Per target:                                     │    │
+ │    │                                                  │    │
+ │    │  Phase 1: Extract + Merge                        │    │
+ │    │    parallel(conversations):                      │    │
+ │    │      Low-tier LLM extracts observations          │    │
+ │    │      with quote citations                        │    │
+ │    │    join: embed each observation, cluster         │    │
+ │    │      against existing candidates (vectors),      │    │
+ │    │      deterministically merge counts + refs       │    │
+ │    │                                                  │    │
+ │    │  Phase 2: Evaluate + Promote + Age + Regen       │    │
+ │    │    Higher-tier LLM evaluates candidates that     │    │
+ │    │      crossed the promotion threshold             │    │
+ │    │    Promote → theories list (deterministic)       │    │
+ │    │    Age out unreinforced candidates and theories  │    │
+ │    │    Regenerate markdown from JSON via template    │    │
+ │    └──────────────────────────────────────────────────┘    │
+ └────────────────────────────────────────────────────────────┘
+```
+
+JSON is the source of truth. Markdown is regenerated each cycle as a deterministic template render.
+
+## Configured targets (initial)
+
+Two targets at launch. Each is an independent instance of the same pipeline.
+
+### theory-of-self
+
+- **Input filter**: all turns from the conversation log since the last dream.
+- **Augmentation**: structured behavior summary per conversation (tool call count, iteration count, retried-after-error, exceeded-budget, self-corrected) computed mechanically — not asked of an LLM.
+- **Tag observations with trigger context** (conversation / scheduled / heartbeat). Otherwise the agent will conclude things about itself that are only true of one mode.
+- **Promotion threshold**: higher (more turns produce noisier evidence).
+
+### theory-of-user
+
+- **Input filter**: turns where `Source == user`, plus the agent responses to them. Not the agent's intermediate tool calls or scheduled-task activity — the user never sees those, so they aren't user signal. "User-authored" rather than "user-initiated": replies inside an agent-started chain still count.
+- **Augmentation**: none. Tool noise is irrelevant here.
+- **Promotion threshold**: lower (each user turn is a deliberate human choice, denser signal per turn).
+
+The two pipelines are independent and run in parallel.
+
+## Per-target configuration shape
+
+```csharp
+public sealed class ObservationTarget
+{
+    public string Name { get; init; }
+    public ITranscriptFilter Filter { get; init; }
+    public string ExtractionPrompt { get; init; }
+    public string EvaluationPrompt { get; init; }
+    public string StateFilePath { get; init; }      // JSON
+    public string OutputMarkdownPath { get; init; }
+    public LlmTier ExtractionTier { get; init; }    // Low
+    public LlmTier EvaluationTier { get; init; }    // Balanced/High
+    public int PromotionThreshold { get; init; }    // distinct conversations
+    public int CandidateAgingWindowDreams { get; init; }
+    public int TheoryAgingWindowDreams { get; init; }
+    public bool IncludeBehaviorSummary { get; init; }
+}
+```
+
+## State file shape (JSON)
+
+One file per target. Schema versioned for future migration.
+
+```jsonc
+{
+  "schemaVersion": 1,
+  "lastDreamAt": "2026-05-07T12:00:00Z",
+  "candidates": [
+    {
+      "id": "cand_abc123",
+      "text": "User reverts diffs that touch tests they did not ask about.",
+      "clusterId": "clust_42",
+      "count": 2,
+      "firstSeen": "2026-04-22T11:00:00Z",
+      "lastSeen": "2026-05-03T09:30:00Z",
+      "references": [
+        { "conversationId": "conv_001", "turnId": "turn_017", "quote": "..." },
+        { "conversationId": "conv_044", "turnId": "turn_004", "quote": "..." }
+      ]
+    }
+  ],
+  "theories": [
+    {
+      "id": "thry_xyz789",
+      "text": "User prefers terse responses with no trailing summaries.",
+      "promotedAt": "2026-03-15T08:00:00Z",
+      "lastReinforced": "2026-05-06T18:00:00Z",
+      "sourceCandidateIds": ["cand_..."],
+      "references": [ /* same shape */ ]
+    }
+  ]
+}
+```
+
+References (conversation id + turn id + quote) are the load-bearing piece. They are what makes "promote when seen N times" honest — N distinct conversations, not N paraphrases of one.
+
+## Pipeline mechanics
+
+### Phase 1: Extract + Merge
+
+Per conversation in the input set (parallel, bounded by the LLM gateway):
+
+1. Format the conversation according to the target's filter and augmentation rules.
+2. Low-tier LLM call with the target's extraction prompt. Output: a list of candidate observations, each with at least one verbatim quote from the input.
+3. Validation: drop any observation whose claimed quote is not actually present in the source. This is the single biggest anti-hallucination lever.
+
+After all per-conversation extractions complete, join (single-threaded, in-memory, fast):
+
+4. Embed each observation (local vector model — free in production environments).
+5. Cluster against existing candidate vectors. Match threshold is target-configurable.
+6. For each match, increment count and append references. For non-matches, create a new candidate.
+7. Slightly imperfect clustering is fine — Phase 2 sorts it out.
+
+### Phase 2: Evaluate + Promote + Age + Regenerate
+
+Per target (parallel across targets):
+
+1. Identify candidates whose count has crossed the promotion threshold and that have not yet been promoted.
+2. Higher-tier LLM call with the evaluation prompt. Differential framing: "for each candidate, is it grounded in the cited references? does it conflict with existing theories? should it be promoted, refined, or rejected?" Verification against fixed input is much harder to confabulate than open-ended generation.
+3. Apply the LLM's verdicts deterministically: promoted candidates become theory entries (carrying their references); rejected ones are removed.
+4. Aging (deterministic):
+   - Drop candidates with no new references in the last *K* dreams.
+   - Drop or demote theories with no new supporting references in the last *M* dreams (M > K).
+5. Regenerate the markdown file from the JSON state via a pure template. No LLM polish — that re-introduces the rewriting risk.
+
+## Anti-hallucination levers (summary)
+
+The pipeline assumes the LLM will confabulate if given the chance. Defenses, in order of importance:
+
+1. **Quote-grounding.** Every observation must cite a verbatim quote from the input. Mechanically validated. No quote = observation discarded before it enters the pool.
+2. **Behavior-only, not motivation.** Observations describe observable actions, not inferred mental state. "User reverts test diffs" stays; "user values test stability" doesn't.
+3. **Differential evaluation.** Phase 2 verifies candidates against existing theories rather than generating freely.
+4. **Multi-conversation graduation.** Single instances don't promote. A hallucinated pattern would have to be hallucinated the same way in independent conversations, which is unlikely.
+5. **Aging.** Anomalies that don't reinforce fade out automatically.
+
+## Parallelism
+
+Two levels:
+
+- **Across targets**: each configured target runs the full pipeline in parallel with others.
+- **Within a target, Phase 1**: per-conversation extraction calls run concurrently.
+
+Joins (cluster-merge, evaluation-promotion-aging-regen) are deterministic and serial within a target, but are cheap.
+
+Concurrency is not bounded by the framework itself — it is bounded by the LLM gateway (see "Dependency: LLM gateway" below). The framework dispatches without restraint and lets the gateway throttle.
+
+## Dream cycle integration
+
+Today, `DreamService.DreamAsync` runs ~15 phases serially with `ct.ThrowIfCancellationRequested()` between each so a user message can preempt. The observation phase slots in as one additional phase. Internal parallelism is the framework's concern; the dream cycle just calls into it.
+
+The phase needs to run *after* memory consolidation has settled (so the latest reinforced memories are available if any prompt references them) but does not have a hard ordering relationship with most other phases. Identity reflection runs near the end of the existing pipeline — observation can sit near it.
+
+This phase MUST flow `ct` through to every LLM call inside it. If any path uses `CancellationToken.None`, user preemption stops working for that path. See "Dependency: LLM gateway" for the discipline this imposes.
+
+Broader dream-cycle parallelism (running multiple existing phases concurrently) is out of scope here. It is a separate refactor with real risk (concurrent writes to memory store, graph store, etc.) and is not required to land this feature.
+
+## Project placement
+
+New project: **`RockBot.Observation`**.
+
+Dependencies:
+- LLM client (`ILlmClient`)
+- Vector embedding service (already present for hybrid search)
+
+It does *not* depend on messaging. The dream cycle is the only invoker. Agent code's role is limited to:
+- Registering observation targets at startup (DI configuration).
+- Loading the regenerated markdown files into agent context (this already happens for the existing theory-of files; nothing changes there).
+
+## Schema evolution
+
+`schemaVersion: 1` lives at the top of every state file. When a future change requires migration, the framework reads the version field and routes to a migration step before the pipeline runs. Cheap to add now, painful to retrofit.
+
+## Dependency: LLM gateway
+
+The observation framework's parallelism makes a global LLM rate-limit-handling and concurrency-capping layer a prerequisite. Without it, every concurrent extraction call risks 429s and every call site needs its own retry logic. See [`llm-gateway.md`](llm-gateway.md) for that design. Key contract from the framework's perspective:
+
+- The framework dispatches LLM calls without restraint; the gateway throttles via per-tier concurrency caps.
+- Cancellation propagates: when dream's `ct` fires, every dream LLM call currently waiting at the gateway aborts.
+- Every LLM call from the framework MUST flow `ct`. Any path using `CancellationToken.None` becomes a black hole where user preemption fails.
+
+## Open questions
+
+- **Behavior summary metric set.** What mechanically computed metrics are most useful for theory-of-self extraction? Tool call count and iteration count are obvious; what else carries signal without dragging in raw transcripts?
+- **Exact placement in `DreamService.DreamAsync`.** After memory consolidation, before or after identity reflection? The existing phase order has accumulated reasons that should be reviewed.
+- **Promotion threshold defaults.** Two distinct conversations? Three? Different per target. Calibrate against real dream output, not by guessing up front.
+- **Aging window defaults.** At 2 dreams/day, K=14 (one week) for candidates feels right; M=60+ for theories. Should be reviewed once there's data.
+- **Evaluation prompt structure.** Differential framing is the right shape, but the exact prompt template needs iteration once Phase 1 is producing real candidate pools.
+- **Telemetry surfacing.** Should the framework emit an end-of-phase summary message ("X candidates added, Y promoted, Z aged out per target") so dream activity is visible in logs without inspecting JSON files?


### PR DESCRIPTION
## Summary

- **`design/observation-framework.md`** — generalizable pipeline that accumulates evidence-grounded observations across dream cycles, promotes candidates to theories once supported by enough distinct conversations, and ages out unreinforced entries. Theory-of-self and theory-of-user are the first two configured targets. Tracks #353.
- **`design/llm-gateway.md`** — global per-tier concurrency cap with `Retry-After`-aware retry, ct-driven cancellation in place of priority lanes, bounded queue, and centralized metrics. Prerequisite for the parallelism the observation framework depends on. Tracks #352.

Docs only — no code changes. Implementation lands under the linked issues.

## Test plan

- [ ] Read `design/observation-framework.md` end-to-end and confirm pipeline shape, anti-hallucination story, and target configurations match intent
- [ ] Read `design/llm-gateway.md` end-to-end and confirm cancellation-as-priority reasoning is captured correctly
- [ ] Verify cross-references between the two docs render and resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)