### PR TITLE
Self-repair Phase 2: falsifiable capability claims (#346)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.10.39</Version>
+<Version>0.10.40</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.Host.Abstractions/CapabilityClaim.cs
+++ b/src/RockBot.Host.Abstractions/CapabilityClaim.cs
@@ -1,0 +1,24 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// A falsifiable assertion about a tool's capability boundary, persisted in long-term memory
+/// under category <c>claim/capability/{server}/{tool}</c>. Every claim carries a structured
+/// <see cref="VerifyShape"/> that lets a future session falsify it by re-running the call.
+/// </summary>
+/// <remarks>
+/// Capability claims are written exclusively by internal code paths
+/// (<see cref="ICapabilityClaimWriter"/>) — the LLM cannot create them directly via tool calls.
+/// </remarks>
+/// <param name="Server">MCP server the claim is about (e.g. <c>calendar-mcp</c>).</param>
+/// <param name="Tool">Tool the claim is about (e.g. <c>get_calendar_events</c>).</param>
+/// <param name="Statement">Human-readable statement of the asserted limitation.</param>
+/// <param name="Verify">Predicate that falsifies the claim when it succeeds.</param>
+/// <param name="Evidence">Free-text evidence entries (error messages, session ids, observation digests) supporting the claim at write time.</param>
+/// <param name="CreatedAt">When the claim was first written.</param>
+public sealed record CapabilityClaim(
+    string Server,
+    string Tool,
+    string Statement,
+    VerifyShape Verify,
+    IReadOnlyList<string> Evidence,
+    DateTimeOffset CreatedAt);

--- a/src/RockBot.Host.Abstractions/CapabilityClaimCategories.cs
+++ b/src/RockBot.Host.Abstractions/CapabilityClaimCategories.cs
@@ -1,0 +1,28 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Well-known long-term memory category names for capability claims (see
+/// <see cref="CapabilityClaim"/>). Entries under these categories carry a
+/// <see cref="VerifyShape"/> on <see cref="MemoryEntry.Verify"/> and are subject to
+/// read-side falsification before injection.
+/// </summary>
+public static class CapabilityClaimCategories
+{
+    /// <summary>Category prefix for all capability-claim entries.</summary>
+    public const string Prefix = "claim/capability";
+
+    /// <summary>
+    /// Builds the full per-tool category path: <c>claim/capability/{server}/{tool}</c>.
+    /// </summary>
+    public static string For(string server, string tool) =>
+        $"{Prefix}/{server}/{tool}";
+
+    /// <summary>
+    /// Returns <c>true</c> when the given category names a capability claim.
+    /// Accepts <c>null</c> and returns <c>false</c>.
+    /// </summary>
+    public static bool IsCapabilityClaim(string? category) =>
+        category is not null
+        && (category.Equals(Prefix, StringComparison.Ordinal)
+            || category.StartsWith(Prefix + "/", StringComparison.Ordinal));
+}

--- a/src/RockBot.Host.Abstractions/ICapabilityClaimVerifier.cs
+++ b/src/RockBot.Host.Abstractions/ICapabilityClaimVerifier.cs
@@ -1,0 +1,16 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Evaluates a <see cref="VerifyShape"/> against the live system. Implementations cache
+/// results per-process so a shape used many times in a session does not pay the
+/// gateway cost on every call.
+/// </summary>
+public interface ICapabilityClaimVerifier
+{
+    /// <summary>
+    /// Returns a categorical outcome. Never throws on predicate evaluation; gateway
+    /// errors and budget exhaustion are reported as <see cref="VerifyOutcome.Uncertain"/>.
+    /// May propagate <see cref="OperationCanceledException"/> when the caller's token is cancelled.
+    /// </summary>
+    Task<VerifyResult> VerifyAsync(VerifyShape shape, CancellationToken ct = default);
+}

--- a/src/RockBot.Host.Abstractions/ICapabilityClaimWriter.cs
+++ b/src/RockBot.Host.Abstractions/ICapabilityClaimWriter.cs
@@ -1,0 +1,20 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Internal write API for capability claims. Not exposed as an LLM tool — only the MCP
+/// gateway (after exhausted recovery) and the dream service (when promoting an
+/// observation to a claim) call this.
+/// </summary>
+public interface ICapabilityClaimWriter
+{
+    /// <summary>
+    /// Persists a capability claim in long-term memory under the conventional
+    /// <c>claim/capability/{server}/{tool}</c> category.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when the claim is missing required fields, lacks a verify shape, or has
+    /// an inconsistent expectation (e.g. <see cref="VerifyExpectationKind.FailureWithMessage"/>
+    /// without a <see cref="VerifyExpectation.FailurePattern"/>).
+    /// </exception>
+    Task SaveCapabilityClaimAsync(CapabilityClaim claim, CancellationToken cancellationToken = default);
+}

--- a/src/RockBot.Host.Abstractions/MemoryEntry.cs
+++ b/src/RockBot.Host.Abstractions/MemoryEntry.cs
@@ -35,4 +35,13 @@ public sealed record MemoryEntry(
     /// Starts at 1 for a fresh save; merges sum this across source entries.
     /// </summary>
     public int ReinforcementCount { get; init; } = 1;
+
+    /// <summary>
+    /// Optional structured predicate that lets readers falsify this entry by re-running
+    /// the call it describes. Populated only on entries in the
+    /// <c>claim/capability/*</c> category (see <see cref="CapabilityClaimCategories"/>);
+    /// always <c>null</c> for general memory entries. Read-side filters in the
+    /// agent context builder evaluate this shape before injection.
+    /// </summary>
+    public VerifyShape? Verify { get; init; }
 }

--- a/src/RockBot.Host.Abstractions/VerifyExpectation.cs
+++ b/src/RockBot.Host.Abstractions/VerifyExpectation.cs
@@ -1,0 +1,15 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// What outcome a <see cref="VerifyShape"/> expects when the claim is wrong (i.e. the
+/// predicate succeeds and the underlying capability claim should be evicted).
+/// </summary>
+/// <param name="Kind">The kind of outcome that constitutes predicate success.</param>
+/// <param name="FailurePattern">
+/// Required when <see cref="Kind"/> is <see cref="VerifyExpectationKind.FailureWithMessage"/>.
+/// Substring (case-insensitive) matched against the verify call's error message.
+/// Ignored when <see cref="Kind"/> is <see cref="VerifyExpectationKind.Success"/>.
+/// </param>
+public sealed record VerifyExpectation(
+    VerifyExpectationKind Kind,
+    string? FailurePattern = null);

--- a/src/RockBot.Host.Abstractions/VerifyExpectationKind.cs
+++ b/src/RockBot.Host.Abstractions/VerifyExpectationKind.cs
@@ -1,0 +1,17 @@
+using System.Text.Json.Serialization;
+
+namespace RockBot.Host;
+
+/// <summary>Discriminator for <see cref="VerifyExpectation"/>.</summary>
+[JsonConverter(typeof(JsonStringEnumConverter<VerifyExpectationKind>))]
+public enum VerifyExpectationKind
+{
+    /// <summary>Predicate succeeds when the verify call returns without error.
+    /// Use when the underlying claim asserts the call always fails.</summary>
+    Success,
+
+    /// <summary>Predicate succeeds when the verify call fails with an error message
+    /// containing <see cref="VerifyExpectation.FailurePattern"/> (case-insensitive
+    /// substring). Use when the claim asserts the call always succeeds.</summary>
+    FailureWithMessage
+}

--- a/src/RockBot.Host.Abstractions/VerifyOutcome.cs
+++ b/src/RockBot.Host.Abstractions/VerifyOutcome.cs
@@ -1,0 +1,17 @@
+using System.Text.Json.Serialization;
+
+namespace RockBot.Host;
+
+/// <summary>Categorical outcome of evaluating a <see cref="VerifyShape"/>.</summary>
+[JsonConverter(typeof(JsonStringEnumConverter<VerifyOutcome>))]
+public enum VerifyOutcome
+{
+    /// <summary>Predicate succeeded — observed behaviour falsifies the claim. Entry should be evicted from memory and skipped.</summary>
+    PredicateSucceeded,
+
+    /// <summary>Predicate failed — observed behaviour is consistent with the claim. Entry should be injected as before.</summary>
+    PredicateFailed,
+
+    /// <summary>Predicate could not be evaluated within budget (timeout or gateway error unrelated to the predicate). Entry should be injected with a verifier-uncertain annotation.</summary>
+    Uncertain
+}

--- a/src/RockBot.Host.Abstractions/VerifyResult.cs
+++ b/src/RockBot.Host.Abstractions/VerifyResult.cs
@@ -1,0 +1,10 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Outcome of running a <see cref="VerifyShape"/> against the live system.
+/// </summary>
+/// <param name="Outcome">Categorical outcome — drives whether the underlying claim is evicted, retained, or annotated.</param>
+/// <param name="Detail">Optional diagnostic detail (error message, recovery trail) for logging and uncertainty annotations.</param>
+public sealed record VerifyResult(
+    VerifyOutcome Outcome,
+    string? Detail = null);

--- a/src/RockBot.Host.Abstractions/VerifyShape.cs
+++ b/src/RockBot.Host.Abstractions/VerifyShape.cs
@@ -1,0 +1,18 @@
+using System.Text.Json;
+
+namespace RockBot.Host;
+
+/// <summary>
+/// Structured predicate that lets a <see cref="CapabilityClaim"/> be falsified by re-issuing
+/// the call. Stored alongside the claim's memory entry; evaluated by the read-side verifier
+/// before the entry is injected into a session prompt.
+/// </summary>
+/// <param name="Server">MCP server name to invoke (e.g. <c>calendar-mcp</c>).</param>
+/// <param name="Tool">Tool name on the server (e.g. <c>get_calendar_events</c>).</param>
+/// <param name="Arguments">JSON arguments to pass to the tool. Stored verbatim and round-tripped.</param>
+/// <param name="Expect">What outcome the predicate expects when the claim is wrong.</param>
+public sealed record VerifyShape(
+    string Server,
+    string Tool,
+    JsonElement Arguments,
+    VerifyExpectation Expect);

--- a/src/RockBot.Host/AgentContextBuilder.cs
+++ b/src/RockBot.Host/AgentContextBuilder.cs
@@ -30,7 +30,8 @@ public sealed class AgentContextBuilder(
     IEnumerable<IKnowledgeGraph> knowledgeGraphProviders,
     IOptions<KnowledgeGraphOptions> knowledgeGraphOptions,
     IEnumerable<IEmbeddingGenerator<string, Embedding<float>>> embeddingGenerators,
-    ILogger<AgentContextBuilder> logger)
+    ILogger<AgentContextBuilder> logger,
+    ICapabilityClaimVerifier? capabilityClaimVerifier = null)
 {
     private const int MaxLlmContextTurns = 20;
     private readonly IServiceSearchIndex? _serviceSearchIndex = serviceSearchIndexProviders.FirstOrDefault();
@@ -176,6 +177,15 @@ public sealed class AgentContextBuilder(
         if (recalled.Count == 0 && history.Count == 1)
             recalled = await longTermMemory.SearchAsync(new MemorySearchCriteria(MaxResults: 5));
 
+        // Phase 2 read-side falsification: capability-claim entries (entries with a
+        // VerifyShape under category claim/capability/*) get re-verified before injection.
+        // Predicate-succeeded claims are evicted from the store and dropped from injection;
+        // uncertain claims are kept but annotated so the LLM sees the unsettled status.
+        var uncertainClaimAnnotations = new Dictionary<string, string>(StringComparer.Ordinal);
+        recalled = await FilterCapabilityClaimsAsync(recalled, uncertainClaimAnnotations, ct);
+        episodes = await FilterCapabilityClaimsAsync(episodes, uncertainClaimAnnotations, ct);
+        identityEntries = await FilterCapabilityClaimsAsync(identityEntries, uncertainClaimAnnotations, ct);
+
         // Knowledge graph traverse: BFS from user-seed entities at MaxHops, then expand
         // a second time from top-ranked recalled memories at the (shorter) MemorySeedMaxHops.
         // User-seed triples fill the budget first; memory-seed triples fill any remaining
@@ -283,7 +293,7 @@ public sealed class AgentContextBuilder(
             if (newEntries.Count > 0)
             {
                 var lines = newEntries.Select(e =>
-                    $"- [{e.Id}] ({e.Category ?? "general"}, importance={e.ImportanceScore:F2}): {e.Content}");
+                    $"- [{e.Id}] ({e.Category ?? "general"}, importance={e.ImportanceScore:F2}): {e.Content}{ClaimAnnotation(uncertainClaimAnnotations, e.Id)}");
                 var recallContext =
                     "Recalled from long-term memory (relevant to this message):\n" +
                     string.Join("\n", lines);
@@ -305,7 +315,7 @@ public sealed class AgentContextBuilder(
             if (newEpisodes.Count > 0)
             {
                 var lines = newEpisodes.Select(e =>
-                    $"- [{e.Id}] (importance={e.ImportanceScore:F2}): {e.Content}");
+                    $"- [{e.Id}] (importance={e.ImportanceScore:F2}): {e.Content}{ClaimAnnotation(uncertainClaimAnnotations, e.Id)}");
                 var episodicContext =
                     "Relevant past experiences (episodic memory):\n" +
                     string.Join("\n", lines);
@@ -322,7 +332,7 @@ public sealed class AgentContextBuilder(
             {
                 var isPrimary = systemPromptOverride is null;
                 var lines = identityEntries.Select(e =>
-                    $"- ({e.Category ?? AgentIdentityCategories.SelfModel}): {e.Content}");
+                    $"- ({e.Category ?? AgentIdentityCategories.SelfModel}): {e.Content}{ClaimAnnotation(uncertainClaimAnnotations, e.Id)}");
 
                 string identityContext;
                 if (isPrimary)
@@ -620,4 +630,85 @@ public sealed class AgentContextBuilder(
 
         return chatMessages;
     }
+
+    /// <summary>
+    /// Phase 2 read-side falsification gate. For each entry under
+    /// <c>claim/capability/*</c> with a <see cref="VerifyShape"/>, runs the verifier
+    /// and (a) drops + evicts entries whose predicate succeeds, (b) keeps entries
+    /// whose predicate fails, (c) keeps entries whose verifier was uncertain and
+    /// records an annotation in <paramref name="uncertainAnnotations"/>. Non-claim
+    /// entries pass through unchanged. Returns the kept-for-injection list.
+    /// </summary>
+    private async Task<IReadOnlyList<MemoryEntry>> FilterCapabilityClaimsAsync(
+        IReadOnlyList<MemoryEntry> entries,
+        IDictionary<string, string> uncertainAnnotations,
+        CancellationToken ct)
+    {
+        if (capabilityClaimVerifier is null || entries.Count == 0)
+            return entries;
+
+        var keep = new List<MemoryEntry>(entries.Count);
+        foreach (var entry in entries)
+        {
+            if (entry.Verify is null || !CapabilityClaimCategories.IsCapabilityClaim(entry.Category))
+            {
+                keep.Add(entry);
+                continue;
+            }
+
+            VerifyResult result;
+            try
+            {
+                result = await capabilityClaimVerifier.VerifyAsync(entry.Verify, ct);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex,
+                    "Capability claim verifier threw for entry {Id} ({Category}); injecting with uncertainty annotation",
+                    entry.Id, entry.Category);
+                uncertainAnnotations[entry.Id] = "verifier-error";
+                keep.Add(entry);
+                continue;
+            }
+
+            switch (result.Outcome)
+            {
+                case VerifyOutcome.PredicateSucceeded:
+                    logger.LogInformation(
+                        "Capability claim {Id} ({Category}) falsified by verifier — evicting from long-term memory",
+                        entry.Id, entry.Category);
+                    try
+                    {
+                        await longTermMemory.DeleteAsync(entry.Id, ct);
+                    }
+                    catch (Exception delEx)
+                    {
+                        logger.LogWarning(delEx, "Failed to evict falsified claim {Id}", entry.Id);
+                    }
+                    // Skip — do not inject.
+                    break;
+
+                case VerifyOutcome.PredicateFailed:
+                    keep.Add(entry);
+                    break;
+
+                case VerifyOutcome.Uncertain:
+                default:
+                    uncertainAnnotations[entry.Id] = result.Detail ?? "uncertain";
+                    keep.Add(entry);
+                    break;
+            }
+        }
+
+        return keep;
+    }
+
+    private static string ClaimAnnotation(IReadOnlyDictionary<string, string> uncertain, string id) =>
+        uncertain.TryGetValue(id, out var detail)
+            ? $" [verifier-uncertain: {detail}]"
+            : string.Empty;
 }

--- a/src/RockBot.Host/AgentMemoryExtensions.cs
+++ b/src/RockBot.Host/AgentMemoryExtensions.cs
@@ -55,6 +55,11 @@ public static class AgentMemoryExtensions
 
         builder.Services.AddSingleton<ILongTermMemory, FileMemoryStore>();
 
+        // Phase 2 self-repair: capability-claim writer and read-side verifier.
+        // Both are internal services — not exposed as LLM tools.
+        builder.Services.AddSingleton<ICapabilityClaimWriter, CapabilityClaimWriter>();
+        builder.Services.AddSingleton<ICapabilityClaimVerifier, CapabilityClaimVerifier>();
+
         return builder;
     }
 

--- a/src/RockBot.Host/CapabilityClaimVerifier.cs
+++ b/src/RockBot.Host/CapabilityClaimVerifier.cs
@@ -1,0 +1,195 @@
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using RockBot.Tools;
+
+namespace RockBot.Host;
+
+/// <summary>
+/// Evaluates a <see cref="VerifyShape"/> against the live system by re-running its tool
+/// call through <c>mcp_invoke_tool</c>. Caches results per-process, keyed by a normalized
+/// hash of the shape, so a shape that is hot in a session does not pay the gateway cost
+/// for every injection.
+/// </summary>
+/// <remarks>
+/// The verifier deliberately routes through <c>mcp_invoke_tool</c> (rather than calling
+/// the MCP proxy directly) so it benefits from any cross-cutting concerns wrapped around
+/// that tool — including the Phase 1 mechanical recovery layer (#345). That means a verify
+/// call whose missing argument is auto-filled by recovery counts as a successful call,
+/// which is intentional: the predicate asks "would a real session calling this tool
+/// succeed?" and recovery is part of every real session's behaviour.
+/// </remarks>
+public sealed class CapabilityClaimVerifier : ICapabilityClaimVerifier
+{
+    /// <summary>Default result cache TTL: 5 minutes.</summary>
+    public static readonly TimeSpan DefaultCacheTtl = TimeSpan.FromMinutes(5);
+
+    /// <summary>Default per-call wallclock budget: 5 seconds.</summary>
+    public static readonly TimeSpan DefaultBudget = TimeSpan.FromSeconds(5);
+
+    private const string McpInvokeTool = "mcp_invoke_tool";
+
+    private static readonly JsonSerializerOptions ArgsJsonOptions = new()
+    {
+        PropertyNamingPolicy = null,            // mcp_invoke_tool expects snake_case literals
+        WriteIndented = false
+    };
+
+    private readonly IToolRegistry _toolRegistry;
+    private readonly ILogger<CapabilityClaimVerifier> _logger;
+    private readonly TimeProvider _time;
+    private readonly TimeSpan _cacheTtl;
+    private readonly TimeSpan _budget;
+
+    private readonly ConcurrentDictionary<string, CachedResult> _cache = new();
+
+    public CapabilityClaimVerifier(
+        IToolRegistry toolRegistry,
+        ILogger<CapabilityClaimVerifier> logger,
+        TimeProvider? timeProvider = null,
+        TimeSpan? cacheTtl = null,
+        TimeSpan? budget = null)
+    {
+        _toolRegistry = toolRegistry ?? throw new ArgumentNullException(nameof(toolRegistry));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _time = timeProvider ?? TimeProvider.System;
+        _cacheTtl = cacheTtl ?? DefaultCacheTtl;
+        _budget = budget ?? DefaultBudget;
+    }
+
+    /// <summary>
+    /// Evaluates the shape and returns a categorical outcome. Never throws on predicate
+    /// evaluation; gateway errors and budget exhaustion are reported as
+    /// <see cref="VerifyOutcome.Uncertain"/>.
+    /// </summary>
+    public async Task<VerifyResult> VerifyAsync(VerifyShape shape, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(shape);
+
+        var key = HashShape(shape);
+        if (_cache.TryGetValue(key, out var cached) && cached.ExpiresAt > _time.GetUtcNow())
+        {
+            _logger.LogDebug("CapabilityClaimVerifier cache hit for {Server}/{Tool}", shape.Server, shape.Tool);
+            return cached.Result;
+        }
+
+        var executor = _toolRegistry.GetExecutor(McpInvokeTool);
+        if (executor is null)
+        {
+            var miss = new VerifyResult(VerifyOutcome.Uncertain,
+                $"{McpInvokeTool} executor not registered — verifier cannot run");
+            _logger.LogWarning("Verifier could not run: {Detail}", miss.Detail);
+            // Don't cache uncertain-due-to-config — fix the config and the next call should retry.
+            return miss;
+        }
+
+        var request = BuildRequest(shape);
+
+        VerifyResult result;
+        using var budgetCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        budgetCts.CancelAfter(_budget);
+
+        try
+        {
+            var response = await executor.ExecuteAsync(request, budgetCts.Token);
+            result = EvaluateExpectation(response, shape.Expect);
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            result = new VerifyResult(VerifyOutcome.Uncertain,
+                $"verify budget exceeded ({_budget.TotalSeconds:F1}s)");
+        }
+        catch (OperationCanceledException)
+        {
+            // Caller cancelled — propagate.
+            throw;
+        }
+        catch (Exception ex)
+        {
+            result = new VerifyResult(VerifyOutcome.Uncertain,
+                $"verifier error: {ex.GetType().Name}: {ex.Message}");
+        }
+
+        _cache[key] = new CachedResult(result, _time.GetUtcNow() + _cacheTtl);
+
+        _logger.LogDebug(
+            "CapabilityClaimVerifier evaluated {Server}/{Tool} → {Outcome}{Detail}",
+            shape.Server, shape.Tool, result.Outcome,
+            result.Detail is null ? "" : $" ({result.Detail})");
+
+        return result;
+    }
+
+    private static ToolInvokeRequest BuildRequest(VerifyShape shape)
+    {
+        // mcp_invoke_tool expects { server_name, tool_name, arguments } as the args body.
+        var argsObj = new Dictionary<string, object?>
+        {
+            ["server_name"] = shape.Server,
+            ["tool_name"] = shape.Tool,
+            ["arguments"] = shape.Arguments
+        };
+
+        return new ToolInvokeRequest
+        {
+            ToolCallId = "verify-" + Guid.NewGuid().ToString("N")[..12],
+            ToolName = McpInvokeTool,
+            Arguments = JsonSerializer.Serialize(argsObj, ArgsJsonOptions)
+        };
+    }
+
+    internal static VerifyResult EvaluateExpectation(ToolInvokeResponse response, VerifyExpectation expect) =>
+        expect.Kind switch
+        {
+            VerifyExpectationKind.Success =>
+                response.IsError
+                    ? new VerifyResult(VerifyOutcome.PredicateFailed,
+                        $"expected success, got error: {Truncate(response.Content)}")
+                    : new VerifyResult(VerifyOutcome.PredicateSucceeded),
+
+            VerifyExpectationKind.FailureWithMessage =>
+                MatchFailurePattern(response, expect.FailurePattern!),
+
+            _ => new VerifyResult(VerifyOutcome.Uncertain, $"unknown expectation kind: {expect.Kind}")
+        };
+
+    private static VerifyResult MatchFailurePattern(ToolInvokeResponse response, string pattern)
+    {
+        if (!response.IsError)
+            return new VerifyResult(VerifyOutcome.PredicateFailed, "expected error, got success");
+
+        var content = response.Content ?? string.Empty;
+        var hit = content.IndexOf(pattern, StringComparison.OrdinalIgnoreCase) >= 0;
+        return hit
+            ? new VerifyResult(VerifyOutcome.PredicateSucceeded)
+            : new VerifyResult(VerifyOutcome.PredicateFailed,
+                $"error did not contain '{pattern}': {Truncate(content)}");
+    }
+
+    private static string HashShape(VerifyShape shape)
+    {
+        // Canonical form: server | tool | raw-arguments-json | expect-kind | failure-pattern.
+        // GetRawText preserves formatting from the original document; for cache identity we
+        // accept that semantically-identical-but-differently-formatted JSON hashes differently.
+        // That's fine — two shapes that disagree on whitespace are written by different code paths.
+        var argsRaw = shape.Arguments.ValueKind == JsonValueKind.Undefined
+            ? ""
+            : shape.Arguments.GetRawText();
+        var input = string.Join(
+            '|',
+            shape.Server,
+            shape.Tool,
+            argsRaw,
+            shape.Expect.Kind.ToString(),
+            shape.Expect.FailurePattern ?? "");
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(input));
+        return Convert.ToHexString(hash);
+    }
+
+    private static string Truncate(string? s, int max = 200) =>
+        s is null ? "" : (s.Length <= max ? s : s[..max] + "…");
+
+    private sealed record CachedResult(VerifyResult Result, DateTimeOffset ExpiresAt);
+}

--- a/src/RockBot.Host/CapabilityClaimWriter.cs
+++ b/src/RockBot.Host/CapabilityClaimWriter.cs
@@ -1,0 +1,103 @@
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace RockBot.Host;
+
+/// <summary>
+/// Default <see cref="ICapabilityClaimWriter"/>. Validates the claim shape, builds the
+/// conventional <c>claim/capability/{server}/{tool}</c> category, and persists the entry
+/// via <see cref="ILongTermMemory"/> with the verify shape attached.
+/// </summary>
+internal sealed class CapabilityClaimWriter : ICapabilityClaimWriter
+{
+    private readonly ILongTermMemory _memory;
+
+    public CapabilityClaimWriter(ILongTermMemory memory)
+    {
+        _memory = memory ?? throw new ArgumentNullException(nameof(memory));
+    }
+
+    public Task SaveCapabilityClaimAsync(CapabilityClaim claim, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(claim);
+        Validate(claim);
+
+        var entry = new MemoryEntry(
+            Id: BuildId(claim),
+            Content: claim.Statement,
+            Category: CapabilityClaimCategories.For(claim.Server, claim.Tool),
+            Tags: BuildTags(claim),
+            CreatedAt: claim.CreatedAt,
+            Metadata: BuildMetadata(claim))
+        {
+            Verify = claim.Verify
+        };
+
+        return _memory.SaveAsync(entry, cancellationToken);
+    }
+
+    private static void Validate(CapabilityClaim claim)
+    {
+        if (string.IsNullOrWhiteSpace(claim.Server))
+            throw new ArgumentException("Capability claim requires a non-empty Server.", nameof(claim));
+        if (string.IsNullOrWhiteSpace(claim.Tool))
+            throw new ArgumentException("Capability claim requires a non-empty Tool.", nameof(claim));
+        if (string.IsNullOrWhiteSpace(claim.Statement))
+            throw new ArgumentException("Capability claim requires a non-empty Statement.", nameof(claim));
+        if (claim.Verify is null)
+            throw new ArgumentException(
+                "Capability claim requires a VerifyShape — claims without a falsifiable predicate are rejected.",
+                nameof(claim));
+        if (string.IsNullOrWhiteSpace(claim.Verify.Server))
+            throw new ArgumentException("VerifyShape requires a non-empty Server.", nameof(claim));
+        if (string.IsNullOrWhiteSpace(claim.Verify.Tool))
+            throw new ArgumentException("VerifyShape requires a non-empty Tool.", nameof(claim));
+        if (claim.Verify.Expect.Kind == VerifyExpectationKind.FailureWithMessage
+            && string.IsNullOrEmpty(claim.Verify.Expect.FailurePattern))
+        {
+            throw new ArgumentException(
+                "VerifyExpectationKind.FailureWithMessage requires a non-empty FailurePattern.",
+                nameof(claim));
+        }
+    }
+
+    private static string BuildId(CapabilityClaim claim)
+    {
+        // Hash over (server, tool, statement) so re-saving an identical claim overwrites
+        // rather than accumulating duplicates; different statements for the same (server, tool)
+        // coexist as separate entries.
+        var text = $"{claim.Server}|{claim.Tool}|{claim.Statement}";
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(text));
+        return $"claim-{Convert.ToHexString(hash, 0, 8).ToLowerInvariant()}";
+    }
+
+    private static IReadOnlyList<string> BuildTags(CapabilityClaim claim) =>
+    [
+        "capability-claim",
+        $"server:{claim.Server}",
+        $"tool:{claim.Tool}"
+    ];
+
+    private static IReadOnlyDictionary<string, string> BuildMetadata(CapabilityClaim claim)
+    {
+        var metadata = new Dictionary<string, string>
+        {
+            ["kind"] = "capability-claim",
+            ["server"] = claim.Server,
+            ["tool"] = claim.Tool
+        };
+
+        if (claim.Evidence is { Count: > 0 })
+        {
+            metadata["evidenceCount"] = claim.Evidence.Count.ToString(CultureInfo.InvariantCulture);
+
+            // Compact join — clip per-item and total to keep entries searchable but bounded.
+            var joined = string.Join(" | ", claim.Evidence.Select(e =>
+                e.Length > 256 ? e[..256] + "…" : e));
+            metadata["evidence"] = joined.Length > 4096 ? joined[..4096] + "…" : joined;
+        }
+
+        return metadata;
+    }
+}

--- a/src/RockBot.Memory/MemoryTools.cs
+++ b/src/RockBot.Memory/MemoryTools.cs
@@ -120,10 +120,30 @@ public sealed class MemoryTools
         _logger.LogInformation("Tool call: SaveMemory (queuing background task) content={Content}, category={Category}",
             content, category);
 
-        _ = Task.Run(() => SaveMemoryBackgroundAsync(content, category, tags));
+        // Phase 2 soft gate — capability-claim language is flagged as an observation
+        // (write proceeds; the appended observation tag rides through to the persisted entry).
+        var (augmentedTags, hint) = ApplyObservationSoftGate(content, tags);
 
-        return Task.FromResult("Memory save queued.");
+        _ = Task.Run(() => SaveMemoryBackgroundAsync(content, category, augmentedTags));
+
+        return Task.FromResult($"Memory save queued.{hint}");
     }
