### PR TITLE
Per-run in-memory task list tools for AgentLoopRunner (#336)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.10.37</Version>
+<Version>0.10.38</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.Host/AgentLoopRunner.cs
+++ b/src/RockBot.Host/AgentLoopRunner.cs
@@ -308,6 +308,13 @@ public sealed partial class AgentLoopRunner(
         // Inject reasoning scaffolding so the model knows its iteration budget.
         InjectReasoningScaffolding(chatMessages);
 
+        // Per-run task list (issue #336): in-memory plan that survives context trimming
+        // because RefreshTaskListContext rebuilds the system message from this state on
+        // each iteration. Built fresh per RunAsync — not persisted, not shared.
+        var taskList = new AgentTaskList();
+        var taskListTools = new AgentTaskListTools(taskList, logger);
+        AppendTaskListTools(chatOptions, taskListTools);
+
         var originalUserRequest = ExtractOriginalUserRequest(chatMessages);
         var maxReprompts = modelBehavior.MaxCompletionRepromptsOverride
             ?? hostOptions.Value.MaxCompletionReprompts;
@@ -318,9 +325,18 @@ public sealed partial class AgentLoopRunner(
             var result = modelBehavior.UseTextBasedToolCalling
                 ? await RunTextBasedLoopAsync(
                     chatMessages, chatOptions, sessionId, firstResponse, tier,
-                    onPreToolCall, onProgress, onToolTimeout, cancellationToken)
+                    onPreToolCall, onProgress, onToolTimeout, taskList, cancellationToken)
                 : await RunNativeLoopAsync(
-                    chatMessages, chatOptions, firstResponse, tier, sessionId, cancellationToken);
+                    chatMessages, chatOptions, firstResponse, tier, sessionId, taskList, cancellationToken);
+
+            if (taskList.HasUnfinishedItems)
+            {
+                logger.LogWarning(
+                    "Task list ended with unfinished items: {Items}",
+                    string.Join("; ", taskList.Snapshot()
+                        .Where(t => !string.Equals(t.Status, AgentTaskList.StatusCompleted, StringComparison.OrdinalIgnoreCase))
+                        .Select(t => $"{t.Id}=[{t.Status}] {t.Description}")));
+            }
 
             // Clear first response after the first iteration — it's already been consumed.
             firstResponse = null;
@@ -441,7 +457,7 @@ public sealed partial class AgentLoopRunner(
                         chatMessages, chatOptions, sessionId, result.Response,
                         originalUserRequest, tier, complexityScore,
                         onPreToolCall, onProgress, onToolTimeout, onStageProgress,
-                        cancellationToken);
+                        taskList, cancellationToken);
 
                     return followUpResult ?? result.Response;
                 }
@@ -485,7 +501,7 @@ public sealed partial class AgentLoopRunner(
                         chatMessages, chatOptions, sessionId, result.Response,
                         originalUserRequest, tier, complexityScore,
                         onPreToolCall, onProgress, onToolTimeout, onStageProgress,
-                        cancellationToken);
+                        taskList, cancellationToken);
 
                     return followUpResult ?? result.Response;
                 }
