### PR TITLE
Self-repair Phase 1: mechanical recovery in MCP gateway

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.10.37</Version>
+<Version>0.10.39</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.Tools.Mcp/McpManagementExecutor.cs
+++ b/src/RockBot.Tools.Mcp/McpManagementExecutor.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using RockBot.Host;
 using RockBot.Messaging;
+using RockBot.Tools.Mcp.Recovery;
 
 namespace RockBot.Tools.Mcp;
 
@@ -27,6 +28,7 @@ public sealed class McpManagementExecutor : IToolExecutor, IAsyncDisposable
     private readonly AgentIdentity _identity;
     private readonly ILogger<McpManagementExecutor> _logger;
     private readonly TimeSpan _timeout;
+    private readonly McpRecoveryExecutor? _recovery;
 
     private readonly ConcurrentDictionary<string, TaskCompletionSource<MessageEnvelope>> _pending = new();
     private ISubscription? _responseSubscription;
@@ -48,7 +50,8 @@ public sealed class McpManagementExecutor : IToolExecutor, IAsyncDisposable
         IMessageSubscriber subscriber,
         AgentIdentity identity,
         ILogger<McpManagementExecutor> logger,
-        TimeSpan? timeout = null)
+        TimeSpan? timeout = null,
+        McpRecoveryExecutor? recovery = null)
     {
         _index = index;
         _proxy = proxy;
@@ -57,6 +60,7 @@ public sealed class McpManagementExecutor : IToolExecutor, IAsyncDisposable
         _identity = identity;
         _logger = logger;
         _timeout = timeout ?? TimeSpan.FromSeconds(30);
+        _recovery = recovery;
     }
 
     public string ResponseTopic => $"mcp.manage.response.{_identity.Name}";
@@ -152,7 +156,18 @@ public sealed class McpManagementExecutor : IToolExecutor, IAsyncDisposable
             [McpHeaders.ServerName] = serverName
         };
 
-        return await _proxy.ExecuteAsync(innerRequest, extraHeaders, ct);
+        var response = await _proxy.ExecuteAsync(innerRequest, extraHeaders, ct);
+
+        // Always pass through recovery — it inspects both IsError=true responses
+        // and IsError=false responses with embedded JSON error bodies (some MCP
+        // servers report schema errors that way). Recovery short-circuits cheaply
+        // when the response is genuinely successful.
+        if (_recovery is not null)
+        {
+            response = await _recovery.RecoverAsync(serverName, toolName, innerRequest, response, ct);
+        }
+
+        return response;
     }
 
     // ── mcp_register_server ──────────────────────────────────────────────────

--- a/src/RockBot.Tools.Mcp/McpServiceCollectionExtensions.cs
+++ b/src/RockBot.Tools.Mcp/McpServiceCollectionExtensions.cs
@@ -1,7 +1,10 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using RockBot.Host;
 using RockBot.Tools;
+using RockBot.Tools.Mcp.Recovery;
+using RockBot.Tools.Mcp.Recovery.Providers;
 
 namespace RockBot.Tools.Mcp;
 
@@ -41,6 +44,19 @@ public static class McpServiceCollectionExtensions
         builder.Services.AddSingleton<McpManagementExecutor>();
         builder.Services.AddHostedService<McpStartupProbeService>();
         builder.Services.AddSingleton<IToolSkillProvider, McpToolSkillProvider>();
+
+        // Self-repair Phase 1: mechanical recovery for missing required parameters.
+        // See design/self-repair.md.
+        builder.Services.AddSingleton<McpInvokeDelegate>(sp =>
+        {
+            var proxy = sp.GetRequiredService<McpToolProxy>();
+            return (req, headers, ct) => proxy.ExecuteAsync(req, headers, ct);
+        });
+        builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IToolArgumentDefaultsProvider, TimeZoneDefaultProvider>());
+        builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IToolArgumentDefaultsProvider, CurrentTimeDefaultProvider>());
+        builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IToolArgumentDefaultsProvider, AccountIdFanoutProvider>());
+        builder.Services.AddSingleton<StageBLlmFiller>();
+        builder.Services.AddSingleton<McpRecoveryExecutor>();
 
         builder.HandleMessage<McpServersIndexed, McpServersIndexedHandler>();
         builder.SubscribeTo($"tool.meta.mcp.{agentName}");

--- a/src/RockBot.Tools.Mcp/Recovery/IToolArgumentDefaultsProvider.cs
+++ b/src/RockBot.Tools.Mcp/Recovery/IToolArgumentDefaultsProvider.cs
@@ -1,0 +1,48 @@
+namespace RockBot.Tools.Mcp.Recovery;
+
+/// <summary>
+/// Resolves a default value for a missing required tool argument.
+/// Implementations are queried in registration order; the first one whose
+/// <see cref="CanResolve"/> returns <c>true</c> wins. See
+/// <c>design/self-repair.md</c> Phase 1, Stage A.
+/// </summary>
+public interface IToolArgumentDefaultsProvider
+{
+    /// <summary>
+    /// Cheap predicate. Returns <c>true</c> if this provider can produce a value
+    /// for the given (server, tool, field). Must not perform I/O.
+    /// </summary>
+    bool CanResolve(string serverName, string toolName, string fieldName);
+
+    /// <summary>
+    /// Produces a value (or null if resolution unexpectedly fails). May perform I/O.
+    /// </summary>
+    Task<ResolvedDefault?> ResolveAsync(ResolveContext ctx, CancellationToken ct);
+}
+
+/// <summary>
+/// Inputs to <see cref="IToolArgumentDefaultsProvider.ResolveAsync"/>.
+/// </summary>
+public sealed record ResolveContext(
+    string ServerName,
+    string ToolName,
+    string FieldName,
+    IReadOnlyDictionary<string, object?> ExistingArgs);
+
+/// <summary>
+/// Output of <see cref="IToolArgumentDefaultsProvider.ResolveAsync"/>.
+/// When <see cref="RequiresFanOut"/> is <c>true</c>, <see cref="Value"/> must be
+/// an <see cref="System.Collections.IEnumerable"/> of values; the recovery executor
+/// will issue one tool call per element and aggregate the responses.
+/// </summary>
+public sealed record ResolvedDefault(object? Value, bool RequiresFanOut = false);
+
+/// <summary>
+/// Delegate over <see cref="McpToolProxy.ExecuteAsync(ToolInvokeRequest, IReadOnlyDictionary{string, string}?, CancellationToken)"/>.
+/// Lets recovery code and providers issue MCP calls without taking a hard dependency
+/// on the sealed proxy type, which simplifies unit testing.
+/// </summary>
+public delegate Task<ToolInvokeResponse> McpInvokeDelegate(
+    ToolInvokeRequest request,
+    IReadOnlyDictionary<string, string>? extraHeaders,
+    CancellationToken ct);