+
+    private static (string? Tags, string Hint) ApplyObservationSoftGate(string content, string? tags)
+    {
+        var existing = ParseTagsList(tags);
+        var (gated, hint) = ObservationLanguageDetector.ApplySoftGate(content, existing);
+        if (gated is null || gated.Count == 0)
+            return (tags, hint);
+
+        // Re-serialise to the comma-separated string the background path expects.
+        return (string.Join(",", gated), hint);
+    }
+
+    private static IReadOnlyList<string>? ParseTagsList(string? tags) =>
+        string.IsNullOrWhiteSpace(tags)
+            ? null
+            : tags.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
     [Description("Search long-term memory for previously saved facts, preferences, or patterns. " +
                  "Use query for keyword search and category for scoping to a knowledge area. " +

--- a/src/RockBot.Memory/ObservationLanguageDetector.cs
+++ b/src/RockBot.Memory/ObservationLanguageDetector.cs
@@ -1,0 +1,61 @@
+using System.Text.RegularExpressions;
+
+namespace RockBot.Memory;
+
+/// <summary>
+/// Detects free-text content that reads like an agent-self capability claim
+/// ("blocked", "cannot", "wrapper limitation", etc.) so the soft-gate on
+/// <c>save_to_working_memory</c> and <c>save_memory</c> can tag it as an
+/// observation rather than promote it directly to a capability claim.
+/// </summary>
+/// <remarks>
+/// This is intentionally a low-precision keyword filter — false positives are tolerable
+/// (the entry still writes; only the <c>kind=observation</c> tag is added) and false
+/// negatives are recoverable (the dream service can promote later). The filter is not
+/// the place for semantic precision; the verify shape on real claims is.
+/// </remarks>
+public static partial class ObservationLanguageDetector
+{
+    [GeneratedRegex(
+        @"\b(blocked|cannot|wrapper limitation|not supported|does not expose)\b",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant,
+        matchTimeoutMilliseconds: 200)]
+    private static partial Regex ClaimLanguagePattern();
+
+    /// <summary>
+    /// Returns <c>true</c> when the given content contains language characteristic of a
+    /// capability claim. Returns <c>false</c> for null, empty, or whitespace-only input.
+    /// </summary>
+    public static bool LooksLikeCapabilityClaim(string? content) =>
+        !string.IsNullOrWhiteSpace(content) && ClaimLanguagePattern().IsMatch(content);
+
+    /// <summary>The tag value applied to entries flagged by the soft gate.</summary>
+    public const string ObservationTag = "kind=observation";
+
+    /// <summary>Informational hint appended to the tool result for flagged entries.</summary>
+    public const string ObservationHint =
+        "Note: this looks like a capability claim. Agent-self capability claims are tracked as observations and require a structured verify shape (set internally by the dream service or recovery layer) to become claims that the read-side verifier can falsify.";
+
+    /// <summary>
+    /// Applies the Phase 2 soft gate to a memory write. If the content looks like a
+    /// capability claim and the entry is not already tagged as an observation, returns
+    /// the original tag list augmented with <see cref="ObservationTag"/> and a non-empty
+    /// hint to surface to the LLM. Otherwise returns the inputs unchanged with an empty hint.
+    /// Writes are never blocked.
+    /// </summary>
+    public static (IReadOnlyList<string>? Tags, string Hint) ApplySoftGate(
+        string? content, IReadOnlyList<string>? existingTags)
+    {
+        if (!LooksLikeCapabilityClaim(content))
+            return (existingTags, "");
+
+        if (existingTags is not null
+            && existingTags.Any(t => string.Equals(t, ObservationTag, StringComparison.OrdinalIgnoreCase)))
+        {
+            return (existingTags, "");
+        }
+
+        var augmented = new List<string>(existingTags ?? []) { ObservationTag };
+        return (augmented, " " + ObservationHint);
+    }
+}

--- a/src/RockBot.Memory/WorkingMemoryTools.cs
+++ b/src/RockBot.Memory/WorkingMemoryTools.cs
@@ -58,8 +58,13 @@ public sealed class WorkingMemoryTools
         _logger.LogInformation("Tool call: SaveToWorkingMemory(key={Key}, ttl={Ttl}min, category={Category})", fullKey, ttl_minutes, category);
         var ttl = ttl_minutes.HasValue ? TimeSpan.FromMinutes(ttl_minutes.Value) : (TimeSpan?)null;
         var tagList = ParseTags(tags);
-        await _workingMemory.SetAsync(fullKey, data, ttl, category, tagList);
-        return $"Saved to working memory under key '{fullKey}'.";
+
+        // Phase 2 soft gate — capability-claim language is flagged as an observation
+        // (write proceeds; tag added so the dream service can later evaluate promotion).
+        var (gatedTags, hint) = ObservationLanguageDetector.ApplySoftGate(data, tagList);
+
+        await _workingMemory.SetAsync(fullKey, data, ttl, category, gatedTags);
+        return $"Saved to working memory under key '{fullKey}'.{hint}";
     }
 
     [Description("Retrieve previously cached data from working memory by key. " +

--- a/src/RockBot.Tools.Mcp/Recovery/McpRecoveryExecutor.cs
+++ b/src/RockBot.Tools.Mcp/Recovery/McpRecoveryExecutor.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
+using RockBot.Host;
 
 namespace RockBot.Tools.Mcp.Recovery;
 
@@ -40,17 +41,20 @@ public sealed class McpRecoveryExecutor
     private readonly McpInvokeDelegate _invoke;
     private readonly IReadOnlyList<IToolArgumentDefaultsProvider> _providers;
     private readonly StageBLlmFiller? _stageB;
+    private readonly ICapabilityClaimWriter? _capabilityClaimWriter;
     private readonly ILogger<McpRecoveryExecutor> _logger;
 
     public McpRecoveryExecutor(
         McpInvokeDelegate invoke,
         IEnumerable<IToolArgumentDefaultsProvider> providers,
         ILogger<McpRecoveryExecutor> logger,
-        StageBLlmFiller? stageB = null)
+        StageBLlmFiller? stageB = null,
+        ICapabilityClaimWriter? capabilityClaimWriter = null)
     {
         _invoke = invoke;
         _providers = providers.ToList();
         _stageB = stageB;
+        _capabilityClaimWriter = capabilityClaimWriter;
         _logger = logger;
     }
 
@@ -80,9 +84,15 @@ public sealed class McpRecoveryExecutor
         {
             // Chain exhausted — if the response still carries a recoverable error,
             // annotate so the agent sees recovery was attempted but ran out of budget.
-            return TryExtractRecoverableError(response) is not null
-                ? Annotate(response, $"chain-exhausted at depth {depth}")
-                : response;
+            var chainErrorText = TryExtractRecoverableError(response);
+            if (chainErrorText is null) return response;
+
+            await EmitCapabilityClaimAsync(
+                serverName, toolName, innerRequest,
+                statement: $"recovery-exhausted: chain depth {depth} reached for {serverName}/{toolName}",
+                evidence: chainErrorText,
+                ct);
+            return Annotate(response, $"chain-exhausted at depth {depth}");
         }
 
         var errorText = TryExtractRecoverableError(response);
@@ -162,6 +172,11 @@ public sealed class McpRecoveryExecutor
             }
 
             // Retry still failed and isn't chainable.
+            await EmitCapabilityClaimAsync(
+                serverName, toolName, innerRequest,
+                statement: $"recovery-exhausted: Stage A provider {providerName} resolved field {fieldName} but the call still failed",
+                evidence: retryError ?? errorText,
+                ct);
             return Annotate(response, $"stageA={providerName} retry-failed: {Truncate(retryResponse.Content)}");
         }
 
