### PR TITLE
LLM gateway: ct audit + mandatory ct on ILlmClient (phase 4 of #352)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.10.34</Version>
+<Version>0.10.35</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.A2A/AgentCardSummarizer.cs
+++ b/src/RockBot.A2A/AgentCardSummarizer.cs
@@ -58,7 +58,7 @@ internal sealed class AgentCardSummarizer(
                 """;
 
             var messages = new[] { new ChatMessage(ChatRole.User, prompt) };
-            var response = await llmClient.GetResponseAsync(messages, ModelTier.Low, cancellationToken: ct);
+            var response = await llmClient.GetResponseAsync(messages, ModelTier.Low, options: null, cancellationToken: ct);
             return response.Text?.Trim() ?? fallback;
         }
         catch (Exception ex)

--- a/src/RockBot.Agent/McpBridge/McpBridgeService.cs
+++ b/src/RockBot.Agent/McpBridge/McpBridgeService.cs
@@ -563,7 +563,7 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
                     """;
 
                 var messages = new[] { new ChatMessage(ChatRole.User, prompt) };
-                var response = await _llmClient.GetResponseAsync(messages, cancellationToken: ct);
+                var response = await _llmClient.GetResponseAsync(messages, options: null, cancellationToken: ct);
                 summaryText = response.Text?.Trim();
             }
             catch (Exception ex)

--- a/src/RockBot.Host.Abstractions/ILlmClient.cs
+++ b/src/RockBot.Host.Abstractions/ILlmClient.cs
@@ -18,17 +18,27 @@ public interface ILlmClient
     /// <summary>
     /// Calls the LLM using the <see cref="ModelTier.Balanced"/> client.
     /// </summary>
+    /// <remarks>
+    /// <paramref name="cancellationToken"/> is mandatory: the gateway uses it to
+    /// drain queued and in-flight calls when the caller is preempted (e.g. when
+    /// a user message cancels the dream cycle). Callers without a natural ct
+    /// MUST pass <see cref="CancellationToken.None"/> explicitly so the choice
+    /// is intentional and visible in code review. See <c>design/llm-gateway.md</c>.
+    /// </remarks>
     Task<ChatResponse> GetResponseAsync(
         IEnumerable<ChatMessage> messages,
-        ChatOptions? options = null,
-        CancellationToken cancellationToken = default);
+        ChatOptions? options,
+        CancellationToken cancellationToken);
 
     /// <summary>
     /// Calls the LLM using the client for the specified <paramref name="tier"/>.
     /// </summary>
+    /// <remarks>
+    /// <paramref name="cancellationToken"/> is mandatory: see the single-arg overload.
+    /// </remarks>
     Task<ChatResponse> GetResponseAsync(
         IEnumerable<ChatMessage> messages,
         ModelTier tier,
-        ChatOptions? options = null,
-        CancellationToken cancellationToken = default);
+        ChatOptions? options,
+        CancellationToken cancellationToken);
 }

