### PR TITLE
Observation framework dream integration (phase 5 of #353)

### DIFF
--- a/src/RockBot.Agent/Program.cs
+++ b/src/RockBot.Agent/Program.cs
@@ -12,6 +12,7 @@ using RockBot.Agent.McpBridge;
 using RockBot.Scripts.Remote;
 using RockBot.Agent;
 using RockBot.Memory;
+using RockBot.Observation;
 using RockBot.Skills;
 using RockBot.Tools;
 using RockBot.Tools.Mcp;
@@ -373,6 +374,25 @@ builder.Services.AddHostedService<McpBridgeService>();
 
 // Remote script runner — delegates script execution to the Script Manager pod via RabbitMQ
 builder.Services.AddRemoteScriptRunner("RockBot");
+
+// Observation framework — registers core services (state store, extractor,
+// evaluator, pipeline phases, coordinator) plus the default theory-of-self
+// and theory-of-user targets. The dream cycle's RunObservationPassAsync
+// drives the pipeline once per dream when DreamOptions.ObservationEnabled
+// is true. Markdown copies are written under {profile}/observation/ for
+// inspection; promoted theories are also published as long-term memory
+// entries (category="observation/theory/{name}") so SearchMemory finds them.
+{
+    var profileBasePath = builder.Configuration["AgentProfile:BasePath"]
+        ?? builder.Configuration["AgentProfile__BasePath"]
+        ?? "agent";
+    var resolvedProfileBasePath = Path.IsPathRooted(profileBasePath)
+        ? profileBasePath
+        : Path.Combine(AppContext.BaseDirectory, profileBasePath);
+
+    builder.Services.AddRockBotObservation();
+    builder.Services.AddDefaultObservationTargets(resolvedProfileBasePath);
+}
 
 var app = builder.Build();
 

--- a/src/RockBot.Agent/RockBot.Agent.csproj
+++ b/src/RockBot.Agent/RockBot.Agent.csproj
@@ -39,6 +39,7 @@
     <ProjectReference Include="..\RockBot.Telemetry\RockBot.Telemetry.csproj" />
     <ProjectReference Include="..\RockBot.Llm\RockBot.Llm.csproj" />
     <ProjectReference Include="..\RockBot.Memory\RockBot.Memory.csproj" />
+    <ProjectReference Include="..\RockBot.Observation\RockBot.Observation.csproj" />
     <ProjectReference Include="..\RockBot.Skills\RockBot.Skills.csproj" />
     <ProjectReference Include="..\RockBot.Tools\RockBot.Tools.csproj" />
     <ProjectReference Include="..\RockBot.Tools.Mcp\RockBot.Tools.Mcp.csproj" />

--- a/src/RockBot.Host.Abstractions/DreamOptions.cs
+++ b/src/RockBot.Host.Abstractions/DreamOptions.cs
@@ -163,6 +163,17 @@ public sealed class DreamOptions
     public string ToolSuccessLearningDirectivePath { get; set; } = "tool-success-learning.md";
 
     /// <summary>
+    /// Whether the observation framework pass is enabled. When true, the
+    /// dream cycle runs the observation pipeline (theory-of-self,
+    /// theory-of-user, plus any other registered targets) between the
+    /// memory-mining and preference-inference passes. The framework
+    /// requires <c>IEmbeddingGenerator&lt;string, Embedding&lt;float&gt;&gt;</c>
+    /// and <see cref="ILongTermMemory"/> to be registered; if either is
+    /// missing, agent startup fails.
+    /// </summary>
+    public bool ObservationEnabled { get; set; } = true;
+
+    /// <summary>
     /// Days of no reinforcement (measured against <see cref="MemoryEntry.LastSeenAt"/>)
     /// before importance decay begins. Entries younger than this are left alone regardless
     /// of their score. Default: 30 days.

--- a/src/RockBot.Host/AgentMemoryExtensions.cs
+++ b/src/RockBot.Host/AgentMemoryExtensions.cs
@@ -136,6 +136,12 @@ public static class AgentMemoryExtensions
 
         builder.Services.AddSingleton<IConversationLog, FileConversationLog>();
 
+        // Adapter that exposes the conversation log to the observation
+        // framework. Registered alongside IConversationLog so its lifecycle
+        // tracks the log; DreamService takes it as an optional dependency
+        // and skips the observation pass when this is absent.
+        builder.Services.AddSingleton<ConversationLogTranscriptAdapter>();
+
         return builder;
     }
 