--- a/src/RockBot.Tools.Mcp/Recovery/McpRecoveryExecutor.cs
+++ b/src/RockBot.Tools.Mcp/Recovery/McpRecoveryExecutor.cs
@@ -1,0 +1,456 @@
+using System.Collections;
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace RockBot.Tools.Mcp.Recovery;
+
+/// <summary>
+/// Recovery wrapper around <see cref="McpToolProxy"/>. When an
+/// <c>mcp_invoke_tool</c> call fails with a "missing required field" schema
+/// error, runs Stage A (deterministic providers) then Stage B (Low-tier LLM
+/// fill), retries the call once, and either returns the recovered response or
+/// returns the original error annotated with a recovery trail.
+///
+/// Some MCP servers report schema errors with <see cref="ToolInvokeResponse.IsError"/>
+/// set to <c>false</c> and the error embedded in a JSON body like
+/// <c>{"error":"&lt;X&gt; is required"}</c>. This wrapper inspects content
+/// regardless of the <c>IsError</c> flag so we are robust to that pattern.
+/// Chained recovery (multiple missing fields surfaced one at a time) is
+/// supported up to a fixed depth.
+///
+/// See <c>design/self-repair.md</c> Phase 1.
+/// </summary>
+public sealed class McpRecoveryExecutor
+{
+    /// <summary>
+    /// Maximum number of chained recovery iterations for a single tool call.
+    /// Each iteration handles one missing field, so this caps the number of
+    /// fields a single recovery sequence can fill before giving up.
+    /// </summary>
+    internal const int MaxChainDepth = 4;
+
+    /// <summary>
+    /// Maximum content length to scan for embedded JSON error fields. Larger
+    /// payloads are assumed to be legitimate tool output, not error envelopes.
+    /// </summary>
+    internal const int MaxEmbeddedErrorScanLength = 4096;
+
+    private readonly McpInvokeDelegate _invoke;
+    private readonly IReadOnlyList<IToolArgumentDefaultsProvider> _providers;
+    private readonly StageBLlmFiller? _stageB;
+    private readonly ILogger<McpRecoveryExecutor> _logger;
+
+    public McpRecoveryExecutor(
+        McpInvokeDelegate invoke,
+        IEnumerable<IToolArgumentDefaultsProvider> providers,
+        ILogger<McpRecoveryExecutor> logger,
+        StageBLlmFiller? stageB = null)
+    {
+        _invoke = invoke;
+        _providers = providers.ToList();
+        _stageB = stageB;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Returns the original response when no recovery is possible (no recoverable
+    /// error pattern, no provider, Stage B unavailable or unsuccessful), or a
+    /// successful recovered response. Exhausted-recovery responses carry an
+    /// annotated trail in <see cref="ToolInvokeResponse.Content"/>.
+    /// </summary>
+    public Task<ToolInvokeResponse> RecoverAsync(
+        string serverName,
+        string toolName,
+        ToolInvokeRequest innerRequest,
+        ToolInvokeResponse response,
+        CancellationToken ct) =>
+        TryRecoverAsync(serverName, toolName, innerRequest, response, depth: 0, ct);
+
+    private async Task<ToolInvokeResponse> TryRecoverAsync(
+        string serverName,
+        string toolName,
+        ToolInvokeRequest innerRequest,
+        ToolInvokeResponse response,
+        int depth,
+        CancellationToken ct)
+    {
+        if (depth >= MaxChainDepth)
+        {
+            // Chain exhausted — if the response still carries a recoverable error,
+            // annotate so the agent sees recovery was attempted but ran out of budget.
+            return TryExtractRecoverableError(response) is not null
+                ? Annotate(response, $"chain-exhausted at depth {depth}")
+                : response;
+        }
+
+        var errorText = TryExtractRecoverableError(response);
+        if (errorText is null) return response;
+
+        if (!SchemaErrorPatterns.TryExtractMissingField(errorText, out var fieldName))
+            return response;
+
+        var existingArgs = McpToolExecutor.ParseArguments(innerRequest.Arguments);
+        if (existingArgs.ContainsKey(fieldName))
+        {
+            // The field is already present — the error is something else despite matching
+            // the pattern (e.g., the value was wrong, not missing). Don't loop.
+            return response;
+        }
+
+        var sw = Stopwatch.StartNew();
+        var ctx = new ResolveContext(serverName, toolName, fieldName, existingArgs);
+
+        // ── Stage A ─────────────────────────────────────────────────────────
+        foreach (var provider in _providers)
+        {
+            if (!provider.CanResolve(serverName, toolName, fieldName)) continue;
+
+            ResolvedDefault? resolved;
+            try
+            {
+                resolved = await provider.ResolveAsync(ctx, ct);
+            }
+            catch (OperationCanceledException) { throw; }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Recovery provider {Provider} threw resolving {Server}/{Tool} field {Field}",
+                    provider.GetType().Name, serverName, toolName, fieldName);
+                continue;
+            }
+
+            if (resolved is null) continue;
+
+            var providerName = provider.GetType().Name;
+            var (retryResponse, mergedArgs) = await RetryAsync(
+                serverName, toolName, innerRequest, existingArgs, fieldName, resolved, ct);
+
+            sw.Stop();
+
+            var retryError = TryExtractRecoverableError(retryResponse);
+            var recovered = retryError is null;
+            RecordTelemetry(serverName, toolName, fieldName, "A", recovered, providerName,
+                sw.Elapsed.TotalMilliseconds, fanout: resolved.RequiresFanOut);
+
+            if (recovered)
+            {
+                _logger.LogInformation(
+                    "MCP auto-recovered {Server}/{Tool} field {Field} via {Provider}",
+                    serverName, toolName, fieldName, providerName);
+                return retryResponse;
+            }
+
+            // Chained recovery: only recurse when the retry's error names a DIFFERENT
+            // missing field (otherwise we'd loop on the same problem). Fan-out responses
+            // are not recursable — each leg may have a different error and we cannot
+            // pick one to chain from.
+            if (mergedArgs is not null && ShouldChain(retryError, fieldName))
+            {
+                _logger.LogInformation(
+                    "MCP recovery {Server}/{Tool} field {Field} resolved via {Provider} but response surfaced another missing field — chaining (depth {Depth})",
+                    serverName, toolName, fieldName, providerName, depth + 1);
+
+                var nextRequest = new ToolInvokeRequest
+                {
+                    ToolCallId = innerRequest.ToolCallId,
+                    ToolName = toolName,
+                    Arguments = JsonSerializer.Serialize(mergedArgs)
+                };
+                return await TryRecoverAsync(serverName, toolName, nextRequest, retryResponse, depth + 1, ct);
+            }
+
+            // Retry still failed and isn't chainable.
+            return Annotate(response, $"stageA={providerName} retry-failed: {Truncate(retryResponse.Content)}");
+        }
+
+        // ── Stage B ─────────────────────────────────────────────────────────
+        if (_stageB is not null)
+        {
+            var filled = await _stageB.TryFillAsync(
+                serverName, toolName, fieldName, existingArgs, errorText, ct);
+
+            if (filled is not null)
+            {
+                var resolved = new ResolvedDefault(filled);
+                var (retryResponse, mergedArgs) = await RetryAsync(
+                    serverName, toolName, innerRequest, existingArgs, fieldName, resolved, ct);
+
+                sw.Stop();
+                var retryError = TryExtractRecoverableError(retryResponse);
+                var recovered = retryError is null;
+                RecordTelemetry(serverName, toolName, fieldName, "B", recovered, "StageBLlmFiller",
+                    sw.Elapsed.TotalMilliseconds);
+
+                if (recovered)
+                {
+                    _logger.LogInformation(
+                        "MCP auto-recovered {Server}/{Tool} field {Field} via Stage B",
+                        serverName, toolName, fieldName);
+                    return retryResponse;
+                }
+
+                if (mergedArgs is not null && ShouldChain(retryError, fieldName))
+                {
+                    _logger.LogInformation(
+                        "MCP recovery {Server}/{Tool} field {Field} resolved via Stage B but response surfaced another missing field — chaining (depth {Depth})",
+                        serverName, toolName, fieldName, depth + 1);
+
+                    var nextRequest = new ToolInvokeRequest
+                    {
+                        ToolCallId = innerRequest.ToolCallId,
+                        ToolName = toolName,
+                        Arguments = JsonSerializer.Serialize(mergedArgs)
+                    };
+                    return await TryRecoverAsync(serverName, toolName, nextRequest, retryResponse, depth + 1, ct);
+                }
+
+                return Annotate(response,
+                    $"stageA=no-provider; stageB=filled retry-failed: {Truncate(retryResponse.Content)}");
+            }
+
+            sw.Stop();
+            RecordTelemetry(serverName, toolName, fieldName, "B", recovered: false, "StageBLlmFiller",
+                sw.Elapsed.TotalMilliseconds);
+            return Annotate(response, "stageA=no-provider; stageB=fill-failed");
+        }
+
+        sw.Stop();
+        RecordTelemetry(serverName, toolName, fieldName, "A", recovered: false, "no-provider",
+            sw.Elapsed.TotalMilliseconds);
+        return Annotate(response, "stageA=no-provider; stageB=disabled");
+    }
+
+    /// <summary>
+    /// Returns the error text to attempt recovery against, or null if the response
+    /// is not in a recoverable error state. Handles two shapes:
+    /// <list type="number">
+    ///   <item><see cref="ToolInvokeResponse.IsError"/> is <c>true</c> — content is the error.</item>
+    ///   <item><see cref="ToolInvokeResponse.IsError"/> is <c>false</c> but content is a small JSON
+    ///         object with an <c>error</c> property — some MCP servers report schema
+    ///         failures this way instead of flagging IsError.</item>
+    /// </list>
+    /// </summary>
+    internal static string? TryExtractRecoverableError(ToolInvokeResponse response)
+    {
+        if (response.IsError)
+            return response.Content;
+
+        var content = response.Content;
+        if (string.IsNullOrWhiteSpace(content)) return null;
+        if (content.Length > MaxEmbeddedErrorScanLength) return null;
+
+        // Cheap shape check: must look like a JSON object.
+        var trimmed = content.AsSpan().TrimStart();
+        if (trimmed.Length == 0 || trimmed[0] != '{') return null;
+
+        try
+        {
+            using var doc = JsonDocument.Parse(content);
+            if (doc.RootElement.ValueKind != JsonValueKind.Object) return null;
+
+            // "error" or "Error" (in that order) — only string values count.
+            // Deliberately not "message" — too many legitimate success responses use that.
+            foreach (var key in EmbeddedErrorKeys)
+            {
+                if (doc.RootElement.TryGetProperty(key, out var v)
+                    && v.ValueKind == JsonValueKind.String)
+                {
+                    var text = v.GetString();
+                    return string.IsNullOrWhiteSpace(text) ? null : text;
+                }
+            }
+        }
+        catch (JsonException)
+        {
+            // Not JSON; nothing to extract.
+        }
+
+        return null;
+    }
+
+    private static readonly string[] EmbeddedErrorKeys = ["error", "Error"];
+
+    /// <summary>
+    /// Returns true if a retry response's error indicates a *different* missing
+    /// field than the one we just filled, meaning chained recovery has a fresh
+    /// problem to solve. Returns false if there's no recoverable error, no
+    /// pattern match, or the same field is reported (which would loop).
+    /// </summary>
+    private static bool ShouldChain(string? retryError, string justFilledField)
+    {
+        if (retryError is null) return false;
+        if (!SchemaErrorPatterns.TryExtractMissingField(retryError, out var nextField)) return false;
+        return !string.Equals(nextField, justFilledField, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private async Task<(ToolInvokeResponse Response, Dictionary<string, object?>? MergedArgs)> RetryAsync(
+        string serverName,
+        string toolName,
+        ToolInvokeRequest innerRequest,
+        Dictionary<string, object?> existingArgs,
+        string fieldName,
+        ResolvedDefault resolved,
+        CancellationToken ct)
+    {
+        if (resolved.RequiresFanOut)
+        {
+            if (resolved.Value is not IEnumerable enumerable || resolved.Value is string)
+            {
+                _logger.LogWarning(
+                    "Recovery provider for {Server}/{Tool} field {Field} requested fan-out but value is not enumerable",
+                    serverName, toolName, fieldName);
+                return (ErrorResponse(innerRequest,
+                    "recovery: fan-out provider returned non-enumerable value"), null);
+            }
+
+            var values = enumerable.Cast<object?>().Where(v => v is not null).ToList();
+            if (values.Count == 0)
+            {
+                return (ErrorResponse(innerRequest, "recovery: fan-out provider returned no values"), null);
+            }
+
+            var aggregated = await FanOutAsync(serverName, toolName, innerRequest, existingArgs, fieldName, values, ct);
+            return (aggregated, null);
+        }
+
+        var merged = MergeArgs(existingArgs, fieldName, resolved.Value);
+        var response = await CallAsync(serverName, toolName, innerRequest, merged, ct);
+        return (response, merged);
+    }
+
+    private async Task<ToolInvokeResponse> FanOutAsync(
+        string serverName,
+        string toolName,
+        ToolInvokeRequest innerRequest,
+        Dictionary<string, object?> existingArgs,
+        string fieldName,
+        IReadOnlyList<object?> values,
+        CancellationToken ct)
+    {
+        var tasks = values.Select(v =>
+        {
+            var merged = MergeArgs(existingArgs, fieldName, v);
+            return CallAsync(serverName, toolName, innerRequest, merged, ct);
+        }).ToList();
+
+        var responses = await Task.WhenAll(tasks);
+        return AggregateFanOut(innerRequest, fieldName, values, responses);
+    }
+
+    private async Task<ToolInvokeResponse> CallAsync(
+        string serverName,
+        string toolName,
+        ToolInvokeRequest innerRequest,
+        Dictionary<string, object?> merged,
+        CancellationToken ct)
+    {
+        var argsJson = JsonSerializer.Serialize(merged);
+        var retried = new ToolInvokeRequest
+        {
+            ToolCallId = innerRequest.ToolCallId,
+            ToolName = toolName,
+            Arguments = argsJson
+        };
+        var headers = new Dictionary<string, string>
+        {
+            [McpHeaders.ServerName] = serverName
+        };
+        return await _invoke(retried, headers, ct);
+    }
+
+    private static Dictionary<string, object?> MergeArgs(
+        Dictionary<string, object?> existing, string fieldName, object? value)
+    {
+        var copy = new Dictionary<string, object?>(existing);
+        copy[fieldName] = value;
+        return copy;
+    }
+
+    private static ToolInvokeResponse AggregateFanOut(
+        ToolInvokeRequest innerRequest,
+        string fieldName,
+        IReadOnlyList<object?> values,
+        IReadOnlyList<ToolInvokeResponse> responses)
+    {
+        var combined = new List<ToolContentBlock>();
+        var sb = new StringBuilder();
+        var anyError = false;
+
+        for (var i = 0; i < responses.Count; i++)
+        {
+            var r = responses[i];
+            var label = $"[{fieldName}={values[i]}]";
+
+            // A leg "errored" if either IsError=true or its content carries an embedded error.
+            if (TryExtractRecoverableError(r) is not null) anyError = true;
+
+            sb.Append(label).Append(' ');
+            if (!string.IsNullOrEmpty(r.Content))
+                sb.Append(r.Content);
+            else
+                sb.Append("(no content)");
+            sb.AppendLine();
+
+            if (r.ContentBlocks is not null)
+            {
+                combined.Add(new ToolContentBlock { Type = "text", Text = label });
+                foreach (var b in r.ContentBlocks)
+                    combined.Add(b);
+            }
+        }
+
+        return new ToolInvokeResponse
+        {
+            ToolCallId = innerRequest.ToolCallId,
+            ToolName = innerRequest.ToolName,
+            Content = sb.ToString().TrimEnd(),
+            ContentBlocks = combined.Count > 0 ? combined : null,
+            IsError = anyError
+        };
+    }
+
+    private static ToolInvokeResponse Annotate(ToolInvokeResponse failed, string trail) => new()
+    {
+        ToolCallId = failed.ToolCallId,
+        ToolName = failed.ToolName,
+        Content = $"{failed.Content}\n[recovery-trail] {trail}",
+        ContentBlocks = failed.ContentBlocks,
+        IsError = true
+    };
+
+    private static ToolInvokeResponse ErrorResponse(ToolInvokeRequest req, string message) => new()
+    {
+        ToolCallId = req.ToolCallId,
+        ToolName = req.ToolName,
+        Content = message,
+        IsError = true
+    };
+
+    private static string Truncate(string? s, int max = 240)
+    {
+        if (string.IsNullOrEmpty(s)) return "(no content)";
+        return s.Length <= max ? s : s[..max] + "…";
+    }
+
+    private static void RecordTelemetry(
+        string server, string tool, string field, string stage,
+        bool recovered, string provider, double durationMs, bool fanout = false)
+    {
+        var outcome = recovered ? "recovered" : "failed";
+        var tags = new TagList
+        {
+            { "server", server },
+            { "tool", tool },
+            { "field", field },
+            { "stage", stage },
+            { "outcome", outcome },
+            { "provider", provider }
+        };
+        if (fanout) tags.Add("fanout", "true");
+
+        RecoveryDiagnostics.Attempts.Add(1, tags);
+        RecoveryDiagnostics.Duration.Record(durationMs, tags);
+    }
+}

--- a/src/RockBot.Tools.Mcp/Recovery/Providers/AccountIdFanoutProvider.cs
+++ b/src/RockBot.Tools.Mcp/Recovery/Providers/AccountIdFanoutProvider.cs
@@ -1,0 +1,121 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace RockBot.Tools.Mcp.Recovery.Providers;
+
+/// <summary>
+/// Resolves <c>accountId</c> for the <c>calendar-mcp</c> server by calling
+/// <c>list_accounts</c> and returning the resulting account IDs as a fan-out
+/// collection. The recovery executor issues one tool call per account and
+/// aggregates the responses.
+/// </summary>
+public sealed class AccountIdFanoutProvider(
+    McpInvokeDelegate invoke,
+    ILogger<AccountIdFanoutProvider> logger) : IToolArgumentDefaultsProvider
+{
+    private const string TargetServer = "calendar-mcp";
+    private const string TargetField = "accountId";
+    private const string ListAccountsTool = "list_accounts";
+
+    public bool CanResolve(string serverName, string toolName, string fieldName) =>
+        string.Equals(serverName, TargetServer, StringComparison.OrdinalIgnoreCase) &&
+        string.Equals(fieldName, TargetField, StringComparison.OrdinalIgnoreCase);
+
+    public async Task<ResolvedDefault?> ResolveAsync(ResolveContext ctx, CancellationToken ct)
+    {
+        var headers = new Dictionary<string, string>
+        {
+            [McpHeaders.ServerName] = TargetServer
+        };
+
+        var request = new ToolInvokeRequest
+        {
+            ToolCallId = $"recovery-list-accounts-{Guid.NewGuid():N}",
+            ToolName = ListAccountsTool,
+            Arguments = "{}"
+        };
+
+        var response = await invoke(request, headers, ct);
+        if (response.IsError)
+        {
+            logger.LogWarning("AccountIdFanoutProvider: list_accounts failed: {Content}", response.Content);
+            return null;
+        }
+
+        var ids = ExtractAccountIds(response.Content);
+        if (ids.Count == 0)
+        {
+            logger.LogWarning("AccountIdFanoutProvider: list_accounts returned no account IDs");
+            return null;
+        }
+
+        return new ResolvedDefault(ids, RequiresFanOut: true);
+    }
+
+    /// <summary>
+    /// Extracts account IDs from a list_accounts response. Tolerant of common shapes:
+    /// a JSON array of strings, an array of objects with id/accountId/email properties,
+    /// or an object containing such an array under common keys.
+    /// </summary>
+    internal static List<string> ExtractAccountIds(string? content)
+    {
+        var ids = new List<string>();
+        if (string.IsNullOrWhiteSpace(content)) return ids;
+
+        try
+        {
+            using var doc = JsonDocument.Parse(content);
+            CollectIds(doc.RootElement, ids);
+        }
+        catch (JsonException)
+        {
+            // Not JSON; nothing to extract.
+        }
+
+        return ids
+            .Where(s => !string.IsNullOrWhiteSpace(s))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static readonly string[] IdKeys = ["id", "accountId", "account_id", "email", "name"];
+    private static readonly string[] CollectionKeys = ["accounts", "items", "results", "data"];
+
+    private static void CollectIds(JsonElement element, List<string> ids)
+    {
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Array:
+                foreach (var item in element.EnumerateArray())
+                {
+                    if (item.ValueKind == JsonValueKind.String)
+                    {
+                        ids.Add(item.GetString() ?? string.Empty);
+                    }
+                    else if (item.ValueKind == JsonValueKind.Object)
+                    {
+                        foreach (var key in IdKeys)
+                        {
+                            if (item.TryGetProperty(key, out var v) && v.ValueKind == JsonValueKind.String)
+                            {
+                                ids.Add(v.GetString() ?? string.Empty);
+                                break;
+                            }
+                        }
+                    }
+                }
+                break;
+
+            case JsonValueKind.Object:
+                foreach (var key in CollectionKeys)
+                {
+                    if (element.TryGetProperty(key, out var arr) && arr.ValueKind == JsonValueKind.Array)
+                    {
+                        CollectIds(arr, ids);
+                        return;
+                    }
+                }
+                break;
+        }
+    }
+}

--- a/src/RockBot.Tools.Mcp/Recovery/Providers/CurrentTimeDefaultProvider.cs
+++ b/src/RockBot.Tools.Mcp/Recovery/Providers/CurrentTimeDefaultProvider.cs
@@ -1,0 +1,21 @@
+using RockBot.Host;
+
+namespace RockBot.Tools.Mcp.Recovery.Providers;
+
+/// <summary>
+/// Resolves <c>now</c>, <c>currentTime</c>, or <c>referenceTime</c> required-field
+/// errors using <see cref="AgentClock.Now"/>. Returns ISO-8601 with offset.
+/// </summary>
+public sealed class CurrentTimeDefaultProvider(AgentClock clock) : IToolArgumentDefaultsProvider
+{
+    private static readonly HashSet<string> Fields = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "now", "currentTime", "referenceTime"
+    };
+
+    public bool CanResolve(string serverName, string toolName, string fieldName) =>
+        Fields.Contains(fieldName);
+
+    public Task<ResolvedDefault?> ResolveAsync(ResolveContext ctx, CancellationToken ct) =>
+        Task.FromResult<ResolvedDefault?>(new ResolvedDefault(clock.Now.ToString("o")));
+}

--- a/src/RockBot.Tools.Mcp/Recovery/Providers/TimeZoneDefaultProvider.cs
+++ b/src/RockBot.Tools.Mcp/Recovery/Providers/TimeZoneDefaultProvider.cs
@@ -1,0 +1,21 @@
+using RockBot.Host;
+
+namespace RockBot.Tools.Mcp.Recovery.Providers;
+
+/// <summary>
+/// Resolves <c>timeZone</c>, <c>tz</c>, or <c>timezone</c> required-field errors
+/// from <see cref="AgentClock.Zone"/> — the same source the system prompt builder reads.
+/// </summary>
+public sealed class TimeZoneDefaultProvider(AgentClock clock) : IToolArgumentDefaultsProvider
+{
+    private static readonly HashSet<string> Fields = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "timeZone", "timezone", "tz"
+    };
+
+    public bool CanResolve(string serverName, string toolName, string fieldName) =>
+        Fields.Contains(fieldName);
+
+    public Task<ResolvedDefault?> ResolveAsync(ResolveContext ctx, CancellationToken ct) =>
+        Task.FromResult<ResolvedDefault?>(new ResolvedDefault(clock.Zone.Id));
+}

