### PR TITLE
Observation framework skeleton (phase 1 of #353)

### DIFF
--- a/RockBot.slnx
+++ b/RockBot.slnx
@@ -34,6 +34,7 @@
     <Project Path="src/RockBot.UserProxy.Blazor/RockBot.UserProxy.Blazor.csproj" />
     <Project Path="src/RockBot.Memory/RockBot.Memory.csproj" />
     <Project Path="src/RockBot.Skills/RockBot.Skills.csproj" />
+    <Project Path="src/RockBot.Observation/RockBot.Observation.csproj" />
     <Project Path="src/RockBot.Agent/RockBot.Agent.csproj" />
     <Project Path="src/RockBot.Tools.FileSystem/RockBot.Tools.FileSystem.csproj" />
     <Project Path="src/RockBot.Tools.Web/RockBot.Tools.Web.csproj" />
@@ -63,6 +64,7 @@
     <Project Path="tests/RockBot.UserProxy.Blazor.Tests/RockBot.UserProxy.Blazor.Tests.csproj" />
     <Project Path="tests/RockBot.A2A.IntegrationTests/RockBot.A2A.IntegrationTests.csproj" />
     <Project Path="tests/RockBot.A2A.Gateway.Tests/RockBot.A2A.Gateway.Tests.csproj" />
+    <Project Path="tests/RockBot.Observation.Tests/RockBot.Observation.Tests.csproj" />
   </Folder>
   <Project Path="src/RockBot.Messaging.Abstractions/RockBot.Messaging.Abstractions.csproj" />
   <Project Path="src/RockBot.Messaging.RabbitMQ/RockBot.Messaging.RabbitMQ.csproj" />

--- a/src/RockBot.Observation/Candidate.cs
+++ b/src/RockBot.Observation/Candidate.cs
@@ -1,0 +1,54 @@
+namespace RockBot.Observation;
+
+/// <summary>
+/// A candidate observation: extracted from one or more conversations but not yet
+/// reinforced enough times to graduate into a <see cref="Theory"/>. Each candidate
+/// represents one logical claim; multiple textual variants from different
+/// conversations are merged into the same candidate via vector clustering.
+/// </summary>
+public sealed class Candidate
+{
+    /// <summary>Stable ID assigned at creation time.</summary>
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// Canonical text of the observation. Updated when the cluster picks up new
+    /// references whose phrasing better captures the underlying claim; the
+    /// canonical-form rewrite is performed by a Low-tier LLM call from the
+    /// pipeline's merge step, never by direct user input.
+    /// </summary>
+    public required string Text { get; set; }
+
+    /// <summary>
+    /// Vector cluster the candidate belongs to. New observations join the
+    /// candidate when their embedding falls within the configured similarity
+    /// threshold of this cluster.
+    /// </summary>
+    public required string ClusterId { get; init; }
+
+    /// <summary>
+    /// Number of distinct conversations contributing to this candidate. This is
+    /// the metric the promotion threshold compares against — derivable from
+    /// <see cref="References"/> but cached here for fast reads in the markdown
+    /// template and during evaluation.
+    /// </summary>
+    public int Count { get; set; }
+
+    /// <summary>When this candidate was first created.</summary>
+    public DateTimeOffset FirstSeen { get; init; }
+
+    /// <summary>
+    /// Most recent reference observation timestamp. Used by the aging pass: a
+    /// candidate with no new references in the configured candidate-aging window
+    /// is dropped.
+    /// </summary>
+    public DateTimeOffset LastSeen { get; set; }
+
+    /// <summary>
+    /// Evidence backing this candidate. Each reference pins the observation to
+    /// a specific conversation and turn with a verbatim quote. References from
+    /// the same conversation collapse to a single contributing conversation
+    /// for promotion-threshold counting.
+    /// </summary>
+    public List<ObservationReference> References { get; init; } = [];
+}

--- a/src/RockBot.Observation/FileObservationStateStore.cs
+++ b/src/RockBot.Observation/FileObservationStateStore.cs
@@ -1,0 +1,93 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace RockBot.Observation;
+
+/// <summary>
+/// Filesystem-backed <see cref="IObservationStateStore"/>. Writes go to
+/// <c>&lt;StateFilePath&gt;.tmp</c> and are renamed into place; a crash mid-write
+/// leaves the canonical file intact. Schema-version mismatches are surfaced as
+/// exceptions rather than silently coerced.
+/// </summary>
+internal sealed class FileObservationStateStore(ILogger<FileObservationStateStore> logger)
+    : IObservationStateStore
+{
+    public async Task<ObservationState> LoadAsync(
+        ObservationTarget target,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+
+        if (!File.Exists(target.StateFilePath))
+        {
+            logger.LogInformation(
+                "Observation: no state file for target {Target} at {Path}; starting fresh",
+                target.Name, target.StateFilePath);
+            return new ObservationState();
+        }
+
+        await using var stream = new FileStream(
+            target.StateFilePath,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read,
+            bufferSize: 4096,
+            useAsync: true);
+
+        var state = await JsonSerializer.DeserializeAsync<ObservationState>(
+            stream, ObservationStateJsonOptions.Instance, cancellationToken).ConfigureAwait(false);
+
+        if (state is null)
+            throw new InvalidDataException(
+                $"Observation state at {target.StateFilePath} deserialised to null.");
+
+        if (state.SchemaVersion != ObservationState.CurrentSchemaVersion)
+            throw new InvalidDataException(
+                $"Observation state at {target.StateFilePath} has schemaVersion={state.SchemaVersion}, " +
+                $"but this build only handles {ObservationState.CurrentSchemaVersion}. " +
+                "Migration logic has not been implemented.");
+
+        return state;
+    }
+
+    public async Task SaveAsync(
+        ObservationTarget target,
+        ObservationState state,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        ArgumentNullException.ThrowIfNull(state);
+
+        var dir = Path.GetDirectoryName(target.StateFilePath);
+        if (!string.IsNullOrEmpty(dir))
+            Directory.CreateDirectory(dir);
+
+        // Temp file in the same directory as the target so the rename is atomic
+        // (rename across filesystems is not).
+        var tempPath = target.StateFilePath + ".tmp";
+
+        await using (var stream = new FileStream(
+            tempPath,
+            FileMode.Create,
+            FileAccess.Write,
+            FileShare.None,
+            bufferSize: 4096,
+            useAsync: true))
+        {
+            state.SchemaVersion = ObservationState.CurrentSchemaVersion;
+            await JsonSerializer.SerializeAsync(
+                stream, state, ObservationStateJsonOptions.Instance, cancellationToken)
+                .ConfigureAwait(false);
+            await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        // Atomic rename: readers see either the old file or the new one, never
+        // a partially-written file. File.Move with overwrite is atomic on the
+        // .NET runtimes we target.
+        File.Move(tempPath, target.StateFilePath, overwrite: true);
+
+        logger.LogDebug(
+            "Observation: wrote state for target {Target} ({Candidates} candidates, {Theories} theories)",
+            target.Name, state.Candidates.Count, state.Theories.Count);
+    }
+}

--- a/src/RockBot.Observation/IObservationStateStore.cs
+++ b/src/RockBot.Observation/IObservationStateStore.cs
@@ -1,0 +1,23 @@
+namespace RockBot.Observation;
+
+/// <summary>
+/// Atomic reader/writer for an <see cref="ObservationState"/> file. Implementations
+/// must guarantee that a partially-written file is never observed: writes go to
+/// a temp path and are renamed into place. A crash mid-write leaves the canonical
+/// file untouched.
+/// </summary>
+public interface IObservationStateStore
+{
+    /// <summary>
+    /// Reads the state for the given target. Returns a fresh empty
+    /// <see cref="ObservationState"/> if the file does not exist.
+    /// </summary>
+    Task<ObservationState> LoadAsync(ObservationTarget target, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Writes the state for the given target atomically. Implementations must
+    /// write to a temporary path, fsync, and rename to the canonical path so
+    /// that readers never observe a partially-written file.
+    /// </summary>
+    Task SaveAsync(ObservationTarget target, ObservationState state, CancellationToken cancellationToken);
+}

--- a/src/RockBot.Observation/ITranscriptFilter.cs
+++ b/src/RockBot.Observation/ITranscriptFilter.cs
@@ -1,0 +1,23 @@
+namespace RockBot.Observation;
+
+/// <summary>
+/// Filters the conversation transcript that an observation target sees during
+/// phase 1 extraction. Theory-of-self looks at all turns; theory-of-user looks
+/// only at user-authored turns plus the agent responses to them. Future targets
+/// might want yet other filters, so the filter is pluggable per-target.
+/// </summary>
+/// <remarks>
+/// Filters operate on opaque <see cref="TranscriptTurn"/> records so the framework
+/// stays decoupled from specific conversation-log shapes. Adapters that wrap
+/// existing conversation logs implement this interface.
+/// </remarks>
+public interface ITranscriptFilter
+{
+    /// <summary>
+    /// Returns the subset of <paramref name="turns"/> that this target should
+    /// extract observations from. The relative order of returned turns must
+    /// match the input order so the resulting context is intelligible to the
+    /// extractor.
+    /// </summary>
+    IEnumerable<TranscriptTurn> Filter(IReadOnlyList<TranscriptTurn> turns);
+}

--- a/src/RockBot.Observation/ObservationReference.cs
+++ b/src/RockBot.Observation/ObservationReference.cs
@@ -1,0 +1,18 @@
+namespace RockBot.Observation;
+
+/// <summary>
+/// Concrete evidence pinning a candidate or theory observation to a specific
+/// place in conversation history. The combination of <see cref="ConversationId"/>,
+/// <see cref="TurnId"/>, and <see cref="Quote"/> is what makes
+/// "promote when seen N distinct conversations" honest — N must be N independent
+/// conversations, not N paraphrases of the same one.
+/// </summary>
+/// <param name="ConversationId">Conversation the quote came from.</param>
+/// <param name="TurnId">Turn within the conversation.</param>
+/// <param name="Quote">Verbatim snippet from the source turn. Mechanically validated against the input transcript at extraction time; observations whose quote is not actually present in the source are discarded before they enter the candidate pool.</param>
+/// <param name="ObservedAt">When the extraction that produced this reference ran.</param>
+public sealed record ObservationReference(
+    string ConversationId,
+    string TurnId,
+    string Quote,
+    DateTimeOffset ObservedAt);

--- a/src/RockBot.Observation/ObservationState.cs
+++ b/src/RockBot.Observation/ObservationState.cs
@@ -1,0 +1,50 @@
+namespace RockBot.Observation;
+
+/// <summary>
+/// Top-level persistent state for one observation target. Serialised to the
+/// target's configured JSON state file. The file is the source of truth;
+/// the regenerated markdown is a derived artifact that can be rebuilt
+/// deterministically from this state.
+/// </summary>
+public sealed class ObservationState
+{
+    /// <summary>
+    /// Current schema version. Used to route through future migrations when
+    /// the shape of this record changes incompatibly.
+    /// </summary>
+    public const int CurrentSchemaVersion = 1;
+
+    /// <summary>
+    /// Schema version this state file was written under. Always set to
+    /// <see cref="CurrentSchemaVersion"/> by code; older values are recognized
+    /// for migration.
+    /// </summary>
+    public int SchemaVersion { get; set; } = CurrentSchemaVersion;
+
+    /// <summary>
+    /// Timestamp of the most recent dream cycle that completed phase 1 for
+    /// this target. Used by the conversation-window selection in the next
+    /// cycle to avoid re-extracting the same conversations.
+    /// </summary>
+    public DateTimeOffset? LastDreamAt { get; set; }
+
+    /// <summary>
+    /// Candidate observations: extracted but not yet reinforced enough to
+    /// promote. Counted for promotion-threshold checks; aged out per the
+    /// candidate-aging window.
+    /// </summary>
+    public List<Candidate> Candidates { get; init; } = [];
+
+    /// <summary>
+    /// Promoted theories: candidates that crossed the promotion threshold
+    /// and were validated by the evaluation pass. These are what populate
+    /// the "Theories" section of the regenerated markdown.
+    /// </summary>
+    public List<Theory> Theories { get; init; } = [];
+
+    /// <summary>
+    /// Historical snapshots of the regenerated markdown body, oldest first.
+    /// Length is bounded by the target's <c>SnapshotRetentionCount</c>.
+    /// </summary>
+    public List<Snapshot> Snapshots { get; init; } = [];
+}

--- a/src/RockBot.Observation/ObservationStateJsonOptions.cs
+++ b/src/RockBot.Observation/ObservationStateJsonOptions.cs
@@ -1,0 +1,20 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace RockBot.Observation;
+
+/// <summary>
+/// Shared <see cref="JsonSerializerOptions"/> for reading and writing
+/// <see cref="ObservationState"/>. CamelCase property names match the
+/// shape committed to in the design doc.
+/// </summary>
+internal static class ObservationStateJsonOptions
+{
+    public static readonly JsonSerializerOptions Instance = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        WriteIndented = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+    };
+}

--- a/src/RockBot.Observation/ObservationTarget.cs
+++ b/src/RockBot.Observation/ObservationTarget.cs
@@ -1,0 +1,107 @@
+using RockBot.Host;
+
+namespace RockBot.Observation;
+
+/// <summary>
+/// Per-target configuration for the observation framework. One instance is
+/// registered for each target the agent maintains (theory-of-self, theory-of-user,
+/// future targets). The framework's pipeline service iterates registered targets
+/// during a dream cycle and runs the same pipeline for each.
+/// </summary>
+public sealed class ObservationTarget
+{
+    /// <summary>
+    /// Stable target identifier used in metric tags, log lines, and JSON state
+    /// filenames. Should be lowercase-kebab, e.g. "theory-of-self".
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Filter that scopes what conversation turns this target observes.
+    /// </summary>
+    public required ITranscriptFilter Filter { get; init; }
+
+    /// <summary>
+    /// Whether the per-conversation behavior summary (tool-call counts,
+    /// iteration counts, retried-after-error, etc.) is included as
+    /// augmentation alongside the filtered turns. Useful for theory-of-self
+    /// (where behavior is the subject); not useful for theory-of-user (where
+    /// the user never sees the agent's tool calls).
+    /// </summary>
+    public bool IncludeBehaviorSummary { get; init; }
+
+    /// <summary>
+    /// Prompt fed to the extraction LLM call. The framework will append the
+    /// formatted transcript and behavior summary; this prompt sets the
+    /// extraction stance and grounding rules.
+    /// </summary>
+    public required string ExtractionPrompt { get; init; }
+
+    /// <summary>
+    /// Prompt fed to the evaluation LLM call. Differential framing: each
+    /// candidate is verified against existing theories rather than generated
+    /// freely.
+    /// </summary>
+    public required string EvaluationPrompt { get; init; }
+
+    /// <summary>
+    /// Absolute or PVC-relative path to the JSON state file. Source of truth
+    /// for the target.
+    /// </summary>
+    public required string StateFilePath { get; init; }
+
+    /// <summary>
+    /// Absolute or PVC-relative path to the regenerated markdown output.
+    /// Overwritten each dream by the phase-2 template render.
+    /// </summary>
+    public required string OutputMarkdownPath { get; init; }
+
+    /// <summary>
+    /// LLM tier used for per-conversation observation extraction. Cheap tier
+    /// is appropriate for high-recall mechanical extraction.
+    /// </summary>
+    public ModelTier ExtractionTier { get; init; } = ModelTier.Low;
+
+    /// <summary>
+    /// LLM tier used for evaluation/promotion. Higher tier earns its cost
+    /// here: the evaluation pass is judgment work over a small candidate set.
+    /// </summary>
+    public ModelTier EvaluationTier { get; init; } = ModelTier.Balanced;
+
+    /// <summary>
+    /// Number of distinct conversations a candidate must be reinforced from
+    /// before it is eligible for promotion. Default 3; higher values for
+    /// noisier targets (theory-of-self) and lower values for denser-signal
+    /// targets (theory-of-user).
+    /// </summary>
+    public int PromotionThreshold { get; init; } = 3;
+
+    /// <summary>
+    /// Number of dream cycles a candidate may go without new references
+    /// before it is dropped. At twice-daily dreaming, 14 dreams is one week.
+    /// </summary>
+    public int CandidateAgingWindowDreams { get; init; } = 14;
+
+    /// <summary>
+    /// Number of dream cycles a theory may go without new supporting
+    /// references before it is demoted or removed. Should be substantially
+    /// longer than <see cref="CandidateAgingWindowDreams"/> — promoted
+    /// theories represent durable observations and should not fade quickly
+    /// just because the agent hasn't had relevant conversations recently.
+    /// </summary>
+    public int TheoryAgingWindowDreams { get; init; } = 60;
+
+    /// <summary>
+    /// Vector-similarity cosine threshold for matching new observations to
+    /// existing candidate clusters. Higher = stricter (fewer false merges,
+    /// more singleton candidates). Default 0.85; calibration is per-target
+    /// and per-embedding-model.
+    /// </summary>
+    public float ClusteringSimilarityThreshold { get; init; } = 0.85f;
+
+    /// <summary>
+    /// Maximum snapshots retained in <see cref="ObservationState.Snapshots"/>.
+    /// At twice-daily dreaming, 12 snapshots cover roughly the last week.
+    /// </summary>
+    public int SnapshotRetentionCount { get; init; } = 12;
+}

--- a/src/RockBot.Observation/RockBot.Observation.csproj
+++ b/src/RockBot.Observation/RockBot.Observation.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>RockBot.Observation</RootNamespace>
+    <IsPackable>true</IsPackable>
+    <Description>Evidence-grounded observation accumulation framework for RockBot agents. Maintains theory-of-self / theory-of-user style artifacts via a dream-cycle pipeline.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="RockBot.Observation.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.AI" Version="10.*" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\RockBot.Host.Abstractions\RockBot.Host.Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/RockBot.Observation/ServiceCollectionExtensions.cs
+++ b/src/RockBot.Observation/ServiceCollectionExtensions.cs
@@ -1,0 +1,39 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace RockBot.Observation;
+
+/// <summary>
+/// DI registration helpers for the observation framework.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the framework's core services (state store) and ensures the
+    /// configured target list is available via DI. Targets themselves are
+    /// added with <see cref="AddObservationTarget"/>.
+    /// </summary>
+    public static IServiceCollection AddRockBotObservation(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.TryAddSingleton<IObservationStateStore, FileObservationStateStore>();
+        return services;
+    }
+
+    /// <summary>
+    /// Registers a single <see cref="ObservationTarget"/> with the framework.
+    /// Multiple targets can be registered; the pipeline iterates all of them
+    /// during a dream cycle.
+    /// </summary>
+    public static IServiceCollection AddObservationTarget(
+        this IServiceCollection services,
+        ObservationTarget target)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(target);
+
+        services.AddSingleton(target);
+        return services;
+    }
+}