@@ -539,11 +555,19 @@ public sealed partial class AgentLoopRunner(
         ChatResponse? firstResponse,
         ModelTier tier,
         string? sessionId,
+        AgentTaskList taskList,
         CancellationToken cancellationToken)
     {
         logger.LogInformation(
             "Tool execution path: NATIVE (M.E.AI FunctionInvokingChatClient) — {MessageCount} messages in context",
             chatMessages.Count);
+
+        // Refresh the task-list system message from the in-memory state. The native
+        // path does not expose a per-iteration hook (FunctionInvokingChatClient owns
+        // the inner loop), so this is a once-per-request snapshot. Within the inner
+        // loop the model still sees task_create/task_update tool results as it goes —
+        // the system message just doesn't track those updates until the next request.
+        RefreshTaskListContext(chatMessages, taskList);
 
         // If there's a pre-fetched first response with tool calls, add it to history
         // and let the middleware continue from there.
@@ -650,6 +674,73 @@ public sealed partial class AgentLoopRunner(
         chatMessages.Insert(insertAt, new ChatMessage(ChatRole.System, text));
     }
 
+    private const string TaskListMarker = "Current task list:";
+
+    /// <summary>
+    /// Adds the per-run task-list tools (<c>task_create</c>, <c>task_update</c>) to
+    /// <paramref name="chatOptions"/>. Initialises <see cref="ChatOptions.Tools"/> if null.
+    /// </summary>
+    private static void AppendTaskListTools(ChatOptions chatOptions, AgentTaskListTools taskListTools)
+    {
+        chatOptions.Tools ??= [];
+        foreach (var tool in taskListTools.Tools)
+            chatOptions.Tools.Add(tool);
+    }
+
+    /// <summary>
+    /// Re-renders the per-run task list (<paramref name="taskList"/>) into a system
+    /// message inside <paramref name="chatMessages"/>. Idempotent: replaces an existing
+    /// task-list system message if present, otherwise inserts one just before the final
+    /// user message for recency. Removes the message entirely when the list is empty.
+    /// Issue #336: the rendering is rebuilt from in-memory state on every call, so the
+    /// current plan is always visible to the model even after older task_create /
+    /// task_update tool results have been trimmed by <see cref="TrimLargeToolResults"/>.
+    /// </summary>
+    private static void RefreshTaskListContext(List<ChatMessage> chatMessages, AgentTaskList taskList)
+    {
+        var existingIndex = -1;
+        for (var i = 0; i < chatMessages.Count; i++)
+        {
+            if (chatMessages[i].Role == ChatRole.System &&
+                chatMessages[i].Text?.StartsWith(TaskListMarker) == true)
+            {
+                existingIndex = i;
+                break;
+            }
+        }
+
+        if (taskList.IsEmpty)
+        {
+            if (existingIndex >= 0)
+                chatMessages.RemoveAt(existingIndex);
+            return;
+        }
+
+        var sb = new StringBuilder();
+        sb.AppendLine(TaskListMarker);
+        foreach (var item in taskList.Snapshot())
+            sb.AppendLine($"  {item.Id}. [{item.Status}] {item.Description}");
+        var text = sb.ToString().TrimEnd();
+
+        var msg = new ChatMessage(ChatRole.System, text);
+        if (existingIndex >= 0)
+        {
+            chatMessages[existingIndex] = msg;
+            return;
+        }
+
+        var insertAt = chatMessages.Count;
+        for (var i = chatMessages.Count - 1; i >= 0; i--)
+        {
+            if (chatMessages[i].Role == ChatRole.User)
+            {
+                insertAt = i;
+                break;
+            }
+        }
+        chatMessages.Insert(insertAt, msg);
+    }
+
     /// <summary>
     /// Text-based tool-calling loop for models that do not support native structured
     /// tool calling (e.g. DeepSeek). Parses tool calls from free text and manually
@@ -664,6 +755,7 @@ public sealed partial class AgentLoopRunner(
         Func<string, CancellationToken, Task>? onPreToolCall,
         Func<string, CancellationToken, Task>? onProgress,
         Func<string, CancellationToken, Task>? onToolTimeout,
+        AgentTaskList taskList,
         CancellationToken cancellationToken)
     {
         logger.LogInformation(
@@ -698,6 +790,11 @@ public sealed partial class AgentLoopRunner(
             }
             else
             {
+                // Refresh the task-list system message from the in-memory state so the
+                // current plan is always visible to the model, even after older tool
+                // results that recorded earlier task_update calls have been trimmed.
+                RefreshTaskListContext(chatMessages, taskList);
+
                 if (_knownContextLimit is int preLimit)
                     TrimLargeToolResults(chatMessages, preLimit);
 
@@ -1615,6 +1712,7 @@ public sealed partial class AgentLoopRunner(
         Func<string, CancellationToken, Task>? onProgress,
         Func<string, CancellationToken, Task>? onToolTimeout,
         Func<string, CancellationToken, Task>? onStageProgress,
+        AgentTaskList taskList,
         CancellationToken cancellationToken)
     {
         var maxFollowUps = modelBehavior.MaxFollowUpPassesOverride
@@ -1679,9 +1777,9 @@ public sealed partial class AgentLoopRunner(
         var result = modelBehavior.UseTextBasedToolCalling
             ? await RunTextBasedLoopAsync(
                 chatMessages, chatOptions, sessionId, null, tier,
-                onPreToolCall, onProgress, onToolTimeout, cancellationToken)
+                onPreToolCall, onProgress, onToolTimeout, taskList, cancellationToken)
             : await RunNativeLoopAsync(
-                chatMessages, chatOptions, null, tier, sessionId, cancellationToken);
+                chatMessages, chatOptions, null, tier, sessionId, taskList, cancellationToken);
 
         // Native path: FunctionCallContent in response messages.
         // Text-based path: tool results appear as "[Tool result for ...]" user messages.

--- a/src/RockBot.Host/AgentTaskList.cs
+++ b/src/RockBot.Host/AgentTaskList.cs
@@ -1,0 +1,105 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Per-<see cref="AgentLoopRunner.RunAsync"/> in-memory task list. Holds the agent's
+/// committed plan as structured state so it survives context trimming — the list is
+/// rendered into a system message that <see cref="AgentLoopRunner"/> refreshes from
+/// this state on each iteration, rather than living only in the chat history where
+/// trimming or aging can degrade it.
+/// </summary>
+internal sealed class AgentTaskList
+{
+    public const string StatusPending = "pending";
+    public const string StatusInProgress = "in_progress";
+    public const string StatusCompleted = "completed";
+
+    private static readonly HashSet<string> ValidStatuses = new(StringComparer.OrdinalIgnoreCase)
+    {
+        StatusPending, StatusInProgress, StatusCompleted
+    };
+
+    private readonly Lock _gate = new();
+    private readonly List<TaskItem> _items = [];
+
+    public sealed record TaskItem(int Id, string Description, string Status);
+
+    public bool IsEmpty
+    {
+        get { lock (_gate) return _items.Count == 0; }
+    }
+
+    public bool HasUnfinishedItems
+    {
+        get
+        {
+            lock (_gate)
+            {
+                foreach (var item in _items)
+                {
+                    if (!string.Equals(item.Status, StatusCompleted, StringComparison.OrdinalIgnoreCase))
+                        return true;
+                }
+                return false;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Replaces the current list with the given items. Each item gets a sequential
+    /// id starting at 1 and an initial status of <see cref="StatusPending"/>. Returns
+    /// the newly created items.
+    /// </summary>
+    public IReadOnlyList<TaskItem> CreateOrReplace(IEnumerable<string> items)
+    {
+        ArgumentNullException.ThrowIfNull(items);
+
+        lock (_gate)
+        {
+            _items.Clear();
+            var id = 1;
+            foreach (var description in items)
+            {
+                if (string.IsNullOrWhiteSpace(description))
+                    continue;
+                _items.Add(new TaskItem(id++, description.Trim(), StatusPending));
+            }
+            return _items.ToArray();
+        }
+    }
+
+    /// <summary>
+    /// Updates a single item's status. Returns the updated item, or null when no
+    /// item with the given id exists. Throws <see cref="ArgumentException"/> for
+    /// unknown status values.
+    /// </summary>
+    public TaskItem? Update(int id, string status)
+    {
+        ArgumentNullException.ThrowIfNull(status);
+
+        if (!ValidStatuses.Contains(status))
+            throw new ArgumentException(
+                $"Invalid status '{status}'. Valid statuses: {string.Join(", ", ValidStatuses)}.",
+                nameof(status));
+
+        var normalized = status.ToLowerInvariant();
+
+        lock (_gate)
+        {
+            for (var i = 0; i < _items.Count; i++)
+            {
+                if (_items[i].Id == id)
+                {
+                    var updated = _items[i] with { Status = normalized };
+                    _items[i] = updated;
+                    return updated;
+                }
+            }
+            return null;
+        }
+    }
+
+    public IReadOnlyList<TaskItem> Snapshot()
+    {
+        lock (_gate) return _items.ToArray();
+    }
+}

--- a/src/RockBot.Host/AgentTaskListTools.cs
+++ b/src/RockBot.Host/AgentTaskListTools.cs
@@ -1,0 +1,98 @@
+using System.ComponentModel;
+using System.Text;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+
+namespace RockBot.Host;
+
+/// <summary>
+/// LLM-callable tools for the per-run task list (<see cref="AgentTaskList"/>). Built
+/// once per <see cref="AgentLoopRunner.RunAsync"/> invocation over a fresh state object.
+///
+/// The list itself is rendered into a system message that the loop refreshes from the
+/// underlying state — so even if old <c>task_create</c>/<c>task_update</c> tool results
+/// get trimmed by <c>TrimLargeToolResults</c>, the model still sees the current list at
+/// the next iteration.
+/// </summary>
+internal sealed class AgentTaskListTools
+{
+    private readonly AgentTaskList _taskList;
+    private readonly ILogger _logger;
+
+    public AgentTaskListTools(AgentTaskList taskList, ILogger logger)
+    {
+        _taskList = taskList;
+        _logger = logger;
+
+        Tools =
+        [
+            AIFunctionFactory.Create(TaskCreate),
+            AIFunctionFactory.Create(TaskUpdate)
+        ];
+    }
+
+    public IList<AITool> Tools { get; }
+
+    [Description(
+        "Record a multi-step plan for the current request as a structured task list. " +
+        "Use this once at the start of any non-trivial work to lay out the steps you intend " +
+        "to take, then call task_update as each step progresses or completes. The list is " +
+        "re-rendered fresh each iteration so it survives context trimming. " +
+        "Calling task_create REPLACES the existing list — to add a step you discovered later, " +
+        "call task_create again with the full updated set of items. Returns the assigned ids " +
+        "(1, 2, 3, …) you will use with task_update.")]
+    public string TaskCreate(
+        [Description("Ordered list of short imperative task descriptions, e.g. " +
+                     "[\"Read the planning doc\", \"Search emails for context\", \"Draft response\"]. " +
+                     "Empty array clears the list.")] string[] items)
+    {
+        _logger.LogInformation("Tool call: TaskCreate({Count} items)", items?.Length ?? 0);
+
+        var created = _taskList.CreateOrReplace(items ?? []);
+        if (created.Count == 0)
+            return "Task list cleared.";
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"Task list set ({created.Count} items):");
+        foreach (var item in created)
+            sb.AppendLine($"  {item.Id}. [{item.Status}] {item.Description}");
+        return sb.ToString().TrimEnd();
+    }
+
+    [Description(
+        "Update the status of a single task in the current task list. Statuses: " +
+        "'pending' (not started), 'in_progress' (currently working), 'completed' (done). " +
+        "Mark a task in_progress when you start it and completed when finished — keeping the " +
+        "list accurate is what makes it useful across many iterations.")]
+    public string TaskUpdate(
+        [Description("The task id as returned by task_create (1, 2, 3, …)")] int id,
+        [Description("New status: 'pending', 'in_progress', or 'completed'")] string status)
+    {
+        _logger.LogInformation("Tool call: TaskUpdate(id={Id}, status={Status})", id, status);
+
+        if (string.IsNullOrWhiteSpace(status))
+            return "Error: status is required (use 'pending', 'in_progress', or 'completed').";
+
+        AgentTaskList.TaskItem? updated;
+        try
+        {
+            updated = _taskList.Update(id, status);
+        }
+        catch (ArgumentException ex)
+        {
+            return $"Error: {ex.Message}";
+        }
+
+        if (updated is null)
+        {
+            var snapshot = _taskList.Snapshot();
+            if (snapshot.Count == 0)
+                return $"Error: no task with id {id} — the task list is empty. Call task_create first.";
+
+            var ids = string.Join(", ", snapshot.Select(t => t.Id));
+            return $"Error: no task with id {id}. Known ids: {ids}.";
+        }
+
+        return $"Task {updated.Id} → [{updated.Status}] {updated.Description}";
+    }
+}

--- a/tests/RockBot.Host.Tests/AgentTaskListTests.cs
+++ b/tests/RockBot.Host.Tests/AgentTaskListTests.cs
@@ -1,0 +1,153 @@
+namespace RockBot.Host.Tests;
+
+[TestClass]
+public class AgentTaskListTests
+{
+    [TestMethod]
+    public void IsEmpty_WhenNew_ReturnsTrue()
+    {
+        var list = new AgentTaskList();
+        Assert.IsTrue(list.IsEmpty);
+        Assert.IsFalse(list.HasUnfinishedItems);
+        Assert.AreEqual(0, list.Snapshot().Count);
+    }
+
+    [TestMethod]
+    public void CreateOrReplace_AssignsSequentialIdsStartingAtOne()
+    {
+        var list = new AgentTaskList();
+
+        var created = list.CreateOrReplace(["read doc", "search emails", "draft response"]);
+
+        Assert.AreEqual(3, created.Count);
+        Assert.AreEqual(1, created[0].Id);
+        Assert.AreEqual(2, created[1].Id);
+        Assert.AreEqual(3, created[2].Id);
+        Assert.AreEqual("read doc", created[0].Description);
+        Assert.AreEqual(AgentTaskList.StatusPending, created[0].Status);
+    }
+
+    [TestMethod]
+    public void CreateOrReplace_TrimsWhitespaceAndSkipsBlankItems()
+    {
+        var list = new AgentTaskList();
+
+        var created = list.CreateOrReplace(["  step one  ", "", "   ", "step two"]);
+
+        Assert.AreEqual(2, created.Count);
+        Assert.AreEqual("step one", created[0].Description);
+        Assert.AreEqual("step two", created[1].Description);
+        Assert.AreEqual(1, created[0].Id);
+        Assert.AreEqual(2, created[1].Id);
+    }
+
+    [TestMethod]
+    public void CreateOrReplace_ResetsExistingState()
+    {
+        var list = new AgentTaskList();
+        list.CreateOrReplace(["a", "b", "c"]);
+        list.Update(1, AgentTaskList.StatusCompleted);
+
+        var created = list.CreateOrReplace(["x", "y"]);
+
+        Assert.AreEqual(2, created.Count);
+        Assert.AreEqual(1, created[0].Id);
+        Assert.AreEqual("x", created[0].Description);
+        Assert.AreEqual(AgentTaskList.StatusPending, created[0].Status,
+            "Replacing the list should reset all statuses to pending");
+    }
+
+    [TestMethod]
+    public void CreateOrReplace_WithEmptyEnumerable_ClearsList()
+    {
+        var list = new AgentTaskList();
+        list.CreateOrReplace(["a", "b"]);
+
+        var created = list.CreateOrReplace(Array.Empty<string>());
+
+        Assert.AreEqual(0, created.Count);
+        Assert.IsTrue(list.IsEmpty);
+    }
+
+    [TestMethod]
+    public void Update_KnownId_UpdatesStatusAndReturnsItem()
+    {
+        var list = new AgentTaskList();
+        list.CreateOrReplace(["a", "b"]);
+
+        var updated = list.Update(2, AgentTaskList.StatusInProgress);
+
+        Assert.IsNotNull(updated);
+        Assert.AreEqual(2, updated.Id);
+        Assert.AreEqual(AgentTaskList.StatusInProgress, updated.Status);
+        Assert.AreEqual("b", updated.Description);
+
+        // Underlying snapshot reflects the change.
+        var snapshot = list.Snapshot();
+        Assert.AreEqual(AgentTaskList.StatusPending, snapshot[0].Status);
+        Assert.AreEqual(AgentTaskList.StatusInProgress, snapshot[1].Status);
+    }
+
+    [TestMethod]
+    public void Update_UnknownId_ReturnsNull()
+    {
+        var list = new AgentTaskList();
+        list.CreateOrReplace(["a"]);
+
+        var updated = list.Update(99, AgentTaskList.StatusCompleted);
+
+        Assert.IsNull(updated);
+    }
+
+    [TestMethod]
+    public void Update_InvalidStatus_Throws()
+    {
+        var list = new AgentTaskList();
+        list.CreateOrReplace(["a"]);
+
+        Assert.ThrowsExactly<ArgumentException>(() => list.Update(1, "blocked"));
+    }
+
+    [TestMethod]
+    public void Update_StatusCaseInsensitive_NormalisedToLowercase()
+    {
+        var list = new AgentTaskList();
+        list.CreateOrReplace(["a"]);
+
+        var updated = list.Update(1, "IN_PROGRESS");
+
+        Assert.IsNotNull(updated);
+        Assert.AreEqual(AgentTaskList.StatusInProgress, updated.Status);
+    }
+
+    [TestMethod]
+    public void HasUnfinishedItems_TrueWhilePendingOrInProgress()
+    {
+        var list = new AgentTaskList();
+        list.CreateOrReplace(["a", "b"]);
+
+        Assert.IsTrue(list.HasUnfinishedItems, "All pending should count as unfinished");
+
+        list.Update(1, AgentTaskList.StatusCompleted);
+        Assert.IsTrue(list.HasUnfinishedItems, "One completed, one pending → unfinished");
+
+        list.Update(2, AgentTaskList.StatusInProgress);
+        Assert.IsTrue(list.HasUnfinishedItems, "in_progress counts as unfinished");
+
+        list.Update(2, AgentTaskList.StatusCompleted);
+        Assert.IsFalse(list.HasUnfinishedItems, "All completed → finished");
+    }
+
+    [TestMethod]
+    public void Snapshot_IsIndependentCopy()
+    {
+        var list = new AgentTaskList();
+        list.CreateOrReplace(["a"]);
+
+        var snapshot = list.Snapshot();
+        list.Update(1, AgentTaskList.StatusCompleted);
+
+        Assert.AreEqual(AgentTaskList.StatusPending, snapshot[0].Status,
+            "Snapshot should not reflect changes made after it was taken");
+    }
+}

--- a/tests/RockBot.Host.Tests/AgentTaskListToolsTests.cs
+++ b/tests/RockBot.Host.Tests/AgentTaskListToolsTests.cs
@@ -1,0 +1,132 @@
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace RockBot.Host.Tests;
+
+[TestClass]
+public class AgentTaskListToolsTests
+{
+    private static AgentTaskListTools NewTools(out AgentTaskList list)
+    {
+        list = new AgentTaskList();
+        return new AgentTaskListTools(list, NullLogger.Instance);
+    }
+
+    [TestMethod]
+    public void Tools_ExposesTaskCreateAndTaskUpdate()
+    {
+        var tools = NewTools(out _);
+
+        var names = tools.Tools.OfType<AIFunction>().Select(f => f.Name).ToHashSet();
+
+        Assert.AreEqual(2, names.Count);
+        Assert.IsTrue(names.Contains("TaskCreate") || names.Contains("task_create"),
+            $"Expected a task_create-style tool. Got: {string.Join(", ", names)}");
+        Assert.IsTrue(names.Contains("TaskUpdate") || names.Contains("task_update"),
+            $"Expected a task_update-style tool. Got: {string.Join(", ", names)}");
+    }
+
+    [TestMethod]
+    public void TaskCreate_ReturnsConfirmationListingIds()
+    {
+        var tools = NewTools(out var list);
+
+        var result = tools.TaskCreate(["read doc", "search emails"]);
+
+        Assert.IsTrue(result.Contains("2 items"), $"Result missing item count: {result}");
+        Assert.IsTrue(result.Contains("1.") && result.Contains("2."),
+            $"Result missing assigned ids: {result}");
+        Assert.IsTrue(result.Contains("read doc") && result.Contains("search emails"),
+            $"Result missing item descriptions: {result}");
+
+        // State updated.
+        Assert.AreEqual(2, list.Snapshot().Count);
+    }
+
+    [TestMethod]
+    public void TaskCreate_EmptyItems_ClearsAndReportsCleared()
+    {
+        var tools = NewTools(out var list);
+        tools.TaskCreate(["a", "b"]);
+
+        var result = tools.TaskCreate(Array.Empty<string>());
+
+        Assert.AreEqual("Task list cleared.", result);
+        Assert.IsTrue(list.IsEmpty);
+    }
+
+    [TestMethod]
+    public void TaskCreate_NullItems_ClearsList()
+    {
+        var tools = NewTools(out var list);
+        tools.TaskCreate(["a"]);
+
+        var result = tools.TaskCreate(null!);
+
+        Assert.AreEqual("Task list cleared.", result);
+        Assert.IsTrue(list.IsEmpty);
+    }
+
+    [TestMethod]
+    public void TaskUpdate_KnownId_UpdatesAndReturnsConfirmation()
+    {
+        var tools = NewTools(out var list);
+        tools.TaskCreate(["one", "two"]);
+
+        var result = tools.TaskUpdate(1, AgentTaskList.StatusInProgress);
+
+        Assert.IsTrue(result.Contains("Task 1"), $"Missing task id in result: {result}");
+        Assert.IsTrue(result.Contains(AgentTaskList.StatusInProgress),
+            $"Missing status in result: {result}");
+        Assert.AreEqual(AgentTaskList.StatusInProgress, list.Snapshot()[0].Status);
+    }
+
+    [TestMethod]
+    public void TaskUpdate_UnknownId_ReturnsFriendlyError()
+    {
+        var tools = NewTools(out _);
+        tools.TaskCreate(["only one"]);
+
+        var result = tools.TaskUpdate(42, AgentTaskList.StatusCompleted);
+
+        Assert.IsTrue(result.StartsWith("Error:"), $"Expected error prefix: {result}");
+        Assert.IsTrue(result.Contains("42"), $"Should mention the bad id: {result}");
+        Assert.IsTrue(result.Contains("1"), $"Should list known ids: {result}");
+    }
+
+    [TestMethod]
+    public void TaskUpdate_EmptyTaskList_ReturnsHelpfulError()
+    {
+        var tools = NewTools(out _);
+
+        var result = tools.TaskUpdate(1, AgentTaskList.StatusCompleted);
+
+        Assert.IsTrue(result.StartsWith("Error:"), $"Expected error prefix: {result}");
+        Assert.IsTrue(result.Contains("task_create"),
+            $"Should hint to call task_create: {result}");
+    }
+
+    [TestMethod]
+    public void TaskUpdate_InvalidStatus_ReturnsFriendlyError()
+    {
+        var tools = NewTools(out _);
+        tools.TaskCreate(["a"]);
+
+        var result = tools.TaskUpdate(1, "blocked");
+
+        Assert.IsTrue(result.StartsWith("Error:"), $"Expected error prefix: {result}");
+        Assert.IsTrue(result.Contains("blocked"),
+            $"Should echo the bad status: {result}");
+    }
+
+    [TestMethod]
+    public void TaskUpdate_BlankStatus_ReturnsFriendlyError()
+    {
+        var tools = NewTools(out _);
+        tools.TaskCreate(["a"]);
+
+        var result = tools.TaskUpdate(1, "   ");
+
+        Assert.IsTrue(result.StartsWith("Error:"), $"Expected error prefix: {result}");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `AgentTaskList` (per-run state) and `AgentTaskListTools` exposing `task_create` / `task_update` to the LLM.
- `AgentLoopRunner` builds a fresh task list per `RunAsync` call, appends the tools to `chatOptions.Tools`, and re-renders the list as a system message (`Current task list:`) at the top of every text-based iteration.
- Native path renders the system message once per request — `FunctionInvokingChatClient` owns the inner loop so per-iteration injection isn't available there. Threaded through to the follow-up pass so the same list survives.
- Logs a warning at end of run when items remain `pending` / `in_progress` (MVP — not blocking, surfaced as a hint per the issue's open question).
- 20 new unit tests covering the state class and tool surface.

The list is rebuilt from in-memory state each iteration, so an agent's committed plan survives `TrimLargeToolResults` even when older `task_create` / `task_update` tool results have been truncated.

## Test plan

- [x] `dotnet build RockBot.slnx` — succeeds, no warnings
- [x] `dotnet test RockBot.slnx` — 1598 passed, 0 failed (including 20 new tests)
- [ ] Manual smoke: deploy to cluster, observe a long-horizon subagent run uses `task_create` / `task_update`

Out of scope (per issue): persistence, sharing across runs, `add_item`/`remove_item`, completion-evaluator integration.

Closes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)