--- a/src/RockBot.Host/ConversationLogTranscriptAdapter.cs
+++ b/src/RockBot.Host/ConversationLogTranscriptAdapter.cs
@@ -1,0 +1,104 @@
+using Microsoft.Extensions.Logging;
+using RockBot.Observation;
+
+namespace RockBot.Host;
+
+/// <summary>
+/// Host-side adapter that reads the existing <see cref="IConversationLog"/>
+/// and produces <see cref="TranscriptTurn"/> records for the observation
+/// framework. Source values are derived from session-id prefixes so the
+/// framework's filters can scope what each target sees.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The conversation log is naturally the "since last dream" window because
+/// <c>RunPreferenceInferencePassAsync</c> calls <c>ClearAsync</c> at the end
+/// of every dream cycle. The observation phase MUST run before preference
+/// inference so it sees the same data.
+/// </para>
+/// <para>
+/// Session prefixes mapped to <see cref="TranscriptSources"/>:
+/// </para>
+/// <list type="bullet">
+///   <item><c>patrol/...</c> — scheduled tasks and heartbeat patrols</item>
+///   <item><c>a2a-inbound/...</c> — calls from other agents (mapped to <see cref="TranscriptSources.Agent"/> since the human user is not the originator)</item>
+///   <item>everything else — treated as a normal user conversation</item>
+/// </list>
+/// <para>
+/// Within a normal user conversation, the role determines the source for
+/// each turn: <c>role=user</c> → <see cref="TranscriptSources.User"/>;
+/// anything else (assistant, system) → <see cref="TranscriptSources.Agent"/>.
+/// </para>
+/// </remarks>
+public sealed class ConversationLogTranscriptAdapter(
+    IConversationLog conversationLog,
+    ILogger<ConversationLogTranscriptAdapter> logger)
+{
+    /// <summary>
+    /// Reads the current conversation log and returns the entries as
+    /// <see cref="TranscriptTurn"/> records sorted by timestamp. Each turn
+    /// is given a stable <c>turnId</c> derived from its position within the
+    /// session so the observation framework can quote-validate against it.
+    /// </summary>
+    public async Task<IReadOnlyList<TranscriptTurn>> GetTranscriptAsync(
+        CancellationToken cancellationToken)
+    {
+        var entries = await conversationLog.ReadAllAsync(cancellationToken).ConfigureAwait(false);
+        if (entries.Count == 0)
+        {
+            logger.LogDebug("Observation adapter: conversation log is empty");
+            return [];
+        }
+
+        // Stable per-session ordering: for each session, ordered turns get
+        // an index. The turnId combines session and index so the framework
+        // can resolve a quote back to a specific entry.
+        var bySession = entries
+            .GroupBy(e => e.SessionId, StringComparer.Ordinal)
+            .OrderBy(g => g.Key, StringComparer.Ordinal);
+
+        var result = new List<TranscriptTurn>(entries.Count);
+        foreach (var group in bySession)
+        {
+            var ordered = group.OrderBy(e => e.Timestamp).ToList();
+            var source = MapSource(group.Key);
+            for (var i = 0; i < ordered.Count; i++)
+            {
+                var entry = ordered[i];
+                var turnSource = source ?? MapRoleToSource(entry.Role);
+                result.Add(new TranscriptTurn(
+                    ConversationId: entry.SessionId,
+                    TurnId: $"t{i}",
+                    Source: turnSource,
+                    Role: entry.Role,
+                    Content: entry.Content,
+                    Timestamp: entry.Timestamp));
+            }
+        }
+
+        logger.LogDebug(
+            "Observation adapter: produced {TurnCount} turns across {SessionCount} sessions",
+            result.Count, bySession.Count());
+
+        return result;
+    }
+
+    /// <summary>
+    /// When the session prefix uniquely identifies a non-user origin (patrol,
+    /// inbound A2A), returns that source. Otherwise returns <c>null</c> so
+    /// per-turn role mapping decides between <c>User</c> and <c>Agent</c>.
+    /// </summary>
+    private static string? MapSource(string sessionId)
+    {
+        if (sessionId.StartsWith("patrol/", StringComparison.OrdinalIgnoreCase))
+            return TranscriptSources.ScheduledTask;
+        if (sessionId.StartsWith("a2a-inbound/", StringComparison.OrdinalIgnoreCase))
+            return TranscriptSources.Agent;
+        return null;
+    }
+
+    private static string MapRoleToSource(string role) =>
+        string.Equals(role, "user", StringComparison.OrdinalIgnoreCase)
+            ? TranscriptSources.User
+            : TranscriptSources.Agent;
+}

--- a/src/RockBot.Host/DreamService.cs
+++ b/src/RockBot.Host/DreamService.cs
@@ -39,6 +39,8 @@ internal sealed class DreamService : IHostedService, IDisposable
     private readonly DreamOptions _options;
     private readonly AgentProfileOptions _profileOptions;
     private readonly ILogger<DreamService> _logger;
+    private readonly RockBot.Observation.IObservationPipelineCoordinator? _observationCoordinator;
+    private readonly ConversationLogTranscriptAdapter? _observationTranscriptAdapter;
     private Timer? _timer;
     private CronExpression? _cron;
     private string? _dreamDirective;
@@ -75,7 +77,9 @@ internal sealed class DreamService : IHostedService, IDisposable
         IToolCallLog? toolCallLog = null,
         IKnowledgeGraph? knowledgeGraph = null,
         IWispExecutionLog? wispExecutionLog = null,