--- a/src/RockBot.Tools.Mcp/Recovery/RecoveryDiagnostics.cs
+++ b/src/RockBot.Tools.Mcp/Recovery/RecoveryDiagnostics.cs
@@ -1,0 +1,23 @@
+using System.Diagnostics.Metrics;
+
+namespace RockBot.Tools.Mcp.Recovery;
+
+/// <summary>
+/// Counters and histograms for the MCP recovery layer. Reuses the
+/// <c>RockBot.Tools</c> Meter so events flow through the existing
+/// telemetry registration in <see cref="RockBot.Telemetry"/>.
+/// </summary>
+internal static class RecoveryDiagnostics
+{
+    public static readonly Counter<long> Attempts =
+        ToolDiagnostics.Meter.CreateCounter<long>(
+            "rockbot.mcp.recovery.attempts",
+            unit: "{attempt}",
+            description: "MCP recovery attempts. Tags: server, tool, field, stage, outcome, provider.");
+
+    public static readonly Histogram<double> Duration =
+        ToolDiagnostics.Meter.CreateHistogram<double>(
+            "rockbot.mcp.recovery.duration",
+            unit: "ms",
+            description: "Duration of an MCP recovery attempt (Stage A or B), end-to-end.");
+}

--- a/src/RockBot.Tools.Mcp/Recovery/SchemaErrorPatterns.cs
+++ b/src/RockBot.Tools.Mcp/Recovery/SchemaErrorPatterns.cs
@@ -1,0 +1,48 @@
+using System.Text.RegularExpressions;
+
+namespace RockBot.Tools.Mcp.Recovery;
+
+/// <summary>
+/// Pattern matchers for common JSON-schema "missing required field" error shapes
+/// emitted by MCP servers. The captured group is always the field name.
+/// See <c>design/self-repair.md</c> Phase 1, Stage A.
+/// </summary>
+internal static class SchemaErrorPatterns
+{
+    private const RegexOptions Opts = RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant;
+
+    private static readonly Regex[] Patterns =
+    [
+        // Required parameter 'X' / Required parameter "X" / Required parameter X
+        new(@"Required\s+parameter\s+['""]?(?<f>[A-Za-z_][A-Za-z0-9_]*)['""]?", Opts),
+        // X is required / 'X' is required / "X" is required
+        new(@"['""]?(?<f>[A-Za-z_][A-Za-z0-9_]*)['""]?\s+is\s+required\b", Opts),
+        // missing required argument X / missing required argument 'X'
+        new(@"missing\s+required\s+argument\s+['""]?(?<f>[A-Za-z_][A-Za-z0-9_]*)['""]?", Opts),
+        // expected field X / expected field 'X'
+        new(@"expected\s+field\s+['""]?(?<f>[A-Za-z_][A-Za-z0-9_]*)['""]?", Opts),
+        // X: must be provided
+        new(@"['""]?(?<f>[A-Za-z_][A-Za-z0-9_]*)['""]?\s*:\s*must\s+be\s+provided", Opts),
+    ];
+
+    /// <summary>
+    /// Attempts to extract a missing field name from an error string.
+    /// Returns <c>true</c> and sets <paramref name="fieldName"/> on a match.
+    /// </summary>
+    public static bool TryExtractMissingField(string? errorText, out string fieldName)
+    {
+        fieldName = string.Empty;
+        if (string.IsNullOrWhiteSpace(errorText)) return false;
+
+        foreach (var rx in Patterns)
+        {
+            var m = rx.Match(errorText);
+            if (m.Success)
+            {
+                fieldName = m.Groups["f"].Value;
+                return !string.IsNullOrEmpty(fieldName);
+            }
+        }
+        return false;
+    }
+}