@@ -206,6 +221,11 @@ public sealed class McpRecoveryExecutor
                     return await TryRecoverAsync(serverName, toolName, nextRequest, retryResponse, depth + 1, ct);
                 }
 
+                await EmitCapabilityClaimAsync(
+                    serverName, toolName, innerRequest,
+                    statement: $"recovery-exhausted: Stage B filled field {fieldName} but the call still failed",
+                    evidence: retryError ?? errorText,
+                    ct);
                 return Annotate(response,
                     $"stageA=no-provider; stageB=filled retry-failed: {Truncate(retryResponse.Content)}");
             }
@@ -213,6 +233,11 @@ public sealed class McpRecoveryExecutor
             sw.Stop();
             RecordTelemetry(serverName, toolName, fieldName, "B", recovered: false, "StageBLlmFiller",
                 sw.Elapsed.TotalMilliseconds);
+            await EmitCapabilityClaimAsync(
+                serverName, toolName, innerRequest,
+                statement: $"recovery-exhausted: Stage B could not fill field {fieldName}",
+                evidence: errorText,
+                ct);
             return Annotate(response, "stageA=no-provider; stageB=fill-failed");
         }
 
@@ -452,5 +477,72 @@ public sealed class McpRecoveryExecutor
 
         RecoveryDiagnostics.Attempts.Add(1, tags);
         RecoveryDiagnostics.Duration.Record(durationMs, tags);
+    }
+
+    /// <summary>
+    /// Phase 2 producer side: when recovery has been attempted but exhausted, write
+    /// a falsifiable capability claim against (server, tool, current arguments).
+    /// The verify shape replays the same call expecting success — so the next
+    /// session that pulls the claim will evict it automatically once the underlying
+    /// problem is fixed (e.g. a future provider lands that fills the missing field,
+    /// or the MCP server starts accepting the call). Best-effort; failures here
+    /// never break the recovery path.
+    /// </summary>
+    private async Task EmitCapabilityClaimAsync(
+        string serverName,
+        string toolName,
+        ToolInvokeRequest innerRequest,
+        string statement,
+        string? evidence,
+        CancellationToken ct)
+    {
+        if (_capabilityClaimWriter is null) return;
+
+        JsonElement argsElement;
+        try
+        {
+            using var doc = JsonDocument.Parse(
+                string.IsNullOrWhiteSpace(innerRequest.Arguments) ? "{}" : innerRequest.Arguments!);
+            argsElement = doc.RootElement.Clone();
+        }
+        catch (JsonException)
+        {
+            // Arguments aren't JSON we can replay — record a claim with empty args
+            // rather than skipping; the statement still names server/tool.
+            using var fallback = JsonDocument.Parse("{}");
+            argsElement = fallback.RootElement.Clone();
+        }
+
+        var verify = new VerifyShape(
+            Server: serverName,
+            Tool: toolName,
+            Arguments: argsElement,
+            Expect: new VerifyExpectation(VerifyExpectationKind.Success));
+
+        var claim = new CapabilityClaim(
+            Server: serverName,
+            Tool: toolName,
+            Statement: statement,
+            Verify: verify,
+            Evidence: evidence is null ? [] : [Truncate(evidence, 512)],
+            CreatedAt: DateTimeOffset.UtcNow);
+
+        try
+        {
+            await _capabilityClaimWriter.SaveCapabilityClaimAsync(claim, ct);
+            _logger.LogInformation(
+                "Saved capability claim after exhausted recovery for {Server}/{Tool}: {Statement}",
+                serverName, toolName, statement);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to save capability claim after exhausted recovery for {Server}/{Tool}",
+                serverName, toolName);
+        }
     }
 }

--- a/tests/RockBot.Agent.Tests/MemoryToolsTests.cs
+++ b/tests/RockBot.Agent.Tests/MemoryToolsTests.cs
@@ -297,6 +297,33 @@ public class MemoryToolsTests
 
     private static MemoryEntry Entry(string id, string content, DateTimeOffset createdAt) =>
         new(id, content, null, [], createdAt);