-        IWorkingMemory? workingMemory = null)
+        IWorkingMemory? workingMemory = null,
+        RockBot.Observation.IObservationPipelineCoordinator? observationCoordinator = null,
+        ConversationLogTranscriptAdapter? observationTranscriptAdapter = null)
     {
         _memory = memory;
         _skillStore = skillStores.FirstOrDefault();
@@ -95,6 +99,8 @@ internal sealed class DreamService : IHostedService, IDisposable
         _options = options.Value;
         _profileOptions = profileOptions.Value;
         _logger = logger;
+        _observationCoordinator = observationCoordinator;
+        _observationTranscriptAdapter = observationTranscriptAdapter;
     }
 
     public Task StartAsync(CancellationToken cancellationToken)
@@ -524,6 +530,12 @@ internal sealed class DreamService : IHostedService, IDisposable
             ct.ThrowIfCancellationRequested(); await RunGraphConsolidationPassAsync(ct);
 
             ct.ThrowIfCancellationRequested(); await RunMemoryMiningPassAsync(ct);
+
+            // Observation framework reads the same conversation log used by
+            // memory mining and preference inference, so it must run before
+            // RunPreferenceInferencePassAsync (which clears the log in its
+            // finally block).
+            ct.ThrowIfCancellationRequested(); await RunObservationPassAsync(ct);
 
             ct.ThrowIfCancellationRequested(); await RunPreferenceInferencePassAsync(ct);
 
@@ -2151,6 +2163,78 @@ internal sealed class DreamService : IHostedService, IDisposable
         {
             _logger.LogWarning(ex, "DreamService: failed to load subagent whiteboard entries for memory mining");
         }
+    }
+
+    /// <summary>
+    /// Runs the observation framework pipeline (theory-of-self, theory-of-user,
+    /// plus any other registered targets) against the conversation log.
+    /// Promoted theories are published to long-term memory so they appear
+    /// in <c>SearchMemory</c>; markdown copies are written to the agent
+    /// profile's <c>observation/</c> subdirectory for human inspection.
+    /// </summary>
+    /// <remarks>
+    /// Skipped silently when <see cref="DreamOptions.ObservationEnabled"/>
+    /// is false or when the framework's services are not registered (no
+    /// targets in DI, no coordinator available). Per-target failures are
+    /// logged inside the coordinator and do not block other targets.
+    /// MUST run before <see cref="RunPreferenceInferencePassAsync"/> because
+    /// pref inference clears the conversation log in its finally block.
+    /// </remarks>
+    private async Task RunObservationPassAsync(CancellationToken ct)
+    {
+        if (!_options.ObservationEnabled) return;
+        if (_observationCoordinator is null || _observationTranscriptAdapter is null)
+        {
+            _logger.LogDebug(
+                "DreamService: observation pass skipped — coordinator or adapter not registered");
+            return;
+        }
+
+        await RunPassAsync("observation", async () =>
+        {
+            var transcripts = await _observationTranscriptAdapter
+                .GetTranscriptAsync(ct).ConfigureAwait(false);
+
+            if (transcripts.Count == 0)
+            {
+                _logger.LogDebug(
+                    "DreamService: observation pass — no transcripts in this dream window");
+                return;
+            }
+
+            var results = await _observationCoordinator
+                .RunAllAsync(transcripts, ct).ConfigureAwait(false);
+
+            foreach (var r in results)
+            {
+                if (r.Failure is not null)
+                {
+                    _logger.LogWarning(
+                        "DreamService: observation target {Target} failed: {Message}",
+                        r.TargetName, r.Failure.Message);
+                    continue;
+                }
+
+                _logger.LogInformation(
+                    "DreamService: observation target {Target} — " +
+                    "phase1: {Proposed} proposed/{Grounded} grounded → " +
+                    "{NewCands} new candidate(s), {Matched} matched; " +
+                    "phase2: {Eligible} evaluated, {Promoted} promoted, " +
+                    "{Refined} refined, {Rejected} rejected, " +
+                    "{CandsAged} candidates aged out, {ThriesAged} theories aged out",
+                    r.TargetName,
+                    r.ExtractionResult?.ProposalsReceived ?? 0,
+                    r.ExtractionResult?.ProposalsGrounded ?? 0,
+                    r.ExtractionResult?.NewCandidatesCreated ?? 0,
+                    r.ExtractionResult?.MatchedExistingCandidates ?? 0,
+                    r.EvaluationResult?.CandidatesEvaluated ?? 0,
+                    r.EvaluationResult?.CandidatesPromoted ?? 0,
+                    r.EvaluationResult?.CandidatesRefined ?? 0,
+                    r.EvaluationResult?.CandidatesRejected ?? 0,
+                    r.EvaluationResult?.CandidatesAged ?? 0,
+                    r.EvaluationResult?.TheoriesAged ?? 0);
+            }
+        });
     }
 
     /// <summary>

--- a/src/RockBot.Host/RockBot.Host.csproj
+++ b/src/RockBot.Host/RockBot.Host.csproj
@@ -29,6 +29,7 @@
     <ProjectReference Include="..\RockBot.Host.Abstractions\RockBot.Host.Abstractions.csproj" />
     <ProjectReference Include="..\RockBot.Llm.Abstractions\RockBot.Llm.Abstractions.csproj" />
     <ProjectReference Include="..\RockBot.Memory\RockBot.Memory.csproj" />