--- a/src/RockBot.Tools.Mcp/Recovery/StageBLlmFiller.cs
+++ b/src/RockBot.Tools.Mcp/Recovery/StageBLlmFiller.cs
@@ -1,0 +1,91 @@
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using RockBot.Host;
+
+namespace RockBot.Tools.Mcp.Recovery;
+
+/// <summary>
+/// Stage B fallback: when no deterministic provider claims a missing required field,
+/// ask the <see cref="ModelTier.Low"/> tier for a single JSON value to fill it.
+/// No tools, no narrative — single-shot. See <c>design/self-repair.md</c> Phase 1, Stage B.
+/// </summary>
+public class StageBLlmFiller(
+    ILlmClient llm,
+    ILogger<StageBLlmFiller> logger)
+{
+    /// <summary>
+    /// Attempts to fill <paramref name="fieldName"/> by prompting a Low-tier LLM.
+    /// Returns the parsed JSON value (already converted to a CLR type) or null on
+    /// any failure — caller then surfaces the original error with a recovery trail.
+    /// </summary>
+    public virtual async Task<object?> TryFillAsync(
+        string serverName,
+        string toolName,
+        string fieldName,
+        IReadOnlyDictionary<string, object?> existingArgs,
+        string? originalErrorText,
+        CancellationToken ct)
+    {
+        try
+        {
+            var existingJson = JsonSerializer.Serialize(existingArgs);
+
+            var prompt =
+                $"Tool: {serverName}/{toolName}\n" +
+                $"Required field: {fieldName}\n" +
+                $"Original call args: {existingJson}\n" +
+                (originalErrorText is { Length: > 0 } ? $"Original error: {originalErrorText}\n" : "") +
+                $"Return only a JSON value for {fieldName}. " +
+                "Output nothing else — no narration, no markdown fences, no explanation. " +
+                "Strings must be JSON-quoted.";
+
+            var messages = new List<ChatMessage>
+            {
+                new(ChatRole.User, prompt)
+            };
+
+            var response = await llm.GetResponseAsync(
+                messages, ModelTier.Low, new ChatOptions(), ct);
+
+            var raw = response.Text?.Trim();
+            if (string.IsNullOrEmpty(raw))
+            {
+                logger.LogWarning(
+                    "Stage B fill returned empty response for {Server}/{Tool} field {Field}",
+                    serverName, toolName, fieldName);
+                return null;
+            }
+
+            // Strip code fences if the model added them despite instructions.
+            raw = StripCodeFence(raw);
+
+            using var doc = JsonDocument.Parse(raw);
+            return McpToolExecutor.ConvertJsonElement(doc.RootElement);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "Stage B fill failed for {Server}/{Tool} field {Field}",
+                serverName, toolName, fieldName);
+            return null;
+        }
+    }
+
+    internal static string StripCodeFence(string text)
+    {
+        if (!text.StartsWith("```", StringComparison.Ordinal)) return text;
+
+        var firstNewline = text.IndexOf('\n');
+        if (firstNewline < 0) return text;
+
+        var inner = text[(firstNewline + 1)..];
+        var endFence = inner.LastIndexOf("```", StringComparison.Ordinal);
+        if (endFence >= 0) inner = inner[..endFence];
+        return inner.Trim();
+    }
+}

