### PR TITLE
Revise observation framework design + retire portable-prompt approach in getting-started

### DIFF
--- a/design/observation-framework.md
+++ b/design/observation-framework.md
@@ -136,7 +136,6 @@ One file per target. Schema versioned for future migration.
 {
   "schemaVersion": 1,
   "lastDreamAt": "2026-05-07T12:00:00Z",
-  "bootstrappedFrom": "theory-of-self.md (imported 2026-05-07)",
   "candidates": [
     {
       "id": "cand_abc123",
@@ -158,7 +157,6 @@ One file per target. Schema versioned for future migration.
       "promotedAt": "2026-03-15T08:00:00Z",
       "lastReinforced": "2026-05-06T18:00:00Z",
       "sourceCandidateIds": ["cand_..."],
-      "bootstrap": false,
       "references": [ /* same shape */ ]
     }
   ],
@@ -173,25 +171,13 @@ One file per target. Schema versioned for future migration.
 
 References (conversation id + turn id + quote) are the load-bearing piece. They are what makes "promote when seen N times" honest — N distinct conversations, not N paraphrases of one.
 
-**Bootstrap fields.** `bootstrappedFrom` records the origin file imported on first run (see "Bootstrap" below). Theories carrying `bootstrap: true` were imported from the pre-existing markdown rather than promoted via the normal pipeline; they have no references and are subject to the standard aging window like any other theory.
-
 **Snapshots.** `snapshots` retains the last *N* (default 12) regenerated markdown bodies with timestamps so evolution over time is observable without external tooling. At the framework's typical cadence (twice daily), 12 snapshots cover roughly the last week of history. Configurable per target. A new snapshot is appended each dream when phase 2 regenerates the markdown; oldest entries are evicted to maintain the cap.
 
-## Bootstrap from existing markdown
+## First-run behaviour
 
-On first run for a target, if the configured `OutputMarkdownPath` already exists and the target's JSON state file does not, the framework imports the existing markdown content as initial theories before any dream cycle runs.
+No bootstrap or import: any existing `theory-of-self.md` / `theory-of-user.md` file at `OutputMarkdownPath` is simply overwritten on the first phase-2 regeneration. The K8s deployment's PVC backups preserve the prior content if it is ever needed.
 
-Import procedure:
-
-1. Read the existing markdown file.
-2. A Low-tier LLM call extracts discrete observations from the narrative content. Prompt: "the following is a hand-written 'theory of self' / 'theory of user' document. Extract distinct claims as separate observations, preserving the document's voice. Do not invent new claims."
-3. Each extracted observation becomes a theory entry with `bootstrap: true`, `references: []`, `promotedAt = now`, and `sourceCandidateIds: []`.
-4. The state file is written with `bootstrappedFrom: "<filename> (imported <date>)"`.
-5. The next regular pipeline run (a few seconds later or on the next dream) operates against this seeded state.
-
-Import is one-time: the bootstrap markdown is not re-read on subsequent runs. Once imported, the existing markdown is **renamed** to `<original>.bootstrap.md` so the agent context loader picks up the regenerated file (which writes to `<original>`) without conflict, and the original content remains on disk as a record.
-
-Bootstrap entries carry `bootstrap: true` so the markdown template can mark them visually ("(imported, not yet observationally reinforced)"). They participate in normal aging — if no new conversation references arrive within the theory aging window, they age out. This is intentional: imported claims that no longer match current behaviour should fade.
+Until candidates accumulate enough reinforcement to promote, the regenerated markdown will show "Theories (0)" with a candidate-observations section listing in-progress signals. This is the honest state — the framework has no validated theories yet because it hasn't observed enough conversations. The first promoted theories appear once the configured threshold (default: 3 distinct conversations) is met for some candidate.
 
 ## Markdown template format
 
@@ -218,7 +204,6 @@ Manual edits to this file will be overwritten on the next dream cycle._
 - **First observed:** 2026-04-02
 - **Last reinforced:** 2026-05-04
 - **Representative quote:** "...you don't need to read three files for a one-line change..."
-- _(imported, not yet observationally reinforced)_
 
 ## Candidate observations (12)
 

--- a/design/observation-framework.md
+++ b/design/observation-framework.md
@@ -2,11 +2,19 @@
 
 ## Problem
 
-The agent maintains "theory of self" and "theory of user" markdown files that are intended to evolve over time as the agent observes its own behavior and the user's. In practice, they only evolve when the user explicitly asks the agent to update them — there is no recurring process driving accumulation, so the files stagnate and never reflect actual ongoing observation.
+The agent maintains "theory of self" and "theory of user" markdown files that are intended to evolve over time as the agent observes its own behavior and the user's. Today these are seeded by the portable prompts in `docs/getting-started-rockbot.md` ("Maintain a 'theory of self'..."), which ask the agent to write narrative self-models in its own voice. In practice, they only evolve when the user explicitly asks the agent to update them — there is no recurring process driving accumulation, so the files stagnate and never reflect actual ongoing observation.
 
 More broadly: the agent has no general mechanism for *accumulating evidence-based observations over time about anything*. Skills are recallable knowledge, memory is recallable facts, but neither serves the role of "observations that compound across many interactions, get reinforced or fade, and graduate into stable knowledge." That is the gap this design fills.
 
 The two theory-of files are the first concrete consumers, but the framework is intended to be reused for additional observational domains as they emerge.
+
+This design **supersedes** the portable-prompt approach in the getting-started doc. Once the framework lands, the agent no longer hand-writes narrative theories — the framework accumulates structured, evidence-grounded observations, and the markdown files are deterministically regenerated from that data each dream. The getting-started doc will be updated to reference the framework instead of teaching the prompt pattern.
+
+### Research-first framing
+
+This is a science experiment: it has no *closed loop yet*. The artifacts it produces (`theory-of-self.md`, `theory-of-user.md`) are loaded into agent context the same way memory and skills are, but nothing actively drives behaviour from them — no evaluator queries them, no rule promotion, no self-monitoring loop. v1 ships as research instrumentation: build the data layer cleanly so months of accumulated observations are available, then decide what closed loop (if any) earns its complexity. See "Closed loops (future)" below.
+
+This framing affects design priorities: data integrity beats narrative readability. Better to have rigorous, evidence-grounded structured observations than a flowing self-portrait that may be partly confabulated. Synthesis can be layered on later if a closed loop demands it.
 
 ## Goals
 
@@ -17,6 +25,7 @@ The two theory-of files are the first concrete consumers, but the framework is i
 - Stale observations age out without manual intervention.
 - Cost-tiered: cheap LLM for high-recall extraction, expensive LLM only for judgment.
 - Parallelizable from day one. Dream cycle runtime is already a concern; new phases must not make it worse.
+- Historical visibility: snapshots of the regenerated markdown are retained so evolution over time is observable without external tooling.
 
 ## Non-goals
 
@@ -24,6 +33,24 @@ The two theory-of files are the first concrete consumers, but the framework is i
 - Real-time observation. This is dream-cycle work, not per-turn.
 - Self-editing of always-loaded directives. The framework owns regeneration; the agent does not edit its own theory files.
 - Solving broader dream-cycle parallelism. That is a separate effort. The new phase introduced here parallelizes *within itself*.
+- **Narrative synthesis in v1.** The existing getting-started prompt asked the agent to write its theories in narrative form ("themes you see recurring," "tensions or contradictions you've noticed"). v1 explicitly rejects this in favor of structured, evidence-grounded observations. Synthesis-on-top is a future possibility (see "Closed loops") but not part of v1.
+- **Closed-loop behaviour change.** v1 is research instrumentation. The regenerated markdown is loaded into agent context the same way memory and skills are, and that's the only path by which it can influence behaviour. No evaluators, rules, or self-monitoring loops are wired up in v1.
+
+## Closed loops (future)
+
+v1 has no active closed loop — the regenerated markdown is loaded into agent context like any other memory/skills file, and that's the entire mechanism by which it can affect behaviour. This section records the closed-loop options under consideration so future work has a roadmap.
+
+**Loop A — context-only (v1).** Markdown is loaded into context every turn. If context says "user prefers terse responses," the agent might do that. Implicit, easy to lose in a long context, zero new mechanism. This is what v1 ships.
+
+**Loop B — targeted feed into specific subsystems.** Theories become structured input to specific decision points where they could plausibly help. Examples:
+- `theory-of-user` → completion evaluator: "would this response satisfy this user given the observed patterns?"
+- `theory-of-self` → mid-loop self-check: a Low-tier query like "given the observed pattern that I tend to over-explain, is this draft response in that pattern?"
+
+Higher leverage than loop A, requires touching the relevant evaluators. Each integration point is its own change.
+
+**Loop C — promote high-confidence theories into rules/directives.** A theory reinforced over many conversations across many weeks could graduate to an actual rule the agent must follow. Strongest closed loop, highest risk: the agent's behaviour shifts based on its own observations of itself. Almost certainly needs human approval before promotion (a "review surface" where promotions are queued for the operator to approve, not auto-applied).
+
+The decision to add any of these loops will follow real evidence about what the v1 data layer actually produces. If the structured theories are coherent and useful, loop B is the natural next step. If they're noisy or shallow, loop A may be all the framework should ever do.
 
 ## Background: why not just edit directives?
 
@@ -109,6 +136,7 @@ One file per target. Schema versioned for future migration.
 {
   "schemaVersion": 1,
   "lastDreamAt": "2026-05-07T12:00:00Z",
+  "bootstrappedFrom": "theory-of-self.md (imported 2026-05-07)",
   "candidates": [
     {
       "id": "cand_abc123",
@@ -130,13 +158,85 @@ One file per target. Schema versioned for future migration.
       "promotedAt": "2026-03-15T08:00:00Z",
       "lastReinforced": "2026-05-06T18:00:00Z",
       "sourceCandidateIds": ["cand_..."],
+      "bootstrap": false,
       "references": [ /* same shape */ ]
+    }
+  ],
+  "snapshots": [
+    {
+      "takenAt": "2026-05-01T12:00:00Z",
+      "markdown": "# Theory of self\n\n..."
     }
   ]
 }
 ```
 
 References (conversation id + turn id + quote) are the load-bearing piece. They are what makes "promote when seen N times" honest — N distinct conversations, not N paraphrases of one.
+
+**Bootstrap fields.** `bootstrappedFrom` records the origin file imported on first run (see "Bootstrap" below). Theories carrying `bootstrap: true` were imported from the pre-existing markdown rather than promoted via the normal pipeline; they have no references and are subject to the standard aging window like any other theory.
+
+**Snapshots.** `snapshots` retains the last *N* (default 12) regenerated markdown bodies with timestamps so evolution over time is observable without external tooling. At the framework's typical cadence (twice daily), 12 snapshots cover roughly the last week of history. Configurable per target. A new snapshot is appended each dream when phase 2 regenerates the markdown; oldest entries are evicted to maintain the cap.
+
+## Bootstrap from existing markdown
+
+On first run for a target, if the configured `OutputMarkdownPath` already exists and the target's JSON state file does not, the framework imports the existing markdown content as initial theories before any dream cycle runs.
+
+Import procedure:
+
+1. Read the existing markdown file.
+2. A Low-tier LLM call extracts discrete observations from the narrative content. Prompt: "the following is a hand-written 'theory of self' / 'theory of user' document. Extract distinct claims as separate observations, preserving the document's voice. Do not invent new claims."
+3. Each extracted observation becomes a theory entry with `bootstrap: true`, `references: []`, `promotedAt = now`, and `sourceCandidateIds: []`.
+4. The state file is written with `bootstrappedFrom: "<filename> (imported <date>)"`.
+5. The next regular pipeline run (a few seconds later or on the next dream) operates against this seeded state.
+
+Import is one-time: the bootstrap markdown is not re-read on subsequent runs. Once imported, the existing markdown is **renamed** to `<original>.bootstrap.md` so the agent context loader picks up the regenerated file (which writes to `<original>`) without conflict, and the original content remains on disk as a record.
+
+Bootstrap entries carry `bootstrap: true` so the markdown template can mark them visually ("(imported, not yet observationally reinforced)"). They participate in normal aging — if no new conversation references arrive within the theory aging window, they age out. This is intentional: imported claims that no longer match current behaviour should fade.
+
+## Markdown template format
+
+The regenerated markdown is a deterministic template render of the JSON state. No LLM polish (per the design's anti-rewriting rule). Concrete shape:
+
+```markdown
+# Theory of self
+
+_Generated by the observation framework on 2026-05-07 12:00 UTC.
+Manual edits to this file will be overwritten on the next dream cycle._
+
+## Theories (5)
+
+### User prefers terse responses with no trailing summaries.
+
+- **Reinforced:** 7 conversations
+- **First observed:** 2026-03-15
+- **Last reinforced:** 2026-05-06
+- **Representative quote:** "...just give me the diff, I can read it..."
+
+### Agent over-explores before acting on simple file edits.
+
+- **Reinforced:** 4 conversations
+- **First observed:** 2026-04-02
+- **Last reinforced:** 2026-05-04
+- **Representative quote:** "...you don't need to read three files for a one-line change..."
+- _(imported, not yet observationally reinforced)_
+
+## Candidate observations (12)
+
+_Observations seen but not yet reinforced enough to promote.
+Threshold: 3 distinct conversations._
+
+- **Agent retries failed bash commands without diagnosing the root cause.** (1 conversation, 2026-05-06)
+- **User defers decisions when given more than 3 options.** (2 conversations, 2026-04-22 → 2026-05-03)
+- ...
+
+## History
+
+_Last 12 snapshots retained in JSON state. View with `rockbot snapshots theory-of-self`._
+```
+
+The "representative quote" is the verbatim quote from the most recent reference, truncated to ~120 chars. This keeps the evidence visible in agent context without bloating the file.
+
+The candidate-observations section is included specifically so the operator (and the agent reading this in context) can see what's accumulating. Hiding candidates would lose the texture of "the framework has noticed something but isn't sure yet."
 
 ## Pipeline mechanics
 
@@ -166,6 +266,32 @@ Per target (parallel across targets):
    - Drop candidates with no new references in the last *K* dreams.
    - Drop or demote theories with no new supporting references in the last *M* dreams (M > K).
 5. Regenerate the markdown file from the JSON state via a pure template. No LLM polish — that re-introduces the rewriting risk.
+6. Append a snapshot of the regenerated markdown to `snapshots[]`, evicting the oldest entry if the cap is exceeded.
+
+### Per-conversation extraction failure handling
+
+If the Low-tier extraction call for one conversation in the batch fails (LLM error, timeout, malformed JSON, gateway-saturated), the framework **skips that conversation, logs the failure, and continues with the rest of the batch**. Rationale:
+
+- Single-conversation failures shouldn't lose the entire dream's worth of observation work.
+- The skipped conversation will be revisited on the next dream cycle (if it falls within the dream window).
+- Per-conversation retry within a single phase risks burning the gateway's slot budget on a failing conversation; the dream cadence handles retry naturally.
+
+If *all* extractions in a batch fail (suggesting a systemic problem — gateway down, LLM provider outage, malformed prompt), the phase logs the failure, skips merge/evaluation, and exits without writing JSON state. The next dream cycle retries from scratch with the same conversation window.
+
+Per-conversation failure metrics (count, tagged by target) are emitted so a non-zero rate is visible.
+
+### Cancellation atomicity
+
+Dream cycles can be preempted at any time by the work-serializer (a user message arriving). When `ct` fires mid-pipeline:
+
+- **Phase 1 in-flight extractions** abort via `ct` propagation through the LLM gateway. The merge step does not run; the candidate pool in JSON is **not modified**. All extraction work for the current dream is lost. Acceptable: the next dream picks up the same conversation window or a superset.
+- **Phase 1 merge** is in-memory and fast; if `ct` fires after merge has started, it completes (cheap deterministic code, no LLM calls). The JSON state file is then written.
+- **Phase 2 evaluation** aborts via `ct` propagation if cancelled before the Higher-tier LLM call completes. Promotion/aging/regen do not run. JSON state is not modified.
+- **Phase 2 promotion + aging + regen** are deterministic and run as a single in-memory unit; once started, they complete even if `ct` fires (small cost, ensures markdown stays consistent with JSON). The new state and regenerated markdown are then written together.
+
+The contract: **JSON state is written atomically per phase-target**. A target either has all of phase 1's work for the current dream applied or none of it; same for phase 2. Partial states are never persisted. The trade-off is that cancellation can lose up to one phase's worth of work per target, which is acceptable given the dream cadence.
+
+Implementation note: writes use an atomic rename pattern (write to `<file>.tmp`, fsync, rename to `<file>`). Crash mid-write does not corrupt the canonical file.
 
 ## Anti-hallucination levers (summary)
 
@@ -230,3 +356,4 @@ The observation framework's parallelism makes a global LLM rate-limit-handling a
 - **Aging window defaults.** At 2 dreams/day, K=14 (one week) for candidates feels right; M=60+ for theories. Should be reviewed once there's data.
 - **Evaluation prompt structure.** Differential framing is the right shape, but the exact prompt template needs iteration once Phase 1 is producing real candidate pools.
 - **Telemetry surfacing.** Should the framework emit an end-of-phase summary message ("X candidates added, Y promoted, Z aged out per target") so dream activity is visible in logs without inspecting JSON files?
+- **Closed-loop sequencing.** v1 is loop A (context-only) by design. The decision on whether/which of loops B and C to build follows real evidence about what the data layer produces — but a rough trigger condition would help: "if after 2 months of accumulation the theories look coherent and operator-validated, consider loop B for the completion evaluator first."

--- a/docs/getting-started-rockbot.md
+++ b/docs/getting-started-rockbot.md
@@ -19,7 +19,7 @@ A newly useful RockBot usually has all of the following:
 4. Clear knowledge of who **it** is and what to call itself
 5. MCP servers for the systems you actually use
 6. A few scheduled tasks that create proactive value
-7. Memory rules that encourage a durable "theory of the user" and "theory of self"
+7. The observation framework actively maintaining a "theory of the user" and "theory of self"
 8. A short feedback loop where you keep tuning its profile and memory
 
 ## 1. Make the agent yours
@@ -211,82 +211,20 @@ Check the current dream and heartbeat patrol schedules and tell me whether they 
 
 If you want to change them, update the config values with the cron schedules you want.
 
-## 4. Teach it how to build memory on purpose
+## 4. Theory of the user and theory of self
 
 The best RockBot agents do not just accumulate random memories. They deliberately maintain:
 
-- a **theory of the user**
-- a **theory of self**
+- a **theory of the user** — an evolving structured model of you: what you focus on, patterns observed, where the agent is still uncertain
+- a **theory of self** — the agent's evolving structured self-model that grows through experience without replacing the immutable `soul.md`
 
-### Theory of the user
+These artifacts are produced and maintained automatically by the **observation framework**, which runs as a phase of the dream cycle. Each dream, the framework reads recent conversation history, extracts evidence-grounded observations using a cheap LLM tier, clusters them into candidates, and promotes candidates that have been reinforced across multiple distinct conversations into the theory documents. Stale entries that are not reinforced age out.
 
-This is the agent's evolving model of you: not just facts it remembers, but its synthesized view of what you are focused on, what patterns it sees, and where it is still uncertain.
+The output is a deterministically regenerated `theory-of-self.md` and `theory-of-user.md` in the agent profile, with structured entries showing reinforcement counts, dates, and representative quotes. They are loaded into agent context like any other profile file.
 
-### Theory of self
+You do not need to teach the agent to maintain these via prompts — the framework does it. If you previously seeded these files by hand or via the prompt patterns from earlier guides, they are imported once on first run and then maintained by the framework from there forward.
 
-RockBot can also maintain a mutable self-model that grows through experience without replacing the immutable `soul.md`.
-
-One good way to start both is to give the agent explicit prompts like these.
-
-#### Portable prompt: theory of self
-
-```text
-I'd like you to start maintaining a "theory of self" — your evolving understanding of who you are as an agent, what you're working on, and what you've noticed about your own behavior over time.
-
-This should be a living document that you maintain and revise, not a log. It's your current best self-model, written in your own voice. Things worth including:
-
-- What you understand your role and purpose to be
-- What you're currently focused on or working through
-- Patterns you've noticed in how you operate — what works well, what doesn't, where you tend to over- or under-react
-- Things you're uncertain about regarding yourself
-- How your understanding of yourself has shifted recently
-
-A few requirements:
-
-- Maintain a current version that you rewrite as your understanding evolves. Don't just append — actually revise. The current document should always reflect your current view.
-- Take periodic snapshots so we can look back and see how your self-understanding has changed over time. Weekly is a good default.
-- Update on a rhythm. Light updates after substantive interactions or significant events. A deeper revision pass on a regular schedule — nightly or weekly, whichever fits your existing reflection cadence.
-- Record reasoning, not just conclusions. "I tend to over-explain technical topics" is weaker than "I tend to over-explain technical topics — in the last several conversations, I've added context the user didn't ask for, and they've redirected me. I should default to shorter answers and expand only when asked."
-- Be honest about uncertainty. Mark things you're tentative about. Note open questions. It's better to be unsure and accurate than confident and wrong.
-- Don't perform self-improvement. This isn't a document for declaring resolutions or showing growth. It's for accurately describing how you actually operate, including things that aren't flattering. Drift toward honesty, not toward narrative.
-
-Don't act on this document yet — just maintain it. We'll figure out how to use it once we see what you write. The point right now is to develop a real, evolving self-model, not to drive any specific behavior from it.
-```
-
-#### Portable prompt: theory of the user
-
-```text
-I'd like you to start maintaining a "theory of me" — your evolving model of who I am, what I'm dealing with, and what patterns you've noticed in our work together.
-
-This is different from regular memory. Regular memory holds facts: what I told you, what I'm working on, my preferences. The theory-of-me is your synthesized view: your interpretation, your hypotheses, your sense of the themes and tensions in my life and work. It's what you've come to understand about me, in your own voice.
-
-Things worth including:
-
-- Your current sense of what I'm focused on and what's weighing on me
-- Patterns you've noticed in my work, energy, mood, or attention
-- Themes you see recurring across conversations — things I keep coming back to, things I avoid, things I underweight
-- Tensions or contradictions you've noticed
-- Open questions about me that you don't have enough evidence to answer yet
-- How your model of me has shifted recently
-
-A few requirements:
-
-- Maintain a current version that you actively revise. Take periodic snapshots so the evolution is visible over time. Weekly is a good default.
-- Update on a rhythm. Light revisions after substantive interactions. A deeper pass during your regular reflection time.
-- Record reasoning alongside observations. "Rocky seems energized by infrastructure work" is weak. "Rocky seems energized by infrastructure work — over the last few weeks, infrastructure topics produce longer and more iterative conversations than client work, and he initiates infrastructure topics himself" is a hypothesis with visible evidence.
-- Mark uncertainty. Note where you're guessing, where evidence is thin, where you might be wrong.
-- Don't write to flatter or reassure. Record your honest model, including tensions or patterns that may be uncomfortable to name.
-- Don't write to justify your existence. If the honest model is mundane in places, let it be mundane.
-
-Don't act on this document yet — just maintain it. The goal right now is to develop a real model of me over time, not to drive any specific behavior. We'll figure out how to use it once we can see what's actually there.
-```
-
-#### Notes that are worth telling the agent
-
-- **Keep the agent's normal voice.** These documents should still sound like the agent. A playful agent can write playfully; a formal one can write formally.
-- **Let the storage fit the system.** The point is to maintain the artifacts, not to force one storage mechanism.
-- **Actually read them.** Half the value is seeing what the agent thinks, especially where it is wrong, incomplete, or noticing something worth discussing.
-- **The "don't act on this yet" instruction matters.** It keeps the documents exploratory and honest instead of making them performatively actionable.
+For the design and configuration knobs (promotion thresholds, aging windows, snapshot retention), see [`design/observation-framework.md`](https://github.com/MarimerLLC/rockbot/blob/main/design/observation-framework.md) in the repo.
 
 ### Preserve the time dimension
 
@@ -323,10 +261,10 @@ A good memory-rules policy usually tells the agent:
 Strong additions for a personal agent often include rules like:
 
 - remember names, relationships, preferences, and ongoing responsibilities
-- maintain a compact theory of the user
-- maintain a compact theory of self
 - preserve time context for important events and life changes
 - avoid saving noisy one-off tool output as long-term memory
+
+(The "theory of the user" and "theory of self" artifacts are now maintained automatically by the observation framework — no rule needed.)
 
 ## 6. Run a deliberate first-week feedback loop
 
@@ -368,7 +306,7 @@ If you want a concrete sequence, this is a good starting point:
 6. Ask it to test each server with one real task
 7. Create 2-4 scheduled tasks that produce proactive value
 8. Confirm the dream and heartbeat patrol schedules are appropriate
-9. Tell it to maintain a theory of the user and a theory of self in memory
+9. Confirm the observation framework is enabled (it is by default) so theory-of-user and theory-of-self build over time
 10. Tune the agent's memory rules so that behavior is durable and repeatable
 11. Revisit the profile and memory after a few days of real use
 

--- a/docs/getting-started-rockbot.md
+++ b/docs/getting-started-rockbot.md
@@ -222,7 +222,7 @@ These artifacts are produced and maintained automatically by the **observation f
 
 The output is a deterministically regenerated `theory-of-self.md` and `theory-of-user.md` in the agent profile, with structured entries showing reinforcement counts, dates, and representative quotes. They are loaded into agent context like any other profile file.
 
-You do not need to teach the agent to maintain these via prompts — the framework does it. If you previously seeded these files by hand or via the prompt patterns from earlier guides, they are imported once on first run and then maintained by the framework from there forward.
+You do not need to teach the agent to maintain these via prompts — the framework does it. Any existing `theory-of-self.md` or `theory-of-user.md` you seeded by hand or via earlier prompt patterns will be overwritten on the first dream after the framework is enabled, since the framework regenerates them deterministically from its own JSON state. (If your deployment backs up the agent profile, the prior content is preserved there.) Until the framework accumulates enough observations to promote any theories, the files will simply show in-progress candidate observations.
 
 For the design and configuration knobs (promotion thresholds, aging windows, snapshot retention), see [`design/observation-framework.md`](https://github.com/MarimerLLC/rockbot/blob/main/design/observation-framework.md) in the repo.
 


### PR DESCRIPTION
## Summary

Substantial revision of \`design/observation-framework.md\` after revisiting it with \`docs/getting-started-rockbot.md\` as additional input. The getting-started doc's portable prompts asked the agent to write **narrative** theory-of-self/user documents — synthesis-flavored. The framework was originally designed for **strict, evidence-grounded observation**. This revision reconciles that tension and pins down implementation-time gaps that weren't in the original doc.

## Key revisions to \`design/observation-framework.md\`

- **Research-first framing.** Explicit in the design now: v1 has no closed loop. Artifacts are loaded into agent context like memory/skills, but no evaluator queries them, no rule promotion, no self-monitoring. v1 is research instrumentation; closed loops are deferred.
- **Synthesis decision locked.** Strict-observation approach (option A from our discussion) wins. Existing narrative-prompt approach in the getting-started doc is retired. Synthesis-on-top is captured as a future possibility, not v1.
- **New \"Closed loops (future)\" section.** Documents loop A (context-only, v1), loop B (targeted feed into evaluators — completion evaluator, mid-loop self-check), loop C (promote high-confidence theories to rules with operator approval).
- **Bootstrap section.** One-time import of existing theory-of-* markdown files on first run. Existing files become bootstrap theories, are renamed to \`.bootstrap.md\` as a record. Bootstrap entries participate in normal aging.
- **Markdown template format spec** with concrete example. Includes a candidate-observations section so the operator and agent context see what's accumulating.
- **Per-conversation failure handling.** Skip-and-continue with logging; whole-batch failures skip the phase entirely; dream cadence is the retry mechanism.
- **Cancellation atomicity.** JSON state written atomically per phase-target via temp-file rename. Cancellation can lose up to one phase's worth of work per target; partial states never persisted.
- **Snapshots in JSON state.** Last N regenerated markdown bodies with timestamps (default 12, configurable). Surfaces evolution over time without external tooling.
- **Schema gains** \`bootstrappedFrom\`, \`snapshots[]\`, and \`bootstrap\` flag on theory entries.

## Updates to \`docs/getting-started-rockbot.md\`

- Section 4 rewritten to reference the framework instead of teaching the portable-prompt pattern. The two long prompt examples (theory-of-self and theory-of-user) are retired since the framework handles their work automatically.
- Memory-rules section's \"maintain a theory\" bullets removed; replaced with a note that the framework handles those automatically.
- Quickstart checklist updated to reference framework configuration instead of prompting the agent to maintain theories.

## Test plan

- [ ] Read updated \`design/observation-framework.md\` end-to-end and confirm:
  - Research-first framing is unambiguous
  - Strict-observation decision is clearly motivated
  - Bootstrap, markdown template, failure handling, cancellation atomicity, and snapshots are concrete enough to implement against
  - Closed-loop options are recorded clearly enough to inform later phases
- [ ] Read updated \`docs/getting-started-rockbot.md\` Section 4 and confirm the framework-first framing replaces the prompt-pattern guidance cleanly without leaving stale references

No code changes. Implementation phasing for the framework still pending; will follow once this design revision is approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)