+    <ProjectReference Include="..\RockBot.Observation\RockBot.Observation.csproj" />
     <ProjectReference Include="..\RockBot.Messaging.Abstractions\RockBot.Messaging.Abstractions.csproj" />
     <ProjectReference Include="..\RockBot.Skills\RockBot.Skills.csproj" />
     <ProjectReference Include="..\RockBot.Tools.Abstractions\RockBot.Tools.Abstractions.csproj" />

--- a/src/RockBot.Observation/IObservationPipelineCoordinator.cs
+++ b/src/RockBot.Observation/IObservationPipelineCoordinator.cs
@@ -1,0 +1,41 @@
+namespace RockBot.Observation;
+
+/// <summary>
+/// One-shot driver that runs the observation pipeline for every registered
+/// <see cref="ObservationTarget"/> against a single batch of transcripts.
+/// Encapsulates the per-target loop so the dream cycle's hook is a single
+/// call.
+/// </summary>
+public interface IObservationPipelineCoordinator
+{
+    /// <summary>
+    /// For each registered target: applies the target's
+    /// <see cref="ITranscriptFilter"/>, runs phase 1 (extraction + merge),
+    /// and runs phase 2 (evaluation + promotion + aging + regeneration +
+    /// memory publish). Returns one <see cref="ObservationTargetRunResult"/>
+    /// per target — including for targets where the pipeline failed, so the
+    /// caller can log per-target outcomes.
+    /// </summary>
+    /// <remarks>
+    /// Each target runs independently. A failure for one target is logged
+    /// and does not prevent other targets from running. Cancellation is
+    /// honored across the whole loop — when <paramref name="cancellationToken"/>
+    /// fires, in-flight targets abort and remaining targets are not started.
+    /// </remarks>
+    Task<IReadOnlyList<ObservationTargetRunResult>> RunAllAsync(
+        IReadOnlyList<TranscriptTurn> transcripts,
+        CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Per-target outcome from <see cref="IObservationPipelineCoordinator.RunAllAsync"/>.
+/// </summary>
+/// <param name="TargetName">The target whose pipeline ran.</param>
+/// <param name="ExtractionResult">Phase 1 result, or <c>null</c> if phase 1 was not reached (e.g. the target threw before phase 1).</param>
+/// <param name="EvaluationResult">Phase 2 result, or <c>null</c> if phase 2 was not reached.</param>
+/// <param name="Failure">Captured exception when the target's pipeline threw an unhandled exception. <c>null</c> on success.</param>
+public sealed record ObservationTargetRunResult(
+    string TargetName,
+    ExtractionPhaseResult? ExtractionResult,
+    EvaluationPhaseResult? EvaluationResult,
+    Exception? Failure);

--- a/src/RockBot.Observation/ObservationPipelineCoordinator.cs
+++ b/src/RockBot.Observation/ObservationPipelineCoordinator.cs
@@ -1,0 +1,68 @@
+using Microsoft.Extensions.Logging;
+
+namespace RockBot.Observation;
+
+/// <summary>
+/// Default <see cref="IObservationPipelineCoordinator"/>. Runs targets
+/// sequentially: each target applies its own filter, runs phase 1, then
+/// phase 2. Per-target exceptions are caught and logged so a failing
+/// target does not block its peers.
+/// </summary>
+internal sealed class ObservationPipelineCoordinator(
+    IEnumerable<ObservationTarget> targets,
+    IObservationExtractionPhase extractionPhase,
+    IObservationEvaluationPhase evaluationPhase,
+    ILogger<ObservationPipelineCoordinator> logger) : IObservationPipelineCoordinator
+{
+    private readonly List<ObservationTarget> _targets = targets.ToList();
+
+    public async Task<IReadOnlyList<ObservationTargetRunResult>> RunAllAsync(
+        IReadOnlyList<TranscriptTurn> transcripts,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(transcripts);
+
+        if (_targets.Count == 0)
+        {
+            logger.LogInformation("Observation: no targets registered; pipeline is a no-op");
+            return [];
+        }
+
+        var results = new List<ObservationTargetRunResult>(_targets.Count);
+
+        foreach (var target in _targets)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                var filtered = target.Filter.Filter(transcripts).ToList();
+
+                var extractionResult = await extractionPhase
+                    .ExecuteAsync(target, filtered, cancellationToken)
+                    .ConfigureAwait(false);
+
+                var evaluationResult = await evaluationPhase
+                    .ExecuteAsync(target, cancellationToken)
+                    .ConfigureAwait(false);
+
+                results.Add(new ObservationTargetRunResult(
+                    target.Name, extractionResult, evaluationResult, Failure: null));
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex,
+                    "Observation: pipeline failed for target {Target}; other targets continue",
+                    target.Name);
+                results.Add(new ObservationTargetRunResult(
+                    target.Name, ExtractionResult: null, EvaluationResult: null, Failure: ex));
+            }
+        }
+
+        return results;
+    }
+}