--- a/tests/RockBot.Tools.Tests/Recovery/AccountIdFanoutProviderTests.cs
+++ b/tests/RockBot.Tools.Tests/Recovery/AccountIdFanoutProviderTests.cs
@@ -1,0 +1,62 @@
+using RockBot.Tools.Mcp.Recovery.Providers;
+
+namespace RockBot.Tools.Tests.Recovery;
+
+[TestClass]
+public class AccountIdFanoutProviderTests
+{
+    [TestMethod]
+    public void Extract_ArrayOfStrings()
+    {
+        var ids = AccountIdFanoutProvider.ExtractAccountIds("""["a@x.com","b@x.com"]""");
+        CollectionAssert.AreEquivalent(new[] { "a@x.com", "b@x.com" }, ids);
+    }
+
+    [TestMethod]
+    public void Extract_ArrayOfObjectsWithIdProperty()
+    {
+        var ids = AccountIdFanoutProvider.ExtractAccountIds("""[{"id":"a"},{"id":"b"}]""");
+        CollectionAssert.AreEquivalent(new[] { "a", "b" }, ids);
+    }
+
+    [TestMethod]
+    public void Extract_ObjectWithAccountsArray()
+    {
+        var ids = AccountIdFanoutProvider.ExtractAccountIds("""{"accounts":[{"email":"a@x.com"},{"email":"b@x.com"}]}""");
+        CollectionAssert.AreEquivalent(new[] { "a@x.com", "b@x.com" }, ids);
+    }
+
+    [TestMethod]
+    public void Extract_DedupesAndSkipsEmpty()
+    {
+        var ids = AccountIdFanoutProvider.ExtractAccountIds("""["a","a","",null,"b"]""");
+        CollectionAssert.AreEquivalent(new[] { "a", "b" }, ids);
+    }
+
+    [TestMethod]
+    public void Extract_NotJson_ReturnsEmpty()
+    {
+        var ids = AccountIdFanoutProvider.ExtractAccountIds("not json at all");
+        Assert.AreEqual(0, ids.Count);
+    }
+
+    [TestMethod]
+    public void Extract_NullOrEmpty_ReturnsEmpty()
+    {
+        Assert.AreEqual(0, AccountIdFanoutProvider.ExtractAccountIds(null).Count);
+        Assert.AreEqual(0, AccountIdFanoutProvider.ExtractAccountIds("").Count);
+    }
+
+    [TestMethod]
+    public void CanResolve_OnlyForCalendarMcpAccountId()
+    {
+        var p = new AccountIdFanoutProvider(
+            (_, _, _) => Task.FromResult(new ToolInvokeResponse { ToolCallId = "x", ToolName = "y", Content = "[]" }),
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<AccountIdFanoutProvider>.Instance);
+
+        Assert.IsTrue(p.CanResolve("calendar-mcp", "get_events", "accountId"));
+        Assert.IsTrue(p.CanResolve("CALENDAR-MCP", "get_events", "ACCOUNTID"));
+        Assert.IsFalse(p.CanResolve("calendar-mcp", "get_events", "timeZone"));
+        Assert.IsFalse(p.CanResolve("other-server", "get", "accountId"));
+    }
+}