--- a/src/RockBot.Host/LlmClient.cs
+++ b/src/RockBot.Host/LlmClient.cs
@@ -20,16 +20,16 @@ internal sealed class LlmClient(
     /// <summary>Calls the LLM using the Balanced tier.</summary>
     public Task<ChatResponse> GetResponseAsync(
         IEnumerable<ChatMessage> messages,
-        ChatOptions? options = null,
-        CancellationToken cancellationToken = default)
+        ChatOptions? options,
+        CancellationToken cancellationToken)
         => GetResponseAsync(messages, ModelTier.Balanced, options, cancellationToken);
 
     /// <summary>Calls the LLM using the specified tier, falling back to Balanced on failure for Low/High tiers.</summary>
     public async Task<ChatResponse> GetResponseAsync(
         IEnumerable<ChatMessage> messages,
         ModelTier tier,
-        ChatOptions? options = null,
-        CancellationToken cancellationToken = default)
+        ChatOptions? options,
+        CancellationToken cancellationToken)
     {
         try
         {

--- a/src/RockBot.Host/SessionSummaryService.cs
+++ b/src/RockBot.Host/SessionSummaryService.cs
@@ -149,7 +149,11 @@ internal sealed class SessionSummaryService : IHostedService, IDisposable
 
         try
         {
-            var response = await _llmClient.GetResponseAsync(messages, new ChatOptions());
+            // Timer-driven background evaluation: no caller-supplied ct. A future
+            // refactor could expose IHostApplicationLifetime.ApplicationStopping so
+            // agent shutdown cancels in-flight evaluation. For now the work is tied
+            // to the agent process lifetime.
+            var response = await _llmClient.GetResponseAsync(messages, new ChatOptions(), CancellationToken.None);
             var raw = response.Text?.Trim() ?? string.Empty;
             var json = ExtractJsonObject(raw);
 

--- a/src/RockBot.Memory/MemoryTools.cs
+++ b/src/RockBot.Memory/MemoryTools.cs
@@ -349,7 +349,12 @@ public sealed class MemoryTools
 
         try
         {
-            var response = await _llmClient.GetResponseAsync(messages, options);
+            // Detached background work: SaveMemory queues this via Task.Run with no
+            // caller-supplied ct, so the LLM call has no cancellation source. A future
+            // refactor could plumb IHostApplicationLifetime.ApplicationStopping for
+            // graceful shutdown of in-flight extraction; for now the work is tied to
+            // the agent process lifetime.
+            var response = await _llmClient.GetResponseAsync(messages, options, CancellationToken.None);
             var raw = response.Text?.Trim() ?? string.Empty;
             var json = ExtractJsonArray(raw);
 

--- a/src/RockBot.Skills/SkillTools.cs
+++ b/src/RockBot.Skills/SkillTools.cs
@@ -190,7 +190,12 @@ public sealed class SkillTools
                 new(ChatRole.User, content)
             };
 
-            var response = await _llmClient.GetResponseAsync(messages, new ChatOptions());
+            // Detached background work: skill save queues this via Task.Run with no
+            // caller-supplied ct, so the LLM call has no cancellation source. The
+            // summary refresh is best-effort; if the agent shuts down mid-call the
+            // task is orphaned. A future refactor could use ApplicationStopping.
+            var response = await _llmClient.GetResponseAsync(
+                messages, new ChatOptions(), CancellationToken.None);
             var summary = response.Text?.Trim() ?? string.Empty;
 
             if (string.IsNullOrWhiteSpace(summary))

--- a/tests/RockBot.Host.Tests/LlmGatewayTests.cs
+++ b/tests/RockBot.Host.Tests/LlmGatewayTests.cs
@@ -192,6 +192,43 @@ public class LlmGatewayTests
     }
 
     [TestMethod]
+    public async Task ExecuteAsync_CancellationWhileInFlight_AbortsAndReleasesSlot()
+    {
+        using var gateway = CreateGateway(low: 1);
+        using var cts = new CancellationTokenSource();
+        var operationStarted = new TaskCompletionSource();
+
+        // Operation respects ct: it parks until ct fires, then throws.
+        var task = gateway.ExecuteAsync<int>(ModelTier.Low, async ct =>
+        {
+            operationStarted.SetResult();
+            await Task.Delay(Timeout.Infinite, ct);
+            return 0;
+        }, cts.Token);
+
+        await operationStarted.Task;
+        await WaitUntilAsync(
+            () => gateway.GetInFlightCount(ModelTier.Low) == 1,
+            TimeSpan.FromSeconds(5));
+
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () => await task);
+
+        // Slot should have been released; in-flight back to zero
+        await WaitUntilAsync(
+            () => gateway.GetInFlightCount(ModelTier.Low) == 0,
+            TimeSpan.FromSeconds(5));
+
+        // And a follow-up call should proceed
+        var followup = await gateway.ExecuteAsync(
+            ModelTier.Low,
+            ct => Task.FromResult(123),
+            CancellationToken.None);
+        Assert.AreEqual(123, followup);
+    }
+
+    [TestMethod]
     public async Task ExecuteAsync_ExceptionInOperation_ReleasesSlot()
     {
         using var gateway = CreateGateway(low: 1);


### PR DESCRIPTION
Final phase of `design/llm-gateway.md`. Closes the cancellation contract: audits every existing `ILlmClient` call site and makes `ct` a mandatory parameter so future violations cannot be introduced silently.

Builds on phases 1 (#355) and 3 (#358).

## Audit results

16 `ILlmClient.GetResponseAsync` call sites across the codebase. 13 already passed `ct` correctly. **3 violations found and fixed**:

| File | Issue |
|---|---|
| `RockBot.Memory/MemoryTools.cs:352` | Background SaveMemory worker via `Task.Run` — no caller-supplied ct |
| `RockBot.Skills/SkillTools.cs:193` | Background skill summary generation via `Task.Run` — no caller-supplied ct |
| `RockBot.Host/SessionSummaryService.cs:152` | Timer-driven evaluation — no caller-supplied ct |

All three are detached background work with no natural ct. They now pass `CancellationToken.None` explicitly, with comments documenting the design choice and noting that a future refactor could plumb `IHostApplicationLifetime.ApplicationStopping` for graceful shutdown of in-flight LLM calls. The audit forces this to be intentional rather than accidental.

## Compile-time enforcement

- `ILlmClient.GetResponseAsync` (both overloads) drop `= default` on `cancellationToken`. The compiler now catches any future call site that tries to omit it.
- `LlmClient` implementation matched (defaults removed for consistency).
- Two existing call sites (`AgentCardSummarizer`, `McpBridgeService`) used the named-arg pattern `cancellationToken: ct` which silently picked up the default for `options`. These are made explicit with `options: null` in the same change.

## Tests

- Adds `ExecuteAsync_CancellationWhileInFlight_AbortsAndReleasesSlot` to close the in-flight cancellation gap the design called for in this phase. Verifies cancellation mid-operation aborts, releases the slot, and follow-up calls succeed.
- 13/13 `LlmGatewayTests` pass.
- 629/629 Host tests pass.
- Full solution test run clean.

## Test plan

- [x] `dotnet build RockBot.slnx` — clean
- [x] `dotnet test --filter "FullyQualifiedName~LlmGatewayTests"` — 13/13 pass
- [x] Full Host suite — 629/629 pass
- [x] Full solution test run — all projects pass

## Closes #352

Phase 1 (concurrency cap), phase 3 (bounded queue), and phase 4 (ct audit + mandatory ct) all landed. Phase 2 (gateway retry) was dropped in favor of keeping SDK retry enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)