--- a/src/RockBot.Observation/ServiceCollectionExtensions.cs
+++ b/src/RockBot.Observation/ServiceCollectionExtensions.cs
@@ -22,6 +22,7 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<IObservationExtractionPhase, ObservationExtractionPhase>();
         services.TryAddSingleton<IObservationEvaluator, LlmObservationEvaluator>();
         services.TryAddSingleton<IObservationEvaluationPhase, ObservationEvaluationPhase>();
+        services.TryAddSingleton<IObservationPipelineCoordinator, ObservationPipelineCoordinator>();
         return services;
     }
 

--- a/tests/RockBot.Host.Tests/ConversationLogTranscriptAdapterTests.cs
+++ b/tests/RockBot.Host.Tests/ConversationLogTranscriptAdapterTests.cs
@@ -1,0 +1,182 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using RockBot.Observation;
+
+namespace RockBot.Host.Tests;
+
+[TestClass]
+public class ConversationLogTranscriptAdapterTests
+{
+    private static ConversationLogEntry Entry(
+        string sessionId, string role, string content, DateTimeOffset? timestamp = null) =>
+        new(sessionId, role, content, timestamp ?? DateTimeOffset.UtcNow);
+
+    private ConversationLogTranscriptAdapter Adapter(IConversationLog log) =>
+        new(log, NullLogger<ConversationLogTranscriptAdapter>.Instance);
+
+    [TestMethod]
+    public async Task GetTranscriptAsync_EmptyLog_ReturnsEmpty()
+    {
+        var log = new InMemoryConversationLog();
+        var turns = await Adapter(log).GetTranscriptAsync(CancellationToken.None);
+        Assert.AreEqual(0, turns.Count);
+    }
+
+    [TestMethod]
+    public async Task GetTranscriptAsync_UserSession_MapsRolesToSources()
+    {
+        var t0 = DateTimeOffset.Parse("2026-05-08T10:00:00Z");
+        var log = new InMemoryConversationLog
+        {
+            Entries =
+            {
+                Entry("session/blazor-session", "user", "hello", t0),
+                Entry("session/blazor-session", "assistant", "hi", t0.AddSeconds(1)),
+                Entry("session/blazor-session", "system", "note", t0.AddSeconds(2)),
+            },
+        };
+
+        var turns = await Adapter(log).GetTranscriptAsync(CancellationToken.None);
+
+        Assert.AreEqual(3, turns.Count);
+        Assert.AreEqual(TranscriptSources.User, turns[0].Source);
+        Assert.AreEqual(TranscriptSources.Agent, turns[1].Source,
+            "Assistant role in a user session maps to Agent source");
+        Assert.AreEqual(TranscriptSources.Agent, turns[2].Source,
+            "System role in a user session maps to Agent source");
+    }
+
+    [TestMethod]
+    public async Task GetTranscriptAsync_PatrolSession_MapsAllToScheduledTask()
+    {
+        var log = new InMemoryConversationLog
+        {
+            Entries =
+            {
+                Entry("patrol/heartbeat", "user", "(scheduled trigger)"),
+                Entry("patrol/heartbeat", "assistant", "did the patrol"),
+            },
+        };
+
+        var turns = await Adapter(log).GetTranscriptAsync(CancellationToken.None);
+
+        Assert.AreEqual(2, turns.Count);
+        Assert.IsTrue(turns.All(t => t.Source == TranscriptSources.ScheduledTask),
+            "All patrol turns regardless of role map to ScheduledTask source");
+    }
+
+    [TestMethod]
+    public async Task GetTranscriptAsync_A2AInbound_MapsToAgent()
+    {
+        var log = new InMemoryConversationLog
+        {
+            Entries =
+            {
+                Entry("a2a-inbound/abc-123", "user", "calling agent"),
+                Entry("a2a-inbound/abc-123", "assistant", "responded"),
+            },
+        };
+
+        var turns = await Adapter(log).GetTranscriptAsync(CancellationToken.None);
+
+        Assert.AreEqual(2, turns.Count);
+        Assert.IsTrue(turns.All(t => t.Source == TranscriptSources.Agent),
+            "A2A inbound turns map to Agent source — not human user signal");
+    }
+
+    [TestMethod]
+    public async Task GetTranscriptAsync_TurnIdsStableWithinSession()
+    {
+        var log = new InMemoryConversationLog
+        {
+            Entries =
+            {
+                Entry("session/a", "user", "first", DateTimeOffset.Parse("2026-05-08T10:00:00Z")),
+                Entry("session/a", "assistant", "second", DateTimeOffset.Parse("2026-05-08T10:00:01Z")),
+                Entry("session/a", "user", "third", DateTimeOffset.Parse("2026-05-08T10:00:02Z")),
+            },
+        };
+
+        var turns = await Adapter(log).GetTranscriptAsync(CancellationToken.None);
+
+        var ids = turns.Select(t => t.TurnId).ToArray();
+        CollectionAssert.AreEqual(new[] { "t0", "t1", "t2" }, ids);
+    }
+
+    [TestMethod]
+    public async Task GetTranscriptAsync_OrdersByTimestampWithinSession()
+    {
+        var t0 = DateTimeOffset.Parse("2026-05-08T10:00:00Z");
+        // Insert in reverse-chronological order; adapter must reorder by timestamp.
+        var log = new InMemoryConversationLog
+        {
+            Entries =
+            {
+                Entry("session/a", "user", "third", t0.AddSeconds(2)),
+                Entry("session/a", "user", "first", t0),
+                Entry("session/a", "user", "second", t0.AddSeconds(1)),
+            },
+        };
+
+        var turns = await Adapter(log).GetTranscriptAsync(CancellationToken.None);
+
+        CollectionAssert.AreEqual(
+            new[] { "first", "second", "third" },
+            turns.Select(t => t.Content).ToArray());
+    }
+
+    [TestMethod]
+    public async Task GetTranscriptAsync_MultipleSessions_AllAppear()
+    {
+        var log = new InMemoryConversationLog
+        {
+            Entries =
+            {
+                Entry("session/a", "user", "from a"),
+                Entry("patrol/heartbeat", "user", "from patrol"),
+                Entry("a2a-inbound/x", "user", "from a2a"),
+            },
+        };
+
+        var turns = await Adapter(log).GetTranscriptAsync(CancellationToken.None);
+
+        Assert.AreEqual(3, turns.Count);
+        var sessions = turns.Select(t => t.ConversationId).Distinct().ToArray();
+        Assert.AreEqual(3, sessions.Length);
+    }
+
+    [TestMethod]
+    public async Task GetTranscriptAsync_HonorsCancellationToken()
+    {
+        var log = new InMemoryConversationLog { ThrowOnRead = true };
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await Adapter(log).GetTranscriptAsync(cts.Token));
+    }
+
+    private sealed class InMemoryConversationLog : IConversationLog
+    {
+        public List<ConversationLogEntry> Entries { get; } = [];
+        public bool ThrowOnRead { get; set; }
+
+        public Task AppendAsync(ConversationLogEntry entry, CancellationToken cancellationToken = default)
+        {
+            Entries.Add(entry);
+            return Task.CompletedTask;
+        }
+
+        public Task<IReadOnlyList<ConversationLogEntry>> ReadAllAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (ThrowOnRead) throw new InvalidOperationException("test failure");
+            return Task.FromResult<IReadOnlyList<ConversationLogEntry>>(Entries.ToList());
+        }
+
+        public Task ClearAsync(CancellationToken cancellationToken = default)
+        {
+            Entries.Clear();
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/RockBot.Host.Tests/RockBot.Host.Tests.csproj
+++ b/tests/RockBot.Host.Tests/RockBot.Host.Tests.csproj
@@ -23,6 +23,7 @@
     <ProjectReference Include="..\..\src\RockBot.Host.Abstractions\RockBot.Host.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\RockBot.Host\RockBot.Host.csproj" />
     <ProjectReference Include="..\..\src\RockBot.Messaging.Abstractions\RockBot.Messaging.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\RockBot.Observation\RockBot.Observation.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/RockBot.Observation.Tests/ObservationPipelineCoordinatorTests.cs
+++ b/tests/RockBot.Observation.Tests/ObservationPipelineCoordinatorTests.cs
@@ -1,0 +1,207 @@
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace RockBot.Observation.Tests;
+
+[TestClass]
+public class ObservationPipelineCoordinatorTests
+{
+    private static ObservationTarget MakeTarget(string name, ITranscriptFilter? filter = null) => new()
+    {
+        Name = name,
+        Filter = filter ?? new PassThrough(),
+        ExtractionPrompt = "x",
+        EvaluationPrompt = "y",
+        StateFilePath = "/tmp/" + name + ".json",
+        OutputMarkdownPath = "/tmp/" + name + ".md",
+    };
+
+    private static TranscriptTurn Turn(string convId, string id, string source = TranscriptSources.User) =>
+        new(convId, id, source, "user", "content " + id, DateTimeOffset.UtcNow);
+
+    [TestMethod]
+    public async Task RunAllAsync_NoTargets_ReturnsEmpty()
+    {
+        var coord = new ObservationPipelineCoordinator(
+            [],
+            new StubExtractionPhase(),
+            new StubEvaluationPhase(),
+            NullLogger<ObservationPipelineCoordinator>.Instance);
+
+        var results = await coord.RunAllAsync(new[] { Turn("c", "t1") }, CancellationToken.None);
+
+        Assert.AreEqual(0, results.Count);
+    }
+
+    [TestMethod]
+    public async Task RunAllAsync_RunsBothPhasesPerTarget()
+    {
+        var t1 = MakeTarget("t1");
+        var t2 = MakeTarget("t2");
+        var ext = new StubExtractionPhase();
+        var ev = new StubEvaluationPhase();
+
+        var coord = new ObservationPipelineCoordinator(
+            [t1, t2], ext, ev, NullLogger<ObservationPipelineCoordinator>.Instance);
+
+        var results = await coord.RunAllAsync(new[] { Turn("c", "t1") }, CancellationToken.None);
+
+        Assert.AreEqual(2, results.Count);
+        Assert.AreEqual(2, ext.Calls.Count);
+        Assert.AreEqual(2, ev.Calls.Count);
+        CollectionAssert.AreEqual(
+            new[] { "t1", "t2" },
+            results.Select(r => r.TargetName).ToArray());
+        Assert.IsTrue(results.All(r => r.Failure is null));
+    }
+
+    [TestMethod]
+    public async Task RunAllAsync_PerTargetFailureDoesNotBlockOthers()
+    {
+        var good = MakeTarget("good");
+        var bad = MakeTarget("bad");
+
+        var ext = new StubExtractionPhase
+        {
+            ThrowForTarget = "bad",
+        };
+        var ev = new StubEvaluationPhase();
+
+        var coord = new ObservationPipelineCoordinator(
+            [bad, good], ext, ev, NullLogger<ObservationPipelineCoordinator>.Instance);
+
+        var results = await coord.RunAllAsync(new[] { Turn("c", "t1") }, CancellationToken.None);
+
+        Assert.AreEqual(2, results.Count);
+        var badResult = results.Single(r => r.TargetName == "bad");
+        Assert.IsNotNull(badResult.Failure);
+        Assert.IsNull(badResult.ExtractionResult);
+
+        var goodResult = results.Single(r => r.TargetName == "good");
+        Assert.IsNull(goodResult.Failure);
+        Assert.IsNotNull(goodResult.ExtractionResult);
+        Assert.IsNotNull(goodResult.EvaluationResult);
+    }
+
+    [TestMethod]
+    public async Task RunAllAsync_AppliesPerTargetFilterBeforeExtraction()
+    {
+        var userOnly = MakeTarget("user-only", TranscriptFilters.UserAuthored);
+        var ext = new StubExtractionPhase();
+        var ev = new StubEvaluationPhase();
+
+        var transcripts = new[]
+        {
+            Turn("c", "t1", TranscriptSources.User),
+            Turn("c", "t2", TranscriptSources.ScheduledTask),
+            Turn("c", "t3", TranscriptSources.Agent),
+        };
+
+        var coord = new ObservationPipelineCoordinator(
+            [userOnly], ext, ev, NullLogger<ObservationPipelineCoordinator>.Instance);
+
+        await coord.RunAllAsync(transcripts, CancellationToken.None);
+
+        var passed = ext.Calls.Single().Transcripts;
+        // user-only filter excludes ScheduledTask. Agent assistant turns
+        // would be kept by UserAuthored, but we sent role=user with source=Agent
+        // which the filter doesn't match → only the User-source turn survives.
+        // Verify: at least the ScheduledTask is excluded; t1 and t3 may both pass
+        // depending on role mapping — UserAuthored allows source=user OR
+        // (source=agent && role=assistant). Our t3 has role=user so it doesn't pass.
+        Assert.IsTrue(passed.All(t => t.Source != TranscriptSources.ScheduledTask),
+            "Filter should drop scheduled-task turns");
+    }
+
+    [TestMethod]
+    public async Task RunAllAsync_Cancellation_StopsBeforeNextTarget()
+    {
+        var t1 = MakeTarget("t1");
+        var t2 = MakeTarget("t2");
+        using var cts = new CancellationTokenSource();
+
+        var ext = new StubExtractionPhase
+        {
+            BeforeReturn = (target) =>
+            {
+                if (target.Name == "t1") cts.Cancel();
+            },
+        };
+        var ev = new StubEvaluationPhase();
+
+        var coord = new ObservationPipelineCoordinator(
+            [t1, t2], ext, ev, NullLogger<ObservationPipelineCoordinator>.Instance);
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await coord.RunAllAsync(new[] { Turn("c", "x") }, cts.Token));
+
+        Assert.AreEqual(1, ext.Calls.Count, "Only the first target should have run");
+    }
+
+    [TestMethod]
+    public async Task RunAllAsync_NullTranscripts_Throws()
+    {
+        var coord = new ObservationPipelineCoordinator(
+            [MakeTarget("t")],
+            new StubExtractionPhase(), new StubEvaluationPhase(),
+            NullLogger<ObservationPipelineCoordinator>.Instance);
+
+        await Assert.ThrowsExactlyAsync<ArgumentNullException>(async () =>
+            await coord.RunAllAsync(null!, CancellationToken.None));
+    }
+
+    private sealed class PassThrough : ITranscriptFilter
+    {
+        public IEnumerable<TranscriptTurn> Filter(IReadOnlyList<TranscriptTurn> turns) => turns;
+    }
+
+    private sealed class StubExtractionPhase : IObservationExtractionPhase
+    {
+        public List<(ObservationTarget Target, IReadOnlyList<TranscriptTurn> Transcripts)> Calls { get; } = [];
+        public string? ThrowForTarget { get; set; }
+        public Action<ObservationTarget>? BeforeReturn { get; set; }
+
+        public Task<ExtractionPhaseResult> ExecuteAsync(
+            ObservationTarget target,
+            IReadOnlyList<TranscriptTurn> transcripts,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Calls.Add((target, transcripts));
+            BeforeReturn?.Invoke(target);
+
+            if (target.Name == ThrowForTarget)
+                throw new InvalidOperationException("simulated phase 1 failure for " + target.Name);
+
+            return Task.FromResult(new ExtractionPhaseResult(
+                ConversationsProcessed: 1,
+                ConversationsFailed: 0,
+                ProposalsReceived: 0,
+                ProposalsGrounded: 0,
+                MatchedExistingCandidates: 0,
+                NewCandidatesCreated: 0,
+                StateWritten: true));
+        }
+    }
+
+    private sealed class StubEvaluationPhase : IObservationEvaluationPhase
+    {
+        public List<ObservationTarget> Calls { get; } = [];
+
+        public Task<EvaluationPhaseResult> ExecuteAsync(
+            ObservationTarget target,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Calls.Add(target);
+            return Task.FromResult(new EvaluationPhaseResult(
+                CandidatesAged: 0,
+                TheoriesAged: 0,
+                CandidatesEvaluated: 0,
+                CandidatesPromoted: 0,
+                CandidatesRefined: 0,
+                CandidatesRejected: 0,
+                MarkdownRegenerated: true,
+                StateWritten: true));
+        }
+    }
+}