--- a/src/RockBot.Observation/Snapshot.cs
+++ b/src/RockBot.Observation/Snapshot.cs
@@ -1,0 +1,14 @@
+namespace RockBot.Observation;
+
+/// <summary>
+/// Historical snapshot of the regenerated markdown output. The framework
+/// retains the last N snapshots in <see cref="ObservationState.Snapshots"/>
+/// so evolution over time is observable without external tooling. Snapshots
+/// are appended at the end of phase 2 (after a fresh markdown render);
+/// oldest entries are evicted to maintain the configured cap.
+/// </summary>
+/// <param name="TakenAt">When the snapshot was captured.</param>
+/// <param name="Markdown">Full text of the regenerated markdown body at that time.</param>
+public sealed record Snapshot(
+    DateTimeOffset TakenAt,
+    string Markdown);

--- a/src/RockBot.Observation/Theory.cs
+++ b/src/RockBot.Observation/Theory.cs
@@ -1,0 +1,47 @@
+namespace RockBot.Observation;
+
+/// <summary>
+/// A promoted observation that has been reinforced across enough distinct
+/// conversations to graduate from candidate status. Theories are what appear
+/// in the regenerated markdown's "Theories" section and are loaded into agent
+/// context as part of the agent profile.
+/// </summary>
+public sealed class Theory
+{
+    /// <summary>Stable ID assigned at promotion time.</summary>
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// Canonical text of the theory. Established at promotion and may be
+    /// refined by the evaluation pass when new supporting references arrive
+    /// that better articulate the underlying claim. As with
+    /// <see cref="Candidate.Text"/>, refinements are LLM-mediated through
+    /// the pipeline, not direct.
+    /// </summary>
+    public required string Text { get; set; }
+
+    /// <summary>When the candidate graduated into this theory.</summary>
+    public DateTimeOffset PromotedAt { get; init; }
+
+    /// <summary>
+    /// Most recent reference observation timestamp from any contributing
+    /// conversation (including post-promotion reinforcements). Used by the
+    /// theory-aging pass: a theory with no new supporting references in the
+    /// configured theory-aging window is dropped or demoted.
+    /// </summary>
+    public DateTimeOffset LastReinforced { get; set; }
+
+    /// <summary>
+    /// IDs of the candidate(s) that produced this theory. A theory may have
+    /// more than one source candidate when the evaluation pass merges
+    /// related candidates at promotion time.
+    /// </summary>
+    public List<string> SourceCandidateIds { get; init; } = [];
+
+    /// <summary>
+    /// Evidence accumulated across the theory's lifetime — both the references
+    /// the source candidate(s) carried at promotion and any references added
+    /// by post-promotion reinforcements that matched the theory's cluster.
+    /// </summary>
+    public List<ObservationReference> References { get; init; } = [];
+}