+
+    // -------------------------------------------------------------------------
+    // SaveMemory — observation soft gate (Phase 2)
+    // -------------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task SaveMemory_ClaimLanguage_AppendsObservationHintToResult()
+    {
+        var memory = new StubLongTermMemory();
+        var tools = MakeTools(memory);
+
+        var result = await tools.SaveMemory("calendar wrapper cannot pass arguments");
+
+        StringAssert.Contains(result, "looks like a capability claim");
+    }
+
+    [TestMethod]
+    public async Task SaveMemory_BenignContent_ReturnsBareQueuedMessage()
+    {
+        var memory = new StubLongTermMemory();
+        var tools = MakeTools(memory);
+
+        var result = await tools.SaveMemory("user prefers concise updates");
+
+        Assert.IsFalse(result.Contains("capability claim"),
+            "Benign content must not produce a soft-gate hint.");
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/RockBot.Host.Tests/AgentContextBuilderCapabilityClaimTests.cs
+++ b/tests/RockBot.Host.Tests/AgentContextBuilderCapabilityClaimTests.cs
@@ -1,0 +1,282 @@
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using RockBot.Host;
+using RockBot.Llm;
+using RockBot.Memory;
+using RockBot.Skills;
+
+namespace RockBot.Host.Tests;
+
+/// <summary>
+/// Phase 2 read-side falsification tests for <see cref="AgentContextBuilder"/>.
+/// Stubs the verifier so each outcome (PredicateSucceeded, PredicateFailed, Uncertain)
+/// can be exercised deterministically.
+/// </summary>
+[TestClass]
+public class AgentContextBuilderCapabilityClaimTests
+{
+    [TestMethod]
+    public async Task BuildAsync_PredicateSucceeded_EvictsClaimAndSkipsInjection()
+    {
+        var claim = ClaimEntry("claim-a", "wrapper cannot pass arguments");
+        var ltm = new RecordingMemory([claim]);
+        var verifier = new StubVerifier(VerifyOutcome.PredicateSucceeded);
+        var builder = NewBuilder(ltm, verifier);
+
+        var messages = await builder.BuildAsync("session-1", "anything", CancellationToken.None);
+
+        Assert.AreEqual(1, ltm.DeletedIds.Count, "Falsified claim must be evicted from LTM.");
+        Assert.AreEqual("claim-a", ltm.DeletedIds[0]);
+        Assert.IsFalse(messages.Any(m => m.Text?.Contains("claim-a") == true),
+            "Evicted claim must not appear in any injected context.");
+    }
+
+    [TestMethod]
+    public async Task BuildAsync_PredicateFailed_InjectsClaimWithoutAnnotation()
+    {
+        var claim = ClaimEntry("claim-b", "wrapper cannot pass arguments");
+        var ltm = new RecordingMemory([claim]);
+        var verifier = new StubVerifier(VerifyOutcome.PredicateFailed);
+        var builder = NewBuilder(ltm, verifier);
+
+        var messages = await builder.BuildAsync("session-1", "anything", CancellationToken.None);
+
+        Assert.AreEqual(0, ltm.DeletedIds.Count, "Predicate-failed claim must NOT be evicted.");
+        var injected = messages.FirstOrDefault(m => m.Text?.Contains("claim-b") == true);
+        Assert.IsNotNull(injected, "Predicate-failed claim must be injected as before.");
+        Assert.IsFalse(injected!.Text!.Contains("verifier-uncertain"),
+            "Predicate-failed claim must not carry an uncertainty annotation.");
+    }
+
+    [TestMethod]
+    public async Task BuildAsync_Uncertain_InjectsClaimWithAnnotation()
+    {
+        var claim = ClaimEntry("claim-c", "wrapper cannot pass arguments");
+        var ltm = new RecordingMemory([claim]);
+        var verifier = new StubVerifier(VerifyOutcome.Uncertain, detail: "budget exceeded");
+        var builder = NewBuilder(ltm, verifier);
+
+        var messages = await builder.BuildAsync("session-1", "anything", CancellationToken.None);
+
+        Assert.AreEqual(0, ltm.DeletedIds.Count, "Uncertain claim must NOT be evicted.");
+        var injected = messages.FirstOrDefault(m => m.Text?.Contains("claim-c") == true);
+        Assert.IsNotNull(injected, "Uncertain claim must be injected.");
+        StringAssert.Contains(injected!.Text!, "verifier-uncertain");
+        StringAssert.Contains(injected!.Text!, "budget exceeded");
+    }
+
+    [TestMethod]
+    public async Task BuildAsync_NonClaimEntries_PassThroughUnchanged()
+    {
+        var regular = new MemoryEntry("regular-1", "user prefers concise updates", "user-preferences", [], DateTimeOffset.UtcNow);
+        var ltm = new RecordingMemory([regular]);
+        var verifier = new StubVerifier(VerifyOutcome.PredicateSucceeded); // would evict if it ran
+        var builder = NewBuilder(ltm, verifier);
+
+        var messages = await builder.BuildAsync("session-1", "anything", CancellationToken.None);
+
+        Assert.AreEqual(0, ltm.DeletedIds.Count, "Non-claim entries must not be evicted.");
+        Assert.AreEqual(0, verifier.CallCount, "Verifier must not be invoked for non-claim entries.");
+        Assert.IsTrue(messages.Any(m => m.Text?.Contains("regular-1") == true),
+            "Regular entry must be injected as before.");
+    }
+
+    [TestMethod]
+    public async Task BuildAsync_NoVerifierConfigured_ClaimsPassThrough_BackwardCompat()
+    {
+        var claim = ClaimEntry("claim-d", "wrapper cannot pass arguments");
+        var ltm = new RecordingMemory([claim]);
+        var builder = NewBuilder(ltm, verifier: null);
+
+        var messages = await builder.BuildAsync("session-1", "anything", CancellationToken.None);
+
+        Assert.AreEqual(0, ltm.DeletedIds.Count);
+        Assert.IsTrue(messages.Any(m => m.Text?.Contains("claim-d") == true),
+            "Without a verifier, claim entries fall through to the existing injection path.");
+    }
+
+    [TestMethod]
+    public async Task BuildAsync_VerifierThrows_InjectsWithUncertaintyAnnotation()
+    {
+        var claim = ClaimEntry("claim-e", "wrapper cannot pass arguments");
+        var ltm = new RecordingMemory([claim]);
+        var verifier = new StubVerifier(VerifyOutcome.PredicateSucceeded)
+        {
+            ThrowOnNext = new InvalidOperationException("bridge unavailable")
+        };
+        var builder = NewBuilder(ltm, verifier);
+
+        var messages = await builder.BuildAsync("session-1", "anything", CancellationToken.None);
+
+        Assert.AreEqual(0, ltm.DeletedIds.Count, "Verifier exceptions must not cause eviction.");
+        var injected = messages.FirstOrDefault(m => m.Text?.Contains("claim-e") == true);
+        Assert.IsNotNull(injected);
+        StringAssert.Contains(injected!.Text!, "verifier-error");
+    }
+
+    // --- helpers -------------------------------------------------------------
+
+    private static MemoryEntry ClaimEntry(string id, string statement) =>
+        new(id, statement,
+            CapabilityClaimCategories.For("calendar-mcp", "get_calendar_events"),
+            ["capability-claim"],
+            DateTimeOffset.UtcNow)
+        {
+            Verify = new VerifyShape(
+                "calendar-mcp", "get_calendar_events",
+                JsonDocument.Parse("""{"timeZone":"America/Chicago"}""").RootElement,
+                new VerifyExpectation(VerifyExpectationKind.Success))
+        };
+
+    private static AgentContextBuilder NewBuilder(ILongTermMemory ltm, StubVerifier? verifier)
+    {
+        var profileHolder = new ProfileHolder();
+        var doc = new AgentProfileDocument("soul", null, [], "Test agent.");
+        profileHolder.Update(new AgentProfile(doc, doc));
+
+        var profileOpts = Options.Create(new AgentProfileOptions
+        {
+            BasePath = Path.Combine(Path.GetTempPath(), "rockbot-claim-test-" + Guid.NewGuid().ToString("N"))
+        });
+        Directory.CreateDirectory(profileOpts.Value.BasePath);
+
+        var clock = new AgentClock(
+            new ConfigurationBuilder().Build(),
+            profileOpts,
+            NullLoggerFactory.Instance.CreateLogger<AgentClock>());
+
+        return new AgentContextBuilder(
+            profileHolder: profileHolder,
+            agent: new AgentIdentity("TestBot"),
+            promptBuilder: new DefaultSystemPromptBuilder(profileHolder, new AgentNameHolder()),
+            rulesStore: new StubRulesStore(),
+            modelBehavior: ModelBehavior.Default,
+            conversationMemory: new StubConversationMemory(),
+            longTermMemory: ltm,
+            injectedMemoryTracker: new InjectedMemoryTracker(),
+            workingMemory: new StubWorkingMemory(),
+            skillStore: new StubSkillStore(),
+            skillIndexTracker: new SkillIndexTracker(),
+            skillRecallTracker: new SkillRecallTracker(),
+            clock: clock,
+            serviceSearchIndexProviders: [],
+            knowledgeGraphProviders: [],
+            knowledgeGraphOptions: Options.Create(new KnowledgeGraphOptions()),
+            embeddingGenerators: [],
+            logger: NullLogger<AgentContextBuilder>.Instance,
+            capabilityClaimVerifier: verifier);
+    }
+
+    /// <summary>
+    /// In-test <see cref="ICapabilityClaimVerifier"/> with deterministic outcomes.
+    /// Lets us exercise each branch of the AgentContextBuilder filter without spinning
+    /// up the real MCP gateway path.
+    /// </summary>
+    private sealed class StubVerifier : ICapabilityClaimVerifier
+    {
+        public StubVerifier(VerifyOutcome outcome, string? detail = null)
+        {
+            Outcome = outcome;
+            Detail = detail;
+        }
+        public VerifyOutcome Outcome { get; }
+        public string? Detail { get; }
+        public Exception? ThrowOnNext { get; set; }
+        public int CallCount { get; set; }
+
+        public Task<VerifyResult> VerifyAsync(VerifyShape shape, CancellationToken ct = default)
+        {
+            CallCount++;
+            if (ThrowOnNext is { } ex)
+            {
+                ThrowOnNext = null;
+                throw ex;
+            }
+            return Task.FromResult(new VerifyResult(Outcome, Detail));
+        }
+    }
+
+    private sealed class RecordingMemory : ILongTermMemory
+    {
+        private readonly List<MemoryEntry> _entries;
+        public List<string> DeletedIds { get; } = new();
+
+        public RecordingMemory(IReadOnlyList<MemoryEntry> seed) => _entries = [.. seed];
+
+        public Task SaveAsync(MemoryEntry entry, CancellationToken cancellationToken = default)
+        {
+            _entries.RemoveAll(e => e.Id == entry.Id);
+            _entries.Add(entry);
+            return Task.CompletedTask;
+        }
+
+        public Task<IReadOnlyList<MemoryEntry>> SearchAsync(MemorySearchCriteria criteria, CancellationToken cancellationToken = default)
+        {
+            // Return everything for the unbiased recall path; nothing for category-scoped queries
+            // (episodic / identity) so we focus assertions on the LTM seam.
+            if (criteria.Category is not null)
+                return Task.FromResult<IReadOnlyList<MemoryEntry>>([]);
+            return Task.FromResult<IReadOnlyList<MemoryEntry>>([.. _entries]);
+        }
+
+        public Task<MemoryEntry?> GetAsync(string id, CancellationToken cancellationToken = default) =>
+            Task.FromResult(_entries.FirstOrDefault(e => e.Id == id));
+
+        public Task DeleteAsync(string id, CancellationToken cancellationToken = default)
+        {
+            DeletedIds.Add(id);
+            _entries.RemoveAll(e => e.Id == id);
+            return Task.CompletedTask;
+        }
+
+        public Task<IReadOnlyList<string>> ListTagsAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<string>>([]);
+
+        public Task<IReadOnlyList<string>> ListCategoriesAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<string>>([]);
+    }
+
+    private sealed class StubConversationMemory : IConversationMemory
+    {
+        public Task AddTurnAsync(string sessionId, ConversationTurn turn, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task<IReadOnlyList<ConversationTurn>> GetTurnsAsync(string sessionId, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<ConversationTurn>>([]);
+        public Task ClearAsync(string sessionId, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task<IReadOnlyList<string>> ListSessionsAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<string>>([]);
+    }
+
+    private sealed class StubWorkingMemory : IWorkingMemory
+    {
+        public Task SetAsync(string key, string value, TimeSpan? ttl = null, string? category = null, IReadOnlyList<string>? tags = null) => Task.CompletedTask;
+        public Task<string?> GetAsync(string key) => Task.FromResult<string?>(null);
+        public Task<IReadOnlyList<WorkingMemoryEntry>> ListAsync(string? prefix = null) =>
+            Task.FromResult<IReadOnlyList<WorkingMemoryEntry>>([]);
+        public Task DeleteAsync(string key) => Task.CompletedTask;
+        public Task ClearAsync(string? prefix = null) => Task.CompletedTask;
+        public Task<IReadOnlyList<WorkingMemoryEntry>> SearchAsync(MemorySearchCriteria criteria, string? prefix = null) =>
+            Task.FromResult<IReadOnlyList<WorkingMemoryEntry>>([]);
+    }
+
+    private sealed class StubSkillStore : ISkillStore
+    {
+        public Task SaveAsync(Skill skill) => Task.CompletedTask;
+        public Task<Skill?> GetAsync(string name) => Task.FromResult<Skill?>(null);
+        public Task<IReadOnlyList<Skill>> ListAsync() => Task.FromResult<IReadOnlyList<Skill>>([]);
+        public Task DeleteAsync(string name) => Task.CompletedTask;
+        public Task<IReadOnlyList<Skill>> SearchAsync(string query, int maxResults, CancellationToken cancellationToken = default, float[]? queryEmbedding = null) =>
+            Task.FromResult<IReadOnlyList<Skill>>([]);
+    }
+
+    private sealed class StubRulesStore : IRulesStore
+    {
+        public IReadOnlyList<string> Rules => [];
+        public Task<IReadOnlyList<string>> ListAsync() => Task.FromResult<IReadOnlyList<string>>([]);
+        public Task AddAsync(string rule) => Task.CompletedTask;
+        public Task RemoveAsync(string rule) => Task.CompletedTask;
+    }
+}

--- a/tests/RockBot.Host.Tests/AgentMemoryExtensionsTests.cs
+++ b/tests/RockBot.Host.Tests/AgentMemoryExtensionsTests.cs
@@ -111,4 +111,69 @@ public class AgentMemoryExtensionsTests
 
         Assert.AreSame(memory1, memory2);
     }
+
+    [TestMethod]
+    public void WithLongTermMemory_RegistersCapabilityClaimWriter()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddRockBotHost(agent =>
+        {
+            agent.WithIdentity("test-agent");
+            agent.WithProfile();
+            agent.WithLongTermMemory();
+        });
+
+        var provider = services.BuildServiceProvider();
+        var writer = provider.GetService<ICapabilityClaimWriter>();
+
+        Assert.IsNotNull(writer, "Phase 2 requires ICapabilityClaimWriter to be registered alongside ILongTermMemory.");
+    }
+
+    [TestMethod]
+    public void WithLongTermMemory_CapabilityClaimWriter_IsSingleton()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddRockBotHost(agent =>
+        {
+            agent.WithIdentity("test-agent");
+            agent.WithProfile();
+            agent.WithLongTermMemory();
+        });
+
+        var provider = services.BuildServiceProvider();
+        var first = provider.GetRequiredService<ICapabilityClaimWriter>();
+        var second = provider.GetRequiredService<ICapabilityClaimWriter>();
+
+        Assert.AreSame(first, second);
+    }
+
+    [TestMethod]
+    public void WithLongTermMemory_RegistersCapabilityClaimVerifier()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddRockBotHost(agent =>
+        {
+            agent.WithIdentity("test-agent");
+            agent.WithProfile();
+            agent.WithLongTermMemory();
+        });
+        // Verifier needs an IToolRegistry — supply a minimal one for resolution.
+        services.AddSingleton<RockBot.Tools.IToolRegistry, EmptyToolRegistry>();
+
+        var provider = services.BuildServiceProvider();
+        var verifier = provider.GetService<ICapabilityClaimVerifier>();
+
+        Assert.IsNotNull(verifier, "Phase 2 requires ICapabilityClaimVerifier to be registered alongside ILongTermMemory.");
+    }
+
+    private sealed class EmptyToolRegistry : RockBot.Tools.IToolRegistry
+    {
+        public IReadOnlyList<RockBot.Tools.ToolRegistration> GetTools() => [];
+        public RockBot.Tools.IToolExecutor? GetExecutor(string toolName) => null;
+        public void Register(RockBot.Tools.ToolRegistration registration, RockBot.Tools.IToolExecutor executor) { }
+        public bool Unregister(string toolName) => false;
+    }
 }

