### PR TITLE
Observation pass visibility + conv-log .bak on clear

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.10.36</Version>
+<Version>0.10.37</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.Host/DreamService.cs
+++ b/src/RockBot.Host/DreamService.cs
@@ -2182,11 +2182,16 @@ internal sealed class DreamService : IHostedService, IDisposable
     /// </remarks>
     private async Task RunObservationPassAsync(CancellationToken ct)
     {
-        if (!_options.ObservationEnabled) return;
+        if (!_options.ObservationEnabled)
+        {
+            _logger.LogInformation("DreamService: observation pass disabled by configuration");
+            return;
+        }
         if (_observationCoordinator is null || _observationTranscriptAdapter is null)
         {
-            _logger.LogDebug(
-                "DreamService: observation pass skipped — coordinator or adapter not registered");
+            _logger.LogInformation(
+                "DreamService: observation pass skipped — coordinator={Coordinator}, adapter={Adapter}",
+                _observationCoordinator is not null, _observationTranscriptAdapter is not null);
             return;
         }
 
@@ -2195,13 +2200,13 @@ internal sealed class DreamService : IHostedService, IDisposable
             var transcripts = await _observationTranscriptAdapter
                 .GetTranscriptAsync(ct).ConfigureAwait(false);
 
-            if (transcripts.Count == 0)
-            {
-                _logger.LogDebug(
-                    "DreamService: observation pass — no transcripts in this dream window");
-                return;
-            }
+            _logger.LogInformation(
+                "DreamService: observation pass starting — {TurnCount} transcript turns loaded",
+                transcripts.Count);
 
+            // Run the coordinator even when transcripts.Count == 0: the
+            // evaluation phase still needs to age out stale candidates/theories
+            // and regenerate the markdown so the operator sees current state.
             var results = await _observationCoordinator
                 .RunAllAsync(transcripts, ct).ConfigureAwait(false);
 

--- a/src/RockBot.Host/FileConversationLog.cs
+++ b/src/RockBot.Host/FileConversationLog.cs
@@ -88,8 +88,13 @@ internal sealed class FileConversationLog : IConversationLog
         {
             if (File.Exists(_filePath))
             {
-                File.Delete(_filePath);
-                _logger.LogDebug("ConversationLog: log file cleared");
+                // Move-with-overwrite to a single rolling .bak file so the
+                // previous dream cycle's conversations stay recoverable until
+                // the next clear. Move is atomic (same directory) and removes
+                // the original file in one step.
+                var bakPath = _filePath + ".bak";
+                File.Move(_filePath, bakPath, overwrite: true);
+                _logger.LogDebug("ConversationLog: cleared (previous content moved to {BakPath})", bakPath);
             }
         }
         finally

--- a/tests/RockBot.Host.Tests/FileConversationLogTests.cs
+++ b/tests/RockBot.Host.Tests/FileConversationLogTests.cs
@@ -84,6 +84,60 @@ public class FileConversationLogTests
     }
 
     [TestMethod]
+    public async Task ClearAsync_MovesPreviousContentToBakFile()
+    {
+        var log = CreateLog();
+
+        await log.AppendAsync(MakeEntry("session-1", "user", "first cycle content"));
+        await log.AppendAsync(MakeEntry("session-1", "assistant", "first cycle reply"));
+
+        await log.ClearAsync();
+
+        var bakPath = Path.Combine(_tempDir, "conversation-log", "turns.jsonl.bak");
+        Assert.IsTrue(File.Exists(bakPath), "Clear should move the previous content to a .bak file");
+
+        var bakLines = await File.ReadAllLinesAsync(bakPath);
+        Assert.AreEqual(2, bakLines.Length, ".bak file preserves all entries from before the clear");
+        Assert.IsTrue(bakLines[0].Contains("first cycle content"));
+        Assert.IsTrue(bakLines[1].Contains("first cycle reply"));
+
+        // Original file is gone
+        Assert.IsFalse(File.Exists(Path.Combine(_tempDir, "conversation-log", "turns.jsonl")));
+    }
+
+    [TestMethod]
+    public async Task ClearAsync_OverwritesExistingBakFile()
+    {
+        var log = CreateLog();
+
+        // First cycle
+        await log.AppendAsync(MakeEntry("session-1", "user", "first cycle"));
+        await log.ClearAsync();
+
+        // Second cycle
+        await log.AppendAsync(MakeEntry("session-1", "user", "second cycle"));
+        await log.ClearAsync();
+
+        var bakPath = Path.Combine(_tempDir, "conversation-log", "turns.jsonl.bak");
+        var bakLines = await File.ReadAllLinesAsync(bakPath);
+        Assert.AreEqual(1, bakLines.Length, ".bak should contain only the most recent cycle's content");
+        Assert.IsTrue(bakLines[0].Contains("second cycle"),
+            ".bak should be overwritten with the latest cleared content");
+        Assert.IsFalse(bakLines[0].Contains("first cycle"));
+    }
+
+    [TestMethod]
+    public async Task ClearAsync_WhenNoFile_DoesNotCreateBak()
+    {
+        var log = CreateLog();
+        await log.ClearAsync();
+
+        var bakPath = Path.Combine(_tempDir, "conversation-log", "turns.jsonl.bak");
+        Assert.IsFalse(File.Exists(bakPath),
+            "Empty clear should not create a .bak file");
+    }
+
+    [TestMethod]
     public async Task AppendAsync_AfterClear_StartsFromEmpty()
     {
         var log = CreateLog();


### PR DESCRIPTION
Two small fixes after watching the first observation-enabled dream on v0.10.36 produce no observable output.

## 1. Observation pass visibility

The pass had Debug-level skip messages, so a silent no-op was indistinguishable from a non-running pass. Two changes:

- Skip and "transcripts loaded" log messages promoted from Debug to Info. Now we'll see whether the pass ran, whether the framework is wired correctly, and how many transcripts it saw — every dream.
- Run the coordinator unconditionally, even with 0 transcripts. The extraction phase is a no-op when there's nothing to extract, but the evaluation phase still ages stale candidates/theories and regenerates the markdown. Side benefit: \`/data/agent/observation/\` gets created on the first dream regardless of whether there are transcripts, giving an immediate positive signal that the framework is operational.

## 2. Conversation log .bak on clear

\`FileConversationLog.ClearAsync\` now moves the log file to \`<path>.bak\` instead of deleting it. Single rolling backup; overwritten on each clear.

The motivating scenario is exactly the one we just hit: the first observation-enabled dream produced no output, and we couldn't tell why because the source conversation log had already been wiped by pref inference's clear in the same dream. With this change, the previous cycle's data stays available for post-mortem inspection until the next clear.

\`File.Move\` with \`overwrite: true\` is atomic within a single directory, so there's no window where the canonical log file is gone but the backup hasn't been written.

## Tests

3 new \`FileConversationLogTests\`:
- Clear preserves prior content in \`.bak\`
- Second clear overwrites \`.bak\` with the latest cleared content
- Clear with no source file does not create a \`.bak\`

All 640 \`RockBot.Host.Tests\` pass.

## Test plan

- [x] \`dotnet test tests/RockBot.Host.Tests --filter "FullyQualifiedName~FileConversationLogTests"\` — 10/10 pass
- [x] Full Host suite — 640/640 pass
- [ ] Deploy and watch next dream cycle: should see Info-level "observation pass starting — N transcript turns loaded" and per-target outcome lines, and \`/data/agent/observation/\` directory should appear with markdown files

🤖 Generated with [Claude Code](https://claude.com/claude-code)