--- a/src/RockBot.Observation/TranscriptTurn.cs
+++ b/src/RockBot.Observation/TranscriptTurn.cs
@@ -1,0 +1,22 @@
+namespace RockBot.Observation;
+
+/// <summary>
+/// One turn of conversation surfaced to the observation framework. The framework
+/// is decoupled from the host's conversation log shape: an adapter converts
+/// host-side conversation records into <see cref="TranscriptTurn"/> instances
+/// before passing them to <see cref="ITranscriptFilter"/> and the extraction
+/// pipeline.
+/// </summary>
+/// <param name="ConversationId">Conversation the turn belongs to.</param>
+/// <param name="TurnId">Turn ID within the conversation.</param>
+/// <param name="Source">Origin of the turn — "user", "agent", "scheduled-task", "heartbeat", etc. Filters use this to scope what they extract from.</param>
+/// <param name="Role">Chat role for this turn ("user", "assistant", "system", "tool"). Distinct from <see cref="Source"/>: an agent-authored "assistant" turn during a scheduled-task run has Source="scheduled-task" and Role="assistant".</param>
+/// <param name="Content">Verbatim turn text. Tool calls and structured payloads are not modelled here; targets that care about behavior trajectory (theory-of-self) supplement this with structured behavior summaries computed elsewhere.</param>
+/// <param name="Timestamp">When the turn occurred.</param>
+public sealed record TranscriptTurn(
+    string ConversationId,
+    string TurnId,
+    string Source,
+    string Role,
+    string Content,
+    DateTimeOffset Timestamp);