--- a/tests/RockBot.Host.Tests/CapabilityClaimEndToEndTests.cs
+++ b/tests/RockBot.Host.Tests/CapabilityClaimEndToEndTests.cs
@@ -1,0 +1,223 @@
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using RockBot.Host;
+using RockBot.Llm;
+using RockBot.Memory;
+using RockBot.Skills;
+
+namespace RockBot.Host.Tests;
+
+/// <summary>
+/// End-to-end Phase 2 acceptance test: a capability claim written via
+/// <see cref="ICapabilityClaimWriter"/> into a real <see cref="FileMemoryStore"/>
+/// is evicted from disk when the read-side verifier reports
+/// <see cref="VerifyOutcome.PredicateSucceeded"/>, and the next session sees no entry.
+/// </summary>
+[TestClass]
+public class CapabilityClaimEndToEndTests
+{
+    private string _tempDir = null!;
+
+    [TestInitialize]
+    public void Init()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "rockbot-claim-e2e-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    [TestMethod]
+    public async Task ClaimSurvivesRoundTrip_AndIsEvictedWhenPredicateSucceeds()
+    {
+        // 1. Real file-backed long-term memory.
+        var memoryOpts = Options.Create(new MemoryOptions { BasePath = Path.Combine(_tempDir, "ltm") });
+        var profileOpts = Options.Create(new AgentProfileOptions { BasePath = Path.Combine(_tempDir, "profile") });
+        Directory.CreateDirectory(profileOpts.Value.BasePath);
+        var embedOpts = Options.Create(new EmbeddingOptions());
+
+        var ltm = new FileMemoryStore(
+            memoryOpts, profileOpts, embedOpts,
+            NullLogger<FileMemoryStore>.Instance);
+
+        // 2. Save a claim through the real writer.
+        var writer = new CapabilityClaimWriter(ltm);
+        var claim = new CapabilityClaim(
+            Server: "calendar-mcp",
+            Tool: "get_calendar_events",
+            Statement: "wrapper cannot pass arguments to get_calendar_events",
+            Verify: new VerifyShape(
+                Server: "calendar-mcp",
+                Tool: "get_calendar_events",
+                Arguments: JsonDocument.Parse("""{"accountId":"x","timeZone":"America/Chicago","startDate":"2026-05-08","endDate":"2026-05-08"}""").RootElement,
+                Expect: new VerifyExpectation(VerifyExpectationKind.Success)),
+            Evidence: ["recovery exhausted"],
+            CreatedAt: DateTimeOffset.UtcNow);
+        await writer.SaveCapabilityClaimAsync(claim);
+
+        // 3. Confirm the entry round-trips with Verify populated.
+        var allCategories = await ltm.ListCategoriesAsync();
+        Assert.IsTrue(allCategories.Any(c => c.StartsWith("claim/capability/calendar-mcp")),
+            "Claim category did not appear after save.");
+
+        var search = await ltm.SearchAsync(new MemorySearchCriteria(
+            Category: CapabilityClaimCategories.Prefix, MaxResults: 10));
+        Assert.AreEqual(1, search.Count, "Expected exactly one claim entry on disk.");
+        Assert.IsNotNull(search[0].Verify, "Verify shape did not survive round-trip serialisation.");
+        Assert.AreEqual("calendar-mcp", search[0].Verify!.Server);
+
+        // 4. Run the read-side filter — verifier reports the claim is falsified.
+        var verifier = new AlwaysSucceedingVerifier();
+        var builder = NewBuilder(ltm, verifier, profileOpts);
+
+        // Use a query that BM25 will match against the claim content so the recall path
+        // surfaces the entry; otherwise the entry wouldn't reach the read-side filter.
+        var messages = await builder.BuildAsync("session-1", "wrapper cannot pass arguments", CancellationToken.None);
+
+        // 5. Claim must be evicted from disk and absent from the chat context.
+        var afterSearch = await ltm.SearchAsync(new MemorySearchCriteria(
+            Category: CapabilityClaimCategories.Prefix, MaxResults: 10));
+        Assert.AreEqual(0, afterSearch.Count, "Falsified claim was not evicted from long-term memory.");
+        Assert.IsFalse(messages.Any(m => m.Text?.Contains("wrapper cannot pass arguments") == true),
+            "Falsified claim leaked into injected context.");
+
+        Assert.AreEqual(1, verifier.CallCount, "Verifier was not invoked exactly once for the claim.");
+    }
+
+    [TestMethod]
+    public async Task ClaimWithFailingVerify_IsRetainedAndInjected()
+    {
+        // Claim survives because the verifier reports the predicate failed
+        // (the call returned an error matching the asserted limitation).
+        var memoryOpts = Options.Create(new MemoryOptions { BasePath = Path.Combine(_tempDir, "ltm") });
+        var profileOpts = Options.Create(new AgentProfileOptions { BasePath = Path.Combine(_tempDir, "profile") });
+        Directory.CreateDirectory(profileOpts.Value.BasePath);
+        var embedOpts = Options.Create(new EmbeddingOptions());
+
+        var ltm = new FileMemoryStore(
+            memoryOpts, profileOpts, embedOpts,
+            NullLogger<FileMemoryStore>.Instance);
+
+        var writer = new CapabilityClaimWriter(ltm);
+        await writer.SaveCapabilityClaimAsync(new CapabilityClaim(
+            Server: "calendar-mcp",
+            Tool: "get_calendar_events",
+            Statement: "wrapper cannot pass arguments to get_calendar_events",
+            Verify: new VerifyShape(
+                "calendar-mcp", "get_calendar_events",
+                JsonDocument.Parse("""{"accountId":"x"}""").RootElement,
+                new VerifyExpectation(VerifyExpectationKind.Success)),
+            Evidence: [],
+            CreatedAt: DateTimeOffset.UtcNow));
+
+        var verifier = new AlwaysFailingVerifier();
+        var builder = NewBuilder(ltm, verifier, profileOpts);
+
+        await builder.BuildAsync("session-1", "wrapper cannot pass arguments", CancellationToken.None);
+
+        // Claim is preserved on disk.
+        var search = await ltm.SearchAsync(new MemorySearchCriteria(
+            Category: CapabilityClaimCategories.Prefix, MaxResults: 10));
+        Assert.AreEqual(1, search.Count, "Predicate-failed claim must remain on disk.");
+    }
+
+    private static AgentContextBuilder NewBuilder(
+        ILongTermMemory ltm, ICapabilityClaimVerifier verifier, IOptions<AgentProfileOptions> profileOpts)
+    {
+        var profileHolder = new ProfileHolder();
+        var doc = new AgentProfileDocument("soul", null, [], "Test agent.");
+        profileHolder.Update(new AgentProfile(doc, doc));
+
+        var clock = new AgentClock(
+            new ConfigurationBuilder().Build(),
+            profileOpts,
+            NullLoggerFactory.Instance.CreateLogger<AgentClock>());
+
+        return new AgentContextBuilder(
+            profileHolder: profileHolder,
+            agent: new AgentIdentity("TestBot"),
+            promptBuilder: new DefaultSystemPromptBuilder(profileHolder, new AgentNameHolder()),
+            rulesStore: new EmptyRulesStore(),
+            modelBehavior: ModelBehavior.Default,
+            conversationMemory: new EmptyConversationMemory(),
+            longTermMemory: ltm,
+            injectedMemoryTracker: new InjectedMemoryTracker(),
+            workingMemory: new EmptyWorkingMemory(),
+            skillStore: new EmptySkillStore(),
+            skillIndexTracker: new SkillIndexTracker(),
+            skillRecallTracker: new SkillRecallTracker(),
+            clock: clock,
+            serviceSearchIndexProviders: [],
+            knowledgeGraphProviders: [],
+            knowledgeGraphOptions: Options.Create(new KnowledgeGraphOptions()),
+            embeddingGenerators: [],
+            logger: NullLogger<AgentContextBuilder>.Instance,
+            capabilityClaimVerifier: verifier);
+    }
+
+    private sealed class AlwaysSucceedingVerifier : ICapabilityClaimVerifier
+    {
+        public int CallCount { get; private set; }
+        public Task<VerifyResult> VerifyAsync(VerifyShape shape, CancellationToken ct = default)
+        {
+            CallCount++;
+            return Task.FromResult(new VerifyResult(VerifyOutcome.PredicateSucceeded));
+        }
+    }
+
+    private sealed class AlwaysFailingVerifier : ICapabilityClaimVerifier
+    {
+        public Task<VerifyResult> VerifyAsync(VerifyShape shape, CancellationToken ct = default) =>
+            Task.FromResult(new VerifyResult(VerifyOutcome.PredicateFailed, "expected"));
+    }
+
+    private sealed class EmptyConversationMemory : IConversationMemory
+    {
+        public Task AddTurnAsync(string sessionId, ConversationTurn turn, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task<IReadOnlyList<ConversationTurn>> GetTurnsAsync(string sessionId, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<ConversationTurn>>([]);
+        public Task ClearAsync(string sessionId, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task<IReadOnlyList<string>> ListSessionsAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<string>>([]);
+    }
+
+    private sealed class EmptyWorkingMemory : IWorkingMemory
+    {
+        public Task SetAsync(string key, string value, TimeSpan? ttl = null, string? category = null, IReadOnlyList<string>? tags = null) => Task.CompletedTask;
+        public Task<string?> GetAsync(string key) => Task.FromResult<string?>(null);
+        public Task<IReadOnlyList<WorkingMemoryEntry>> ListAsync(string? prefix = null) =>
+            Task.FromResult<IReadOnlyList<WorkingMemoryEntry>>([]);
+        public Task DeleteAsync(string key) => Task.CompletedTask;
+        public Task ClearAsync(string? prefix = null) => Task.CompletedTask;
+        public Task<IReadOnlyList<WorkingMemoryEntry>> SearchAsync(MemorySearchCriteria criteria, string? prefix = null) =>
+            Task.FromResult<IReadOnlyList<WorkingMemoryEntry>>([]);
+    }
+
+    private sealed class EmptySkillStore : ISkillStore
+    {
+        public Task SaveAsync(Skill skill) => Task.CompletedTask;
+        public Task<Skill?> GetAsync(string name) => Task.FromResult<Skill?>(null);
+        public Task<IReadOnlyList<Skill>> ListAsync() => Task.FromResult<IReadOnlyList<Skill>>([]);
+        public Task DeleteAsync(string name) => Task.CompletedTask;
+        public Task<IReadOnlyList<Skill>> SearchAsync(string query, int maxResults, CancellationToken cancellationToken = default, float[]? queryEmbedding = null) =>
+            Task.FromResult<IReadOnlyList<Skill>>([]);
+    }
+
+    private sealed class EmptyRulesStore : IRulesStore
+    {
+        public IReadOnlyList<string> Rules => [];
+        public Task<IReadOnlyList<string>> ListAsync() => Task.FromResult<IReadOnlyList<string>>([]);
+        public Task AddAsync(string rule) => Task.CompletedTask;
+        public Task RemoveAsync(string rule) => Task.CompletedTask;
+    }
+}

--- a/tests/RockBot.Host.Tests/CapabilityClaimVerifierTests.cs
+++ b/tests/RockBot.Host.Tests/CapabilityClaimVerifierTests.cs
@@ -1,0 +1,315 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using RockBot.Tools;
+
+namespace RockBot.Host.Tests;
+
+[TestClass]
+public class CapabilityClaimVerifierTests
+{
+    [TestMethod]
+    public async Task VerifyAsync_SuccessExpectation_PredicateSucceeds_WhenCallReturnsWithoutError()
+    {
+        var registry = new StubToolRegistry();
+        registry.Executor.NextResponse = new ToolInvokeResponse
+        {
+            ToolCallId = "x", ToolName = "mcp_invoke_tool", Content = "ok", IsError = false
+        };
+        var verifier = NewVerifier(registry);
+
+        var result = await verifier.VerifyAsync(SuccessShape());
+
+        Assert.AreEqual(VerifyOutcome.PredicateSucceeded, result.Outcome);
+    }
+
+    [TestMethod]
+    public async Task VerifyAsync_SuccessExpectation_PredicateFails_WhenCallReturnsError()
+    {
+        var registry = new StubToolRegistry();
+        registry.Executor.NextResponse = new ToolInvokeResponse
+        {
+            ToolCallId = "x", ToolName = "mcp_invoke_tool",
+            Content = "Required parameter 'timeZone' was not provided", IsError = true
+        };
+        var verifier = NewVerifier(registry);
+
+        var result = await verifier.VerifyAsync(SuccessShape());
+
+        Assert.AreEqual(VerifyOutcome.PredicateFailed, result.Outcome);
+        StringAssert.Contains(result.Detail!, "timeZone");
+    }
+
+    [TestMethod]
+    public async Task VerifyAsync_FailurePatternMatches_PredicateSucceeds()
+    {
+        var registry = new StubToolRegistry();
+        registry.Executor.NextResponse = new ToolInvokeResponse
+        {
+            ToolCallId = "x", ToolName = "mcp_invoke_tool",
+            Content = "MCP server timed out after 30s", IsError = true
+        };
+        var verifier = NewVerifier(registry);
+
+        var shape = SuccessShape() with
+        {
+            Expect = new VerifyExpectation(VerifyExpectationKind.FailureWithMessage, "timed out")
+        };
+
+        var result = await verifier.VerifyAsync(shape);
+
+        Assert.AreEqual(VerifyOutcome.PredicateSucceeded, result.Outcome);
+    }
+
+    [TestMethod]
+    public async Task VerifyAsync_FailurePatternMissingFromError_PredicateFails()
+    {
+        var registry = new StubToolRegistry();
+        registry.Executor.NextResponse = new ToolInvokeResponse
+        {
+            ToolCallId = "x", ToolName = "mcp_invoke_tool",
+            Content = "Some other failure mode", IsError = true
+        };
+        var verifier = NewVerifier(registry);
+
+        var shape = SuccessShape() with
+        {
+            Expect = new VerifyExpectation(VerifyExpectationKind.FailureWithMessage, "timed out")
+        };
+
+        var result = await verifier.VerifyAsync(shape);
+
+        Assert.AreEqual(VerifyOutcome.PredicateFailed, result.Outcome);
+    }
+
+    [TestMethod]
+    public async Task VerifyAsync_FailurePatternExpected_ButCallSucceeded_PredicateFails()
+    {
+        var registry = new StubToolRegistry();
+        registry.Executor.NextResponse = new ToolInvokeResponse
+        {
+            ToolCallId = "x", ToolName = "mcp_invoke_tool", Content = "ok", IsError = false
+        };
+        var verifier = NewVerifier(registry);
+
+        var shape = SuccessShape() with
+        {
+            Expect = new VerifyExpectation(VerifyExpectationKind.FailureWithMessage, "timed out")
+        };
+
+        var result = await verifier.VerifyAsync(shape);
+
+        Assert.AreEqual(VerifyOutcome.PredicateFailed, result.Outcome);
+    }
+
+    [TestMethod]
+    public async Task VerifyAsync_GatewayThrows_ReturnsUncertain()
+    {
+        var registry = new StubToolRegistry();
+        registry.Executor.NextThrow = new InvalidOperationException("bridge offline");
+        var verifier = NewVerifier(registry);
+
+        var result = await verifier.VerifyAsync(SuccessShape());
+
+        Assert.AreEqual(VerifyOutcome.Uncertain, result.Outcome);
+        StringAssert.Contains(result.Detail!, "bridge offline");
+    }
+
+    [TestMethod]
+    public async Task VerifyAsync_McpInvokeToolNotRegistered_ReturnsUncertain()
+    {
+        var registry = new StubToolRegistry { ReturnExecutor = false };
+        var verifier = NewVerifier(registry);
+
+        var result = await verifier.VerifyAsync(SuccessShape());
+
+        Assert.AreEqual(VerifyOutcome.Uncertain, result.Outcome);
+        StringAssert.Contains(result.Detail!, "mcp_invoke_tool");
+    }
+
+    [TestMethod]
+    public async Task VerifyAsync_BudgetExceeded_ReturnsUncertain()
+    {
+        var registry = new StubToolRegistry();
+        registry.Executor.DelayBeforeReturn = TimeSpan.FromSeconds(2);
+        registry.Executor.NextResponse = new ToolInvokeResponse
+        {
+            ToolCallId = "x", ToolName = "mcp_invoke_tool", Content = "ok", IsError = false
+        };
+        var verifier = NewVerifier(registry, budget: TimeSpan.FromMilliseconds(50));
+
+        var result = await verifier.VerifyAsync(SuccessShape());
+
+        Assert.AreEqual(VerifyOutcome.Uncertain, result.Outcome);
+        StringAssert.Contains(result.Detail!, "budget");
+    }
+
+    [TestMethod]
+    public async Task VerifyAsync_CallerCancellation_PropagatesAsCancellation()
+    {
+        var registry = new StubToolRegistry();
+        registry.Executor.DelayBeforeReturn = TimeSpan.FromSeconds(2);
+        registry.Executor.NextResponse = new ToolInvokeResponse
+        {
+            ToolCallId = "x", ToolName = "mcp_invoke_tool", Content = "ok", IsError = false
+        };
+        var verifier = NewVerifier(registry, budget: TimeSpan.FromSeconds(10));
+
+        using var cts = new CancellationTokenSource();
+        cts.CancelAfter(TimeSpan.FromMilliseconds(50));
+
+        // TaskCanceledException is a subtype of OperationCanceledException, so assert on the base type.
+        try
+        {
+            await verifier.VerifyAsync(SuccessShape(), cts.Token);
+            Assert.Fail("Expected the caller cancellation to propagate as an OperationCanceledException.");
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected — caller cancellation propagated rather than being swallowed as Uncertain.
+        }
+    }
+
+    [TestMethod]
+    public async Task VerifyAsync_CachesResult_WithinTtl()
+    {
+        var registry = new StubToolRegistry();
+        registry.Executor.NextResponse = new ToolInvokeResponse
+        {
+            ToolCallId = "x", ToolName = "mcp_invoke_tool", Content = "ok", IsError = false
+        };
+        var time = new FakeTimeProvider(new DateTimeOffset(2026, 5, 8, 15, 0, 0, TimeSpan.Zero));
+        var verifier = NewVerifier(registry, time: time, ttl: TimeSpan.FromMinutes(5));
+
+        var shape = SuccessShape();
+
+        var first = await verifier.VerifyAsync(shape);
+        var executionsAfterFirst = registry.Executor.ExecutionCount;
+        var second = await verifier.VerifyAsync(shape);
+
+        Assert.AreEqual(VerifyOutcome.PredicateSucceeded, first.Outcome);
+        Assert.AreEqual(VerifyOutcome.PredicateSucceeded, second.Outcome);
+        Assert.AreEqual(1, executionsAfterFirst, "First call should hit the gateway.");
+        Assert.AreEqual(1, registry.Executor.ExecutionCount, "Second call within TTL should be served from cache.");
+    }
+
+    [TestMethod]
+    public async Task VerifyAsync_CacheExpires_AfterTtl()
+    {
+        var registry = new StubToolRegistry();
+        registry.Executor.NextResponse = new ToolInvokeResponse
+        {
+            ToolCallId = "x", ToolName = "mcp_invoke_tool", Content = "ok", IsError = false
+        };
+        var time = new FakeTimeProvider(new DateTimeOffset(2026, 5, 8, 15, 0, 0, TimeSpan.Zero));
+        var verifier = NewVerifier(registry, time: time, ttl: TimeSpan.FromMinutes(5));
+
+        var shape = SuccessShape();
+
+        await verifier.VerifyAsync(shape);
+        time.Advance(TimeSpan.FromMinutes(5) + TimeSpan.FromSeconds(1));
+        await verifier.VerifyAsync(shape);
+
+        Assert.AreEqual(2, registry.Executor.ExecutionCount,
+            "Call after TTL expiry should re-hit the gateway.");
+    }
+
+    [TestMethod]
+    public async Task VerifyAsync_DifferentShapes_DoNotShareCache()
+    {
+        var registry = new StubToolRegistry();
+        registry.Executor.NextResponse = new ToolInvokeResponse
+        {
+            ToolCallId = "x", ToolName = "mcp_invoke_tool", Content = "ok", IsError = false
+        };
+        var verifier = NewVerifier(registry);
+
+        await verifier.VerifyAsync(SuccessShape() with { Tool = "tool_a" });
+        await verifier.VerifyAsync(SuccessShape() with { Tool = "tool_b" });
+
+        Assert.AreEqual(2, registry.Executor.ExecutionCount,
+            "Different verify shapes must not share a cache slot.");
+    }
+
+    [TestMethod]
+    public async Task VerifyAsync_SerializesArgumentsAsNestedField_ForMcpInvokeTool()
+    {
+        var registry = new StubToolRegistry();
+        registry.Executor.NextResponse = new ToolInvokeResponse
+        {
+            ToolCallId = "x", ToolName = "mcp_invoke_tool", Content = "ok", IsError = false
+        };
+        var verifier = NewVerifier(registry);
+
+        await verifier.VerifyAsync(SuccessShape());
+
+        Assert.IsNotNull(registry.Executor.LastRequest);
+        var doc = JsonDocument.Parse(registry.Executor.LastRequest!.Arguments!);
+        Assert.AreEqual("calendar-mcp", doc.RootElement.GetProperty("server_name").GetString());
+        Assert.AreEqual("get_calendar_events", doc.RootElement.GetProperty("tool_name").GetString());
+        Assert.IsTrue(doc.RootElement.TryGetProperty("arguments", out var args));
+        Assert.AreEqual(JsonValueKind.Object, args.ValueKind);
+        Assert.AreEqual("America/Chicago", args.GetProperty("timeZone").GetString());
+    }
+
+    // --- helpers -------------------------------------------------------------
+
+    private static CapabilityClaimVerifier NewVerifier(
+        StubToolRegistry registry,
+        TimeProvider? time = null,
+        TimeSpan? ttl = null,
+        TimeSpan? budget = null) =>
+        new(registry,
+            NullLogger<CapabilityClaimVerifier>.Instance,
+            time ?? TimeProvider.System,
+            ttl,
+            budget);
+
+    private static VerifyShape SuccessShape() => new(
+        Server: "calendar-mcp",
+        Tool: "get_calendar_events",
+        Arguments: JsonDocument.Parse("""{"accountId":"x","timeZone":"America/Chicago"}""").RootElement,
+        Expect: new VerifyExpectation(VerifyExpectationKind.Success));
+
+    private sealed class StubToolRegistry : IToolRegistry
+    {
+        public StubToolExecutor Executor { get; } = new();
+        public bool ReturnExecutor { get; set; } = true;
+
+        public IReadOnlyList<ToolRegistration> GetTools() => [];
+        public IToolExecutor? GetExecutor(string toolName) => ReturnExecutor ? Executor : null;
+        public void Register(ToolRegistration registration, IToolExecutor executor) { }
+        public bool Unregister(string toolName) => false;
+    }
+
+    private sealed class StubToolExecutor : IToolExecutor
+    {
+        public ToolInvokeResponse? NextResponse { get; set; }
+        public Exception? NextThrow { get; set; }
+        public TimeSpan DelayBeforeReturn { get; set; }
+        public ToolInvokeRequest? LastRequest { get; private set; }
+        public int ExecutionCount { get; private set; }
+
+        public async Task<ToolInvokeResponse> ExecuteAsync(ToolInvokeRequest request, CancellationToken ct)
+        {
+            LastRequest = request;
+            ExecutionCount++;
+
+            if (DelayBeforeReturn > TimeSpan.Zero)
+                await Task.Delay(DelayBeforeReturn, ct);
+
+            if (NextThrow is not null)
+                throw NextThrow;
+
+            return NextResponse ?? throw new InvalidOperationException("Test forgot to set NextResponse");
+        }
+    }
+
+    /// <summary>Minimal fake <see cref="TimeProvider"/> for TTL-expiry testing without the test-package dependency.</summary>
+    private sealed class FakeTimeProvider : TimeProvider
+    {
+        private DateTimeOffset _now;
+        public FakeTimeProvider(DateTimeOffset start) => _now = start;
+        public override DateTimeOffset GetUtcNow() => _now;
+        public void Advance(TimeSpan by) => _now = _now.Add(by);
+    }
+}

--- a/tests/RockBot.Host.Tests/CapabilityClaimWriterTests.cs
+++ b/tests/RockBot.Host.Tests/CapabilityClaimWriterTests.cs
@@ -1,0 +1,201 @@
+using System.Text.Json;
+
+namespace RockBot.Host.Tests;
+
+[TestClass]
+public class CapabilityClaimWriterTests
+{
+    [TestMethod]
+    public async Task SaveCapabilityClaimAsync_BuildsConventionalCategoryAndAttachesVerifyShape()
+    {
+        var memory = new RecordingMemory();
+        var writer = new CapabilityClaimWriter(memory);
+
+        var claim = NewClaim();
+
+        await writer.SaveCapabilityClaimAsync(claim);
+
+        Assert.AreEqual(1, memory.Saved.Count);
+        var saved = memory.Saved[0];
+        Assert.AreEqual("claim/capability/calendar-mcp/get_calendar_events", saved.Category);
+        Assert.IsNotNull(saved.Verify);
+        Assert.AreEqual("calendar-mcp", saved.Verify!.Server);
+        Assert.AreEqual("get_calendar_events", saved.Verify.Tool);
+        Assert.AreEqual(VerifyExpectationKind.Success, saved.Verify.Expect.Kind);
+        CollectionAssert.Contains((System.Collections.ICollection)saved.Tags, "capability-claim");
+        CollectionAssert.Contains((System.Collections.ICollection)saved.Tags, "server:calendar-mcp");
+        CollectionAssert.Contains((System.Collections.ICollection)saved.Tags, "tool:get_calendar_events");
+    }
+
+    [TestMethod]
+    public async Task SaveCapabilityClaimAsync_DeterministicId_OverwritesIdenticalClaim()
+    {
+        var memory = new RecordingMemory();
+        var writer = new CapabilityClaimWriter(memory);
+
+        var claim = NewClaim();
+
+        await writer.SaveCapabilityClaimAsync(claim);
+        await writer.SaveCapabilityClaimAsync(claim);
+
+        // Two saves of an identical claim — IDs match so the store sees the same Id twice.
+        Assert.AreEqual(2, memory.Saved.Count, "Both saves are received by the store.");
+        Assert.AreEqual(memory.Saved[0].Id, memory.Saved[1].Id, "Identical claims must share an ID so the store overwrites instead of accumulating.");
+    }
+
+    [TestMethod]
+    public async Task SaveCapabilityClaimAsync_DifferentStatement_ProducesDistinctId()
+    {
+        var memory = new RecordingMemory();
+        var writer = new CapabilityClaimWriter(memory);
+
+        var first = NewClaim() with { Statement = "wrapper cannot pass arguments" };
+        var second = NewClaim() with { Statement = "wrapper times out under fan-out" };
+
+        await writer.SaveCapabilityClaimAsync(first);
+        await writer.SaveCapabilityClaimAsync(second);
+
+        Assert.AreNotEqual(memory.Saved[0].Id, memory.Saved[1].Id);
+    }
+
+    [TestMethod]
+    public async Task SaveCapabilityClaimAsync_PopulatesEvidenceMetadata()
+    {
+        var memory = new RecordingMemory();
+        var writer = new CapabilityClaimWriter(memory);
+
+        var claim = NewClaim() with { Evidence = ["session a saw timeZone error", "session b saw same"] };
+
+        await writer.SaveCapabilityClaimAsync(claim);
+
+        var meta = memory.Saved[0].Metadata!;
+        Assert.AreEqual("capability-claim", meta["kind"]);
+        Assert.AreEqual("calendar-mcp", meta["server"]);
+        Assert.AreEqual("get_calendar_events", meta["tool"]);
+        Assert.AreEqual("2", meta["evidenceCount"]);
+        StringAssert.Contains(meta["evidence"], "session a saw timeZone error");
+        StringAssert.Contains(meta["evidence"], "session b saw same");
+    }
+
+    [TestMethod]
+    public async Task SaveCapabilityClaimAsync_NullVerifyShape_Throws()
+    {
+        var memory = new RecordingMemory();
+        var writer = new CapabilityClaimWriter(memory);
+
+        var claim = new CapabilityClaim(
+            Server: "calendar-mcp",
+            Tool: "get_calendar_events",
+            Statement: "wrapper cannot pass arguments",
+            Verify: null!,
+            Evidence: [],
+            CreatedAt: DateTimeOffset.UtcNow);
+
+        await Assert.ThrowsExactlyAsync<ArgumentException>(
+            () => writer.SaveCapabilityClaimAsync(claim));
+        Assert.AreEqual(0, memory.Saved.Count, "Invalid claims must not reach the store.");
+    }
+
+    [TestMethod]
+    public async Task SaveCapabilityClaimAsync_FailureExpectationWithoutPattern_Throws()
+    {
+        var memory = new RecordingMemory();
+        var writer = new CapabilityClaimWriter(memory);
+
+        var claim = NewClaim() with
+        {
+            Verify = NewVerify() with
+            {
+                Expect = new VerifyExpectation(VerifyExpectationKind.FailureWithMessage, FailurePattern: null)
+            }
+        };
+
+        await Assert.ThrowsExactlyAsync<ArgumentException>(
+            () => writer.SaveCapabilityClaimAsync(claim));
+    }
+
+    [TestMethod]
+    public async Task SaveCapabilityClaimAsync_FailureExpectationWithEmptyPattern_Throws()
+    {
+        var memory = new RecordingMemory();
+        var writer = new CapabilityClaimWriter(memory);
+
+        var claim = NewClaim() with
+        {
+            Verify = NewVerify() with
+            {
+                Expect = new VerifyExpectation(VerifyExpectationKind.FailureWithMessage, FailurePattern: "")
+            }
+        };
+
+        await Assert.ThrowsExactlyAsync<ArgumentException>(
+            () => writer.SaveCapabilityClaimAsync(claim));
+    }
+
+    [TestMethod]
+    [DataRow("", "tool", "stmt")]
+    [DataRow("server", "", "stmt")]
+    [DataRow("server", "tool", "")]
+    [DataRow("   ", "tool", "stmt")]
+    public async Task SaveCapabilityClaimAsync_MissingRequiredFields_Throws(string server, string tool, string statement)
+    {
+        var memory = new RecordingMemory();
+        var writer = new CapabilityClaimWriter(memory);
+
+        var claim = new CapabilityClaim(
+            Server: server,
+            Tool: tool,
+            Statement: statement,
+            Verify: NewVerify(),
+            Evidence: [],
+            CreatedAt: DateTimeOffset.UtcNow);
+
+        await Assert.ThrowsExactlyAsync<ArgumentException>(
+            () => writer.SaveCapabilityClaimAsync(claim));
+    }
+
+    // --- helpers -------------------------------------------------------------
+
+    private static CapabilityClaim NewClaim() => new(
+        Server: "calendar-mcp",
+        Tool: "get_calendar_events",
+        Statement: "wrapper cannot pass arguments to get_calendar_events",
+        Verify: NewVerify(),
+        Evidence: ["initial observation"],
+        CreatedAt: new DateTimeOffset(2026, 5, 8, 15, 0, 0, TimeSpan.Zero));
+
+    private static VerifyShape NewVerify() => new(
+        Server: "calendar-mcp",
+        Tool: "get_calendar_events",
+        Arguments: JsonDocument.Parse("""{"accountId":"x","timeZone":"America/Chicago","startDate":"2026-05-08","endDate":"2026-05-08"}""").RootElement,
+        Expect: new VerifyExpectation(VerifyExpectationKind.Success));
+
+    private sealed class RecordingMemory : ILongTermMemory
+    {
+        public List<MemoryEntry> Saved { get; } = new();
+
+        public Task SaveAsync(MemoryEntry entry, CancellationToken cancellationToken = default)
+        {
+            Saved.Add(entry);
+            return Task.CompletedTask;
+        }
+
+        public Task<IReadOnlyList<MemoryEntry>> SearchAsync(MemorySearchCriteria criteria, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<MemoryEntry>>([]);
+
+        public Task<MemoryEntry?> GetAsync(string id, CancellationToken cancellationToken = default) =>
+            Task.FromResult<MemoryEntry?>(Saved.FirstOrDefault(e => e.Id == id));
+
+        public Task DeleteAsync(string id, CancellationToken cancellationToken = default)
+        {
+            Saved.RemoveAll(e => e.Id == id);
+            return Task.CompletedTask;
+        }
+
+        public Task<IReadOnlyList<string>> ListTagsAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<string>>([]);
+
+        public Task<IReadOnlyList<string>> ListCategoriesAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<string>>([]);
+    }
+}

--- a/tests/RockBot.Host.Tests/ObservationLanguageDetectorTests.cs
+++ b/tests/RockBot.Host.Tests/ObservationLanguageDetectorTests.cs
@@ -1,0 +1,49 @@
+using RockBot.Memory;
+
+namespace RockBot.Host.Tests;
+
+[TestClass]
+public class ObservationLanguageDetectorTests
+{
+    [TestMethod]
+    [DataRow("the calendar wrapper is blocked", true)]
+    [DataRow("we cannot reach the bridge", true)]
+    [DataRow("Cannot pass arguments", true)]
+    [DataRow("This looks like a wrapper limitation", true)]
+    [DataRow("get_calendar_events is not supported by this account", true)]
+    [DataRow("the tool does not expose the timeZone field", true)]
+    [DataRow("CANNOT pass arguments", true)] // case-insensitive
+    [DataRow("Wrapper Limitation in the bridge", true)]
+    [DataRow("does NOT expose the field", true)]
+    public void LooksLikeCapabilityClaim_PositiveMatches(string content, bool expected)
+    {
+        Assert.AreEqual(expected, ObservationLanguageDetector.LooksLikeCapabilityClaim(content));
+    }
+
+    [TestMethod]
+    [DataRow("user prefers concise answers")]
+    [DataRow("project deadline is May 30")]
+    [DataRow("standup at 10am")]
+    [DataRow("uncannily fast response")] // contains "cann" but not the word "cannot"
+    [DataRow("the road is unblocked now")] // "unblocked" contains "blocked" — false positive risk
+    public void LooksLikeCapabilityClaim_NegativeMatches(string content)
+    {
+        Assert.IsFalse(ObservationLanguageDetector.LooksLikeCapabilityClaim(content),
+            $"Content '{content}' should not match — bare nouns/verbs without claim semantics.");
+    }
+
+    [TestMethod]
+    public void LooksLikeCapabilityClaim_NullEmptyOrWhitespace_ReturnsFalse()
+    {
+        Assert.IsFalse(ObservationLanguageDetector.LooksLikeCapabilityClaim(null));
+        Assert.IsFalse(ObservationLanguageDetector.LooksLikeCapabilityClaim(""));
+        Assert.IsFalse(ObservationLanguageDetector.LooksLikeCapabilityClaim("   \t\n"));
+    }
+
+    [TestMethod]
+    public void LooksLikeCapabilityClaim_KeywordSurroundedByPunctuation_StillMatches()
+    {
+        Assert.IsTrue(ObservationLanguageDetector.LooksLikeCapabilityClaim("(blocked!)"));
+        Assert.IsTrue(ObservationLanguageDetector.LooksLikeCapabilityClaim("status: cannot."));
+    }
+}

--- a/tests/RockBot.Host.Tests/WorkingMemoryToolsSoftGateTests.cs
+++ b/tests/RockBot.Host.Tests/WorkingMemoryToolsSoftGateTests.cs
@@ -1,0 +1,109 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using RockBot.Memory;
+
+namespace RockBot.Host.Tests;
+
+[TestClass]
+public class WorkingMemoryToolsSoftGateTests
+{
+    [TestMethod]
+    public async Task SaveToWorkingMemory_BenignContent_DoesNotAddObservationTag()
+    {
+        var store = new RecordingWorkingMemory();
+        var tools = NewTools(store);
+
+        var result = await tools.SaveToWorkingMemory("note", "user prefers concise updates");
+
+        Assert.IsNull(store.LastTags);
+        Assert.AreEqual("Saved to working memory under key 'session/test/note'.", result);
+    }
+
+    [TestMethod]
+    public async Task SaveToWorkingMemory_ClaimLanguage_AugmentsTagsAndIncludesHint()
+    {
+        var store = new RecordingWorkingMemory();
+        var tools = NewTools(store);
+
+        var result = await tools.SaveToWorkingMemory(
+            key: "calendar-blocked",
+            data: "the calendar wrapper is blocked from passing arguments");
+
+        Assert.IsNotNull(store.LastTags);
+        CollectionAssert.Contains((System.Collections.ICollection)store.LastTags!, ObservationLanguageDetector.ObservationTag);
+        StringAssert.Contains(result, "looks like a capability claim");
+    }
+
+    [TestMethod]
+    public async Task SaveToWorkingMemory_ClaimLanguageWithUserTags_PreservesUserTags()
+    {
+        var store = new RecordingWorkingMemory();
+        var tools = NewTools(store);
+
+        await tools.SaveToWorkingMemory(
+            key: "calendar-blocked",
+            data: "calendar cannot pass arguments",
+            tags: "calendar,urgent");
+
+        Assert.IsNotNull(store.LastTags);
+        CollectionAssert.Contains((System.Collections.ICollection)store.LastTags!, "calendar");
+        CollectionAssert.Contains((System.Collections.ICollection)store.LastTags!, "urgent");
+        CollectionAssert.Contains((System.Collections.ICollection)store.LastTags!, ObservationLanguageDetector.ObservationTag);
+    }
+
+    [TestMethod]
+    public async Task SaveToWorkingMemory_AlreadyTaggedAsObservation_DoesNotDoubleTag()
+    {
+        var store = new RecordingWorkingMemory();
+        var tools = NewTools(store);
+
+        await tools.SaveToWorkingMemory(
+            key: "calendar-blocked",
+            data: "wrapper limitation observed",
+            tags: $"existing,{ObservationLanguageDetector.ObservationTag}");
+
+        Assert.IsNotNull(store.LastTags);
+        var observationTagCount = store.LastTags!.Count(t =>
+            string.Equals(t, ObservationLanguageDetector.ObservationTag, StringComparison.OrdinalIgnoreCase));
+        Assert.AreEqual(1, observationTagCount, "Observation tag must not be applied twice.");
+    }
+
+    [TestMethod]
+    public async Task SaveToWorkingMemory_BenignContent_NoHintInResult()
+    {
+        var store = new RecordingWorkingMemory();
+        var tools = NewTools(store);
+
+        var result = await tools.SaveToWorkingMemory("note", "standup notes from today");
+
+        Assert.IsFalse(result.Contains("capability claim"),
+            "Benign content must not produce a soft-gate hint.");
+    }
+
+    private static WorkingMemoryTools NewTools(IWorkingMemory store) =>
+        new(store, "session/test", NullLogger.Instance);
+
+    private sealed class RecordingWorkingMemory : IWorkingMemory
+    {
+        public IReadOnlyList<string>? LastTags { get; private set; }
+        public string? LastKey { get; private set; }
+
+        public Task SetAsync(string key, string value, TimeSpan? ttl = null, string? category = null, IReadOnlyList<string>? tags = null)
+        {
+            LastKey = key;
+            LastTags = tags;
+            return Task.CompletedTask;
+        }
+
+        public Task<string?> GetAsync(string key) => Task.FromResult<string?>(null);
+
+        public Task DeleteAsync(string key) => Task.CompletedTask;
+
+        public Task ClearAsync(string? prefix = null) => Task.CompletedTask;
+
+        public Task<IReadOnlyList<WorkingMemoryEntry>> ListAsync(string? prefix = null) =>
+            Task.FromResult<IReadOnlyList<WorkingMemoryEntry>>([]);
+
+        public Task<IReadOnlyList<WorkingMemoryEntry>> SearchAsync(MemorySearchCriteria criteria, string? prefix = null) =>
+            Task.FromResult<IReadOnlyList<WorkingMemoryEntry>>([]);
+    }
+}

--- a/tests/RockBot.Tools.Tests/Recovery/McpRecoveryExecutorCapabilityClaimTests.cs
+++ b/tests/RockBot.Tools.Tests/Recovery/McpRecoveryExecutorCapabilityClaimTests.cs
@@ -1,0 +1,321 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using RockBot.Host;
+using RockBot.Tools.Mcp;
+using RockBot.Tools.Mcp.Recovery;
+
+namespace RockBot.Tools.Tests.Recovery;
+
+/// <summary>
+/// Phase 2 wire-in: McpRecoveryExecutor emits a <see cref="CapabilityClaim"/> via
+/// <see cref="ICapabilityClaimWriter"/> when recovery has been attempted but
+/// exhausted. Skipped paths: the no-provider/no-StageB short-circuit (recovery
+/// never actually attempted anything).
+/// </summary>
+[TestClass]
+public class McpRecoveryExecutorCapabilityClaimTests
+{
+    [TestMethod]
+    public async Task StageA_RetryFailed_EmitsCapabilityClaim()
+    {
+        // Recovery resolves a value via Stage A but the retried call still fails.
+        var writer = new RecordingClaimWriter();
+        var provider = new FakeProvider(
+            (_, _, f) => f == "timeZone",
+            _ => new ResolvedDefault("America/Chicago"));
+
+        var calls = 0;
+        McpInvokeDelegate invoke = (r, h, ct) =>
+        {
+            calls++;
+            // First retry returns an unrelated failure that doesn't chain.
+            return Task.FromResult(new ToolInvokeResponse
+            {
+                ToolCallId = r.ToolCallId, ToolName = r.ToolName,
+                Content = "permission denied", IsError = true
+            });
+        };
+
+        var exec = new McpRecoveryExecutor(
+            invoke, [provider], NullLogger<McpRecoveryExecutor>.Instance,
+            stageB: null, capabilityClaimWriter: writer);
+
+        var req = new ToolInvokeRequest
+        {
+            ToolCallId = "1", ToolName = "get_calendar_events",
+            Arguments = """{"accountId":"x"}"""
+        };
+        var failed = Err(req, "Required parameter 'timeZone' was not provided");
+
+        var result = await exec.RecoverAsync("calendar-mcp", "get_calendar_events", req, failed, default);
+
+        Assert.IsTrue(result.IsError);
+        Assert.AreEqual(1, writer.Saved.Count, "Phase 2 claim must be emitted on Stage A retry-failure.");
+        var claim = writer.Saved[0];
+        Assert.AreEqual("calendar-mcp", claim.Server);
+        Assert.AreEqual("get_calendar_events", claim.Tool);
+        StringAssert.Contains(claim.Statement, "Stage A");
+        StringAssert.Contains(claim.Statement, "timeZone");
+        Assert.AreEqual(VerifyExpectationKind.Success, claim.Verify.Expect.Kind,
+            "Claim must be falsifiable: a future successful call evicts it.");
+    }
+
+    [TestMethod]
+    public async Task StageB_FillFails_EmitsCapabilityClaim()
+    {
+        var writer = new RecordingClaimWriter();
+        McpInvokeDelegate invoke = (r, h, ct) => Task.FromResult(Ok(r, "ok"));
+        var stageB = new NullFillingFiller();
+
+        var exec = new McpRecoveryExecutor(
+            invoke, [], NullLogger<McpRecoveryExecutor>.Instance,
+            stageB: stageB.Filler, capabilityClaimWriter: writer);
+
+        var req = new ToolInvokeRequest { ToolCallId = "1", ToolName = "do", Arguments = "{}" };
+        var failed = Err(req, "Required parameter 'novelField'");
+
+        var result = await exec.RecoverAsync("synthetic", "do", req, failed, default);
+
+        Assert.IsTrue(result.IsError);
+        Assert.AreEqual(1, writer.Saved.Count, "Phase 2 claim must be emitted when Stage B can't fill the field.");
+        StringAssert.Contains(writer.Saved[0].Statement, "Stage B");
+        StringAssert.Contains(writer.Saved[0].Statement, "novelField");
+    }
+
+    [TestMethod]
+    public async Task StageB_RetryFailed_EmitsCapabilityClaim()
+    {
+        var writer = new RecordingClaimWriter();
+        // Stage B fills, but the retried call still returns a non-chainable error.
+        McpInvokeDelegate invoke = (r, h, ct) => Task.FromResult(Err(r, "Server unreachable"));
+        var stageB = new CannedFillingFiller("\"some-value\"");
+
+        var exec = new McpRecoveryExecutor(
+            invoke, [], NullLogger<McpRecoveryExecutor>.Instance,
+            stageB: stageB.Filler, capabilityClaimWriter: writer);
+
+        var req = new ToolInvokeRequest { ToolCallId = "1", ToolName = "do", Arguments = "{}" };
+        var failed = Err(req, "Required parameter 'foo'");
+
+        var result = await exec.RecoverAsync("synthetic", "do", req, failed, default);
+
+        Assert.IsTrue(result.IsError);
+        Assert.AreEqual(1, writer.Saved.Count);
+        StringAssert.Contains(writer.Saved[0].Statement, "Stage B");
+        StringAssert.Contains(writer.Saved[0].Statement, "foo");
+    }
+
+    [TestMethod]
+    public async Task NoProviderNoStageB_DoesNotEmitClaim_BecauseRecoveryNeverAttempted()
+    {
+        var writer = new RecordingClaimWriter();
+        McpInvokeDelegate invoke = (r, h, ct) => Task.FromResult(Ok(r, "ok"));
+
+        var exec = new McpRecoveryExecutor(
+            invoke, [], NullLogger<McpRecoveryExecutor>.Instance,
+            stageB: null, capabilityClaimWriter: writer);
+
+        var req = new ToolInvokeRequest { ToolCallId = "1", ToolName = "do", Arguments = "{}" };
+        var failed = Err(req, "Required parameter 'fieldNobodyHandles'");
+
+        await exec.RecoverAsync("synthetic", "do", req, failed, default);
+
+        Assert.AreEqual(0, writer.Saved.Count,
+            "Recovery never tried anything (no provider, Stage B disabled) — no claim.");
+    }
+
+    [TestMethod]
+    public async Task SuccessfulRecovery_DoesNotEmitClaim()
+    {
+        var writer = new RecordingClaimWriter();
+        var provider = new FakeProvider(
+            (_, _, f) => f == "timeZone",
+            _ => new ResolvedDefault("America/Chicago"));
+
+        McpInvokeDelegate invoke = (r, h, ct) => Task.FromResult(Ok(r, "events: []"));
+
+        var exec = new McpRecoveryExecutor(
+            invoke, [provider], NullLogger<McpRecoveryExecutor>.Instance,
+            stageB: null, capabilityClaimWriter: writer);
+
+        var req = new ToolInvokeRequest { ToolCallId = "1", ToolName = "get", Arguments = "{}" };
+        var failed = Err(req, "Required parameter 'timeZone' was not provided");
+
+        var result = await exec.RecoverAsync("srv", "get", req, failed, default);
+
+        Assert.IsFalse(result.IsError);
+        Assert.AreEqual(0, writer.Saved.Count, "A successful recovery must NOT emit a claim.");
+    }
+
+    [TestMethod]
+    public async Task NoClaimWriter_RecoveryStillWorks()
+    {
+        // Wire-in is optional — recovery must continue to function when no writer is registered.
+        McpInvokeDelegate invoke = (r, h, ct) => Task.FromResult(Err(r, "permission denied"));
+        var provider = new FakeProvider(
+            (_, _, f) => f == "timeZone",
+            _ => new ResolvedDefault("America/Chicago"));
+
+        var exec = new McpRecoveryExecutor(
+            invoke, [provider], NullLogger<McpRecoveryExecutor>.Instance,
+            stageB: null, capabilityClaimWriter: null);
+
+        var req = new ToolInvokeRequest { ToolCallId = "1", ToolName = "get", Arguments = "{}" };
+        var failed = Err(req, "Required parameter 'timeZone' was not provided");
+
+        var result = await exec.RecoverAsync("srv", "get", req, failed, default);
+
+        // Recovery still runs and surfaces the annotated trail; no exception.
+        Assert.IsTrue(result.IsError);
+        StringAssert.Contains(result.Content, "retry-failed");
+    }
+
+    [TestMethod]
+    public async Task EmittedClaim_PreservesOriginalArguments_AsVerifyShape()
+    {
+        var writer = new RecordingClaimWriter();
+        // Provider matches the missing field so recovery actually attempts a retry.
+        var provider = new FakeProvider(
+            (_, _, f) => f == "startDate",
+            _ => new ResolvedDefault("2026-05-08"));
+
+        // Retry returns a non-chainable error → triggers Stage A retry-failed path.
+        McpInvokeDelegate invoke = (r, h, ct) => Task.FromResult(Err(r, "permission denied"));
+
+        var exec = new McpRecoveryExecutor(
+            invoke, [provider], NullLogger<McpRecoveryExecutor>.Instance,
+            stageB: null, capabilityClaimWriter: writer);
+
+        var req = new ToolInvokeRequest
+        {
+            ToolCallId = "1", ToolName = "get_calendar_events",
+            Arguments = """{"accountId":"work","timeZone":"UTC"}"""
+        };
+        var failed = Err(req, "Required parameter 'startDate' was not provided");
+
+        await exec.RecoverAsync("calendar-mcp", "get_calendar_events", req, failed, default);
+
+        Assert.AreEqual(1, writer.Saved.Count);
+        var claim = writer.Saved[0];
+        // VerifyShape carries the original call shape — so the next session's verifier
+        // can replay the call and confirm whether the limitation still holds.
+        Assert.AreEqual("calendar-mcp", claim.Verify.Server);
+        Assert.AreEqual("get_calendar_events", claim.Verify.Tool);
+        Assert.AreEqual("work", claim.Verify.Arguments.GetProperty("accountId").GetString());
+        Assert.AreEqual("UTC", claim.Verify.Arguments.GetProperty("timeZone").GetString());
+    }
+
+    [TestMethod]
+    public async Task ClaimWriterThrows_DoesNotBreakRecoveryPath()
+    {
+        var writer = new ThrowingClaimWriter();
+        var provider = new FakeProvider(
+            (_, _, f) => f == "timeZone",
+            _ => new ResolvedDefault("America/Chicago"));
+        McpInvokeDelegate invoke = (r, h, ct) => Task.FromResult(Err(r, "permission denied"));
+
+        var exec = new McpRecoveryExecutor(
+            invoke, [provider], NullLogger<McpRecoveryExecutor>.Instance,
+            stageB: null, capabilityClaimWriter: writer);
+
+        var req = new ToolInvokeRequest { ToolCallId = "1", ToolName = "get", Arguments = "{}" };
+        var failed = Err(req, "Required parameter 'timeZone' was not provided");
+
+        // Must not bubble the writer's exception — recovery is the priority path.
+        var result = await exec.RecoverAsync("srv", "get", req, failed, default);
+
+        Assert.IsTrue(result.IsError);
+        StringAssert.Contains(result.Content, "retry-failed");
+    }
+
+    // --- helpers -------------------------------------------------------------
+
+    private static ToolInvokeResponse Err(ToolInvokeRequest req, string content) => new()
+    {
+        ToolCallId = req.ToolCallId, ToolName = req.ToolName,
+        Content = content, IsError = true
+    };
+
+    private static ToolInvokeResponse Ok(ToolInvokeRequest req, string content) => new()
+    {
+        ToolCallId = req.ToolCallId, ToolName = req.ToolName,
+        Content = content, IsError = false
+    };
+
+    private sealed class FakeProvider(
+        Func<string, string, string, bool> match,
+        Func<ResolveContext, ResolvedDefault?> resolve) : IToolArgumentDefaultsProvider
+    {
+        public bool CanResolve(string s, string t, string f) => match(s, t, f);
+        public Task<ResolvedDefault?> ResolveAsync(ResolveContext ctx, CancellationToken ct) =>
+            Task.FromResult(resolve(ctx));
+    }
+
+    private sealed class RecordingClaimWriter : ICapabilityClaimWriter
+    {
+        public List<CapabilityClaim> Saved { get; } = new();
+        public Task SaveCapabilityClaimAsync(CapabilityClaim claim, CancellationToken cancellationToken = default)
+        {
+            Saved.Add(claim);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class ThrowingClaimWriter : ICapabilityClaimWriter
+    {
+        public Task SaveCapabilityClaimAsync(CapabilityClaim claim, CancellationToken cancellationToken = default) =>
+            throw new InvalidOperationException("ltm offline");
+    }
+
+    private sealed class NullFillingFiller
+    {
+        public StageBLlmFiller Filler { get; } = new TestFiller();
+        private sealed class TestFiller() : StageBLlmFiller(
+            new NoopLlmClient(), NullLogger<StageBLlmFiller>.Instance)
+        {
+            public override Task<object?> TryFillAsync(
+                string serverName, string toolName, string fieldName,
+                IReadOnlyDictionary<string, object?> existingArgs,
+                string? originalErrorText, CancellationToken ct) =>
+                Task.FromResult<object?>(null);
+        }
+    }
+
+    private sealed class CannedFillingFiller
+    {
+        public StageBLlmFiller Filler { get; }
+        public CannedFillingFiller(string canned)
+        {
+            Filler = new TestFiller(canned);
+        }
+        private sealed class TestFiller(string? canned) : StageBLlmFiller(
+            new NoopLlmClient(), NullLogger<StageBLlmFiller>.Instance)
+        {
+            public override Task<object?> TryFillAsync(
+                string serverName, string toolName, string fieldName,
+                IReadOnlyDictionary<string, object?> existingArgs,
+                string? originalErrorText, CancellationToken ct)
+            {
+                if (canned is null) return Task.FromResult<object?>(null);
+                var doc = JsonDocument.Parse(canned);
+                return Task.FromResult<object?>(McpToolExecutor.ConvertJsonElement(doc.RootElement));
+            }
+        }
+    }
+
+    private sealed class NoopLlmClient : RockBot.Host.ILlmClient
+    {
+        public Task<Microsoft.Extensions.AI.ChatResponse> GetResponseAsync(
+            IEnumerable<Microsoft.Extensions.AI.ChatMessage> messages,
+            Microsoft.Extensions.AI.ChatOptions? options,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<Microsoft.Extensions.AI.ChatResponse> GetResponseAsync(
+            IEnumerable<Microsoft.Extensions.AI.ChatMessage> messages,
+            RockBot.Host.ModelTier tier,
+            Microsoft.Extensions.AI.ChatOptions? options,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
Closes #346.

Implements Phase 2 of `design/self-repair.md`. Adds a curated `claim/capability/*` memory subset whose entries carry a structured `VerifyShape` predicate; the read-side filter in `AgentContextBuilder` evaluates the predicate before injection and evicts claims whose predicate succeeds (i.e. the asserted limitation no longer holds). The producer side wires into the Phase 1 recovery executor (#345), so when recovery exhausts itself the call shape is recorded as a falsifiable claim against future sessions.

## What landed

**Internal write API** (`ICapabilityClaimWriter`, internal — not an LLM tool)
- Validates the claim shape (rejects writes lacking a `VerifyShape`, lacking server/tool/statement, or with `FailureWithMessage` expectation but no pattern)
- Persists under `claim/capability/{server}/{tool}` with the verify shape attached to `MemoryEntry.Verify`
- Stable id derived from `SHA256(server|tool|statement)` so identical claims overwrite

**Read-side verifier** (`ICapabilityClaimVerifier`)
- Routes verify calls through `mcp_invoke_tool`, so they ride the Phase 1 recovery layer (recovered verify counts as success — per the design)
- Per-process cache, 5 min TTL, 5s budget, SHA-256 keyed by normalized verify shape
- Three outcomes: `PredicateSucceeded` (evict), `PredicateFailed` (inject), `Uncertain` (inject with annotation)

**Producer-side wire-in** (`McpRecoveryExecutor` updated)
- Optional `ICapabilityClaimWriter` constructor parameter; null-safe when LTM isn't configured
- Emits a claim at the four real-exhaustion paths: chain depth limit, Stage A retry-failed, Stage B retry-failed, Stage B fill-failed
- Skips the no-provider/no-StageB short-circuit (recovery never actually attempted anything)
- Writer exceptions are caught and logged; recovery is the priority path

**Read-side filter in `AgentContextBuilder`**
- Branch on `Category.StartsWith(\"claim/capability/\")` for LTM, episodic, and identity injection seams
- Predicate-succeeded → `ILongTermMemory.DeleteAsync` and skip injection
- Predicate-failed → inject as before
- Uncertain or verifier exception → inject with `[verifier-uncertain: <detail>]` annotation appended

**Soft gate on regular WM/LTM writes** (`save_to_working_memory`, `save_memory`)
- Regex match `\b(blocked|cannot|wrapper limitation|not supported|does not expose)\b` (case-insensitive)
- On match: appends `kind=observation` tag, includes a hint in the tool result
- Writes are never blocked — false positives are tolerable, false negatives are recoverable by the dream service

**DI**
- `WithLongTermMemory` registers `ICapabilityClaimWriter` and `ICapabilityClaimVerifier` as singletons
- Neither is exposed as an LLM tool

## Acceptance (from #346)

- ✅ A claim 'wrapper cannot pass arguments to get_calendar_events' with `Verify={call get_calendar_events with timeZone+accountId, expect Success}` is evicted on the next session that pulls it — `CapabilityClaimEndToEndTests.ClaimSurvivesRoundTrip_AndIsEvictedWhenPredicateSucceeds`
- ✅ An LLM-issued `SaveToWorkingMemory(\"calendar fresh-scan blocked\")` is tagged `kind=observation`, not promoted to a claim — `WorkingMemoryToolsSoftGateTests.SaveToWorkingMemory_ClaimLanguage_AugmentsTagsAndIncludesHint`
- ✅ General WM API and existing entries are unaffected — full suite green (1822 tests, 0 regressions)
- ✅ Verify result cached per-process with 5 min TTL — `CapabilityClaimVerifierTests.VerifyAsync_CachesResult_WithinTtl` and `_CacheExpires_AfterTtl`

## Out of scope

- Contradiction detection on save (Phase 3, #347) — handled there
- DreamService promotion of accumulated `kind=observation` entries into claims — design lists DreamService as a caller of `SaveCapabilityClaim` but the acceptance criteria don't require it; can be a small follow-up

## Test summary

- 11 `CapabilityClaimWriterTests`
- 13 `CapabilityClaimVerifierTests`
- 16 `ObservationLanguageDetectorTests`
- 5 `WorkingMemoryToolsSoftGateTests` + 2 in `MemoryToolsTests`
- 6 `AgentContextBuilderCapabilityClaimTests`
- 4 `AgentMemoryExtensionsTests` (DI)
- 2 `CapabilityClaimEndToEndTests` (file-backed integration)
- 8 `McpRecoveryExecutorCapabilityClaimTests` (producer wire-in)

Total: 67 new tests; all pre-existing tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)