### PR DESCRIPTION
Phase 5 wires the observation pipeline into the dream cycle. After this lands, each dream produces structured observations from the conversation log: phase 1 extracts and merges, phase 2 evaluates, promotes, ages, and publishes promoted theories to `ILongTermMemory` so they appear in `SearchMemory`. Markdown copies live under `{profile}/observation/` for human inspection.

**Closes #353.** Builds on phases 1-4 (#361, #362, #363, #364).

## Summary

**Coordinator** (`IObservationPipelineCoordinator` + `ObservationPipelineCoordinator` in `RockBot.Observation`)
- Runs phase 1 then phase 2 for every registered `ObservationTarget` sequentially
- Per-target failures are caught and logged so a failing target doesn't block its peers
- Cancellation aborts cleanly before the next target starts
- `ObservationTargetRunResult` records per-target outcomes for logging

**Conversation log adapter** (`ConversationLogTranscriptAdapter` in `RockBot.Host`)
- Reads `IConversationLog`, derives `Source` from session-id prefix, produces `IReadOnlyList<TranscriptTurn>` ordered by timestamp with stable per-session turn IDs
- Source mapping:
  - `patrol/*` → `ScheduledTask`
  - `a2a-inbound/*` → `Agent` (other agent calling us, not a human)
  - everything else → role decides (`user` → `User`, `assistant`/`system` → `Agent`)