--- a/tests/RockBot.Tools.Tests/Recovery/McpRecoveryExecutorTests.cs
+++ b/tests/RockBot.Tools.Tests/Recovery/McpRecoveryExecutorTests.cs
@@ -1,0 +1,525 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using RockBot.Tools.Mcp;
+using RockBot.Tools.Mcp.Recovery;
+
+namespace RockBot.Tools.Tests.Recovery;
+
+[TestClass]
+public class McpRecoveryExecutorTests
+{
+    private static ToolInvokeResponse Err(ToolInvokeRequest req, string content) => new()
+    {
+        ToolCallId = req.ToolCallId,
+        ToolName = req.ToolName,
+        Content = content,
+        IsError = true
+    };
+
+    private static ToolInvokeResponse Ok(ToolInvokeRequest req, string content) => new()
+    {
+        ToolCallId = req.ToolCallId,
+        ToolName = req.ToolName,
+        Content = content,
+        IsError = false
+    };
+
+    private sealed class FakeProvider(
+        Func<string, string, string, bool> match,
+        Func<ResolveContext, ResolvedDefault?> resolve) : IToolArgumentDefaultsProvider
+    {
+        public int CallCount { get; private set; }
+        public bool CanResolve(string s, string t, string f) => match(s, t, f);
+        public Task<ResolvedDefault?> ResolveAsync(ResolveContext ctx, CancellationToken ct)
+        {
+            CallCount++;
+            return Task.FromResult(resolve(ctx));
+        }
+    }
+
+    [TestMethod]
+    public async Task EmbeddedErrorInSuccessfulResponse_TriggersRecovery()
+    {
+        // Some MCP servers return IsError=false with {"error":"X is required"} in content.
+        ToolInvokeRequest? captured = null;
+        var calls = 0;
+        McpInvokeDelegate invoke = (r, h, ct) =>
+        {
+            calls++;
+            captured = r;
+            return Task.FromResult(Ok(r, "events: []"));
+        };
+
+        var provider = new FakeProvider(
+            (_, _, f) => f == "timeZone",
+            _ => new ResolvedDefault("America/Chicago"));
+        var exec = new McpRecoveryExecutor(invoke, [provider], NullLogger<McpRecoveryExecutor>.Instance);
+
+        var req = new ToolInvokeRequest { ToolCallId = "1", ToolName = "get", Arguments = "{}" };
+        // Note: IsError = false, but the content is an embedded JSON error envelope.
+        var sneakyOk = new ToolInvokeResponse
+        {
+            ToolCallId = req.ToolCallId,
+            ToolName = req.ToolName,
+            Content = "{\"error\":\"Required parameter 'timeZone' was not provided\"}",
+            IsError = false
+        };
+
+        var result = await exec.RecoverAsync("srv", "get", req, sneakyOk, default);
+
+        Assert.IsFalse(result.IsError);
+        Assert.AreEqual("events: []", result.Content);
+        Assert.AreEqual(1, calls, "recovery should have retried once");
+        Assert.IsNotNull(captured);
+        var args = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(captured.Arguments!);
+        Assert.AreEqual("America/Chicago", args!["timeZone"].GetString());
+    }
+
+    [TestMethod]
+    public async Task EmbeddedError_ChainedRecovery_FillsMultipleFields()
+    {
+        // First retry surfaces a SECOND missing-field error (also IsError=false embedded).
+        // Recovery should chain and fill both fields.
+        var sequence = new Queue<ToolInvokeResponse>();
+        var calls = new List<string>();
+
+        McpInvokeDelegate invoke = (r, h, ct) =>
+        {
+            calls.Add(r.Arguments!);
+            return Task.FromResult(sequence.Dequeue() with
+            {
+                ToolCallId = r.ToolCallId,
+                ToolName = r.ToolName
+            });
+        };
+
+        // Stage A retry #1 (after timeZone fill) returns embedded error about accountId.
+        sequence.Enqueue(new ToolInvokeResponse
+        {
+            ToolCallId = "x", ToolName = "x",
+            Content = "{\"error\":\"accountId is required\"}",
+            IsError = false
+        });
+        // Stage A retry #2 (after accountId fill) returns success.
+        sequence.Enqueue(new ToolInvokeResponse
+        {
+            ToolCallId = "x", ToolName = "x",
+            Content = "[]",
+            IsError = false
+        });
+
+        var tzProvider = new FakeProvider(
+            (_, _, f) => f == "timeZone",
+            _ => new ResolvedDefault("UTC"));
+        var idProvider = new FakeProvider(
+            (_, _, f) => f == "accountId",
+            _ => new ResolvedDefault("a@x.com"));
+
+        var exec = new McpRecoveryExecutor(
+            invoke, [tzProvider, idProvider], NullLogger<McpRecoveryExecutor>.Instance);
+
+        var req = new ToolInvokeRequest { ToolCallId = "1", ToolName = "get_events", Arguments = "{}" };
+        var initial = Err(req, "Required parameter 'timeZone' was not provided");
+
+        var result = await exec.RecoverAsync("calendar-mcp", "get_events", req, initial, default);
+
+        Assert.IsFalse(result.IsError);
+        Assert.AreEqual("[]", result.Content);
+        Assert.AreEqual(2, calls.Count, "should retry twice — once per chained field");
+
+        // First retry should have just timeZone.
+        var args1 = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(calls[0]);
+        Assert.AreEqual("UTC", args1!["timeZone"].GetString());
+        Assert.IsFalse(args1.ContainsKey("accountId"));
+
+        // Second retry should carry both timeZone and accountId.
+        var args2 = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(calls[1]);
+        Assert.AreEqual("UTC", args2!["timeZone"].GetString());
+        Assert.AreEqual("a@x.com", args2["accountId"].GetString());
+    }
+
+    [TestMethod]
+    public async Task ChainedRecovery_BoundedDepth_StopsAtMax()
+    {
+        // Every retry surfaces a new "Required parameter 'fN'" error. Recovery should
+        // give up at MaxChainDepth without infinitely looping.
+        var n = 0;
+        var calls = 0;
+        McpInvokeDelegate invoke = (r, h, ct) =>
+        {
+            calls++;
+            n++;
+            return Task.FromResult(new ToolInvokeResponse
+            {
+                ToolCallId = r.ToolCallId,
+                ToolName = r.ToolName,
+                Content = $"{{\"error\":\"Required parameter 'f{n}'\"}}",
+                IsError = false
+            });
+        };
+
+        // A provider that resolves *anything* — so chain only ends when depth runs out.
+        var provider = new FakeProvider((_, _, _) => true, _ => new ResolvedDefault("v"));
+        var exec = new McpRecoveryExecutor(invoke, [provider], NullLogger<McpRecoveryExecutor>.Instance);
+
+        var req = new ToolInvokeRequest { ToolCallId = "1", ToolName = "get", Arguments = "{}" };
+        var initial = Err(req, "Required parameter 'f0'");
+
+        var result = await exec.RecoverAsync("srv", "get", req, initial, default);
+
+        Assert.IsTrue(result.IsError);
+        // Each chain iteration issues exactly one retry call. With MaxChainDepth=4 we
+        // get at most 4 retries before giving up.
+        Assert.IsTrue(calls <= McpRecoveryExecutor.MaxChainDepth,
+            $"expected ≤ {McpRecoveryExecutor.MaxChainDepth} calls, got {calls}");
+    }
+
+    [TestMethod]
+    public async Task SuccessfulResponse_NoEmbeddedError_PassesThrough()
+    {
+        var calls = 0;
+        McpInvokeDelegate invoke = (r, h, ct) => { calls++; return Task.FromResult(Ok(r, "events")); };
+        var exec = new McpRecoveryExecutor(invoke, [], NullLogger<McpRecoveryExecutor>.Instance);
+
+        var req = new ToolInvokeRequest { ToolCallId = "1", ToolName = "get", Arguments = "{}" };
+        var success = Ok(req, """{"events":[],"count":0}""");
+
+        var result = await exec.RecoverAsync("srv", "get", req, success, default);
+
+        Assert.IsFalse(result.IsError);
+        Assert.AreEqual("""{"events":[],"count":0}""", result.Content);
+        Assert.AreEqual(0, calls, "successful responses should not be re-invoked");
+    }
+
+    [TestMethod]
+    public async Task EmbeddedError_NotMatchingPattern_PassesThrough()
+    {
+        // Embedded error exists but doesn't match any "missing field" pattern.
+        var calls = 0;
+        McpInvokeDelegate invoke = (r, h, ct) => { calls++; return Task.FromResult(Ok(r, "")); };
+        var exec = new McpRecoveryExecutor(invoke, [], NullLogger<McpRecoveryExecutor>.Instance);
+
+        var req = new ToolInvokeRequest { ToolCallId = "1", ToolName = "get", Arguments = "{}" };
+        var rateLimit = new ToolInvokeResponse
+        {
+            ToolCallId = req.ToolCallId,
+            ToolName = req.ToolName,
+            Content = """{"error":"rate limit exceeded"}""",
+            IsError = false
+        };
+
+        var result = await exec.RecoverAsync("srv", "get", req, rateLimit, default);
+
+        Assert.IsFalse(result.IsError);
+        Assert.AreEqual("""{"error":"rate limit exceeded"}""", result.Content);
+        Assert.AreEqual(0, calls);
+    }
+
+    [TestMethod]
+    public void TryExtractRecoverableError_VariousShapes()
+    {
+        // IsError=true: returns content.
+        var asError = new ToolInvokeResponse { ToolCallId = "x", ToolName = "y", Content = "boom", IsError = true };
+        Assert.AreEqual("boom", McpRecoveryExecutor.TryExtractRecoverableError(asError));
+
+        // IsError=false plain text: returns null.
+        var asText = new ToolInvokeResponse { ToolCallId = "x", ToolName = "y", Content = "results", IsError = false };
+        Assert.IsNull(McpRecoveryExecutor.TryExtractRecoverableError(asText));
+
+        // IsError=false JSON with "error" string: returns the error message.
+        var asJsonErr = new ToolInvokeResponse { ToolCallId = "x", ToolName = "y", Content = """{"error":"X is required"}""", IsError = false };
+        Assert.AreEqual("X is required", McpRecoveryExecutor.TryExtractRecoverableError(asJsonErr));
+
+        // IsError=false JSON with "Error" capitalised: also recognised.
+        var asJsonErrCap = new ToolInvokeResponse { ToolCallId = "x", ToolName = "y", Content = """{"Error":"X is required"}""", IsError = false };
+        Assert.AreEqual("X is required", McpRecoveryExecutor.TryExtractRecoverableError(asJsonErrCap));
+
+        // IsError=false JSON without "error" property: null.
+        var asJsonOk = new ToolInvokeResponse { ToolCallId = "x", ToolName = "y", Content = """{"data":[]}""", IsError = false };
+        Assert.IsNull(McpRecoveryExecutor.TryExtractRecoverableError(asJsonOk));
+
+        // IsError=false with non-JSON content starting with '{': null (parse fails).
+        var asMalformed = new ToolInvokeResponse { ToolCallId = "x", ToolName = "y", Content = "{not json", IsError = false };
+        Assert.IsNull(McpRecoveryExecutor.TryExtractRecoverableError(asMalformed));
+
+        // Empty content: null.
+        var asEmpty = new ToolInvokeResponse { ToolCallId = "x", ToolName = "y", Content = "", IsError = false };
+        Assert.IsNull(McpRecoveryExecutor.TryExtractRecoverableError(asEmpty));
+
+        // Large content: skipped.
+        var big = new string('a', McpRecoveryExecutor.MaxEmbeddedErrorScanLength + 1);
+        var asBig = new ToolInvokeResponse { ToolCallId = "x", ToolName = "y", Content = $"{{\"error\":\"{big}\"}}", IsError = false };
+        Assert.IsNull(McpRecoveryExecutor.TryExtractRecoverableError(asBig));
+
+        // "message" field is NOT treated as an error — too many false positives.
+        var asMessage = new ToolInvokeResponse { ToolCallId = "x", ToolName = "y", Content = """{"message":"Required parameter 'x'"}""", IsError = false };
+        Assert.IsNull(McpRecoveryExecutor.TryExtractRecoverableError(asMessage));
+    }
+
+    [TestMethod]
+    public async Task NoErrorMatch_ReturnsOriginalUnchanged()
+    {
+        var calls = new List<(ToolInvokeRequest, IReadOnlyDictionary<string, string>?)>();
+        McpInvokeDelegate invoke = (r, h, ct) =>
+        {
+            calls.Add((r, h));
+            return Task.FromResult(Ok(r, "should not retry"));
+        };
+        var exec = new McpRecoveryExecutor(invoke, [], NullLogger<McpRecoveryExecutor>.Instance);
+
+        var req = new ToolInvokeRequest { ToolCallId = "1", ToolName = "get", Arguments = "{}" };
+        var failed = Err(req, "connection refused");
+
+        var result = await exec.RecoverAsync("srv", "get", req, failed, default);
+
+        Assert.IsTrue(result.IsError);
+        Assert.AreEqual("connection refused", result.Content);
+        Assert.AreEqual(0, calls.Count);
+    }
+
+    [TestMethod]
+    public async Task StageA_FieldAlreadyPresent_DoesNotLoop()
+    {
+        var calls = 0;
+        McpInvokeDelegate invoke = (r, h, ct) => { calls++; return Task.FromResult(Ok(r, "{}")); };
+        var provider = new FakeProvider((_, _, _) => true, _ => new ResolvedDefault("UTC"));
+        var exec = new McpRecoveryExecutor(invoke, [provider], NullLogger<McpRecoveryExecutor>.Instance);
+
+        var req = new ToolInvokeRequest { ToolCallId = "1", ToolName = "get", Arguments = "{\"timeZone\":\"UTC\"}" };
+        var failed = Err(req, "Required parameter 'timeZone'");
+
+        var result = await exec.RecoverAsync("srv", "get", req, failed, default);
+
+        Assert.IsTrue(result.IsError);
+        Assert.AreEqual(0, calls, "should not retry when field is already in args");
+        Assert.AreEqual(0, provider.CallCount, "should not call provider when field already present");
+    }
+
+    [TestMethod]
+    public async Task StageA_ProviderResolves_RetryMergesAndSucceeds()
+    {
+        ToolInvokeRequest? captured = null;
+        IReadOnlyDictionary<string, string>? capturedHeaders = null;
+        McpInvokeDelegate invoke = (r, h, ct) =>
+        {
+            captured = r;
+            capturedHeaders = h;
+            return Task.FromResult(Ok(r, "events: []"));
+        };
+
+        var provider = new FakeProvider(
+            (s, _, f) => s == "calendar-mcp" && f == "timeZone",
+            _ => new ResolvedDefault("America/Chicago"));
+
+        var exec = new McpRecoveryExecutor(invoke, [provider], NullLogger<McpRecoveryExecutor>.Instance);
+
+        var req = new ToolInvokeRequest { ToolCallId = "1", ToolName = "get_events", Arguments = "{\"start\":\"2026-01-01\"}" };
+        var failed = Err(req, "Required parameter 'timeZone'");
+
+        var result = await exec.RecoverAsync("calendar-mcp", "get_events", req, failed, default);
+
+        Assert.IsFalse(result.IsError);
+        Assert.AreEqual("events: []", result.Content);
+        Assert.IsNotNull(captured);
+        var args = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(captured.Arguments!);
+        Assert.IsNotNull(args);
+        Assert.IsTrue(args.ContainsKey("start"), "existing args preserved");
+        Assert.IsTrue(args.ContainsKey("timeZone"));
+        Assert.AreEqual("America/Chicago", args["timeZone"].GetString());
+        Assert.IsNotNull(capturedHeaders);
+        Assert.AreEqual("calendar-mcp", capturedHeaders[McpHeaders.ServerName]);
+    }
+
+    [TestMethod]
+    public async Task StageA_RetryFailsAgain_AnnotatesTrail()
+    {
+        McpInvokeDelegate invoke = (r, h, ct) => Task.FromResult(Err(r, "still broken somehow"));
+        var provider = new FakeProvider((_, _, _) => true, _ => new ResolvedDefault("v"));
+
+        var exec = new McpRecoveryExecutor(invoke, [provider], NullLogger<McpRecoveryExecutor>.Instance);
+        var req = new ToolInvokeRequest { ToolCallId = "1", ToolName = "get", Arguments = "{}" };
+        var failed = Err(req, "Required parameter 'x'");
+
+        var result = await exec.RecoverAsync("srv", "get", req, failed, default);
+
+        Assert.IsTrue(result.IsError);
+        StringAssert.Contains(result.Content, "[recovery-trail]");
+        StringAssert.Contains(result.Content, "stageA=FakeProvider");
+        StringAssert.Contains(result.Content, "still broken somehow");
+        // Original error preserved at the head of the message.
+        StringAssert.StartsWith(result.Content, "Required parameter 'x'");
+    }
+
+    [TestMethod]
+    public async Task StageA_NoProvider_NoStageB_AnnotatesNoProvider()
+    {
+        McpInvokeDelegate invoke = (r, h, ct) => Task.FromResult(Ok(r, ""));
+        var exec = new McpRecoveryExecutor(invoke, [], NullLogger<McpRecoveryExecutor>.Instance);
+
+        var req = new ToolInvokeRequest { ToolCallId = "1", ToolName = "get", Arguments = "{}" };
+        var failed = Err(req, "Required parameter 'novel_field'");
+
+        var result = await exec.RecoverAsync("srv", "get", req, failed, default);
+
+        Assert.IsTrue(result.IsError);
+        StringAssert.Contains(result.Content, "stageA=no-provider");
+        StringAssert.Contains(result.Content, "stageB=disabled");
+    }
+
+    [TestMethod]
+    public async Task ProviderOrder_FirstMatchWins()
+    {
+        var pA = new FakeProvider((_, _, f) => f == "x", _ => new ResolvedDefault("from-A"));
+        var pB = new FakeProvider((_, _, f) => f == "x", _ => new ResolvedDefault("from-B"));
+
+        ToolInvokeRequest? captured = null;
+        McpInvokeDelegate invoke = (r, h, ct) => { captured = r; return Task.FromResult(Ok(r, "ok")); };
+        var exec = new McpRecoveryExecutor(invoke, [pA, pB], NullLogger<McpRecoveryExecutor>.Instance);
+
+        var req = new ToolInvokeRequest { ToolCallId = "1", ToolName = "get", Arguments = "{}" };
+        var failed = Err(req, "Required parameter 'x'");
+
+        var result = await exec.RecoverAsync("srv", "get", req, failed, default);
+
+        Assert.IsFalse(result.IsError);
+        var args = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(captured!.Arguments!);
+        Assert.AreEqual("from-A", args!["x"].GetString());
+        Assert.AreEqual(1, pA.CallCount);
+        Assert.AreEqual(0, pB.CallCount);
+    }
+
+    [TestMethod]
+    public async Task FanOut_IssuesOneCallPerValue_AggregatesContent()
+    {
+        var args = new List<string>();
+        McpInvokeDelegate invoke = (r, h, ct) =>
+        {
+            args.Add(r.Arguments!);
+            // Echo the accountId in the response.
+            var doc = JsonDocument.Parse(r.Arguments!);
+            var id = doc.RootElement.GetProperty("accountId").GetString();
+            return Task.FromResult(Ok(r, $"events for {id}"));
+        };
+
+        var provider = new FakeProvider(
+            (_, _, f) => f == "accountId",
+            _ => new ResolvedDefault(new[] { "a@x.com", "b@x.com" }, RequiresFanOut: true));
+
+        var exec = new McpRecoveryExecutor(invoke, [provider], NullLogger<McpRecoveryExecutor>.Instance);
+        var req = new ToolInvokeRequest { ToolCallId = "1", ToolName = "get_events", Arguments = "{}" };
+        var failed = Err(req, "Required parameter 'accountId'");
+
+        var result = await exec.RecoverAsync("calendar-mcp", "get_events", req, failed, default);
+
+        Assert.IsFalse(result.IsError);
+        Assert.AreEqual(2, args.Count);
+        StringAssert.Contains(result.Content, "events for a@x.com");
+        StringAssert.Contains(result.Content, "events for b@x.com");
+        StringAssert.Contains(result.Content, "[accountId=a@x.com]");
+        StringAssert.Contains(result.Content, "[accountId=b@x.com]");
+    }
+
+    [TestMethod]
+    public async Task FanOut_OneLegFails_MarksOverallError()
+    {
+        var n = 0;
+        McpInvokeDelegate invoke = (r, h, ct) =>
+        {
+            n++;
+            return Task.FromResult(n == 1 ? Ok(r, "good") : Err(r, "leg failed"));
+        };
+
+        var provider = new FakeProvider(
+            (_, _, _) => true,
+            _ => new ResolvedDefault(new[] { "1", "2" }, RequiresFanOut: true));
+        var exec = new McpRecoveryExecutor(invoke, [provider], NullLogger<McpRecoveryExecutor>.Instance);
+
+        var req = new ToolInvokeRequest { ToolCallId = "1", ToolName = "get", Arguments = "{}" };
+        var failed = Err(req, "Required parameter 'k'");
+
+        var result = await exec.RecoverAsync("srv", "get", req, failed, default);
+
+        Assert.IsTrue(result.IsError);
+        StringAssert.Contains(result.Content, "good");
+        StringAssert.Contains(result.Content, "leg failed");
+    }
+
+    [TestMethod]
+    public async Task StageB_FillsNovelField_RetrySucceeds()
+    {
+        ToolInvokeRequest? captured = null;
+        McpInvokeDelegate invoke = (r, h, ct) => { captured = r; return Task.FromResult(Ok(r, "ok")); };
+
+        var stageB = new TestStageBLlmFiller("\"recovered-value\"");
+        var exec = new McpRecoveryExecutor(invoke, [], NullLogger<McpRecoveryExecutor>.Instance, stageB.Filler);
+
+        var req = new ToolInvokeRequest { ToolCallId = "1", ToolName = "do", Arguments = "{}" };
+        var failed = Err(req, "Required parameter 'quux'");
+
+        var result = await exec.RecoverAsync("synthetic", "do", req, failed, default);
+
+        Assert.IsFalse(result.IsError);
+        var args = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(captured!.Arguments!);
+        Assert.AreEqual("recovered-value", args!["quux"].GetString());
+    }
+
+    [TestMethod]
+    public async Task StageB_FillFails_AnnotatesTrail()
+    {
+        McpInvokeDelegate invoke = (r, h, ct) => Task.FromResult(Ok(r, "ok"));
+        var stageB = new TestStageBLlmFiller(null); // returns null → fill failed
+        var exec = new McpRecoveryExecutor(invoke, [], NullLogger<McpRecoveryExecutor>.Instance, stageB.Filler);
+
+        var req = new ToolInvokeRequest { ToolCallId = "1", ToolName = "do", Arguments = "{}" };
+        var failed = Err(req, "Required parameter 'quux'");
+
+        var result = await exec.RecoverAsync("synthetic", "do", req, failed, default);
+
+        Assert.IsTrue(result.IsError);
+        StringAssert.Contains(result.Content, "stageB=fill-failed");
+    }
+
+    /// <summary>
+    /// Wraps StageBLlmFiller with a stub <see cref="Microsoft.Extensions.AI.IChatClient"/>-free
+    /// path. We cannot easily stub <see cref="RockBot.Host.ILlmClient"/> here, so this helper
+    /// builds a derived filler whose <c>TryFillAsync</c> returns the canned JSON.
+    /// </summary>
+    private sealed class TestStageBLlmFiller
+    {
+        public StageBLlmFiller Filler { get; }
+        public TestStageBLlmFiller(string? cannedJson)
+        {
+            Filler = new TestFiller(cannedJson);
+        }
+
+        private sealed class TestFiller(string? cannedJson)
+            : StageBLlmFiller(new NoopLlmClient(), NullLogger<StageBLlmFiller>.Instance)
+        {
+            public override Task<object?> TryFillAsync(
+                string serverName, string toolName, string fieldName,
+                IReadOnlyDictionary<string, object?> existingArgs,
+                string? originalErrorText, CancellationToken ct)
+            {
+                if (cannedJson is null) return Task.FromResult<object?>(null);
+                var doc = JsonDocument.Parse(cannedJson);
+                return Task.FromResult<object?>(McpToolExecutor.ConvertJsonElement(doc.RootElement));
+            }
+        }
+
+        private sealed class NoopLlmClient : RockBot.Host.ILlmClient
+        {
+            public Task<Microsoft.Extensions.AI.ChatResponse> GetResponseAsync(
+                IEnumerable<Microsoft.Extensions.AI.ChatMessage> messages,
+                Microsoft.Extensions.AI.ChatOptions? options,
+                CancellationToken cancellationToken) =>
+                throw new NotSupportedException();
+
+            public Task<Microsoft.Extensions.AI.ChatResponse> GetResponseAsync(
+                IEnumerable<Microsoft.Extensions.AI.ChatMessage> messages,
+                RockBot.Host.ModelTier tier,
+                Microsoft.Extensions.AI.ChatOptions? options,
+                CancellationToken cancellationToken) =>
+                throw new NotSupportedException();
+        }
+    }
+}