--- a/tests/RockBot.Observation.Tests/FileObservationStateStoreTests.cs
+++ b/tests/RockBot.Observation.Tests/FileObservationStateStoreTests.cs
@@ -1,0 +1,182 @@
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace RockBot.Observation.Tests;
+
+[TestClass]
+public class FileObservationStateStoreTests
+{
+    private string _tempDir = null!;
+
+    [TestInitialize]
+    public void Init()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(),
+            "rockbot-observation-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    private ObservationTarget MakeTarget(string name = "test-target") =>
+        new()
+        {
+            Name = name,
+            Filter = new PassThroughFilter(),
+            ExtractionPrompt = "extract",
+            EvaluationPrompt = "evaluate",
+            StateFilePath = Path.Combine(_tempDir, $"{name}.json"),
+            OutputMarkdownPath = Path.Combine(_tempDir, $"{name}.md"),
+        };
+
+    private static IObservationStateStore CreateStore() =>
+        new FileObservationStateStore(NullLogger<FileObservationStateStore>.Instance);
+
+    [TestMethod]
+    public async Task LoadAsync_NoFile_ReturnsEmptyState()
+    {
+        var store = CreateStore();
+        var state = await store.LoadAsync(MakeTarget(), CancellationToken.None);
+
+        Assert.IsNotNull(state);
+        Assert.AreEqual(ObservationState.CurrentSchemaVersion, state.SchemaVersion);
+        Assert.AreEqual(0, state.Candidates.Count);
+        Assert.AreEqual(0, state.Theories.Count);
+        Assert.IsNull(state.LastDreamAt);
+    }
+
+    [TestMethod]
+    public async Task SaveThenLoad_RoundTrips()
+    {
+        var store = CreateStore();
+        var target = MakeTarget();
+        var observed = DateTimeOffset.Parse("2026-05-07T12:00:00Z");
+
+        var state = new ObservationState
+        {
+            LastDreamAt = observed,
+            Candidates =
+            {
+                new Candidate
+                {
+                    Id = "cand_a",
+                    Text = "Observation A",
+                    ClusterId = "c1",
+                    Count = 1,
+                    FirstSeen = observed,
+                    LastSeen = observed,
+                    References = { new ObservationReference("conv1", "t1", "quote a", observed) },
+                },
+            },
+        };
+
+        await store.SaveAsync(target, state, CancellationToken.None);
+
+        Assert.IsTrue(File.Exists(target.StateFilePath), "State file should exist after save");
+
+        var rt = await store.LoadAsync(target, CancellationToken.None);
+        Assert.AreEqual(1, rt.Candidates.Count);
+        Assert.AreEqual("cand_a", rt.Candidates[0].Id);
+        Assert.AreEqual(observed, rt.LastDreamAt);
+    }
+
+    [TestMethod]
+    public async Task SaveAsync_WritesViaTempFile()
+    {
+        var store = CreateStore();
+        var target = MakeTarget();
+        var state = new ObservationState();
+
+        await store.SaveAsync(target, state, CancellationToken.None);
+
+        // Atomic-rename pattern: the temp file should NOT exist after a clean save
+        Assert.IsFalse(File.Exists(target.StateFilePath + ".tmp"),
+            "Temp file should be renamed away on successful save");
+        Assert.IsTrue(File.Exists(target.StateFilePath));
+    }
+
+    [TestMethod]
+    public async Task SaveAsync_OverwritesExistingFile()
+    {
+        var store = CreateStore();
+        var target = MakeTarget();
+
+        await store.SaveAsync(target, new ObservationState
+        {
+            Candidates = { new Candidate
+            {
+                Id = "first", Text = "first", ClusterId = "c", Count = 0,
+                FirstSeen = DateTimeOffset.UtcNow, LastSeen = DateTimeOffset.UtcNow,
+            } },
+        }, CancellationToken.None);
+
+        await store.SaveAsync(target, new ObservationState
+        {
+            Candidates = { new Candidate
+            {
+                Id = "second", Text = "second", ClusterId = "c", Count = 0,
+                FirstSeen = DateTimeOffset.UtcNow, LastSeen = DateTimeOffset.UtcNow,
+            } },
+        }, CancellationToken.None);
+
+        var rt = await store.LoadAsync(target, CancellationToken.None);
+        Assert.AreEqual(1, rt.Candidates.Count);
+        Assert.AreEqual("second", rt.Candidates[0].Id);
+    }
+
+    [TestMethod]
+    public async Task LoadAsync_UnknownSchemaVersion_Throws()
+    {
+        var target = MakeTarget();
+        await File.WriteAllTextAsync(target.StateFilePath,
+            "{\"schemaVersion\": 99, \"candidates\": [], \"theories\": [], \"snapshots\": []}");
+
+        var store = CreateStore();
+        await Assert.ThrowsExactlyAsync<InvalidDataException>(async () =>
+            await store.LoadAsync(target, CancellationToken.None));
+    }
+
+    [TestMethod]
+    public async Task SaveAsync_AlwaysWritesCurrentSchemaVersion()
+    {
+        var store = CreateStore();
+        var target = MakeTarget();
+
+        // Even if a caller hands in a state with the wrong schemaVersion,
+        // the store normalises to the current one on write.
+        var state = new ObservationState { SchemaVersion = 0 };
+        await store.SaveAsync(target, state, CancellationToken.None);
+
+        var rt = await store.LoadAsync(target, CancellationToken.None);
+        Assert.AreEqual(ObservationState.CurrentSchemaVersion, rt.SchemaVersion);
+    }
+
+    [TestMethod]
+    public async Task SaveAsync_CreatesDirectoryIfMissing()
+    {
+        var store = CreateStore();
+        var nestedDir = Path.Combine(_tempDir, "nested", "deeper");
+        var target = new ObservationTarget
+        {
+            Name = "deep",
+            Filter = new PassThroughFilter(),
+            ExtractionPrompt = "x",
+            EvaluationPrompt = "x",
+            StateFilePath = Path.Combine(nestedDir, "deep.json"),
+            OutputMarkdownPath = Path.Combine(nestedDir, "deep.md"),
+        };
+
+        await store.SaveAsync(target, new ObservationState(), CancellationToken.None);
+
+        Assert.IsTrue(File.Exists(target.StateFilePath));
+    }
+
+    private sealed class PassThroughFilter : ITranscriptFilter
+    {
+        public IEnumerable<TranscriptTurn> Filter(IReadOnlyList<TranscriptTurn> turns) => turns;
+    }
+}