- Registered alongside `IConversationLog` in `AgentMemoryExtensions.WithConversationLog()`

**Dream service hook**
- `DreamOptions.ObservationEnabled` (default `true`) gates the new pass
- `DreamService` gains optional `IObservationPipelineCoordinator` and `ConversationLogTranscriptAdapter` constructor parameters; pass is skipped silently if either is missing (keeps existing tests with minimal DI working)
- `RunObservationPassAsync` runs **between memory mining and preference inference** — must precede pref inference because pref inference clears the conversation log in its `finally` block
- Per-target outcomes logged with extraction + evaluation counts

**Agent program wiring**
- `src/RockBot.Agent/Program.cs` registers the framework via `AddRockBotObservation()` + `AddDefaultObservationTargets(profileBasePath)`
- Profile base path resolved from `AgentProfile` config section (same pattern as elsewhere)
- `RockBot.Agent` → `RockBot.Observation` project reference added

## Tests (14 new, 117 total in the observation+adapter surface)

- `ObservationPipelineCoordinatorTests` (6): no targets, two targets both phases, one target fails others continue, per-target filter applied before extraction, cancellation stops before next target, null transcripts throws
- `ConversationLogTranscriptAdapterTests` (8): empty log, role mapping in user sessions, patrol session forces `ScheduledTask`, A2A inbound forces `Agent`, stable per-session turn IDs, ordering by timestamp, multiple sessions, cancellation propagates

## Test plan

- [x] `dotnet build RockBot.slnx` — clean
- [x] `dotnet test tests/RockBot.Observation.Tests` — 103/103 pass
- [x] `dotnet test tests/RockBot.Host.Tests` — 637/637 pass (existing dream tests unaffected; new adapter tests pass)
- [x] Full solution test run — all projects pass
- [ ] **Deploy to k8s for end-to-end validation** — operator-driven; once deployed, the agent will start producing `theory-of-self.md` / `theory-of-user.md` under `{profile}/observation/` after the next dream, and promoted theories will appear in long-term memory under category `observation/theory/{target.Name}`.

## What you'll see after deploy

- `{profile}/observation/theory-of-self.json` and `theory-of-user.json` — framework state (source of truth)
- `{profile}/observation/theory-of-self.md` and `theory-of-user.md` — regenerated each dream for inspection
- New memory entries with category `observation/theory/theory-of-self` or `observation/theory/theory-of-user` once any candidate crosses the promotion threshold (default 3 distinct conversations)
- Dream log lines: `DreamService: observation target {Target} — phase1: ... phase2: ...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)