--- a/tests/RockBot.Tools.Tests/Recovery/SchemaErrorPatternsTests.cs
+++ b/tests/RockBot.Tools.Tests/Recovery/SchemaErrorPatternsTests.cs
@@ -1,0 +1,57 @@
+using RockBot.Tools.Mcp.Recovery;
+
+namespace RockBot.Tools.Tests.Recovery;
+
+[TestClass]
+public class SchemaErrorPatternsTests
+{
+    [TestMethod]
+    [DataRow("Required parameter 'timeZone'", "timeZone")]
+    [DataRow("Required parameter \"accountId\"", "accountId")]
+    [DataRow("Required parameter foo_bar", "foo_bar")]
+    [DataRow("timeZone is required", "timeZone")]
+    [DataRow("'startDate' is required to call this tool", "startDate")]
+    [DataRow("missing required argument userId", "userId")]
+    [DataRow("missing required argument 'token'", "token")]
+    [DataRow("expected field name", "name")]
+    [DataRow("expected field 'recipientEmail'", "recipientEmail")]
+    [DataRow("frobnitz: must be provided", "frobnitz")]
+    public void Match_ExtractsFieldName(string error, string expected)
+    {
+        var ok = SchemaErrorPatterns.TryExtractMissingField(error, out var field);
+        Assert.IsTrue(ok, $"pattern should match: {error}");
+        Assert.AreEqual(expected, field);
+    }
+
+    [TestMethod]
+    [DataRow("connection refused")]
+    [DataRow("HTTP 500: server error")]
+    [DataRow("the calendar is empty")]
+    [DataRow("")]
+    [DataRow(null)]
+    public void NoMatch_ReturnsFalse(string? error)
+    {
+        var ok = SchemaErrorPatterns.TryExtractMissingField(error, out var field);
+        Assert.IsFalse(ok);
+        Assert.AreEqual(string.Empty, field);
+    }
+
+    [TestMethod]
+    public void Match_IsCaseInsensitive()
+    {
+        var ok = SchemaErrorPatterns.TryExtractMissingField("REQUIRED PARAMETER 'X'", out var field);
+        Assert.IsTrue(ok);
+        Assert.AreEqual("X", field);
+    }
+
+    [TestMethod]
+    public void Match_GeneralizesToNovelFieldNames()
+    {
+        // The acceptance bullet from issue #345: a synthetic tool with a deliberately-novel
+        // required field gets matched the same as known fields.
+        var ok = SchemaErrorPatterns.TryExtractMissingField(
+            "Required parameter 'quux_42'", out var field);
+        Assert.IsTrue(ok);
+        Assert.AreEqual("quux_42", field);
+    }
+}

