### PR TITLE
Observation framework targets + memory publishing (phase 4 of #353)

### DIFF
--- a/design/observation-framework.md
+++ b/design/observation-framework.md
@@ -12,7 +12,7 @@ This design **supersedes** the portable-prompt approach in the getting-started d
 
 ### Research-first framing
 
-This is a science experiment: it has no *closed loop yet*. The artifacts it produces (`theory-of-self.md`, `theory-of-user.md`) are loaded into agent context the same way memory and skills are, but nothing actively drives behaviour from them — no evaluator queries them, no rule promotion, no self-monitoring loop. v1 ships as research instrumentation: build the data layer cleanly so months of accumulated observations are available, then decide what closed loop (if any) earns its complexity. See "Closed loops (future)" below.
+This is a science experiment: it has no *closed loop yet* in the sense of pushing structured theories into agent reasoning, but theories ARE published to the host's long-term memory store so they participate in `SearchMemory` and the hybrid-search index. The agent will surface a theory only when its query happens to match — there is no always-loaded injection into the system prompt, no evaluator that interrogates them, no rule promotion. Markdown copies of the state are also written to `{agentProfile}/observation/` for human inspection. Operators read those directly; the agent reaches theories only through normal memory recall. This deliberate scope keeps theories observable (and hybrid-searchable) without forcing them into every turn, so we can evaluate the data layer's quality before committing to any tighter closed loop. See "Closed loops (future)" below.
 
 This framing affects design priorities: data integrity beats narrative readability. Better to have rigorous, evidence-grounded structured observations than a flowing self-portrait that may be partly confabulated. Synthesis can be layered on later if a closed loop demands it.
 
@@ -34,23 +34,26 @@ This framing affects design priorities: data integrity beats narrative readabili
 - Self-editing of always-loaded directives. The framework owns regeneration; the agent does not edit its own theory files.
 - Solving broader dream-cycle parallelism. That is a separate effort. The new phase introduced here parallelizes *within itself*.
 - **Narrative synthesis in v1.** The existing getting-started prompt asked the agent to write its theories in narrative form ("themes you see recurring," "tensions or contradictions you've noticed"). v1 explicitly rejects this in favor of structured, evidence-grounded observations. Synthesis-on-top is a future possibility (see "Closed loops") but not part of v1.
-- **Closed-loop behaviour change.** v1 is research instrumentation. The regenerated markdown is loaded into agent context the same way memory and skills are, and that's the only path by which it can influence behaviour. No evaluators, rules, or self-monitoring loops are wired up in v1.
+- **Always-loaded context injection.** v1 does NOT auto-load the regenerated theory markdown into the agent's system prompt. Theories surface to the agent only when its own queries happen to match them via `SearchMemory` / hybrid search.
+- **Evaluators, rules, self-monitoring loops.** No subsystems consume the theory data programmatically. v1 publishes for visibility; future work decides what to do with it.
 
 ## Closed loops (future)
 
-v1 has no active closed loop — the regenerated markdown is loaded into agent context like any other memory/skills file, and that's the entire mechanism by which it can affect behaviour. This section records the closed-loop options under consideration so future work has a roadmap.
+v1 ships with one minimal closed loop: each promoted theory is published to the host's `ILongTermMemory` so the agent's existing `SearchMemory` tool and hybrid-search index can surface it on relevance. There is no always-loaded injection, no programmatic consumer of the data, and no rule promotion — theories only influence behaviour to the extent that the agent's own queries happen to match them. This section records the additional closed-loop options under consideration for later phases.
 
-**Loop A — context-only (v1).** Markdown is loaded into context every turn. If context says "user prefers terse responses," the agent might do that. Implicit, easy to lose in a long context, zero new mechanism. This is what v1 ships.
+**Loop A — load markdown into context.** Inject the regenerated theory markdown into the agent's system prompt every turn (similar to how soul/directives/style are injected today). Theories would be visible every turn rather than only on relevance match. Costs: token budget per turn, requires plumbing into the profile loader.
 
-**Loop B — targeted feed into specific subsystems.** Theories become structured input to specific decision points where they could plausibly help. Examples:
+**Loop B — publish theories as searchable memory entries (✅ shipped in v1).** Each promoted theory is written via `ILongTermMemory.SaveAsync` with category `observation/theory/{target.Name}`, importance 0.7, tagged with `observation` and the target name. The framework owns the lifecycle: insert on promote, delete on age-out. JSON state remains the source of truth; memory entries are derived. Memory writes are best-effort — JSON commit happens first, then memory writes — so a memory failure leaves a recoverable state.
+
+**Loop C — targeted feed into specific subsystems.** Theories become structured input to specific decision points where they could plausibly help. Examples:
 - `theory-of-user` → completion evaluator: "would this response satisfy this user given the observed patterns?"
 - `theory-of-self` → mid-loop self-check: a Low-tier query like "given the observed pattern that I tend to over-explain, is this draft response in that pattern?"
 
-Higher leverage than loop A, requires touching the relevant evaluators. Each integration point is its own change.
+Higher leverage than A. Each integration point is its own change.
 
-**Loop C — promote high-confidence theories into rules/directives.** A theory reinforced over many conversations across many weeks could graduate to an actual rule the agent must follow. Strongest closed loop, highest risk: the agent's behaviour shifts based on its own observations of itself. Almost certainly needs human approval before promotion (a "review surface" where promotions are queued for the operator to approve, not auto-applied).
+**Loop D — promote high-confidence theories into rules/directives.** A theory reinforced over many conversations across many weeks could graduate to an actual rule the agent must follow. Strongest closed loop, highest risk: the agent's behaviour shifts based on its own observations of itself. Almost certainly needs human approval before promotion (a "review surface" where promotions are queued for the operator to approve, not auto-applied).
 
-The decision to add any of these loops will follow real evidence about what the v1 data layer actually produces. If the structured theories are coherent and useful, loop B is the natural next step. If they're noisy or shallow, loop A may be all the framework should ever do.
+The decision to add loops A, C, or D will follow real evidence about what the v1 data layer actually produces. If theories surface usefully via `SearchMemory` (loop B), loop A may be unnecessary. If queries don't naturally reach them, loop A is a candidate. Loops C/D wait on their own evidence.
 
 ## Background: why not just edit directives?
 
@@ -314,12 +317,13 @@ Broader dream-cycle parallelism (running multiple existing phases concurrently) 
 New project: **`RockBot.Observation`**.
 
 Dependencies:
-- LLM client (`ILlmClient`)
-- Vector embedding service (already present for hybrid search)
+- LLM client (`ILlmClient`) — extraction + evaluation calls.
+- Vector embedding service (`IEmbeddingGenerator<string, Embedding<float>>`) — already present for hybrid search.
+- Long-term memory (`ILongTermMemory`) — publishes promoted theories so they appear in `SearchMemory` and the hybrid-search index. v1 closed loop B.
 
 It does *not* depend on messaging. The dream cycle is the only invoker. Agent code's role is limited to:
 - Registering observation targets at startup (DI configuration).
-- Loading the regenerated markdown files into agent context (this already happens for the existing theory-of files; nothing changes there).
+- Nothing else. The framework is self-contained: agent context loading is unchanged in v1 (markdown is written for inspection but not auto-loaded), and theories reach the agent only via the existing `SearchMemory` tool and hybrid-search index.
 
 ## Schema evolution
 
@@ -341,4 +345,4 @@ The observation framework's parallelism makes a global LLM rate-limit-handling a
 - **Aging window defaults.** Calendar-time aging in days makes the behaviour cadence-independent. Initial defaults: K=7 days for candidates, M=30 days for theories. Should be reviewed once there's data on real reinforcement frequency.
 - **Evaluation prompt structure.** Differential framing is the right shape, but the exact prompt template needs iteration once Phase 1 is producing real candidate pools.
 - **Telemetry surfacing.** Should the framework emit an end-of-phase summary message ("X candidates added, Y promoted, Z aged out per target") so dream activity is visible in logs without inspecting JSON files?
-- **Closed-loop sequencing.** v1 is loop A (context-only) by design. The decision on whether/which of loops B and C to build follows real evidence about what the data layer produces — but a rough trigger condition would help: "if after 2 months of accumulation the theories look coherent and operator-validated, consider loop B for the completion evaluator first."
+- **Closed-loop sequencing.** v1 ships with loop B (memory publish) only. The decision on whether/which of loops A, C, D to build follows real evidence about what the data layer produces — a rough trigger condition would help: "if after 2 months of accumulation theories surface usefully via `SearchMemory`, loop A may be unnecessary; if they're rarely surfaced naturally, loop A is the next step; loops C/D wait on their own evidence."

--- a/docs/getting-started-rockbot.md
+++ b/docs/getting-started-rockbot.md
@@ -220,9 +220,12 @@ The best RockBot agents do not just accumulate random memories. They deliberatel
 
 These artifacts are produced and maintained automatically by the **observation framework**, which runs as a phase of the dream cycle. Each dream, the framework reads recent conversation history, extracts evidence-grounded observations using a cheap LLM tier, clusters them into candidates, and promotes candidates that have been reinforced across multiple distinct conversations into the theory documents. Stale entries that are not reinforced age out.
 
-The output is a deterministically regenerated `theory-of-self.md` and `theory-of-user.md` in the agent profile, with structured entries showing reinforcement counts, dates, and representative quotes. They are loaded into agent context like any other profile file.
+The output is twofold:
 
-You do not need to teach the agent to maintain these via prompts — the framework does it. Any existing `theory-of-self.md` or `theory-of-user.md` you seeded by hand or via earlier prompt patterns will be overwritten on the first dream after the framework is enabled, since the framework regenerates them deterministically from its own JSON state. (If your deployment backs up the agent profile, the prior content is preserved there.) Until the framework accumulates enough observations to promote any theories, the files will simply show in-progress candidate observations.
+1. **Promoted theories are published as long-term memory entries** under category `observation/theory/{target-name}` with importance 0.7 and tags `observation, theory-of-self` (or `theory-of-user`). They participate in the hybrid-search index, so the agent finds them via `SearchMemory` like any other memory. This is the v1 closed loop — searchability without forced context injection.
+2. **Markdown copies** of the state — `theory-of-self.md` and `theory-of-user.md` under `{agent-profile}/observation/` — are regenerated each cycle for human inspection. These are NOT auto-injected into the agent's system prompt; you read them yourself to see what the framework is accumulating.
+
+Any existing `theory-of-self.md` or `theory-of-user.md` you seeded by hand at the agent profile root is left untouched by the framework, which writes only under `observation/`. Until the framework accumulates enough observations to promote any theories, the regenerated markdown will show in-progress candidate observations only and no memory entries will be published.
 
 For the design and configuration knobs (promotion thresholds, aging windows, snapshot retention), see [`design/observation-framework.md`](https://github.com/MarimerLLC/rockbot/blob/main/design/observation-framework.md) in the repo.
 

--- a/src/RockBot.Observation/DefaultPrompts.cs
+++ b/src/RockBot.Observation/DefaultPrompts.cs
@@ -1,0 +1,118 @@
+namespace RockBot.Observation;
+
+/// <summary>
+/// Default extraction and evaluation prompts for the built-in
+/// theory-of-self and theory-of-user targets. Operators can override per
+/// target by constructing <see cref="ObservationTarget"/> directly with
+/// their own prompt text; these defaults exist so the standard targets
+/// work out of the box.
+/// </summary>
+/// <remarks>
+/// The prompts deliberately push the LLM toward strict, evidence-grounded
+/// observations (per <c>design/observation-framework.md</c>). They are not
+/// the narrative synthesis-flavored prompts in earlier versions of the
+/// getting-started doc — those have been retired in favour of the
+/// framework's structured pipeline.
+/// </remarks>
+public static class DefaultPrompts
+{
+    /// <summary>
+    /// System prompt for theory-of-self extraction. Asks the LLM to identify
+    /// concrete, behavior-only observations about the agent with verbatim
+    /// quote evidence.
+    /// </summary>
+    public const string TheoryOfSelfExtraction = """
+        You are observing the agent's behavioral patterns in conversations.
+
+        Extract concrete, evidence-grounded observations about HOW the agent operates:
+        the patterns, habits, and tendencies visible in its actions and responses.
+
+        Strict rules:
+
+        1. BEHAVIOR ONLY, not motivation. Describe what the agent does, not what it
+           wants or values. "The agent reads multiple files before making a one-line
+           edit" is good. "The agent is thorough" or "the agent values context" is bad
+           — those are inferred motivations, not observed behaviors.
+
+        2. QUOTE EVIDENCE. Every observation MUST cite a verbatim or near-verbatim
+           quote from a specific turn that supports the claim. Quotes are mechanically
+           validated against the cited turn; observations whose quote is not present
+           in the cited turn will be discarded before they enter the candidate pool.
+
+        3. SPECIFIC, NOT GENERIC. "The agent often summarises" is too broad. "The agent
+           emits a 1-2 sentence end-of-turn summary even when the user requested a
+           one-word answer" is specific.
+
+        4. HONEST, NOT FLATTERING. Record patterns as you actually see them, including
+           ones that aren't flattering or that contradict the agent's stated identity.
+           Drift toward honesty, not toward narrative.
+
+        5. DON'T FORCE OBSERVATIONS. Many conversations produce nothing worth recording.
+           Returning an empty list is correct when there is no clear pattern.
+        """;
+
+    /// <summary>
+    /// System prompt for theory-of-user extraction. Asks the LLM to identify
+    /// concrete, behavior-only observations about the user with verbatim
+    /// quote evidence.
+    /// </summary>
+    public const string TheoryOfUserExtraction = """
+        You are observing the user's preferences and patterns in conversations with the agent.
+
+        Extract concrete, evidence-grounded observations about HOW the user operates:
+        what they ask for, how they react, what they reject, what they accept, what
+        they redirect.
+
+        Strict rules:
+
+        1. BEHAVIOR ONLY, not motivation. Describe what the user does, not what they
+           feel or value. "User reverts test changes the agent made without being
+           asked" is good. "User values minimalism" or "user is pragmatic" is bad —
+           those are inferred motivations.
+
+        2. QUOTE EVIDENCE. Every observation MUST cite a verbatim or near-verbatim
+           quote from a specific turn that supports the claim. Quotes are mechanically
+           validated against the cited turn; observations whose quote is not present
+           in the cited turn will be discarded.
+
+        3. SPECIFIC, NOT GENERIC. "User likes terse responses" is too broad. "User
+           redirects the agent within one turn whenever the agent's response exceeds
+           ~5 sentences" is specific.
+
+        4. HONEST, NOT FLATTERING. Record patterns as you observe them — including
+           ones that aren't flattering. The point is an honest model of the user, not
+           a polite one. Don't write to justify the agent's existence either.
+
+        5. DON'T FORCE OBSERVATIONS. Many conversations produce nothing worth recording.
+           Returning an empty list is correct when there is no clear pattern.
+        """;
+
+    /// <summary>
+    /// Differential evaluation prompt used by both theory-of-self and
+    /// theory-of-user. The same prompt works for both because the rules
+    /// (grounded? distinct from existing? clear?) are not target-specific.
+    /// </summary>
+    public const string DifferentialEvaluation = """
+        You are reviewing candidate observations to decide whether each one should be
+        promoted to a theory, refined, or rejected.
+
+        For each candidate, choose:
+
+        - promote: the candidate is well-grounded by its quotes, distinct from existing
+          theories, and articulates a real pattern. If the candidate's wording could be
+          clearer, you may provide a refinedText alongside; the theory will use that
+          wording instead.
+
+        - refine: the candidate captures something real, but its wording is too broad,
+          too narrow, or otherwise unclear. Provide refinedText with the corrected
+          wording. The candidate stays in the pool to accumulate more evidence under
+          the new wording.
+
+        - reject: the candidate is poorly grounded by its quotes, duplicates an
+          existing theory, or is too noisy or speculative to keep. The candidate is
+          removed from the pool.
+
+        When in doubt, prefer reject over promote. Promoted theories influence agent
+        context every turn, so the bar should be high.
+        """;
+}

--- a/src/RockBot.Observation/ObservationDefaults.cs
+++ b/src/RockBot.Observation/ObservationDefaults.cs
@@ -1,0 +1,74 @@
+using RockBot.Host;
+
+namespace RockBot.Observation;
+
+/// <summary>
+/// Factory helpers for the framework's standard targets. Hosts that want to
+/// run the default theory-of-self / theory-of-user observation pair register
+/// the targets produced here; hosts wanting different defaults construct
+/// their own <see cref="ObservationTarget"/> instances directly.
+/// </summary>
+public static class ObservationDefaults
+{
+    /// <summary>
+    /// Default target name for the theory-of-self observation pair.
+    /// Used as the JSON state filename stem and as the markdown filename stem.
+    /// </summary>
+    public const string TheoryOfSelfName = "theory-of-self";
+
+    /// <summary>Default target name for theory-of-user.</summary>
+    public const string TheoryOfUserName = "theory-of-user";
+
+    /// <summary>
+    /// Constructs the default theory-of-self target rooted at the given
+    /// agent-profile directory. Both the JSON state and the regenerated
+    /// markdown live under <c>{agentProfileBasePath}/observation/</c> —
+    /// these are inspection artifacts, not agent-profile files. The host's
+    /// profile loader does not auto-inject this markdown into context;
+    /// research-mode v1 is "collect, don't inject."
+    /// </summary>
+    public static ObservationTarget CreateTheoryOfSelf(string agentProfileBasePath) =>
+        new()
+        {
+            Name = TheoryOfSelfName,
+            Filter = TranscriptFilters.Everything,
+            ExtractionPrompt = DefaultPrompts.TheoryOfSelfExtraction,
+            EvaluationPrompt = DefaultPrompts.DifferentialEvaluation,
+            StateFilePath = Path.Combine(agentProfileBasePath, "observation", $"{TheoryOfSelfName}.json"),
+            OutputMarkdownPath = Path.Combine(agentProfileBasePath, "observation", $"{TheoryOfSelfName}.md"),
+            ExtractionTier = ModelTier.Low,
+            EvaluationTier = ModelTier.Balanced,
+            // The design opted into behaviour-summary input for theory-of-self;
+            // the actual summary computation is a future enhancement (see
+            // design open questions). The flag is set true now so the orchestrator
+            // wiring is in place when the summary is added.
+            IncludeBehaviorSummary = true,
+        };
+
+    /// <summary>
+    /// Constructs the default theory-of-user target rooted at the given
+    /// agent-profile directory. Uses the user-authored transcript filter:
+    /// observes user-authored turns and the agent's user-facing replies,
+    /// excluding scheduled-task and heartbeat activity. Output lives under
+    /// <c>{agentProfileBasePath}/observation/</c>; not auto-injected into
+    /// context (research-mode v1 is collect-only).
+    /// </summary>
+    /// <remarks>
+    /// Theory-of-user uses a denser-signal threshold (default unchanged
+    /// from the type's default of 3 reinforcements) — every user turn is
+    /// a deliberate human choice, so signal per turn is high.
+    /// </remarks>
+    public static ObservationTarget CreateTheoryOfUser(string agentProfileBasePath) =>
+        new()
+        {
+            Name = TheoryOfUserName,
+            Filter = TranscriptFilters.UserAuthored,
+            ExtractionPrompt = DefaultPrompts.TheoryOfUserExtraction,
+            EvaluationPrompt = DefaultPrompts.DifferentialEvaluation,
+            StateFilePath = Path.Combine(agentProfileBasePath, "observation", $"{TheoryOfUserName}.json"),
+            OutputMarkdownPath = Path.Combine(agentProfileBasePath, "observation", $"{TheoryOfUserName}.md"),
+            ExtractionTier = ModelTier.Low,
+            EvaluationTier = ModelTier.Balanced,
+            IncludeBehaviorSummary = false,
+        };
+}

--- a/src/RockBot.Observation/ObservationEvaluationPhase.cs
+++ b/src/RockBot.Observation/ObservationEvaluationPhase.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using RockBot.Host;
 
 namespace RockBot.Observation;
 
@@ -6,13 +7,24 @@ namespace RockBot.Observation;
 /// Default <see cref="IObservationEvaluationPhase"/>. Aging is deterministic
 /// in-memory work; evaluation is one Higher-tier LLM call only when there
 /// are candidates eligible for promotion. Markdown is regenerated from the
-/// resulting state and a snapshot is appended.
+/// resulting state and a snapshot is appended. Promoted theories are also
+/// published to <see cref="ILongTermMemory"/> so they participate in the
+/// host's hybrid-search index and surface via <c>SearchMemory</c>; aged-out
+/// theories have their memory entries deleted.
 /// </summary>
 internal sealed class ObservationEvaluationPhase(
     IObservationEvaluator evaluator,
     IObservationStateStore stateStore,
+    ILongTermMemory longTermMemory,
     ILogger<ObservationEvaluationPhase> logger) : IObservationEvaluationPhase
 {
+    /// <summary>
+    /// Importance score assigned to memory entries published for promoted
+    /// theories. Above the default (0.5) — promoted theories represent
+    /// reinforced observations — but not maximum, so they do not crowd out
+    /// hand-saved high-importance memories.
+    /// </summary>
+    private const float TheoryMemoryImportance = 0.7f;
     public async Task<EvaluationPhaseResult> ExecuteAsync(
         ObservationTarget target,
         CancellationToken cancellationToken)
@@ -23,9 +35,11 @@ internal sealed class ObservationEvaluationPhase(
 
         var now = DateTimeOffset.UtcNow;
 
-        // Aging — deterministic, in-memory
+        // Aging — deterministic, in-memory. Capture memory entry IDs of aged
+        // theories so we can delete them from the long-term store after the
+        // JSON save succeeds.
         var candidatesAged = AgeCandidates(state, target, now);
-        var theoriesAged = AgeTheories(state, target, now);
+        var (theoriesAged, agedMemoryEntryIds) = AgeTheories(state, target, now);
 
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -37,13 +51,14 @@ internal sealed class ObservationEvaluationPhase(
         var promoted = 0;
         var refined = 0;
         var rejected = 0;
+        var promotedTheories = new List<Theory>();
 
         if (eligible.Count > 0)
         {
             var verdicts = await evaluator.EvaluateAsync(
                 target, eligible, state.Theories, cancellationToken).ConfigureAwait(false);
 
-            (promoted, refined, rejected) = ApplyVerdicts(state, verdicts, now);
+            (promoted, refined, rejected, promotedTheories) = ApplyVerdicts(state, verdicts, now);
         }
 
         // Regenerate markdown
@@ -53,12 +68,28 @@ internal sealed class ObservationEvaluationPhase(
         // Snapshot — append + evict oldest beyond cap
         AppendSnapshot(state, target, markdown, now);
 
-        // Atomic writes: state first, then markdown. Both files end up
-        // mutually consistent because we hold the rendered markdown in
-        // memory before either write.
+        // Atomic writes: JSON state first (single source of truth), then
+        // markdown. Memory side-effects come AFTER the JSON commit so a
+        // failure during JSON save leaves the long-term store unchanged.
+        // Memory failures after this point leave orphan/missing entries
+        // recoverable on a future dream's reconciliation pass.
         await stateStore.SaveAsync(target, state, cancellationToken).ConfigureAwait(false);
         await WriteMarkdownAtomicAsync(target.OutputMarkdownPath, markdown, cancellationToken)
             .ConfigureAwait(false);
+
+        // Long-term memory side-effects: best-effort. Per-entry exceptions
+        // are logged and swallowed so one broken memory write does not
+        // prevent the rest from completing. Cancellation still propagates.
+        foreach (var memoryId in agedMemoryEntryIds)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await TryDeleteMemoryAsync(memoryId, target, cancellationToken).ConfigureAwait(false);
+        }
+        foreach (var theory in promotedTheories)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await TrySaveTheoryMemoryAsync(target, theory, now, cancellationToken).ConfigureAwait(false);
+        }
 
         var result = new EvaluationPhaseResult(
             CandidatesAged: candidatesAged,
@@ -81,6 +112,49 @@ internal sealed class ObservationEvaluationPhase(
         return result;
     }
 
+    private async Task TryDeleteMemoryAsync(string memoryEntryId, ObservationTarget target, CancellationToken ct)
+    {
+        try
+        {
+            await longTermMemory.DeleteAsync(memoryEntryId, ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "Observation: failed to delete memory entry {MemoryEntryId} for aged theory in target {Target}",
+                memoryEntryId, target.Name);
+        }
+    }
+
+    private async Task TrySaveTheoryMemoryAsync(
+        ObservationTarget target, Theory theory, DateTimeOffset now, CancellationToken ct)
+    {
+        if (theory.MemoryEntryId is null) return;
+
+        var entry = new MemoryEntry(
+            Id: theory.MemoryEntryId,
+            Content: theory.Text,
+            Category: $"observation/theory/{target.Name}",
+            Tags: new[] { "observation", target.Name },
+            CreatedAt: now,
+            UpdatedAt: now,
+            Metadata: null,
+            ImportanceScore: TheoryMemoryImportance);
+
+        try
+        {
+            await longTermMemory.SaveAsync(entry, ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "Observation: failed to publish memory entry {MemoryEntryId} for promoted theory {TheoryId} in target {Target}; theory remains in JSON state but is not searchable until a future reconciliation",
+                theory.MemoryEntryId, theory.Id, target.Name);
+        }
+    }
+
     private static int AgeCandidates(ObservationState state, ObservationTarget target, DateTimeOffset now)
     {
         var threshold = now - TimeSpan.FromDays(target.CandidateAgingWindowDays);
@@ -89,15 +163,21 @@ internal sealed class ObservationEvaluationPhase(
         return before - state.Candidates.Count;
     }
 
-    private static int AgeTheories(ObservationState state, ObservationTarget target, DateTimeOffset now)
+    private static (int Aged, IReadOnlyList<string> AgedMemoryEntryIds) AgeTheories(
+        ObservationState state, ObservationTarget target, DateTimeOffset now)
     {
         var threshold = now - TimeSpan.FromDays(target.TheoryAgingWindowDays);
-        var before = state.Theories.Count;
-        state.Theories.RemoveAll(t => t.LastReinforced < threshold);
-        return before - state.Theories.Count;
+        var aged = state.Theories.Where(t => t.LastReinforced < threshold).ToList();
+        var memoryEntryIds = aged
+            .Where(t => !string.IsNullOrEmpty(t.MemoryEntryId))
+            .Select(t => t.MemoryEntryId!)
+            .ToList();
+        foreach (var t in aged)
+            state.Theories.Remove(t);
+        return (aged.Count, memoryEntryIds);
     }
 
-    private static (int Promoted, int Refined, int Rejected) ApplyVerdicts(
+    private static (int Promoted, int Refined, int Rejected, List<Theory> PromotedTheories) ApplyVerdicts(
         ObservationState state,
         IReadOnlyList<EvaluationVerdict> verdicts,
         DateTimeOffset now)
@@ -105,6 +185,7 @@ internal sealed class ObservationEvaluationPhase(
         var promoted = 0;
         var refined = 0;
         var rejected = 0;
+        var promotedTheories = new List<Theory>();
 
         foreach (var v in verdicts)
         {
@@ -120,12 +201,14 @@ internal sealed class ObservationEvaluationPhase(
                         Text = string.IsNullOrWhiteSpace(v.RefinedText) ? candidate.Text : v.RefinedText,
                         PromotedAt = now,
                         LastReinforced = candidate.LastSeen,
+                        MemoryEntryId = "obs_" + Guid.NewGuid().ToString("N")[..12],
                     };
                     theory.SourceCandidateIds.Add(candidate.Id);
                     foreach (var r in candidate.References)
                         theory.References.Add(r);
                     state.Theories.Add(theory);
                     state.Candidates.Remove(candidate);
+                    promotedTheories.Add(theory);
                     promoted++;
                     break;
 
@@ -149,7 +232,7 @@ internal sealed class ObservationEvaluationPhase(
             }
         }
 
-        return (promoted, refined, rejected);
+        return (promoted, refined, rejected, promotedTheories);
     }
 
     private static void AppendSnapshot(

--- a/src/RockBot.Observation/ServiceCollectionExtensions.cs
+++ b/src/RockBot.Observation/ServiceCollectionExtensions.cs
@@ -40,4 +40,24 @@ public static class ServiceCollectionExtensions
         services.AddSingleton(target);
         return services;
     }
+
+    /// <summary>
+    /// Registers the framework's two default targets — theory-of-self and
+    /// theory-of-user — rooted at the given agent profile directory. The
+    /// targets use the built-in <see cref="TranscriptFilters"/> and
+    /// <see cref="DefaultPrompts"/>. Hosts that want different prompts or
+    /// filters should construct <see cref="ObservationTarget"/> instances
+    /// directly and register them with <see cref="AddObservationTarget"/>.
+    /// </summary>
+    public static IServiceCollection AddDefaultObservationTargets(
+        this IServiceCollection services,
+        string agentProfileBasePath)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentException.ThrowIfNullOrWhiteSpace(agentProfileBasePath);
+
+        services.AddObservationTarget(ObservationDefaults.CreateTheoryOfSelf(agentProfileBasePath));
+        services.AddObservationTarget(ObservationDefaults.CreateTheoryOfUser(agentProfileBasePath));
+        return services;
+    }
 }

--- a/src/RockBot.Observation/Theory.cs
+++ b/src/RockBot.Observation/Theory.cs
@@ -44,4 +44,13 @@ public sealed class Theory
     /// by post-promotion reinforcements that matched the theory's cluster.
     /// </summary>
     public List<ObservationReference> References { get; init; } = [];
+
+    /// <summary>
+    /// ID of the long-term memory entry published for this theory, or null
+    /// when no memory entry exists (e.g. publishing failed last cycle and
+    /// reconciliation has not yet recreated it). The framework writes a
+    /// memory entry on promotion, deletes it on aging, so theories show up
+    /// in <c>SearchMemory</c> and the host's hybrid-search index.
+    /// </summary>
+    public string? MemoryEntryId { get; set; }
 }

--- a/src/RockBot.Observation/TranscriptFilters.cs
+++ b/src/RockBot.Observation/TranscriptFilters.cs
@@ -1,0 +1,52 @@
+namespace RockBot.Observation;
+
+/// <summary>
+/// Built-in <see cref="ITranscriptFilter"/> implementations. Targets pick the
+/// filter that matches what they observe; a target observing the agent's
+/// behaviour wants the everything filter, while a target observing the user
+/// wants only user-authored turns plus the agent's user-facing replies.
+/// </summary>
+public static class TranscriptFilters
+{
+    /// <summary>
+    /// Filter that passes every turn through unchanged. Use for targets like
+    /// theory-of-self that observe the full trajectory regardless of who
+    /// authored what.
+    /// </summary>
+    public static ITranscriptFilter Everything { get; } = new EverythingFilter();
+
+    /// <summary>
+    /// Filter that keeps only user-authored turns and the agent's
+    /// user-facing replies. Excludes scheduled-task and heartbeat activity
+    /// (the user never sees those — they aren't user signal) and excludes
+    /// any tool-call / tool-result turns.
+    /// </summary>
+    /// <remarks>
+    /// "User-facing reply" = a turn with <see cref="TranscriptTurn.Source"/>
+    /// equal to <see cref="TranscriptSources.Agent"/> and
+    /// <see cref="TranscriptTurn.Role"/> equal to <c>"assistant"</c>. Tool
+    /// calls and tool results are stamped with different roles by the host
+    /// adapter, so they fall through.
+    /// </remarks>
+    public static ITranscriptFilter UserAuthored { get; } = new UserAuthoredFilter();
+
+    private sealed class EverythingFilter : ITranscriptFilter
+    {
+        public IEnumerable<TranscriptTurn> Filter(IReadOnlyList<TranscriptTurn> turns) => turns;
+    }
+
+    private sealed class UserAuthoredFilter : ITranscriptFilter
+    {
+        public IEnumerable<TranscriptTurn> Filter(IReadOnlyList<TranscriptTurn> turns)
+        {
+            foreach (var t in turns)
+            {
+                if (t.Source == TranscriptSources.User)
+                    yield return t;
+                else if (t.Source == TranscriptSources.Agent &&
+                         string.Equals(t.Role, "assistant", StringComparison.OrdinalIgnoreCase))
+                    yield return t;
+            }
+        }
+    }
+}

--- a/src/RockBot.Observation/TranscriptSources.cs
+++ b/src/RockBot.Observation/TranscriptSources.cs
@@ -1,0 +1,23 @@
+namespace RockBot.Observation;
+
+/// <summary>
+/// Conventional values for <see cref="TranscriptTurn.Source"/>. The host's
+/// conversation-log adapter is responsible for stamping these correctly; the
+/// framework's filters use them to scope what each target observes.
+/// Hosts may use additional values (e.g. "subagent", "a2a-call"); filters
+/// that don't recognise a source should default to excluding it.
+/// </summary>
+public static class TranscriptSources
+{
+    /// <summary>Turn authored directly by the user (human input).</summary>
+    public const string User = "user";
+
+    /// <summary>Turn authored by the agent's LLM during a normal conversation.</summary>
+    public const string Agent = "agent";
+
+    /// <summary>Turn produced by a scheduled-task trigger (the agent acting on its own initiative on a cron).</summary>
+    public const string ScheduledTask = "scheduled-task";
+
+    /// <summary>Turn produced by the heartbeat patrol (periodic self-check).</summary>
+    public const string Heartbeat = "heartbeat";
+}

--- a/tests/RockBot.Observation.Tests/DefaultPromptsTests.cs
+++ b/tests/RockBot.Observation.Tests/DefaultPromptsTests.cs
@@ -1,0 +1,51 @@
+namespace RockBot.Observation.Tests;
+
+[TestClass]
+public class DefaultPromptsTests
+{
+    [TestMethod]
+    public void TheoryOfSelfExtraction_NonEmptyAndContainsCoreRules()
+    {
+        var p = DefaultPrompts.TheoryOfSelfExtraction;
+        Assert.IsFalse(string.IsNullOrWhiteSpace(p));
+        StringAssert.Contains(p, "BEHAVIOR ONLY",
+            "Behavior-only-not-motivation is the load-bearing anti-hallucination rule");
+        StringAssert.Contains(p, "QUOTE EVIDENCE",
+            "Quote evidence is required by the framework's grounding pipeline");
+        StringAssert.Contains(p, "agent",
+            "Theory-of-self prompt should explicitly orient toward the agent");
+    }
+
+    [TestMethod]
+    public void TheoryOfUserExtraction_NonEmptyAndContainsCoreRules()
+    {
+        var p = DefaultPrompts.TheoryOfUserExtraction;
+        Assert.IsFalse(string.IsNullOrWhiteSpace(p));
+        StringAssert.Contains(p, "BEHAVIOR ONLY");
+        StringAssert.Contains(p, "QUOTE EVIDENCE");
+        StringAssert.Contains(p, "user",
+            "Theory-of-user prompt should explicitly orient toward the user");
+    }
+
+    [TestMethod]
+    public void DifferentialEvaluation_DescribesAllThreeVerdicts()
+    {
+        var p = DefaultPrompts.DifferentialEvaluation;
+        Assert.IsFalse(string.IsNullOrWhiteSpace(p));
+        StringAssert.Contains(p, "promote");
+        StringAssert.Contains(p, "refine");
+        StringAssert.Contains(p, "reject");
+        StringAssert.Contains(p, "prefer reject",
+            "Evaluator should err on the side of rejection given context-influence stakes");
+    }
+
+    [TestMethod]
+    public void Prompts_AreDistinctTexts()
+    {
+        // Cheap sanity check that we didn't accidentally copy/paste the same
+        // body across the three constants.
+        Assert.AreNotEqual(DefaultPrompts.TheoryOfSelfExtraction, DefaultPrompts.TheoryOfUserExtraction);
+        Assert.AreNotEqual(DefaultPrompts.TheoryOfSelfExtraction, DefaultPrompts.DifferentialEvaluation);
+        Assert.AreNotEqual(DefaultPrompts.TheoryOfUserExtraction, DefaultPrompts.DifferentialEvaluation);
+    }
+}

--- a/tests/RockBot.Observation.Tests/ObservationDefaultsTests.cs
+++ b/tests/RockBot.Observation.Tests/ObservationDefaultsTests.cs
@@ -1,0 +1,77 @@
+using Microsoft.Extensions.DependencyInjection;
+using RockBot.Host;
+
+namespace RockBot.Observation.Tests;
+
+[TestClass]
+public class ObservationDefaultsTests
+{
+    private const string Base = "/data/agent";
+
+    [TestMethod]
+    public void CreateTheoryOfSelf_HasExpectedShape()
+    {
+        var t = ObservationDefaults.CreateTheoryOfSelf(Base);
+
+        Assert.AreEqual(ObservationDefaults.TheoryOfSelfName, t.Name);
+        Assert.AreSame(TranscriptFilters.Everything, t.Filter);
+        Assert.AreEqual(DefaultPrompts.TheoryOfSelfExtraction, t.ExtractionPrompt);
+        Assert.AreEqual(DefaultPrompts.DifferentialEvaluation, t.EvaluationPrompt);
+        Assert.AreEqual(ModelTier.Low, t.ExtractionTier);
+        Assert.AreEqual(ModelTier.Balanced, t.EvaluationTier);
+        Assert.IsTrue(t.IncludeBehaviorSummary,
+            "theory-of-self uses behaviour summary input (per design)");
+
+        // Both files live under observation/ — these are inspection
+        // artifacts, not auto-loaded agent-profile files. v1 is collect-only.
+        StringAssert.EndsWith(t.OutputMarkdownPath,
+            Path.Combine(Base, "observation", "theory-of-self.md"));
+        StringAssert.EndsWith(t.StateFilePath,
+            Path.Combine(Base, "observation", "theory-of-self.json"));
+    }
+
+    [TestMethod]
+    public void CreateTheoryOfUser_HasExpectedShape()
+    {
+        var t = ObservationDefaults.CreateTheoryOfUser(Base);
+
+        Assert.AreEqual(ObservationDefaults.TheoryOfUserName, t.Name);
+        Assert.AreSame(TranscriptFilters.UserAuthored, t.Filter,
+            "theory-of-user uses the user-authored filter, not everything");
+        Assert.AreEqual(DefaultPrompts.TheoryOfUserExtraction, t.ExtractionPrompt);
+        Assert.AreEqual(DefaultPrompts.DifferentialEvaluation, t.EvaluationPrompt);
+        Assert.IsFalse(t.IncludeBehaviorSummary,
+            "theory-of-user does not need behaviour summary input — it observes the user, not the agent");
+
+        StringAssert.EndsWith(t.OutputMarkdownPath,
+            Path.Combine(Base, "observation", "theory-of-user.md"));
+        StringAssert.EndsWith(t.StateFilePath,
+            Path.Combine(Base, "observation", "theory-of-user.json"));
+    }
+
+    [TestMethod]
+    public void AddDefaultObservationTargets_RegistersBothTargetsAndCoreServices()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddRockBotObservation();
+        services.AddDefaultObservationTargets(Base);
+
+        var provider = services.BuildServiceProvider();
+
+        var targets = provider.GetServices<ObservationTarget>().ToList();
+        Assert.AreEqual(2, targets.Count);
+        Assert.IsTrue(targets.Any(t => t.Name == ObservationDefaults.TheoryOfSelfName));
+        Assert.IsTrue(targets.Any(t => t.Name == ObservationDefaults.TheoryOfUserName));
+
+        Assert.IsNotNull(provider.GetService<IObservationStateStore>());
+    }
+
+    [TestMethod]
+    public void AddDefaultObservationTargets_NullPath_Throws()
+    {
+        var services = new ServiceCollection();
+        Assert.ThrowsExactly<ArgumentException>(() =>
+            services.AddDefaultObservationTargets(""));
+    }
+}

--- a/tests/RockBot.Observation.Tests/ObservationEvaluationPhaseTests.cs
+++ b/tests/RockBot.Observation.Tests/ObservationEvaluationPhaseTests.cs
@@ -42,8 +42,9 @@ public class ObservationEvaluationPhaseTests
 
     private FileObservationStateStore Store() => new(NullLogger<FileObservationStateStore>.Instance);
 
-    private ObservationEvaluationPhase MakePhase(StubEvaluator evaluator) =>
-        new(evaluator, Store(), NullLogger<ObservationEvaluationPhase>.Instance);
+    private ObservationEvaluationPhase MakePhase(StubEvaluator evaluator, StubLongTermMemory? memory = null) =>
+        new(evaluator, Store(), memory ?? new StubLongTermMemory(),
+            NullLogger<ObservationEvaluationPhase>.Instance);
 
     private static Candidate Candidate(
         string id, int distinctConvs, DateTimeOffset lastSeen, string text = "obs")
@@ -408,5 +409,182 @@ public class ObservationEvaluationPhaseTests
             CallCount++;
             return Task.FromResult<IReadOnlyList<EvaluationVerdict>>(Verdicts);
         }
+    }
+
+    /// <summary>
+    /// Minimal in-memory <see cref="ILongTermMemory"/> stub that records
+    /// saves and deletes for verification. Optionally throws on save/delete
+    /// to exercise the framework's best-effort error handling.
+    /// </summary>
+    internal sealed class StubLongTermMemory : RockBot.Host.ILongTermMemory
+    {
+        public Dictionary<string, RockBot.Host.MemoryEntry> Saved { get; } = new(StringComparer.Ordinal);
+        public List<string> Deleted { get; } = [];
+        public bool ThrowOnSave { get; set; }
+        public bool ThrowOnDelete { get; set; }
+
+        public Task SaveAsync(RockBot.Host.MemoryEntry entry, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (ThrowOnSave) throw new InvalidOperationException("simulated memory save failure");
+            Saved[entry.Id] = entry;
+            return Task.CompletedTask;
+        }
+
+        public Task DeleteAsync(string id, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (ThrowOnDelete) throw new InvalidOperationException("simulated memory delete failure");
+            Deleted.Add(id);
+            Saved.Remove(id);
+            return Task.CompletedTask;
+        }
+
+        public Task<IReadOnlyList<RockBot.Host.MemoryEntry>> SearchAsync(
+            RockBot.Host.MemorySearchCriteria criteria, CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<RockBot.Host.MemoryEntry>>(Saved.Values.ToList());
+
+        public Task<RockBot.Host.MemoryEntry?> GetAsync(string id, CancellationToken cancellationToken = default)
+            => Task.FromResult(Saved.TryGetValue(id, out var entry) ? entry : null);
+
+        public Task<IReadOnlyList<string>> ListTagsAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<string>>(
+                Saved.Values.SelectMany(e => e.Tags).Distinct().ToList());
+
+        public Task<IReadOnlyList<string>> ListCategoriesAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<string>>(
+                Saved.Values.Select(e => e.Category).Where(c => c is not null).Distinct().ToList()!);
+    }
+
+    [TestMethod]
+    public async Task ExecuteAsync_PromotedTheoryPublishedToMemory()
+    {
+        var target = MakeTarget(promotionThreshold: 3);
+        await Store().SaveAsync(target, new ObservationState
+        {
+            Candidates = { Candidate("cand_1", 3, DateTimeOffset.UtcNow, text: "User prefers terse responses") },
+        }, CancellationToken.None);
+
+        var stubEval = new StubEvaluator
+        {
+            Verdicts =
+            {
+                new EvaluationVerdict("cand_1", EvaluationAction.Promote, null, null),
+            },
+        };
+        var stubMemory = new StubLongTermMemory();
+
+        await MakePhase(stubEval, stubMemory).ExecuteAsync(target, CancellationToken.None);
+
+        Assert.AreEqual(1, stubMemory.Saved.Count, "Promoted theory should be published to long-term memory");
+        var entry = stubMemory.Saved.Values.Single();
+        Assert.AreEqual("User prefers terse responses", entry.Content);
+        Assert.AreEqual($"observation/theory/{target.Name}", entry.Category);
+        CollectionAssert.AreEquivalent(new[] { "observation", target.Name }, entry.Tags.ToArray());
+        Assert.IsTrue(entry.ImportanceScore > 0.5f, "Theories carry above-default importance");
+
+        var state = await Store().LoadAsync(target, CancellationToken.None);
+        Assert.AreEqual(entry.Id, state.Theories[0].MemoryEntryId,
+            "Theory should record the published memory entry's ID");
+    }
+
+    [TestMethod]
+    public async Task ExecuteAsync_AgedTheoryRemovedFromMemory()
+    {
+        var target = MakeTarget(theoryAgingDays: 30);
+        var now = DateTimeOffset.UtcNow;
+
+        var stale = Theory("stale", now.AddDays(-90));
+        stale.MemoryEntryId = "obs_existing_stale";
+        var fresh = Theory("fresh", now.AddDays(-5));
+        fresh.MemoryEntryId = "obs_existing_fresh";
+
+        await Store().SaveAsync(target, new ObservationState
+        {
+            Theories = { stale, fresh },
+        }, CancellationToken.None);
+
+        var stubMemory = new StubLongTermMemory();
+        // Pretend the entries existed in memory before this dream
+        stubMemory.Saved["obs_existing_stale"] = new RockBot.Host.MemoryEntry(
+            "obs_existing_stale", "stale", null, [], now.AddDays(-90));
+        stubMemory.Saved["obs_existing_fresh"] = new RockBot.Host.MemoryEntry(
+            "obs_existing_fresh", "fresh", null, [], now.AddDays(-5));
+
+        await MakePhase(new StubEvaluator(), stubMemory).ExecuteAsync(target, CancellationToken.None);
+
+        CollectionAssert.AreEqual(new[] { "obs_existing_stale" }, stubMemory.Deleted.ToArray(),
+            "Aged theory's memory entry should be deleted; fresh theory's preserved");
+        Assert.IsTrue(stubMemory.Saved.ContainsKey("obs_existing_fresh"));
+    }
+
+    [TestMethod]
+    public async Task ExecuteAsync_MemorySaveFailure_PhaseStillSucceeds()
+    {
+        var target = MakeTarget(promotionThreshold: 3);
+        await Store().SaveAsync(target, new ObservationState
+        {
+            Candidates = { Candidate("cand_1", 3, DateTimeOffset.UtcNow) },
+        }, CancellationToken.None);
+
+        var stubEval = new StubEvaluator
+        {
+            Verdicts = { new EvaluationVerdict("cand_1", EvaluationAction.Promote, null, null) },
+        };
+        var stubMemory = new StubLongTermMemory { ThrowOnSave = true };
+
+        var result = await MakePhase(stubEval, stubMemory).ExecuteAsync(target, CancellationToken.None);
+
+        Assert.AreEqual(1, result.CandidatesPromoted,
+            "Phase still reports the promotion even though memory publishing failed");
+
+        var state = await Store().LoadAsync(target, CancellationToken.None);
+        Assert.AreEqual(1, state.Theories.Count,
+            "Theory still committed to JSON state — memory side-effects are best-effort");
+        Assert.IsNotNull(state.Theories[0].MemoryEntryId,
+            "MemoryEntryId is recorded even if the publish failed; reconciliation can recover");
+    }
+
+    [TestMethod]
+    public async Task ExecuteAsync_MemoryDeleteFailure_PhaseStillSucceeds()
+    {
+        var target = MakeTarget(theoryAgingDays: 30);
+        var now = DateTimeOffset.UtcNow;
+
+        var stale = Theory("stale", now.AddDays(-90));
+        stale.MemoryEntryId = "obs_stale";
+        await Store().SaveAsync(target, new ObservationState
+        {
+            Theories = { stale },
+        }, CancellationToken.None);
+
+        var stubMemory = new StubLongTermMemory { ThrowOnDelete = true };
+        var result = await MakePhase(new StubEvaluator(), stubMemory).ExecuteAsync(target, CancellationToken.None);
+
+        Assert.AreEqual(1, result.TheoriesAged);
+
+        var state = await Store().LoadAsync(target, CancellationToken.None);
+        Assert.AreEqual(0, state.Theories.Count,
+            "Theory still removed from JSON; orphaned memory entry is recoverable later");
+    }
+
+    [TestMethod]
+    public async Task ExecuteAsync_RejectedCandidateNotPublishedToMemory()
+    {
+        var target = MakeTarget(promotionThreshold: 3);
+        await Store().SaveAsync(target, new ObservationState
+        {
+            Candidates = { Candidate("cand_1", 3, DateTimeOffset.UtcNow) },
+        }, CancellationToken.None);
+
+        var stubEval = new StubEvaluator
+        {
+            Verdicts = { new EvaluationVerdict("cand_1", EvaluationAction.Reject, null, null) },
+        };
+        var stubMemory = new StubLongTermMemory();
+
+        await MakePhase(stubEval, stubMemory).ExecuteAsync(target, CancellationToken.None);
+
+        Assert.AreEqual(0, stubMemory.Saved.Count, "Rejected candidates must not become memory entries");
     }
 }

--- a/tests/RockBot.Observation.Tests/TranscriptFiltersTests.cs
+++ b/tests/RockBot.Observation.Tests/TranscriptFiltersTests.cs
@@ -1,0 +1,106 @@
+namespace RockBot.Observation.Tests;
+
+[TestClass]
+public class TranscriptFiltersTests
+{
+    private static TranscriptTurn Turn(string source, string role, string content = "x", string id = "t1") =>
+        new("conv1", id, source, role, content, DateTimeOffset.UtcNow);
+
+    [TestMethod]
+    public void Everything_PassesAllTurnsThrough()
+    {
+        var turns = new[]
+        {
+            Turn(TranscriptSources.User, "user", id: "t1"),
+            Turn(TranscriptSources.Agent, "assistant", id: "t2"),
+            Turn(TranscriptSources.Agent, "tool", id: "t3"),
+            Turn(TranscriptSources.ScheduledTask, "assistant", id: "t4"),
+        };
+
+        var filtered = TranscriptFilters.Everything.Filter(turns).ToList();
+
+        Assert.AreEqual(4, filtered.Count);
+        CollectionAssert.AreEqual(
+            turns.Select(t => t.TurnId).ToArray(),
+            filtered.Select(t => t.TurnId).ToArray());
+    }
+
+    [TestMethod]
+    public void UserAuthored_KeepsUserAndAgentAssistantTurns()
+    {
+        var turns = new[]
+        {
+            Turn(TranscriptSources.User, "user", id: "u1"),
+            Turn(TranscriptSources.Agent, "assistant", id: "a1"),
+            Turn(TranscriptSources.User, "user", id: "u2"),
+            Turn(TranscriptSources.Agent, "assistant", id: "a2"),
+        };
+
+        var filtered = TranscriptFilters.UserAuthored.Filter(turns)
+            .Select(t => t.TurnId)
+            .ToArray();
+
+        CollectionAssert.AreEqual(new[] { "u1", "a1", "u2", "a2" }, filtered);
+    }
+
+    [TestMethod]
+    public void UserAuthored_DropsToolAndScheduledTurns()
+    {
+        var turns = new[]
+        {
+            Turn(TranscriptSources.User, "user", id: "u1"),
+            Turn(TranscriptSources.Agent, "tool", id: "tool1"),
+            Turn(TranscriptSources.Agent, "assistant", id: "a1"),
+            Turn(TranscriptSources.ScheduledTask, "assistant", id: "sched1"),
+            Turn(TranscriptSources.Heartbeat, "assistant", id: "hb1"),
+        };
+
+        var filtered = TranscriptFilters.UserAuthored.Filter(turns)
+            .Select(t => t.TurnId)
+            .ToArray();
+
+        CollectionAssert.AreEqual(new[] { "u1", "a1" }, filtered,
+            "Tool, scheduled-task, and heartbeat turns must be excluded");
+    }
+
+    [TestMethod]
+    public void UserAuthored_AssistantRoleIsCaseInsensitive()
+    {
+        var turns = new[]
+        {
+            Turn(TranscriptSources.Agent, "Assistant", id: "a1"),
+            Turn(TranscriptSources.Agent, "ASSISTANT", id: "a2"),
+            Turn(TranscriptSources.Agent, "assistant", id: "a3"),
+        };
+
+        var filtered = TranscriptFilters.UserAuthored.Filter(turns)
+            .Select(t => t.TurnId)
+            .ToArray();
+
+        CollectionAssert.AreEqual(new[] { "a1", "a2", "a3" }, filtered);
+    }
+
+    [TestMethod]
+    public void UserAuthored_UnknownSource_Excluded()
+    {
+        var turns = new[]
+        {
+            Turn(TranscriptSources.User, "user", id: "u1"),
+            Turn("custom-source", "assistant", id: "x1"),
+        };
+
+        var filtered = TranscriptFilters.UserAuthored.Filter(turns)
+            .Select(t => t.TurnId)
+            .ToArray();
+
+        CollectionAssert.AreEqual(new[] { "u1" }, filtered,
+            "Filter defaults to excluding unrecognised sources, not including them");
+    }
+
+    [TestMethod]
+    public void UserAuthored_EmptyInput_EmptyOutput()
+    {
+        var filtered = TranscriptFilters.UserAuthored.Filter([]).ToList();
+        Assert.AreEqual(0, filtered.Count);
+    }
+}


### PR DESCRIPTION
Phase 4 ships the configured targets — `theory-of-self` and `theory-of-user` — with their default filters and prompts, AND adds the v1 closed loop: promoted theories are published to `ILongTermMemory` so they appear in `SearchMemory` and the host's hybrid-search index. Markdown is preserved as an inspection artifact under `{agentProfile}/observation/` but is NOT auto-loaded into the agent's system prompt.

Builds on phases 1-3 (#361, #362, #363).

## Two design corrections made during this phase

1. **The original framing was wrong about context injection.** I'd claimed v1 = "loop A: markdown loaded into context." That's wrong twice over: the host's profile loader does not auto-load `theory-of-*.md` files (only soul/directives/style/memory-rules/etc), and the intent was research-mode collect-don't-inject anyway. Markdown now lives under `observation/` to make the inspection-only nature explicit.

2. **Pure markdown bypasses the hybrid-search pipeline.** As you flagged: writing markdown to disk means `SearchMemory` cannot find theories. The fix lands here as **closed loop B**: promoted theories are also published via `ILongTermMemory.SaveAsync` so they're searchable. Markdown stays for human inspection; memory entries serve the agent.

## Summary

**Targets and prompts**
- `TranscriptSources`: conventional `Source` values (user, agent, scheduled-task, heartbeat) so filters and host adapters speak the same vocabulary
- `TranscriptFilters.Everything` (passes all) and `TranscriptFilters.UserAuthored` (Source=user OR Source=agent && Role=assistant)
- `DefaultPrompts`: `TheoryOfSelfExtraction`, `TheoryOfUserExtraction`, `DifferentialEvaluation` — strict, evidence-grounded, behavior-only, honest-not-flattering tone
- `ObservationDefaults`: factory methods `CreateTheoryOfSelf` / `CreateTheoryOfUser`, both writing outputs under `{agentProfileBasePath}/observation/` (NOT the context-loaded profile root)
- `AddDefaultObservationTargets` DI extension registers both default targets in one call

**Memory publishing (closed loop B)**
- `Theory` schema gains `MemoryEntryId`
- `ObservationEvaluationPhase` now depends on `ILongTermMemory`
- On promote: assigns `MemoryEntryId`, saves `MemoryEntry` with category=`observation/theory/{target.Name}`, tags=[`observation`, target.Name], importance=0.7
- On age-out: deletes the corresponding `MemoryEntry`
- Order: JSON state save first (atomic), then memory side-effects (best-effort). Memory failures are logged but do not abort the phase — JSON state remains source of truth, future reconciliation recovers orphaned/missing entries

**Doc updates**
- `design/observation-framework.md` research-first framing rewritten: v1 ships loop B only; loop A (always-loaded context) is recorded as a future option
- Closed-loop roadmap clarified: A (markdown into context), B ✅, C (targeted evaluators), D (rule promotion)
- `docs/getting-started-rockbot.md` Section 4 updated with the dual output story

## Tests (19 new, 97 total in the project)

- `TranscriptFiltersTests` (6): Everything passes through, UserAuthored keeps user/agent-assistant turns, drops tool/scheduled/heartbeat, case-insensitive on role, excludes unknown sources, empty input
- `ObservationDefaultsTests` (4): theory-of-self/user shape with expected paths, registration via DI, null path throws
- `DefaultPromptsTests` (4): non-empty, contain core anti-hallucination rules, distinct bodies, evaluation describes all three verdicts and prefers reject
- 5 new `ObservationEvaluationPhaseTests`: promoted theory published with correct shape, aged theory's memory entry deleted, save failure is best-effort (theory still committed with MemoryEntryId for future reconciliation), delete failure is best-effort, rejected candidates not published

## Test plan

- [x] `dotnet build RockBot.slnx` — clean
- [x] `dotnet test tests/RockBot.Observation.Tests` — 97/97 pass
- [x] Full solution test run — all projects unaffected

## Out of scope (next phase)

- Phase 5: dream cycle integration. Wire phase 1 + phase 2 into `DreamService.DreamAsync`, with a host-side adapter that turns the conversation log into `IReadOnlyList<TranscriptTurn>` for the framework to consume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)