--- a/tests/RockBot.Observation.Tests/ObservationStateRoundTripTests.cs
+++ b/tests/RockBot.Observation.Tests/ObservationStateRoundTripTests.cs
@@ -1,0 +1,127 @@
+using System.Text.Json;
+using System.Reflection;
+
+namespace RockBot.Observation.Tests;
+
+[TestClass]
+public class ObservationStateRoundTripTests
+{
+    private static readonly JsonSerializerOptions Options = ResolveJsonOptions();
+
+    private static JsonSerializerOptions ResolveJsonOptions()
+    {
+        // Internal type; reach in via reflection to test that it's correctly configured.
+        var assembly = typeof(ObservationState).Assembly;
+        var optionsType = assembly.GetType("RockBot.Observation.ObservationStateJsonOptions")
+            ?? throw new InvalidOperationException("ObservationStateJsonOptions not found");
+        var instanceField = optionsType.GetField("Instance",
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException("Instance field not found");
+        return (JsonSerializerOptions)instanceField.GetValue(null)!;
+    }
+
+    [TestMethod]
+    public void EmptyState_RoundTripsCleanly()
+    {
+        var state = new ObservationState();
+        var json = JsonSerializer.Serialize(state, Options);
+        var roundTripped = JsonSerializer.Deserialize<ObservationState>(json, Options);
+
+        Assert.IsNotNull(roundTripped);
+        Assert.AreEqual(ObservationState.CurrentSchemaVersion, roundTripped.SchemaVersion);
+        Assert.IsNull(roundTripped.LastDreamAt);
+        Assert.AreEqual(0, roundTripped.Candidates.Count);
+        Assert.AreEqual(0, roundTripped.Theories.Count);
+        Assert.AreEqual(0, roundTripped.Snapshots.Count);
+    }
+
+    [TestMethod]
+    public void PopulatedState_RoundTripsAllFields()
+    {
+        var observed = DateTimeOffset.Parse("2026-05-07T12:00:00Z");
+        var state = new ObservationState
+        {
+            LastDreamAt = observed,
+            Candidates =
+            {
+                new Candidate
+                {
+                    Id = "cand_001",
+                    Text = "User reverts diffs that touch tests they did not ask about.",
+                    ClusterId = "clust_42",
+                    Count = 2,
+                    FirstSeen = observed.AddDays(-15),
+                    LastSeen = observed.AddDays(-2),
+                    References =
+                    {
+                        new ObservationReference("conv_001", "turn_017", "...just revert that test change...", observed.AddDays(-15)),
+                        new ObservationReference("conv_044", "turn_004", "...don't touch the test file...", observed.AddDays(-2)),
+                    },
+                },
+            },
+            Theories =
+            {
+                new Theory
+                {
+                    Id = "thry_001",
+                    Text = "User prefers terse responses with no trailing summaries.",
+                    PromotedAt = observed.AddDays(-50),
+                    LastReinforced = observed.AddDays(-1),
+                    SourceCandidateIds = { "cand_seed" },
+                    References =
+                    {
+                        new ObservationReference("conv_010", "turn_003", "...just give me the diff...", observed.AddDays(-50)),
+                    },
+                },
+            },
+            Snapshots =
+            {
+                new Snapshot(observed.AddDays(-1), "# Theory of self\n\n(snapshot body)\n"),
+            },
+        };
+
+        var json = JsonSerializer.Serialize(state, Options);
+        var rt = JsonSerializer.Deserialize<ObservationState>(json, Options);
+
+        Assert.IsNotNull(rt);
+        Assert.AreEqual(observed, rt.LastDreamAt);
+
+        Assert.AreEqual(1, rt.Candidates.Count);
+        var cand = rt.Candidates[0];
+        Assert.AreEqual("cand_001", cand.Id);
+        Assert.AreEqual("clust_42", cand.ClusterId);
+        Assert.AreEqual(2, cand.Count);
+        Assert.AreEqual(2, cand.References.Count);
+        Assert.AreEqual("conv_001", cand.References[0].ConversationId);
+        Assert.AreEqual("turn_017", cand.References[0].TurnId);
+        Assert.IsTrue(cand.References[0].Quote.Contains("revert that test"));
+
+        Assert.AreEqual(1, rt.Theories.Count);
+        var thry = rt.Theories[0];
+        Assert.AreEqual("thry_001", thry.Id);
+        Assert.AreEqual(1, thry.SourceCandidateIds.Count);
+        Assert.AreEqual("cand_seed", thry.SourceCandidateIds[0]);
+
+        Assert.AreEqual(1, rt.Snapshots.Count);
+        Assert.IsTrue(rt.Snapshots[0].Markdown.Contains("snapshot body"));
+    }
+
+    [TestMethod]
+    public void Json_UsesCamelCase()
+    {
+        var state = new ObservationState { LastDreamAt = DateTimeOffset.UnixEpoch };
+        var json = JsonSerializer.Serialize(state, Options);
+
+        Assert.IsTrue(json.Contains("\"schemaVersion\""), "Expected camelCase 'schemaVersion'");
+        Assert.IsTrue(json.Contains("\"lastDreamAt\""), "Expected camelCase 'lastDreamAt'");
+        Assert.IsFalse(json.Contains("\"SchemaVersion\""), "PascalCase should not appear");
+    }
+
+    [TestMethod]
+    public void SchemaVersion_DefaultsToCurrent()
+    {
+        var state = new ObservationState();
+        Assert.AreEqual(1, state.SchemaVersion);
+        Assert.AreEqual(1, ObservationState.CurrentSchemaVersion);
+    }
+}

--- a/tests/RockBot.Observation.Tests/ObservationTargetDefaultsTests.cs
+++ b/tests/RockBot.Observation.Tests/ObservationTargetDefaultsTests.cs
@@ -1,0 +1,38 @@
+using RockBot.Host;
+
+namespace RockBot.Observation.Tests;
+
+[TestClass]
+public class ObservationTargetDefaultsTests
+{
+    [TestMethod]
+    public void Defaults_MatchDesignDocValues()
+    {
+        // Sanity-check that the design's named defaults match what the type ships
+        // with. If these change, design/observation-framework.md must be updated
+        // too.
+        var target = new ObservationTarget
+        {
+            Name = "test",
+            Filter = new NoopFilter(),
+            ExtractionPrompt = "x",
+            EvaluationPrompt = "x",
+            StateFilePath = "/tmp/x.json",
+            OutputMarkdownPath = "/tmp/x.md",
+        };
+
+        Assert.AreEqual(ModelTier.Low, target.ExtractionTier);
+        Assert.AreEqual(ModelTier.Balanced, target.EvaluationTier);
+        Assert.AreEqual(3, target.PromotionThreshold);
+        Assert.AreEqual(14, target.CandidateAgingWindowDreams);
+        Assert.AreEqual(60, target.TheoryAgingWindowDreams);
+        Assert.AreEqual(0.85f, target.ClusteringSimilarityThreshold);
+        Assert.AreEqual(12, target.SnapshotRetentionCount);
+        Assert.IsFalse(target.IncludeBehaviorSummary);
+    }
+
+    private sealed class NoopFilter : ITranscriptFilter
+    {
+        public IEnumerable<TranscriptTurn> Filter(IReadOnlyList<TranscriptTurn> turns) => turns;
+    }
+}

--- a/tests/RockBot.Observation.Tests/RockBot.Observation.Tests.csproj
+++ b/tests/RockBot.Observation.Tests/RockBot.Observation.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.*" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.*" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\RockBot.Observation\RockBot.Observation.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/RockBot.Observation.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/RockBot.Observation.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,98 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace RockBot.Observation.Tests;
+
+[TestClass]
+public class ServiceCollectionExtensionsTests
+{
+    [TestMethod]
+    public void AddRockBotObservation_RegistersStateStore()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddRockBotObservation();
+
+        var provider = services.BuildServiceProvider();
+        var store = provider.GetService<IObservationStateStore>();
+
+        Assert.IsNotNull(store);
+        Assert.IsInstanceOfType<FileObservationStateStore>(store);
+    }
+
+    [TestMethod]
+    public void AddRockBotObservation_TwiceIsIdempotent()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddRockBotObservation();
+        services.AddRockBotObservation();
+
+        var provider = services.BuildServiceProvider();
+        var stores = provider.GetServices<IObservationStateStore>().ToList();
+
+        Assert.AreEqual(1, stores.Count, "TryAdd should keep registration idempotent");
+    }
+
+    [TestMethod]
+    public void AddObservationTarget_RegistersTargetForResolution()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddRockBotObservation();
+
+        var target = new ObservationTarget
+        {
+            Name = "theory-of-self",
+            Filter = new EverythingFilter(),
+            ExtractionPrompt = "extract",
+            EvaluationPrompt = "evaluate",
+            StateFilePath = "/tmp/test.json",
+            OutputMarkdownPath = "/tmp/test.md",
+            IncludeBehaviorSummary = true,
+        };
+        services.AddObservationTarget(target);
+
+        var provider = services.BuildServiceProvider();
+        var resolved = provider.GetServices<ObservationTarget>().ToList();
+
+        Assert.AreEqual(1, resolved.Count);
+        Assert.AreEqual("theory-of-self", resolved[0].Name);
+        Assert.IsTrue(resolved[0].IncludeBehaviorSummary);
+    }
+
+    [TestMethod]
+    public void AddObservationTarget_MultipleTargets_AllResolvable()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddRockBotObservation();
+
+        services.AddObservationTarget(new ObservationTarget
+        {
+            Name = "theory-of-self",
+            Filter = new EverythingFilter(),
+            ExtractionPrompt = "x", EvaluationPrompt = "x",
+            StateFilePath = "/tmp/a.json", OutputMarkdownPath = "/tmp/a.md",
+        });
+        services.AddObservationTarget(new ObservationTarget
+        {
+            Name = "theory-of-user",
+            Filter = new EverythingFilter(),
+            ExtractionPrompt = "x", EvaluationPrompt = "x",
+            StateFilePath = "/tmp/b.json", OutputMarkdownPath = "/tmp/b.md",
+        });
+
+        var provider = services.BuildServiceProvider();
+        var names = provider.GetServices<ObservationTarget>()
+            .Select(t => t.Name)
+            .OrderBy(n => n)
+            .ToArray();
+
+        CollectionAssert.AreEqual(new[] { "theory-of-self", "theory-of-user" }, names);
+    }
+
+    private sealed class EverythingFilter : ITranscriptFilter
+    {
+        public IEnumerable<TranscriptTurn> Filter(IReadOnlyList<TranscriptTurn> turns) => turns;
+    }
+}