--- a/tests/RockBot.Tools.Tests/Recovery/StageBLlmFillerTests.cs
+++ b/tests/RockBot.Tools.Tests/Recovery/StageBLlmFillerTests.cs
@@ -1,0 +1,27 @@
+using RockBot.Tools.Mcp.Recovery;
+
+namespace RockBot.Tools.Tests.Recovery;
+
+[TestClass]
+public class StageBLlmFillerTests
+{
+    [TestMethod]
+    public void StripCodeFence_PassesThroughBareJson()
+    {
+        Assert.AreEqual("\"hello\"", StageBLlmFiller.StripCodeFence("\"hello\""));
+    }
+
+    [TestMethod]
+    public void StripCodeFence_StripsTripleBacktickJson()
+    {
+        var input = "```json\n\"hello\"\n```";
+        Assert.AreEqual("\"hello\"", StageBLlmFiller.StripCodeFence(input));
+    }
+
+    [TestMethod]
+    public void StripCodeFence_StripsBareTripleBacktick()
+    {
+        var input = "```\n42\n```";
+        Assert.AreEqual("42", StageBLlmFiller.StripCodeFence(input));
+    }
+}


### PR DESCRIPTION
Closes #345

## Summary

- Wraps `mcp_invoke_tool` with deterministic (Stage A) + Low-tier LLM (Stage B) recovery for "missing required parameter" schema errors
- Three built-in providers: `TimeZoneDefaultProvider` (from `AgentClock`), `CurrentTimeDefaultProvider`, `AccountIdFanoutProvider` (calls `list_accounts` and fans out per-account)
- Robust to MCP servers that report schema errors as `IsError=false` with `{"error":"X is required"}` embedded in content; chained recovery for tools requiring multiple missing fields (bounded at depth 4)
- Lives at `McpManagementExecutor` so wisp `Direct` MCP steps benefit too

## Test plan

- [x] 43 new unit tests covering pattern matching, Stage A providers, Stage B fill, fan-out aggregation, embedded-error detection, chained recovery, depth-bounded loop, and recovery-trail annotation. Full Tools test suite: 125/125 passing.
- [x] Live verification on the rockbot k8s cluster: a prompt invoking `get_calendar_events` with empty arguments triggered both providers in chain — `TimeZoneDefaultProvider` filled `timeZone`, `AccountIdFanoutProvider` resolved 7 accounts and fan-out aggregated calendar events with `[accountId=<id>]` labels. Logs show `MCP recovery ... chaining (depth 1)` and `MCP auto-recovered ... via AccountIdFanoutProvider`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)