### PR DESCRIPTION
First phase of the observation framework per `design/observation-framework.md`. Project skeleton + types + state I/O + DI + tests. **No pipeline logic yet** — extraction, clustering, evaluation, promotion, aging, and markdown regen all follow in later phases.

## Summary

- **New project `RockBot.Observation`** registered in the solution. Depends on `RockBot.Host.Abstractions` (for `ModelTier`).
- **Core types:**
  - `ObservationState` (top-level, schema-versioned)
  - `Candidate`, `Theory` (sharing `ObservationReference`)
  - `Snapshot` (markdown body + timestamp)
  - `ObservationTarget` (per-target config: name, filter, prompts, paths, tiers, thresholds, aging windows, clustering threshold, snapshot retention)
  - `TranscriptTurn` + `ITranscriptFilter` (per-target input scoping)
- **Schema versioning:** `ObservationState.CurrentSchemaVersion = 1`. Loader rejects unknown versions with `InvalidDataException`. Saver always normalises to the current version.
- **`FileObservationStateStore`:** atomic write-temp-then-rename so partial writes are never observed. Auto-creates target directories. Internal JSON options shared (`camelCase`, `WhenWritingNull`, indented for diffability).
- **DI extensions:** `AddRockBotObservation()` registers the state store; `AddObservationTarget(...)` registers a target instance. Multiple targets supported.

## Tests (16)

- `ObservationStateRoundTripTests` (4) — empty + populated round-trip, camelCase property names, schema version default
- `FileObservationStateStoreTests` (7) — empty load, save+load round-trip, temp-file cleanup, overwrite semantics, schema-version rejection, schema-version normalisation on save, auto-mkdir
- `ServiceCollectionExtensionsTests` (4) — state store registered, registration is idempotent, single + multiple targets resolvable
- `ObservationTargetDefaultsTests` (1) — default values match the design doc (3 promotion threshold, 14 candidate aging, 60 theory aging, 0.85 clustering, 12 snapshots, Low/Balanced tiers)

## Test plan

- [x] `dotnet build RockBot.slnx` — clean
- [x] `dotnet test tests/RockBot.Observation.Tests` — 16/16 pass
- [x] Full solution test run — all projects unaffected

## Out of scope (later phases)

- Phase 2: pipeline phase 1 — extraction + quote-grounding + vector clustering + candidate merge
- Phase 3: pipeline phase 2 — differential evaluation + promotion + aging + markdown regen + snapshots
- Phase 4: two configured targets (theory-of-self, theory-of-user) with their prompts
- Phase 5: dream cycle integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)