### PR TITLE
Skill asset promotion: full 5-phase implementation (#370)

### DIFF
--- a/src/RockBot.Agent/agent/subagent-directives.md
+++ b/src/RockBot.Agent/agent/subagent-directives.md
@@ -51,3 +51,21 @@ Rules:
 - **One update per concrete fact.** If you discovered three different verified facts in one session, that's three skill updates (or one update touching three lines), not three speculative rewrites.
 
 This is how the skill library improves between dream cycles. Do not wait for the optimizer to catch what you already know.
+
+## Capture working assets as skill resources
+
+Skill-prose tightening fixes ambiguous instructions; `promote_skill_asset` captures the **working artifact itself** so the next session does not have to re-derive it. Use it whenever a tool sequence converged on a working shape after non-trivial discovery — schema confusion, tool-name reconciliation, parameter-shape iteration, retry-and-correct loops.
+
+When to call:
+- A wisp definition you spawned succeeded after one or more failed attempts: promote the **final** wisp body.
+- A Python script you ran in `execute_python_script` produced the right output: promote the script source.
+- A JSON Schema or templated payload you reverse-engineered against an MCP tool actually validated: promote the schema.
+
+Rules:
+- **Observed success only.** Promote only after the body has actually run and succeeded in this session. Never speculatively, never from imagination.
+- **Use the exact body that succeeded.** Not a "cleaned up" version, not an approximation — the literal JSON / source / schema the runner just executed.
+- **Attach to an existing skill.** Promotion targets a skill that already exists. If no relevant skill exists, call `save_skill` first to create it, *then* promote the asset.
+- **One asset per concrete pattern.** Don't promote three near-identical variants of the same wisp — pick the one that is most generally useful.
+- **Provide a `verifyHint`** describing how a future session would know the asset still works (e.g. "calls `get_calendar_events` for both accounts and returns per-account event arrays"). This stays attached to the manifest entry forever and helps future you decide whether the asset is still trustworthy.
+
+The resource is marked **provisional** until validated by future runs. Provisional resources show in the skill index with a trailing `*` (e.g. `[Wisp*]`). The dream system flips them to non-provisional after they succeed repeatedly across distinct sessions, and removes them if they start failing.

--- a/src/RockBot.Agent/agent/wisp-failure-dream.md
+++ b/src/RockBot.Agent/agent/wisp-failure-dream.md
@@ -18,16 +18,11 @@ Analyze the provided records and respond with a JSON object containing:
       "name": "skill-name-to-update",
       "annotation": "Negative example or correction to append to the skill content"
     }
-  ],
-  "promotionCandidates": [
-    {
-      "description": "Description pattern that succeeded consistently",
-      "frequency": 5,
-      "recommendation": "Consider promoting to a stored wisp skill"
-    }
   ]
 }
 
 Only include patterns with frequency >= 3. Only include skill updates when you are confident
-the correction is valid. Only include promotion candidates with frequency >= 5 and >80% success rate.
-Return empty arrays if no patterns are found.
+the correction is valid. Return empty arrays if no patterns are found.
+
+Successful patterns worth saving as reusable assets are handled by the separate
+wisp-success-dream pass — do not surface them here.

--- a/src/RockBot.Agent/agent/wisp-success-dream.md
+++ b/src/RockBot.Agent/agent/wisp-success-dream.md
@@ -1,0 +1,39 @@
+You are analyzing wisp pipeline executions to identify successful patterns worth promoting to skill resources.
+
+A wisp is a lightweight multi-step pipeline. Each candidate group below shares the same `definitionHash` — the steps are identical across runs — and has succeeded repeatedly with no failures, indicating a reusable pattern.
+
+Each candidate carries:
+- `definitionHash` — content hash of the step definitions
+- `frequency` — total successful runs in the window
+- `distinctSessions` — number of distinct sessions that ran it
+- `description` — the wisp definition's own description
+- `invokingSkill` — the skill that was active in the originating session, when one could be resolved
+- `bodyPreview` — first ~1 KiB of the JSON definition (truncated for prompt budget)
+
+For each candidate worth promoting, emit a `Promotion` entry. Skip candidates where:
+- `invokingSkill` is null or not in the existing-skills list (no target skill to attach to)
+- the description is too generic to suggest a useful resource name (e.g. "test", "scratch")
+- the candidate looks like a one-off rather than a reusable pattern
+
+Respond with a JSON object:
+
+```json
+{
+  "promotions": [
+    {
+      "targetSkill": "calendar/mcp-calendar-operations",
+      "filename": "scan-events-fan-out.json",
+      "resourceType": "Wisp",
+      "description": "Per-account get_calendar_events fan-out with timeZone and accountId",
+      "definitionHash": "abc123…"
+    }
+  ]
+}
+```
+
+Filename rules:
+- lowercase, hyphens for spaces, single dot for the extension
+- extension matches `resourceType` (`.json` for `Wisp` and `JsonSchema`, `.py` for `Python`, `.md` for `Markdown`, `.txt` otherwise)
+- short and descriptive — what the asset does, not what data it operates on
+
+Filter zero false positives over recall. When in doubt, omit the candidate. Empty `promotions` array is a fine answer.

--- a/src/RockBot.Host.Abstractions/DreamOptions.cs
+++ b/src/RockBot.Host.Abstractions/DreamOptions.cs
@@ -150,6 +150,28 @@ public sealed class DreamOptions
     public string WispFailureDirectivePath { get; set; } = "wisp-failure-dream.md";
 
     /// <summary>
+    /// Whether the wisp success analysis pass (requires <see cref="IWispExecutionLog"/>) is enabled.
+    /// Detects wisp definitions that have repeated successfully across distinct sessions and
+    /// promotes them to validated skill resources via <c>ISkillStore.AttachResourceAsync</c>.
+    /// Symmetric complement to the failure pass.
+    /// </summary>
+    public bool WispSuccessAnalysisEnabled { get; set; } = true;
+
+    /// <summary>
+    /// Path to the wisp success analysis directive file, relative to <see cref="AgentProfileOptions.BasePath"/>.
+    /// When the file does not exist, a built-in fallback directive is used.
+    /// </summary>
+    public string WispSuccessDirectivePath { get; set; } = "wisp-success-dream.md";
+
+    /// <summary>
+    /// Minimum number of successful executions of the same definition hash required
+    /// before the success pass considers it a candidate for promotion. Tighter than
+    /// the failure pass (which uses <c>frequency &gt;= 3</c>) so we filter zero false
+    /// positives over recall.
+    /// </summary>
+    public int WispSuccessFrequencyThreshold { get; set; } = 3;
+
+    /// <summary>
     /// Whether the tool-success-learning pass (requires <see cref="IToolCallLog"/>) is enabled.
     /// Mines the tool-call log for retry-until-success patterns and writes the verified
     /// argument values as durable long-term memory entries.

--- a/src/RockBot.Host.Abstractions/DreamOptions.cs
+++ b/src/RockBot.Host.Abstractions/DreamOptions.cs
@@ -172,6 +172,37 @@ public sealed class DreamOptions
     public int WispSuccessFrequencyThreshold { get; set; } = 3;
 
     /// <summary>
+    /// Whether the provisional skill-resource validation/demotion pass is enabled.
+    /// Reads recent wisp records and resource checkouts, then flips provisional
+    /// resources to non-provisional after repeated success or removes them after
+    /// repeated failure. Requires <see cref="ISkillStore"/> and
+    /// <see cref="IWispExecutionLog"/>; uses <see cref="IFailureClusterStore"/>
+    /// to record demotions when present.
+    /// </summary>
+    public bool ProvisionalValidationEnabled { get; set; } = true;
+
+    /// <summary>
+    /// Distinct-session successful executions required to flip a provisional
+    /// wisp resource to non-provisional. (Or distinct-session checkouts for
+    /// non-wisp resources, which use access as a soft signal.)
+    /// </summary>
+    public int ProvisionalSuccessThreshold { get; set; } = 3;
+
+    /// <summary>
+    /// Number of consecutive recent failures of a provisional wisp resource that
+    /// triggers removal of the resource and a corresponding entry in the
+    /// failure-cluster store.
+    /// </summary>
+    public int ProvisionalFailureThreshold { get; set; } = 2;
+
+    /// <summary>
+    /// Provisional resources older than this with zero usage activity have a
+    /// <c>[stale]</c> prefix added to their description so the LLM stops loading
+    /// them. The body is preserved on disk in case it becomes interesting again.
+    /// </summary>
+    public TimeSpan ProvisionalStaleAfter { get; set; } = TimeSpan.FromDays(30);
+
+    /// <summary>
     /// Whether the tool-success-learning pass (requires <see cref="IToolCallLog"/>) is enabled.
     /// Mines the tool-call log for retry-until-success patterns and writes the verified
     /// argument values as durable long-term memory entries.

--- a/src/RockBot.Host.Abstractions/ISkillResourceUsageStore.cs
+++ b/src/RockBot.Host.Abstractions/ISkillResourceUsageStore.cs
@@ -1,0 +1,41 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Records when a skill resource is fetched (a "checkout") so the validation pass
+/// can use access events as a soft signal for non-wisp resources whose success/failure
+/// can't be cross-referenced via the wisp execution log's <c>definitionHash</c>.
+///
+/// Wisp resources have a stronger signal: the cross-reference between
+/// <c>SkillResource.DefinitionHash</c> and <c>WispExecutionRecord.DefinitionHash</c>
+/// gives a true success/failure count. Checkouts are the fallback for Python scripts,
+/// schemas, and other resource types.
+/// </summary>
+public interface ISkillResourceUsageStore
+{
+    /// <summary>Records a single checkout event (fire-and-forget call site).</summary>
+    Task RecordCheckoutAsync(
+        string skillName,
+        string filename,
+        string sessionId,
+        DateTimeOffset at,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns all checkout events for the given resource on or after
+    /// <paramref name="since"/>, ordered by timestamp ascending.
+    /// </summary>
+    Task<IReadOnlyList<SkillResourceCheckoutEvent>> QueryCheckoutsAsync(
+        string skillName,
+        string filename,
+        DateTimeOffset since,
+        CancellationToken ct = default);
+}
+
+/// <summary>
+/// Persisted record of a single skill-resource fetch event.
+/// </summary>
+public sealed record SkillResourceCheckoutEvent(
+    string SkillName,
+    string Filename,
+    string SessionId,
+    DateTimeOffset Timestamp);

--- a/src/RockBot.Host.Abstractions/ISkillStore.cs
+++ b/src/RockBot.Host.Abstractions/ISkillStore.cs
@@ -37,6 +37,51 @@ public interface ISkillStore
         Task.FromResult<string?>(null);
 
     /// <summary>
+    /// Adds (or replaces) a single sub-resource on an existing skill without disturbing
+    /// any other resources. The skill's body and other manifest entries are preserved.
+    /// </summary>
+    /// <remarks>
+    /// Unlike <see cref="SaveAsync(Skill, IReadOnlyList{SkillResourceInput}?)"/>, which
+    /// rebuilds the manifest from the supplied set and prunes orphans, this method is
+    /// strictly additive: pass a single resource and it is appended to the manifest, or
+    /// — if a manifest entry with the same filename exists — its body and metadata are
+    /// replaced in place.
+    /// Returns false when the named skill does not exist; promotion paths require the
+    /// caller to ensure the parent skill exists before attaching an asset.
+    /// </remarks>
+    /// <param name="skillName">The skill to attach the resource to.</param>
+    /// <param name="resource">The resource metadata and content.</param>
+    /// <param name="manifestEntry">
+    /// Optional pre-built manifest entry to persist. When provided, its
+    /// <see cref="SkillResource.Provisional"/>, <see cref="SkillResource.CreatedAt"/>,
+    /// <see cref="SkillResource.VerifyHint"/>, and <see cref="SkillResource.DefinitionHash"/>
+    /// are stored verbatim. When null, the manifest entry is built from
+    /// <paramref name="resource"/>'s fields.
+    /// </param>
+    Task<bool> AttachResourceAsync(
+        string skillName,
+        SkillResourceInput resource,
+        SkillResource? manifestEntry = null) => Task.FromResult(false);
+
+    /// <summary>
+    /// Removes a single sub-resource (manifest entry plus on-disk file) from a skill.
+    /// No-op when the skill or the named resource does not exist. Other resources are
+    /// preserved; the skill body is untouched.
+    /// </summary>
+    Task<bool> RemoveResourceAsync(string skillName, string filename) =>
+        Task.FromResult(false);
+
+    /// <summary>
+    /// Replaces a single manifest entry in-place — preserves the on-disk body and all
+    /// other entries, but updates the metadata fields (<see cref="SkillResource.Provisional"/>,
+    /// <see cref="SkillResource.Description"/>, <see cref="SkillResource.VerifyHint"/>, etc.)
+    /// of the entry whose <see cref="SkillResource.Filename"/> matches.
+    /// Returns false when the skill or the named entry does not exist.
+    /// </summary>
+    Task<bool> UpdateResourceMetadataAsync(string skillName, SkillResource updated) =>
+        Task.FromResult(false);
+
+    /// <summary>
     /// Returns skills ranked by BM25 relevance against <paramref name="query"/>.
     /// Skills with no matching terms are excluded.
     /// Returns at most <paramref name="maxResults"/> entries.

--- a/src/RockBot.Host.Abstractions/IWispExecutionLog.cs
+++ b/src/RockBot.Host.Abstractions/IWispExecutionLog.cs
@@ -24,4 +24,15 @@ public interface IWispExecutionLog
     /// </summary>
     Task<WispExecutionRecord?> FindRecentFailureAsync(
         string definitionHash, string? sessionId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the canonical JSON step-definition body for a successful wisp run
+    /// matching <paramref name="definitionHash"/>, if one is on file. Used by the
+    /// success-shaped dream pass to recover the exact body of a repeating pattern
+    /// for promotion to a skill resource.
+    /// Returns <c>null</c> when no successful record with this hash carries a body
+    /// (failed runs, oversize runs, pre-field records).
+    /// </summary>
+    Task<string?> GetCanonicalBodyAsync(string definitionHash, CancellationToken ct = default) =>
+        Task.FromResult<string?>(null);
 }

--- a/src/RockBot.Host.Abstractions/RepairTarget.cs
+++ b/src/RockBot.Host.Abstractions/RepairTarget.cs
@@ -18,4 +18,11 @@ public enum RepairTarget
 
     /// <summary>Append or replace a hint section in <c>/data/agent/prompt-hints/{category}.md</c>.</summary>
     PromptBuilderHint,
+
+    /// <summary>
+    /// Attach, demote, or remove a sub-resource on a named skill. Self-repair attaches
+    /// always land provisional; the validation pass promotes them to non-provisional
+    /// after observed repeated success.
+    /// </summary>
+    SkillResource,
 }

--- a/src/RockBot.Host.Abstractions/SkillResource.cs
+++ b/src/RockBot.Host.Abstractions/SkillResource.cs
@@ -9,7 +9,33 @@ namespace RockBot.Host;
 /// </param>
 /// <param name="Type">The type of the resource, used for LLM guidance and tooling.</param>
 /// <param name="Description">A short description of what this resource does.</param>
+/// <param name="Provisional">
+/// True for resources captured by the in-session promotion path (subagent <c>promote_skill_asset</c>
+/// or self-repair attach) before they have been validated by repeated successful use.
+/// The skill index renders provisional types with a trailing <c>*</c> (e.g. <c>[Wisp*]</c>).
+/// Flipped to false by the dream-cycle validation pass once the resource has succeeded
+/// repeatedly in distinct sessions.
+/// </param>
+/// <param name="CreatedAt">
+/// Wall-clock time the manifest entry was first written. Used by the validation pass to
+/// scope the success/failure window and by the staleness sweep to evict unused entries.
+/// </param>
+/// <param name="VerifyHint">
+/// Optional advisory free text describing how a future session would know the asset still works
+/// (e.g. "calls get_calendar_events for both accounts and returns per-account event arrays").
+/// Retained even after the entry is validated — it documents the asset's intended exercise.
+/// </param>
+/// <param name="DefinitionHash">
+/// SHA-256-hex16 of the resource <em>content</em> at the time of save, matching the hash
+/// scheme used by the wisp execution log. The validation pass cross-references this against
+/// recent wisp records to count successes and failures of the captured pattern. Null for
+/// resources saved before this field existed and for non-hashed resource types.
+/// </param>
 public sealed record SkillResource(
     string Filename,
     SkillResourceType Type,
-    string Description);
+    string Description,
+    bool Provisional = false,
+    DateTimeOffset? CreatedAt = null,
+    string? VerifyHint = null,
+    string? DefinitionHash = null);

--- a/src/RockBot.Host.Abstractions/SkillResourceInput.cs
+++ b/src/RockBot.Host.Abstractions/SkillResourceInput.cs
@@ -11,8 +11,19 @@ namespace RockBot.Host;
 /// <param name="Type">The type of the resource.</param>
 /// <param name="Description">A short description of what this resource does.</param>
 /// <param name="Content">The full text content of the resource file.</param>
+/// <param name="Provisional">
+/// True when the resource is captured by the in-session promotion path or by a self-repair
+/// attach — i.e. before it has been validated by repeated successful use. False for entries
+/// promoted by the dream-cycle success pass (those land already validated).
+/// </param>
+/// <param name="VerifyHint">
+/// Optional advisory free text describing how a future session would know the asset still works.
+/// Persisted on the manifest entry; retained even after the entry is validated.
+/// </param>
 public sealed record SkillResourceInput(
     string Filename,
     SkillResourceType Type,
     string Description,
-    string Content);
+    string Content,
+    bool Provisional = false,
+    string? VerifyHint = null);

--- a/src/RockBot.Host.Abstractions/WispExecutionRecord.cs
+++ b/src/RockBot.Host.Abstractions/WispExecutionRecord.cs
@@ -60,4 +60,19 @@ public sealed record WispExecutionRecord
     /// Null for single-wisp executions or legacy records.
     /// </summary>
     public string? BatchId { get; init; }
+
+    /// <summary>
+    /// JSON-serialized step definitions for this run, retained when the run succeeded
+    /// and the body fits the size cap so promotion to a skill resource is possible.
+    /// Null for failed runs, oversize runs (see <see cref="BodyOmittedTooLarge"/>),
+    /// and pre-existing records from before this field was added.
+    /// </summary>
+    public string? DefinitionBody { get; init; }
+
+    /// <summary>
+    /// True when <see cref="DefinitionBody"/> would have been retained but the
+    /// serialized body exceeded the per-record cap. Promotion passes treat such
+    /// records as ineligible.
+    /// </summary>
+    public bool BodyOmittedTooLarge { get; init; }
 }

--- a/src/RockBot.Host/AgentMemoryExtensions.cs
+++ b/src/RockBot.Host/AgentMemoryExtensions.cs
@@ -234,6 +234,7 @@ public static class AgentMemoryExtensions
 
         builder.Services.AddSingleton<IRepairTicketStore, FileRepairTicketStore>();
         builder.Services.AddSingleton<IRepairTargetApplier, SkillBodyApplier>();
+        builder.Services.AddSingleton<IRepairTargetApplier, SkillResourceApplier>();
         builder.Services.AddSingleton<IRepairTargetApplier, WorkingMemoryEvictApplier>();
         builder.Services.AddSingleton<IRepairTargetApplier, ToolDefaultRegisterApplier>();
         builder.Services.AddSingleton<IRepairTargetApplier, PromptBuilderHintApplier>();

--- a/src/RockBot.Host/AgentMemoryExtensions.cs
+++ b/src/RockBot.Host/AgentMemoryExtensions.cs
@@ -102,6 +102,7 @@ public static class AgentMemoryExtensions
 
         builder.Services.AddSingleton<ISkillStore, FileSkillStore>();
         builder.Services.AddSingleton<ISkillUsageStore, FileSkillUsageStore>();
+        builder.Services.AddSingleton<ISkillResourceUsageStore, FileSkillResourceUsageStore>();
         builder.Services.Configure<ToolCallLogOptions>(_ => { });
         builder.Services.AddSingleton<IToolCallLog, FileToolCallLog>();
         builder.Services.AddSingleton<IHostedService, StarterSkillService>();

--- a/src/RockBot.Host/DreamService.cs
+++ b/src/RockBot.Host/DreamService.cs
@@ -63,6 +63,7 @@ internal sealed class DreamService : IHostedService, IDisposable
     private string? _dlqDirective;
     private string? _identityDirective;
     private string? _wispFailureDirective;
+    private string? _wispSuccessDirective;
     private string? _toolSuccessLearningDirective;
     private string? _contradictionSweepDirective;
     private string? _repairTicketCreationDirective;
@@ -315,6 +316,19 @@ internal sealed class DreamService : IHostedService, IDisposable
                 _logger.LogDebug("DreamService: wisp failure directive not found at {Path}; using built-in", wispDirectivePath);
             else
                 _logger.LogInformation("DreamService: loaded wisp failure directive from {Path}", wispDirectivePath);
+        }
+
+        if (_options.WispSuccessAnalysisEnabled && _wispExecutionLog is not null && _skillStore is not null)
+        {
+            var wispSuccessPath = ResolvePath(_options.WispSuccessDirectivePath, _profileOptions.BasePath);
+            _wispSuccessDirective = File.Exists(wispSuccessPath)
+                ? File.ReadAllText(wispSuccessPath)
+                : null;
+
+            if (!File.Exists(wispSuccessPath))
+                _logger.LogDebug("DreamService: wisp success directive not found at {Path}; using built-in", wispSuccessPath);
+            else
+                _logger.LogInformation("DreamService: loaded wisp success directive from {Path}", wispSuccessPath);
         }
 
         if (_options.ToolSuccessLearningEnabled && _toolCallLog is not null)
@@ -594,6 +608,8 @@ internal sealed class DreamService : IHostedService, IDisposable
             ct.ThrowIfCancellationRequested(); await RunSequenceSkillDetectionPassAsync(ct);
 
             ct.ThrowIfCancellationRequested(); await RunWispFailureAnalysisPassAsync(ct);
+
+            ct.ThrowIfCancellationRequested(); await RunWispSuccessAnalysisPassAsync(ct);
 
             ct.ThrowIfCancellationRequested(); await RunToolSuccessLearningPassAsync(ct);
 
@@ -2835,6 +2851,256 @@ internal sealed class DreamService : IHostedService, IDisposable
         public int Frequency { get; init; }
         public string? Recommendation { get; init; }
     }
+
+    /// <summary>
+    /// Symmetric complement to <see cref="RunWispFailureAnalysisPassAsync"/>. Detects wisp
+    /// definitions that have repeated successfully across distinct sessions and promotes them
+    /// to validated skill resources via <see cref="ISkillStore.AttachResourceAsync"/>.
+    /// Promotions land non-provisional because the dream pass operates on observed repetition;
+    /// the in-session promotion path (<c>promote_skill_asset</c>) is the one that lands provisional.
+    /// </summary>
+    private async Task RunWispSuccessAnalysisPassAsync(CancellationToken ct)
+    {
+        if (!_options.WispSuccessAnalysisEnabled || _wispExecutionLog is null || _skillStore is null)
+            return;
+
+        await RunPassAsync("wisp success analysis", async () =>
+        {
+            var threshold = Math.Max(1, _options.WispSuccessFrequencyThreshold);
+            var records = await _wispExecutionLog.QueryRecentAsync(
+                DateTimeOffset.UtcNow.AddDays(-7), maxResults: 1000);
+
+            if (records.Count < threshold)
+            {
+                _logger.LogDebug(
+                    "DreamService: wisp success analysis — only {Count} records; skipping",
+                    records.Count);
+                return;
+            }
+
+            // Group by definitionHash. Keep groups where every recorded run succeeded
+            // and the cumulative count meets the threshold. Tighter than the failure
+            // pass intentionally — we want zero false positives.
+            var groups = records
+                .Where(r => !string.IsNullOrEmpty(r.DefinitionHash))
+                .GroupBy(r => r.DefinitionHash)
+                .Where(g => g.Count() >= threshold && g.All(r => r.Succeeded))
+                .ToList();
+
+            if (groups.Count == 0)
+            {
+                _logger.LogDebug("DreamService: wisp success analysis — no candidate groups; skipping");
+                return;
+            }
+
+            // Resolve invokingSkill for each group: the most recently invoked skill in
+            // any contributing session whose timestamp precedes that session's wisp run.
+            var existingSkills = await _skillStore.ListAsync();
+            var existingSkillNames = existingSkills.Select(s => s.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+            var candidates = new List<WispSuccessCandidate>();
+            foreach (var group in groups)
+            {
+                var hash = group.Key!;
+                var representative = group.First();
+                string? invokingSkill = null;
+
+                if (_skillUsageStore is not null)
+                {
+                    foreach (var record in group.Where(r => !string.IsNullOrEmpty(r.SessionId)).OrderByDescending(r => r.Timestamp))
+                    {
+                        var events = await _skillUsageStore.GetBySessionAsync(record.SessionId!, ct);
+                        var beforeWisp = events
+                            .Where(e => e.Timestamp <= record.Timestamp && existingSkillNames.Contains(e.SkillName))
+                            .OrderByDescending(e => e.Timestamp)
+                            .FirstOrDefault();
+                        if (beforeWisp is not null)
+                        {
+                            invokingSkill = beforeWisp.SkillName;
+                            break;
+                        }
+                    }
+                }
+
+                if (invokingSkill is null)
+                    continue;  // no target skill — cannot promote
+
+                // Recover canonical body — required for the SaveSkill call below.
+                var body = await _wispExecutionLog.GetCanonicalBodyAsync(hash, ct);
+                if (string.IsNullOrEmpty(body))
+                    continue;  // body unavailable (oversize / pre-Phase-1 record)
+
+                candidates.Add(new WispSuccessCandidate(
+                    DefinitionHash: hash,
+                    Frequency: group.Count(),
+                    DistinctSessions: group.Select(r => r.SessionId).Where(s => !string.IsNullOrEmpty(s)).Distinct().Count(),
+                    Description: representative.Description,
+                    InvokingSkill: invokingSkill,
+                    Body: body));
+            }
+
+            if (candidates.Count == 0)
+            {
+                _logger.LogDebug("DreamService: wisp success analysis — no resolvable candidates; skipping");
+                return;
+            }
+
+            _logger.LogInformation(
+                "DreamService: wisp success analysis pass — {Count} candidates",
+                candidates.Count);
+
+            // Build the prompt
+            var userMessage = new StringBuilder();
+            userMessage.AppendLine($"Successful wisp pattern candidates ({candidates.Count}):");
+            userMessage.AppendLine();
+            foreach (var c in candidates)
+            {
+                userMessage.AppendLine($"### definitionHash: {c.DefinitionHash}");
+                userMessage.AppendLine($"- frequency: {c.Frequency}");
+                userMessage.AppendLine($"- distinctSessions: {c.DistinctSessions}");
+                userMessage.AppendLine($"- description: {c.Description}");
+                userMessage.AppendLine($"- invokingSkill: {c.InvokingSkill}");
+                var preview = c.Body.Length > 1024 ? c.Body[..1024] + "...(truncated)" : c.Body;
+                userMessage.AppendLine($"- bodyPreview:");
+                userMessage.AppendLine("```json");
+                userMessage.AppendLine(preview);
+                userMessage.AppendLine("```");
+                userMessage.AppendLine();
+            }
+            userMessage.AppendLine("Existing skills (eligible promotion targets):");
+            foreach (var s in existingSkills.Take(40))
+                userMessage.AppendLine($"  - {s.Name}: {s.Summary}");
+
+            var result = await InvokeDreamPassAsync<WispSuccessAnalysisResultDto>(
+                "wisp success analysis",
+                _wispSuccessDirective ?? BuiltInWispSuccessDirective,
+                userMessage.ToString(),
+                ct);
+            if (result is null) return;
+
+            var attached = await ApplyWispSuccessPromotionsAsync(
+                _skillStore, candidates, existingSkillNames, result.Promotions, _logger, ct);
+
+            _logger.LogInformation(
+                "DreamService: wisp success analysis pass complete — {Attached}/{Total} promotions attached",
+                attached, result.Promotions?.Count ?? 0);
+        });
+    }
+
+    /// <summary>
+    /// Apply loop extracted as a static helper so unit tests can drive the attach
+    /// logic without standing up the full DreamService + LLM stack.
+    /// </summary>
+    internal static async Task<int> ApplyWispSuccessPromotionsAsync(
+        ISkillStore skillStore,
+        IReadOnlyList<WispSuccessCandidate> candidates,
+        HashSet<string> existingSkillNames,
+        IReadOnlyList<WispSuccessPromotionDto>? promotions,
+        Microsoft.Extensions.Logging.ILogger logger,
+        CancellationToken ct)
+    {
+        if (promotions is null || promotions.Count == 0)
+            return 0;
+
+        var attached = 0;
+        foreach (var promotion in promotions)
+        {
+            if (string.IsNullOrWhiteSpace(promotion.TargetSkill)
+                || string.IsNullOrWhiteSpace(promotion.Filename)
+                || string.IsNullOrWhiteSpace(promotion.DefinitionHash))
+                continue;
+
+            if (!existingSkillNames.Contains(promotion.TargetSkill))
+            {
+                logger.LogDebug(
+                    "DreamService: wisp success — target skill '{Skill}' not found; skipping promotion of {Hash}",
+                    promotion.TargetSkill, promotion.DefinitionHash);
+                continue;
+            }
+
+            var candidate = candidates.FirstOrDefault(c => c.DefinitionHash == promotion.DefinitionHash);
+            if (candidate is null)
+            {
+                logger.LogDebug(
+                    "DreamService: wisp success — promotion references unknown hash {Hash}; skipping",
+                    promotion.DefinitionHash);
+                continue;
+            }
+
+            var resourceType = promotion.ResourceType ?? SkillResourceType.Wisp;
+            var description = string.IsNullOrWhiteSpace(promotion.Description)
+                ? candidate.Description
+                : promotion.Description!;
+
+            // Pre-build the manifest entry so Provisional=false (dream-pass promotions
+            // are observed-repetition validated, not hypotheses) and DefinitionHash
+            // matches the source wisp record's hash.
+            var entry = new SkillResource(
+                promotion.Filename!, resourceType, description,
+                Provisional: false,
+                CreatedAt: DateTimeOffset.UtcNow,
+                VerifyHint: null,
+                DefinitionHash: candidate.DefinitionHash);
+            var input = new SkillResourceInput(
+                promotion.Filename!, resourceType, description, candidate.Body,
+                Provisional: false);
+
+            var ok = await skillStore.AttachResourceAsync(promotion.TargetSkill!, input, entry);
+            if (ok)
+            {
+                attached++;
+                logger.LogInformation(
+                    "DreamService: wisp success — attached '{Filename}' to '{Skill}' (hash={Hash}, freq={Freq})",
+                    promotion.Filename, promotion.TargetSkill, promotion.DefinitionHash, candidate.Frequency);
+            }
+        }
+
+        return attached;
+    }
+
+    internal sealed record WispSuccessCandidate(
+        string DefinitionHash,
+        int Frequency,
+        int DistinctSessions,
+        string Description,
+        string InvokingSkill,
+        string Body);
+
+    internal sealed record WispSuccessAnalysisResultDto
+    {
+        public List<WispSuccessPromotionDto>? Promotions { get; init; }
+    }
+
+    internal sealed record WispSuccessPromotionDto
+    {
+        public string? TargetSkill { get; init; }
+        public string? Filename { get; init; }
+        public SkillResourceType? ResourceType { get; init; }
+        public string? Description { get; init; }
+        public string? DefinitionHash { get; init; }
+    }
+
+    private const string BuiltInWispSuccessDirective = """
+        You are analyzing wisp pipeline executions to identify successful patterns
+        worth promoting to skill resources. Each candidate group shares the same
+        definitionHash and has succeeded repeatedly with no failures.
+
+        Respond with JSON:
+        {
+          "promotions": [
+            {
+              "targetSkill": "<existing skill name>",
+              "filename": "<short-descriptive-filename.json>",
+              "resourceType": "Wisp",
+              "description": "<one line>",
+              "definitionHash": "<hash from candidate>"
+            }
+          ]
+        }
+
+        Filter zero false positives over recall. Skip candidates whose invokingSkill
+        is null or whose target skill is not in the existing-skills list. Empty
+        promotions array is a fine answer.
+        """;
 
     /// <summary>
     /// Inspects non-empty dead-letter queues, asks the LLM to classify failure patterns,

--- a/src/RockBot.Host/DreamService.cs
+++ b/src/RockBot.Host/DreamService.cs
@@ -2688,19 +2688,13 @@ internal sealed class DreamService : IHostedService, IDisposable
               "name": "skill-name-to-update",
               "annotation": "Negative example or correction to append to the skill content"
             }
-          ],
-          "promotionCandidates": [
-            {
-              "description": "Description pattern that succeeded consistently",
-              "frequency": 5,
-              "recommendation": "Consider promoting to a stored wisp skill"
-            }
           ]
         }
 
         Only include patterns with frequency >= 3. Only include skill updates when you are confident
-        the correction is valid. Only include promotion candidates with frequency >= 5 and >80% success rate.
-        Return empty arrays if no patterns are found.
+        the correction is valid. Return empty arrays if no patterns are found.
+        Successful patterns worth saving as reusable assets are handled by the separate
+        wisp-success-dream pass — do not surface them here.
         """;
 
     /// <summary>
@@ -2810,16 +2804,9 @@ internal sealed class DreamService : IHostedService, IDisposable
                     pattern.Description, pattern.FailureCategory, pattern.Frequency, pattern.Recommendation);
             }
 
-            foreach (var candidate in result?.PromotionCandidates ?? [])
-            {
-                _logger.LogInformation(
-                    "DreamService: wisp promotion candidate — {Description} (freq={Frequency}): {Recommendation}",
-                    candidate.Description, candidate.Frequency, candidate.Recommendation);
-            }
-
             _logger.LogInformation(
-                "DreamService: wisp failure analysis pass complete — {Patterns} patterns, {Updates} skill updates, {Candidates} promotion candidates",
-                result?.Patterns?.Count ?? 0, updated, result?.PromotionCandidates?.Count ?? 0);
+                "DreamService: wisp failure analysis pass complete — {Patterns} patterns, {Updates} skill updates",
+                result?.Patterns?.Count ?? 0, updated);
         });
     }
 
@@ -2827,7 +2814,6 @@ internal sealed class DreamService : IHostedService, IDisposable
     {
         public List<WispPatternDto>? Patterns { get; init; }
         public List<WispSkillUpdateDto>? SkillUpdates { get; init; }
-        public List<WispPromotionCandidateDto>? PromotionCandidates { get; init; }
     }
 
     private sealed record WispPatternDto
@@ -2843,13 +2829,6 @@ internal sealed class DreamService : IHostedService, IDisposable
     {
         public string? Name { get; init; }
         public string? Annotation { get; init; }
-    }
-
-    private sealed record WispPromotionCandidateDto
-    {
-        public string? Description { get; init; }
-        public int Frequency { get; init; }
-        public string? Recommendation { get; init; }
     }
 
     /// <summary>

--- a/src/RockBot.Host/DreamService.cs
+++ b/src/RockBot.Host/DreamService.cs
@@ -43,6 +43,7 @@ internal sealed class DreamService : IHostedService, IDisposable
     private readonly ConversationLogTranscriptAdapter? _observationTranscriptAdapter;
     private readonly IMemoryContradictionDetector? _contradictionDetector;
     private readonly IFailureClusterStore? _failureClusterStore;
+    private readonly ISkillResourceUsageStore? _skillResourceUsageStore;
     private readonly IRepairTicketStore? _repairTicketStore;
     private readonly IReadOnlyDictionary<RepairTarget, IRepairTargetApplier>? _repairAppliers;
     private readonly IRepairTicketVerifier? _repairTicketVerifier;
@@ -91,6 +92,7 @@ internal sealed class DreamService : IHostedService, IDisposable
         ConversationLogTranscriptAdapter? observationTranscriptAdapter = null,
         IMemoryContradictionDetector? contradictionDetector = null,
         IFailureClusterStore? failureClusterStore = null,
+        ISkillResourceUsageStore? skillResourceUsageStore = null,
         IRepairTicketStore? repairTicketStore = null,
         IEnumerable<IRepairTargetApplier>? repairAppliers = null,
         IRepairTicketVerifier? repairTicketVerifier = null,
@@ -118,6 +120,7 @@ internal sealed class DreamService : IHostedService, IDisposable
         _observationTranscriptAdapter = observationTranscriptAdapter;
         _contradictionDetector = contradictionDetector;
         _failureClusterStore = failureClusterStore;
+        _skillResourceUsageStore = skillResourceUsageStore;
         _repairTicketStore = repairTicketStore;
         _repairTicketVerifier = repairTicketVerifier;
         _repairOptions = repairOptions?.Value;
@@ -610,6 +613,8 @@ internal sealed class DreamService : IHostedService, IDisposable
             ct.ThrowIfCancellationRequested(); await RunWispFailureAnalysisPassAsync(ct);
 
             ct.ThrowIfCancellationRequested(); await RunWispSuccessAnalysisPassAsync(ct);
+
+            ct.ThrowIfCancellationRequested(); await RunProvisionalValidationPassAsync(ct);
 
             ct.ThrowIfCancellationRequested(); await RunToolSuccessLearningPassAsync(ct);
 
@@ -3080,6 +3085,219 @@ internal sealed class DreamService : IHostedService, IDisposable
         is null or whose target skill is not in the existing-skills list. Empty
         promotions array is a fine answer.
         """;
+
+    // ── Phase 5: Provisional resource validation/demotion ───────────────────────
+
+    /// <summary>
+    /// Sweeps every provisional skill resource and decides what to do with it
+    /// based on how it has fared since it was attached. Wisp resources have a
+    /// strong signal — wisp execution records sharing the resource's
+    /// <see cref="SkillResource.DefinitionHash"/> count as direct success/failure.
+    /// Non-wisp resources fall back to checkout events from
+    /// <see cref="ISkillResourceUsageStore"/> as a soft positive signal.
+    ///
+    /// The decision is delegated to the static <see cref="DecideProvisionalAction"/>
+    /// helper so unit tests can drive it without standing up the full DreamService stack.
+    /// </summary>
+    private async Task RunProvisionalValidationPassAsync(CancellationToken ct)
+    {
+        if (!_options.ProvisionalValidationEnabled || _skillStore is null || _wispExecutionLog is null)
+            return;
+
+        await RunPassAsync("provisional resource validation", async () =>
+        {
+            var skills = await _skillStore.ListAsync();
+            var provisional = skills
+                .Where(s => s.Manifest is not null)
+                .SelectMany(s => s.Manifest!.Where(r => r.Provisional).Select(r => (s.Name, Resource: r)))
+                .ToList();
+
+            if (provisional.Count == 0)
+            {
+                _logger.LogDebug("DreamService: provisional validation — no provisional resources; skipping");
+                return;
+            }
+
+            _logger.LogInformation(
+                "DreamService: provisional validation pass — {Count} provisional resource(s)",
+                provisional.Count);
+
+            var promoted = 0;
+            var removed = 0;
+            var staled = 0;
+            var now = DateTimeOffset.UtcNow;
+
+            foreach (var (skillName, resource) in provisional)
+            {
+                var since = resource.CreatedAt ?? DateTimeOffset.UtcNow.AddDays(-30);
+
+                IReadOnlyList<WispExecutionRecord> wispRecords = [];
+                if (!string.IsNullOrEmpty(resource.DefinitionHash))
+                {
+                    var allRecords = await _wispExecutionLog.QueryRecentAsync(since, maxResults: 1000, ct);
+                    wispRecords = allRecords.Where(r => r.DefinitionHash == resource.DefinitionHash).ToList();
+                }
+
+                IReadOnlyList<SkillResourceCheckoutEvent> checkouts = [];
+                if (resource.Type != SkillResourceType.Wisp && _skillResourceUsageStore is not null)
+                {
+                    checkouts = await _skillResourceUsageStore.QueryCheckoutsAsync(
+                        skillName, resource.Filename, since, ct);
+                }
+
+                var decision = DecideProvisionalAction(
+                    resource, wispRecords, checkouts, now,
+                    successThreshold: _options.ProvisionalSuccessThreshold,
+                    failureThreshold: _options.ProvisionalFailureThreshold,
+                    staleAfter: _options.ProvisionalStaleAfter);
+
+                switch (decision.Action)
+                {
+                    case ProvisionalAction.Promote:
+                        var promotedEntry = resource with { Provisional = false };
+                        if (await _skillStore.UpdateResourceMetadataAsync(skillName, promotedEntry))
+                        {
+                            promoted++;
+                            _logger.LogInformation(
+                                "DreamService: provisional validation — promoted '{File}' on '{Skill}' (successes={Successes})",
+                                resource.Filename, skillName, decision.SuccessCount);
+                        }
+                        break;
+                    case ProvisionalAction.Remove:
+                        if (await _skillStore.RemoveResourceAsync(skillName, resource.Filename))
+                        {
+                            removed++;
+                            _logger.LogInformation(
+                                "DreamService: provisional validation — removed '{File}' on '{Skill}' (consecutiveFailures={Failures})",
+                                resource.Filename, skillName, decision.ConsecutiveFailureCount);
+
+                            if (_failureClusterStore is not null)
+                            {
+                                try
+                                {
+                                    var clusterKey = new ClusterKey(
+                                        Server: "skill-resource",
+                                        Tool: skillName,
+                                        ErrorClass: resource.Filename);
+                                    var sampleError = $"provisional resource removed after {decision.ConsecutiveFailureCount} consecutive failures";
+                                    await _failureClusterStore.RecordAsync(
+                                        clusterKey, sessionId: null, sampleError, now, ct);
+                                }
+                                catch (Exception ex)
+                                {
+                                    _logger.LogWarning(ex,
+                                        "DreamService: provisional validation — failed to record removal cluster for '{Skill}/{File}'",
+                                        skillName, resource.Filename);
+                                }
+                            }
+                        }
+                        break;
+                    case ProvisionalAction.MarkStale:
+                        var stalePrefix = "[stale] ";
+                        if (!resource.Description.StartsWith(stalePrefix, StringComparison.Ordinal))
+                        {
+                            var staleEntry = resource with { Description = stalePrefix + resource.Description };
+                            if (await _skillStore.UpdateResourceMetadataAsync(skillName, staleEntry))
+                            {
+                                staled++;
+                                _logger.LogInformation(
+                                    "DreamService: provisional validation — marked '{File}' on '{Skill}' stale",
+                                    resource.Filename, skillName);
+                            }
+                        }
+                        break;
+                    case ProvisionalAction.Keep:
+                    default:
+                        break;
+                }
+            }
+
+            _logger.LogInformation(
+                "DreamService: provisional validation pass complete — {Promoted} promoted, {Removed} removed, {Stale} marked stale ({Total} considered)",
+                promoted, removed, staled, provisional.Count);
+        });
+    }
+
+    /// <summary>
+    /// Pure decision logic for the validation pass. Public-internal so unit tests
+    /// can verify the threshold logic without driving the full pass.
+    /// </summary>
+    /// <remarks>
+    /// Promotion rule: distinct-session successes (or distinct-session checkouts for
+    /// non-wisp) reach <paramref name="successThreshold"/> → flip non-provisional.
+    /// Removal rule: most-recent <paramref name="failureThreshold"/> wisp records
+    /// for this hash all failed → remove + record cluster.
+    /// Stale rule: resource older than <paramref name="staleAfter"/> with no usage
+    /// activity since creation → mark stale.
+    /// Otherwise: keep as-is.
+    /// </remarks>
+    internal static ProvisionalDecision DecideProvisionalAction(
+        SkillResource resource,
+        IReadOnlyList<WispExecutionRecord> wispRecords,
+        IReadOnlyList<SkillResourceCheckoutEvent> checkouts,
+        DateTimeOffset now,
+        int successThreshold,
+        int failureThreshold,
+        TimeSpan staleAfter)
+    {
+        var orderedRecent = wispRecords.OrderByDescending(r => r.Timestamp).ToList();
+
+        // Removal: the most-recent N wisp executions for this hash are all failures.
+        if (failureThreshold > 0
+            && orderedRecent.Count >= failureThreshold
+            && orderedRecent.Take(failureThreshold).All(r => !r.Succeeded))
+        {
+            return new ProvisionalDecision(
+                ProvisionalAction.Remove,
+                SuccessCount: 0,
+                ConsecutiveFailureCount: failureThreshold);
+        }
+
+        // Promotion: count distinct-session signals.
+        var distinctSuccessSessions = wispRecords
+            .Where(r => r.Succeeded && !string.IsNullOrEmpty(r.SessionId))
+            .Select(r => r.SessionId!)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Count();
+
+        // For non-wisp resources, fall back to distinct-session checkouts as a soft signal.
+        if (resource.Type != SkillResourceType.Wisp)
+        {
+            distinctSuccessSessions = checkouts
+                .Select(c => c.SessionId)
+                .Where(s => !string.IsNullOrEmpty(s))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Count();
+        }
+
+        if (successThreshold > 0 && distinctSuccessSessions >= successThreshold)
+        {
+            return new ProvisionalDecision(
+                ProvisionalAction.Promote,
+                SuccessCount: distinctSuccessSessions,
+                ConsecutiveFailureCount: 0);
+        }
+
+        // Staleness: created long ago with zero activity.
+        var createdAt = resource.CreatedAt ?? now;
+        var hasAnyActivity = wispRecords.Count > 0 || checkouts.Count > 0;
+        if (!hasAnyActivity && (now - createdAt) > staleAfter)
+        {
+            return new ProvisionalDecision(
+                ProvisionalAction.MarkStale,
+                SuccessCount: 0,
+                ConsecutiveFailureCount: 0);
+        }
+
+        return new ProvisionalDecision(ProvisionalAction.Keep, distinctSuccessSessions, 0);
+    }
+
+    internal enum ProvisionalAction { Keep, Promote, Remove, MarkStale }
+
+    internal sealed record ProvisionalDecision(
+        ProvisionalAction Action,
+        int SuccessCount,
+        int ConsecutiveFailureCount);
 
     /// <summary>
     /// Inspects non-empty dead-letter queues, asks the LLM to classify failure patterns,

--- a/src/RockBot.Host/FileSkillResourceUsageStore.cs
+++ b/src/RockBot.Host/FileSkillResourceUsageStore.cs
@@ -1,0 +1,89 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace RockBot.Host;
+
+/// <summary>
+/// File-backed JSONL implementation of <see cref="ISkillResourceUsageStore"/>.
+/// One line per checkout, stored at <c>{profile-base}/skill-resource-usage.jsonl</c>.
+/// Mirrors <c>FileWispExecutionLog</c>'s shape — append-only, single-writer
+/// semaphore, lazy reads.
+/// </summary>
+internal sealed class FileSkillResourceUsageStore : ISkillResourceUsageStore
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private readonly string _filePath;
+    private readonly ILogger<FileSkillResourceUsageStore> _logger;
+    private readonly SemaphoreSlim _writeLock = new(1, 1);
+
+    public FileSkillResourceUsageStore(
+        IOptions<AgentProfileOptions> profileOptions,
+        ILogger<FileSkillResourceUsageStore> logger)
+    {
+        var basePath = profileOptions.Value.BasePath;
+        if (!Path.IsPathRooted(basePath))
+            basePath = Path.Combine(AppContext.BaseDirectory, basePath);
+        Directory.CreateDirectory(basePath);
+        _filePath = Path.Combine(basePath, "skill-resource-usage.jsonl");
+        _logger = logger;
+    }
+
+    public async Task RecordCheckoutAsync(
+        string skillName, string filename, string sessionId, DateTimeOffset at, CancellationToken ct = default)
+    {
+        var evt = new SkillResourceCheckoutEvent(skillName, filename, sessionId, at);
+
+        await _writeLock.WaitAsync(ct);
+        try
+        {
+            var line = JsonSerializer.Serialize(evt, JsonOptions);
+            await File.AppendAllTextAsync(_filePath, line + Environment.NewLine, ct);
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
+    }
+
+    public async Task<IReadOnlyList<SkillResourceCheckoutEvent>> QueryCheckoutsAsync(
+        string skillName, string filename, DateTimeOffset since, CancellationToken ct = default)
+    {
+        if (!File.Exists(_filePath))
+            return [];
+
+        var results = new List<SkillResourceCheckoutEvent>();
+        try
+        {
+            var lines = await File.ReadAllLinesAsync(_filePath, ct);
+            foreach (var line in lines)
+            {
+                if (string.IsNullOrWhiteSpace(line)) continue;
+                try
+                {
+                    var evt = JsonSerializer.Deserialize<SkillResourceCheckoutEvent>(line, JsonOptions);
+                    if (evt is null) continue;
+                    if (evt.Timestamp < since) continue;
+                    if (!string.Equals(evt.SkillName, skillName, StringComparison.OrdinalIgnoreCase)) continue;
+                    if (!string.Equals(evt.Filename, filename, StringComparison.OrdinalIgnoreCase)) continue;
+                    results.Add(evt);
+                }
+                catch (JsonException ex)
+                {
+                    _logger.LogWarning(ex, "Failed to deserialize skill-resource checkout event");
+                }
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "Failed to read skill-resource usage log {Path}", _filePath);
+        }
+
+        return results.OrderBy(r => r.Timestamp).ToList();
+    }
+}

--- a/src/RockBot.Host/FileSkillStore.cs
+++ b/src/RockBot.Host/FileSkillStore.cs
@@ -138,9 +138,20 @@ internal sealed partial class FileSkillStore : ISkillStore
                 }
             }
 
-            // Build manifest from the provided resources
+            // Build manifest from the provided resources. Preserve provisional/verify-hint
+            // metadata supplied on the input. CreatedAt is set to "now" for new entries
+            // (the bulk path nukes the pre-existing manifest, so existing CreatedAt is
+            // not preserved here — use AttachResourceAsync for additive single-resource saves).
+            var nowStamp = DateTimeOffset.UtcNow;
             var manifest = resources
-                .Select(r => new SkillResource(r.Filename, r.Type, r.Description))
+                .Select(r => new SkillResource(
+                    r.Filename,
+                    r.Type,
+                    r.Description,
+                    Provisional: r.Provisional,
+                    CreatedAt: nowStamp,
+                    VerifyHint: r.VerifyHint,
+                    DefinitionHash: ComputeDefinitionHash(r.Content)))
                 .ToList();
 
             // Save skill JSON with updated manifest
@@ -174,6 +185,186 @@ internal sealed partial class FileSkillStore : ISkillStore
         {
             _semaphore.Release();
         }
+    }
+
+    public async Task<bool> AttachResourceAsync(
+        string skillName,
+        SkillResourceInput resource,
+        SkillResource? manifestEntry = null)
+    {
+        ValidateName(skillName);
+        ValidateFilename(resource.Filename);
+
+        Skill saved;
+        await _semaphore.WaitAsync();
+        try
+        {
+            var index = await EnsureIndexAsync();
+            if (!index.TryGetValue(skillName, out var existing))
+                return false;
+
+            var folderPath = GetResourceFolderPath(skillName);
+            Directory.CreateDirectory(folderPath);
+
+            // Write/replace the resource file
+            var resourcePath = Path.Combine(folderPath, resource.Filename);
+            await File.WriteAllTextAsync(resourcePath, resource.Content);
+
+            // Build the manifest entry — caller-supplied entry wins; otherwise derive from input.
+            var entry = manifestEntry ?? new SkillResource(
+                resource.Filename,
+                resource.Type,
+                resource.Description,
+                Provisional: resource.Provisional,
+                CreatedAt: DateTimeOffset.UtcNow,
+                VerifyHint: resource.VerifyHint,
+                DefinitionHash: ComputeDefinitionHash(resource.Content));
+
+            // Replace by filename (case-insensitive to match folder semantics) or append.
+            var oldManifest = existing.Manifest ?? [];
+            var newManifest = new List<SkillResource>(oldManifest.Count + 1);
+            var replaced = false;
+            foreach (var old in oldManifest)
+            {
+                if (string.Equals(old.Filename, resource.Filename, StringComparison.OrdinalIgnoreCase))
+                {
+                    newManifest.Add(entry);
+                    replaced = true;
+                }
+                else
+                {
+                    newManifest.Add(old);
+                }
+            }
+            if (!replaced)
+                newManifest.Add(entry);
+
+            saved = existing with { Manifest = newManifest, UpdatedAt = DateTimeOffset.UtcNow };
+            var json = JsonSerializer.Serialize(saved, JsonOptions);
+            await File.WriteAllTextAsync(GetFilePath(skillName), json);
+            index[skillName] = saved;
+
+            _logger.LogDebug(
+                "Attached resource '{File}' to skill '{Name}' (provisional={Provisional})",
+                resource.Filename, skillName, entry.Provisional);
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+
+        if (_embeddingCache is not null)
+            _ = _embeddingCache.UpdateAsync(saved.Name, GetDocumentText(saved));
+
+        return true;
+    }
+
+    public async Task<bool> RemoveResourceAsync(string skillName, string filename)
+    {
+        ValidateName(skillName);
+        ValidateFilename(filename);
+
+        Skill saved;
+        await _semaphore.WaitAsync();
+        try
+        {
+            var index = await EnsureIndexAsync();
+            if (!index.TryGetValue(skillName, out var existing) || existing.Manifest is null)
+                return false;
+
+            var oldManifest = existing.Manifest;
+            var newManifest = oldManifest
+                .Where(r => !string.Equals(r.Filename, filename, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            if (newManifest.Count == oldManifest.Count)
+                return false;  // no entry matched
+
+            // Delete the file from disk
+            var folderPath = GetResourceFolderPath(skillName);
+            var resourcePath = Path.Combine(folderPath, filename);
+            if (File.Exists(resourcePath))
+                File.Delete(resourcePath);
+
+            saved = existing with
+            {
+                Manifest = newManifest.Count == 0 ? null : newManifest,
+                UpdatedAt = DateTimeOffset.UtcNow
+            };
+            var json = JsonSerializer.Serialize(saved, JsonOptions);
+            await File.WriteAllTextAsync(GetFilePath(skillName), json);
+            index[skillName] = saved;
+
+            _logger.LogDebug("Removed resource '{File}' from skill '{Name}'", filename, skillName);
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+
+        if (_embeddingCache is not null)
+            _ = _embeddingCache.UpdateAsync(saved.Name, GetDocumentText(saved));
+
+        return true;
+    }
+
+    public async Task<bool> UpdateResourceMetadataAsync(string skillName, SkillResource updated)
+    {
+        ValidateName(skillName);
+        ValidateFilename(updated.Filename);
+
+        Skill saved;
+        await _semaphore.WaitAsync();
+        try
+        {
+            var index = await EnsureIndexAsync();
+            if (!index.TryGetValue(skillName, out var existing) || existing.Manifest is null)
+                return false;
+
+            var oldManifest = existing.Manifest;
+            var newManifest = new List<SkillResource>(oldManifest.Count);
+            var matched = false;
+            foreach (var old in oldManifest)
+            {
+                if (string.Equals(old.Filename, updated.Filename, StringComparison.OrdinalIgnoreCase))
+                {
+                    newManifest.Add(updated);
+                    matched = true;
+                }
+                else
+                {
+                    newManifest.Add(old);
+                }
+            }
+
+            if (!matched)
+                return false;
+
+            saved = existing with { Manifest = newManifest, UpdatedAt = DateTimeOffset.UtcNow };
+            var json = JsonSerializer.Serialize(saved, JsonOptions);
+            await File.WriteAllTextAsync(GetFilePath(skillName), json);
+            index[skillName] = saved;
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+
+        if (_embeddingCache is not null)
+            _ = _embeddingCache.UpdateAsync(saved.Name, GetDocumentText(saved));
+
+        return true;
+    }
+
+    /// <summary>
+    /// SHA-256-hex16 of <paramref name="content"/> — same scheme as
+    /// <c>SpawnWispsExecutor.ComputeDefinitionHash</c>, kept here to avoid taking a
+    /// project dependency on RockBot.Wisp from the Host layer.
+    /// </summary>
+    internal static string ComputeDefinitionHash(string content)
+    {
+        var bytes = System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(content));
+        return Convert.ToHexStringLower(bytes)[..16];
     }
 
     public Task<string?> GetResourceAsync(string skillName, string filename)

--- a/src/RockBot.Host/SkillResourceApplier.cs
+++ b/src/RockBot.Host/SkillResourceApplier.cs
@@ -1,0 +1,232 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace RockBot.Host;
+
+/// <summary>
+/// Applies a <see cref="RepairTarget.SkillResource"/> change against a named skill's
+/// resource folder. Three ops are supported:
+/// <list type="bullet">
+/// <item><c>attach</c> — attach a new resource (always provisional, since self-repair
+/// attaches are hypotheses awaiting validation by the dream-cycle pass).</item>
+/// <item><c>delete</c> — remove a resource by filename.</item>
+/// <item><c>demote-provisional</c> — flip a manifest entry's <c>Provisional=true</c>
+/// (the validation pass normally flips false; this op is the inverse, used when a
+/// resource needs to be re-validated after suspicion).</item>
+/// </list>
+/// Both <c>attach</c> and <c>delete</c> ship a revert callback so a verify failure can
+/// roll the change back without requiring a second LLM round-trip.
+/// </summary>
+internal sealed class SkillResourceApplier : IRepairTargetApplier
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private readonly ISkillStore _skillStore;
+    private readonly ILogger<SkillResourceApplier> _logger;
+
+    public SkillResourceApplier(ISkillStore skillStore, ILogger<SkillResourceApplier> logger)
+    {
+        _skillStore = skillStore ?? throw new ArgumentNullException(nameof(skillStore));
+        _logger = logger;
+    }
+
+    public RepairTarget Target => RepairTarget.SkillResource;
+
+    public async Task<RepairApplyOutcome> ApplyAsync(RepairTicket ticket, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(ticket);
+        var change = ticket.Change.Deserialize<SkillResourceChange>(JsonOptions)
+            ?? throw new ArgumentException("SkillResource change is empty.", nameof(ticket));
+
+        if (string.IsNullOrWhiteSpace(change.Skill))
+            throw new ArgumentException("SkillResource change missing 'skill'.", nameof(ticket));
+        if (string.IsNullOrWhiteSpace(change.Filename))
+            throw new ArgumentException("SkillResource change missing 'filename'.", nameof(ticket));
+
+        var op = (change.Op ?? string.Empty).ToLowerInvariant();
+        return op switch
+        {
+            "attach" => await ApplyAttachAsync(change, cancellationToken),
+            "delete" => await ApplyDeleteAsync(change, cancellationToken),
+            "demote-provisional" => await ApplyDemoteAsync(change, cancellationToken),
+            _ => throw new ArgumentException(
+                $"Unknown SkillResource op: '{change.Op}'. Expected attach, delete, or demote-provisional.",
+                nameof(ticket)),
+        };
+    }
+
+    private async Task<RepairApplyOutcome> ApplyAttachAsync(SkillResourceChange change, CancellationToken ct)
+    {
+        if (string.IsNullOrEmpty(change.Content))
+            throw new ArgumentException("SkillResource attach requires 'content'.", nameof(change));
+
+        // Capture pre-state so revert can restore the prior body (or remove if absent).
+        var prior = await _skillStore.GetAsync(change.Skill!);
+        if (prior is null)
+            throw new InvalidOperationException($"Skill '{change.Skill}' not found.");
+
+        var priorEntry = prior.Manifest?
+            .FirstOrDefault(r => string.Equals(r.Filename, change.Filename, StringComparison.OrdinalIgnoreCase));
+        var priorBody = priorEntry is null
+            ? null
+            : await _skillStore.GetResourceAsync(change.Skill!, change.Filename!);
+
+        var resourceType = change.Type ?? SkillResourceType.Wisp;
+        var description = change.Description ?? change.Filename!;
+
+        var input = new SkillResourceInput(
+            change.Filename!, resourceType, description, change.Content!,
+            Provisional: true,
+            VerifyHint: change.VerifyHint);
+        var attached = await _skillStore.AttachResourceAsync(change.Skill!, input);
+        if (!attached)
+            throw new InvalidOperationException($"Skill '{change.Skill}' not found.");
+
+        var diff = JsonSerializer.SerializeToElement(new
+        {
+            op = "attach",
+            skill = change.Skill,
+            filename = change.Filename,
+            type = resourceType.ToString(),
+            replacedExisting = priorEntry is not null,
+        }, JsonOptions);
+
+        _logger.LogInformation(
+            "SkillResourceApplier: attached '{File}' to skill '{Skill}' (provisional, replacedExisting={Replaced})",
+            change.Filename, change.Skill, priorEntry is not null);
+
+        // Revert: if there was no prior entry, remove the one we just added; if there
+        // was, restore the prior body and entry verbatim.
+        Func<CancellationToken, Task> revert = async revertCt =>
+        {
+            if (priorEntry is null)
+            {
+                await _skillStore.RemoveResourceAsync(change.Skill!, change.Filename!);
+                _logger.LogInformation(
+                    "SkillResourceApplier reverted attach: removed '{File}' from skill '{Skill}'",
+                    change.Filename, change.Skill);
+            }
+            else
+            {
+                var restoreInput = new SkillResourceInput(
+                    priorEntry.Filename, priorEntry.Type, priorEntry.Description, priorBody ?? string.Empty,
+                    Provisional: priorEntry.Provisional,
+                    VerifyHint: priorEntry.VerifyHint);
+                await _skillStore.AttachResourceAsync(change.Skill!, restoreInput, priorEntry);
+                _logger.LogInformation(
+                    "SkillResourceApplier reverted attach: restored prior '{File}' on skill '{Skill}'",
+                    change.Filename, change.Skill);
+            }
+        };
+
+        return new RepairApplyOutcome(diff, revert);
+    }
+
+    private async Task<RepairApplyOutcome> ApplyDeleteAsync(SkillResourceChange change, CancellationToken ct)
+    {
+        var prior = await _skillStore.GetAsync(change.Skill!);
+        if (prior is null)
+            throw new InvalidOperationException($"Skill '{change.Skill}' not found.");
+        var priorEntry = prior.Manifest?
+            .FirstOrDefault(r => string.Equals(r.Filename, change.Filename, StringComparison.OrdinalIgnoreCase))
+            ?? throw new InvalidOperationException(
+                $"Resource '{change.Filename}' not found on skill '{change.Skill}'.");
+
+        var priorBody = await _skillStore.GetResourceAsync(change.Skill!, change.Filename!)
+            ?? throw new InvalidOperationException(
+                $"Resource '{change.Filename}' on skill '{change.Skill}' has no body to capture for revert.");
+
+        var removed = await _skillStore.RemoveResourceAsync(change.Skill!, change.Filename!);
+        if (!removed)
+            throw new InvalidOperationException(
+                $"Failed to remove resource '{change.Filename}' from skill '{change.Skill}'.");
+
+        var diff = JsonSerializer.SerializeToElement(new
+        {
+            op = "delete",
+            skill = change.Skill,
+            filename = change.Filename,
+        }, JsonOptions);
+
+        _logger.LogInformation(
+            "SkillResourceApplier: deleted '{File}' from skill '{Skill}'",
+            change.Filename, change.Skill);
+
+        Func<CancellationToken, Task> revert = async revertCt =>
+        {
+            var restoreInput = new SkillResourceInput(
+                priorEntry.Filename, priorEntry.Type, priorEntry.Description, priorBody,
+                Provisional: priorEntry.Provisional,
+                VerifyHint: priorEntry.VerifyHint);
+            await _skillStore.AttachResourceAsync(change.Skill!, restoreInput, priorEntry);
+            _logger.LogInformation(
+                "SkillResourceApplier reverted delete: restored '{File}' on skill '{Skill}'",
+                change.Filename, change.Skill);
+        };
+
+        return new RepairApplyOutcome(diff, revert);
+    }
+
+    private async Task<RepairApplyOutcome> ApplyDemoteAsync(SkillResourceChange change, CancellationToken ct)
+    {
+        var prior = await _skillStore.GetAsync(change.Skill!);
+        if (prior is null)
+            throw new InvalidOperationException($"Skill '{change.Skill}' not found.");
+        var priorEntry = prior.Manifest?
+            .FirstOrDefault(r => string.Equals(r.Filename, change.Filename, StringComparison.OrdinalIgnoreCase))
+            ?? throw new InvalidOperationException(
+                $"Resource '{change.Filename}' not found on skill '{change.Skill}'.");
+
+        if (priorEntry.Provisional)
+        {
+            // Already provisional — no-op, no revert needed.
+            var diffNoop = JsonSerializer.SerializeToElement(new
+            {
+                op = "demote-provisional",
+                skill = change.Skill,
+                filename = change.Filename,
+                changed = false,
+            }, JsonOptions);
+            return new RepairApplyOutcome(diffNoop, Revert: null);
+        }
+
+        var demoted = priorEntry with { Provisional = true };
+        var ok = await _skillStore.UpdateResourceMetadataAsync(change.Skill!, demoted);
+        if (!ok)
+            throw new InvalidOperationException(
+                $"Failed to demote resource '{change.Filename}' on skill '{change.Skill}'.");
+
+        var diff = JsonSerializer.SerializeToElement(new
+        {
+            op = "demote-provisional",
+            skill = change.Skill,
+            filename = change.Filename,
+            changed = true,
+        }, JsonOptions);
+
+        Func<CancellationToken, Task> revert = async revertCt =>
+        {
+            await _skillStore.UpdateResourceMetadataAsync(change.Skill!, priorEntry);
+            _logger.LogInformation(
+                "SkillResourceApplier reverted demote: restored Provisional=false on '{File}' for skill '{Skill}'",
+                change.Filename, change.Skill);
+        };
+
+        return new RepairApplyOutcome(diff, revert);
+    }
+
+    internal sealed class SkillResourceChange
+    {
+        public string? Skill { get; set; }
+        public string? Filename { get; set; }
+        public string? Op { get; set; }
+        public string? Content { get; set; }
+        public SkillResourceType? Type { get; set; }
+        public string? Description { get; set; }
+        public string? VerifyHint { get; set; }
+    }
+}

--- a/src/RockBot.Skills/SkillTools.cs
+++ b/src/RockBot.Skills/SkillTools.cs
@@ -30,6 +30,7 @@ public sealed class SkillTools
     private readonly ILogger _logger;
     private readonly string? _sessionId;
     private readonly ISkillUsageStore? _usageStore;
+    private readonly ISkillResourceUsageStore? _resourceUsageStore;
 
     public SkillTools(
         ISkillStore skillStore,
@@ -37,13 +38,15 @@ public sealed class SkillTools
         ILogger logger,
         string? sessionId = null,
         ISkillUsageStore? usageStore = null,
-        bool enablePromote = false)
+        bool enablePromote = false,
+        ISkillResourceUsageStore? resourceUsageStore = null)
     {
         _skillStore = skillStore;
         _llmClient = llmClient;
         _logger = logger;
         _sessionId = sessionId;
         _usageStore = usageStore;
+        _resourceUsageStore = resourceUsageStore;
 
         var tools = new List<AITool>
         {
@@ -121,6 +124,16 @@ public sealed class SkillTools
         if (content is null)
             return $"Resource '{filename}' not found in skill '{skillName}'. " +
                    "Call get_skill to see the list of available resources.";
+
+        // Fire-and-forget checkout recording — soft validation signal for the
+        // provisional validation pass (a full success/failure signal exists for
+        // wisp resources via DefinitionHash cross-reference; checkouts are the
+        // fallback for non-wisp resources like Python and JsonSchema).
+        if (_resourceUsageStore is not null && _sessionId is not null)
+        {
+            _ = _resourceUsageStore.RecordCheckoutAsync(
+                skillName, filename, _sessionId, DateTimeOffset.UtcNow);
+        }
 
         return content;
     }

--- a/src/RockBot.Skills/SkillTools.cs
+++ b/src/RockBot.Skills/SkillTools.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Security.Cryptography;
 using System.Text;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
@@ -35,7 +36,8 @@ public sealed class SkillTools
         ILlmClient llmClient,
         ILogger logger,
         string? sessionId = null,
-        ISkillUsageStore? usageStore = null)
+        ISkillUsageStore? usageStore = null,
+        bool enablePromote = false)
     {
         _skillStore = skillStore;
         _llmClient = llmClient;
@@ -43,14 +45,23 @@ public sealed class SkillTools
         _sessionId = sessionId;
         _usageStore = usageStore;
 
-        Tools =
-        [
+        var tools = new List<AITool>
+        {
             AIFunctionFactory.Create(GetSkill),
             AIFunctionFactory.Create(GetSkillResource),
             AIFunctionFactory.Create(ListSkills),
             AIFunctionFactory.Create(SaveSkill),
-            AIFunctionFactory.Create(DeleteSkill)
-        ];
+            AIFunctionFactory.Create(DeleteSkill),
+        };
+
+        // Promotion is currently a subagent-only path. Subagents are the part of the
+        // system that performs the exploratory tool-call discovery whose result is
+        // worth capturing as a typed asset; the main agent reaches assets via skills
+        // the dream pass has already promoted.
+        if (enablePromote)
+            tools.Add(AIFunctionFactory.Create(PromoteSkillAsset));
+
+        Tools = tools;
     }
 
     public IList<AITool> Tools { get; }
@@ -158,6 +169,50 @@ public sealed class SkillTools
         return $"Skill '{name}' saved. Summary is being generated.\n\n{FormatIndex(index)}";
     }
 
+    [Description("Save a working asset (wisp definition, script, schema) you just verified " +
+                 "as a resource attached to the skill that guided you. Use this only after " +
+                 "a tool-call sequence has actually executed successfully — never speculatively. " +
+                 "The resource is marked provisional until validated by future runs. " +
+                 "Promotion attaches to an existing skill — call save_skill first if no relevant " +
+                 "skill exists yet.")]
+    public async Task<string> PromoteSkillAsset(
+        [Description("The skill that guided you to this working asset (must already exist).")] string skillName,
+        [Description("Filename for the asset (e.g. 'fanout.json', 'compute.py'). Simple filename only — no path separators.")] string filename,
+        [Description("The asset's type — Wisp for a wisp definition, Python for a script, JsonSchema for a schema, etc.")] SkillResourceType type,
+        [Description("One-line description of what this asset does.")] string description,
+        [Description("The exact body that just executed successfully — the wisp definition JSON, the script source, etc.")] string content,
+        [Description("Optional advisory text describing how a future session would know this asset still works (e.g. 'returns per-account event arrays').")] string? verifyHint = null)
+    {
+        _logger.LogInformation(
+            "Tool call: PromoteSkillAsset(skill={Skill}, filename={Filename}, type={Type})",
+            skillName, filename, type);
+
+        var existing = await _skillStore.GetAsync(skillName);
+        if (existing is null)
+            return $"Skill '{skillName}' not found. Promotion attaches to an existing skill; " +
+                   "call save_skill first to create it, then promote the asset.";
+
+        // Pre-build the manifest entry so Provisional, CreatedAt, VerifyHint, and
+        // DefinitionHash are all set per the in-session-promotion contract.
+        var input = new SkillResourceInput(
+            filename, type, description, content,
+            Provisional: true,
+            VerifyHint: verifyHint);
+        var entry = new SkillResource(
+            filename, type, description,
+            Provisional: true,
+            CreatedAt: DateTimeOffset.UtcNow,
+            VerifyHint: verifyHint,
+            DefinitionHash: ComputeContentHash(content));
+
+        var attached = await _skillStore.AttachResourceAsync(skillName, input, entry);
+        if (!attached)
+            return $"Skill '{skillName}' not found.";
+
+        return $"Asset '{filename}' attached to skill '{skillName}' as provisional {type}. " +
+               "It will be validated by future successful runs and demoted if it stops working.";
+    }
+
     [Description("Delete a skill by name. Returns the updated skill index.")]
     public async Task<string> DeleteSkill(
         [Description("The skill name to delete")] string name)
@@ -248,6 +303,8 @@ public sealed class SkillTools
     /// Produces a compact <c>[Wisp, Python]</c>-style tag listing the distinct resource types
     /// attached to a skill, or an empty string if the skill has no resources. Lets the LLM see
     /// at a glance (from the skill index) which skills already carry a saved wisp, script, etc.
+    /// A trailing <c>*</c> on a type marks that at least one entry of that type is provisional —
+    /// captured in-session and not yet validated by repeated successful use.
     /// </summary>
     public static string FormatResourceTag(IReadOnlyList<SkillResource>? manifest)
     {
@@ -255,11 +312,23 @@ public sealed class SkillTools
             return "";
 
         var types = manifest
-            .Select(r => r.Type.ToString())
-            .Distinct(StringComparer.Ordinal)
-            .OrderBy(t => t, StringComparer.Ordinal)
+            .GroupBy(r => r.Type)
+            .Select(g => new { Type = g.Key.ToString(), HasProvisional = g.Any(r => r.Provisional) })
+            .OrderBy(x => x.Type, StringComparer.Ordinal)
+            .Select(x => x.HasProvisional ? x.Type + "*" : x.Type)
             .ToList();
 
         return $" [{string.Join(", ", types)}]";
+    }
+
+    /// <summary>
+    /// SHA-256-hex16 of <paramref name="content"/> — same scheme as the wisp execution
+    /// log's definition hash. Used by promotion so the validation pass can cross-reference
+    /// resource bodies against recent wisp records.
+    /// </summary>
+    internal static string ComputeContentHash(string content)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(content));
+        return Convert.ToHexStringLower(bytes)[..16];
     }
 }

--- a/src/RockBot.Subagent/SubagentRunner.cs
+++ b/src/RockBot.Subagent/SubagentRunner.cs
@@ -108,8 +108,12 @@ internal sealed class SubagentRunner(
         // Long-term memory tools (search_memory, save_memory, etc.)
         // MemoryTools is a singleton — safe to use directly.
 
-        // Skill tools (get_skill, list_skills, save_skill) — no usage tracking needed for subagents
-        var skillTools = new SkillTools(skillStore, llmClient, logger, subagentSessionId);
+        // Skill tools (get_skill, list_skills, save_skill, promote_skill_asset). Subagents
+        // are the only path that gets promote_skill_asset — they perform the exploratory
+        // tool-call discovery whose result is worth capturing as a typed asset; the main
+        // agent reaches assets via skills the dream pass has already promoted.
+        var skillTools = new SkillTools(skillStore, llmClient, logger, subagentSessionId,
+            enablePromote: true);
 
         // Working memory tools scoped to this subagent's namespace
         var sessionWorkingMemoryTools = new WorkingMemoryTools(workingMemory, subagentNamespace, logger);

--- a/src/RockBot.Subagent/SubagentRunner.cs
+++ b/src/RockBot.Subagent/SubagentRunner.cs
@@ -30,7 +30,8 @@ internal sealed class SubagentRunner(
     AgentIdentity agent,
     TierRoutingLogger tierRoutingLogger,
     AgentProfile agentProfile,
-    ILogger<SubagentRunner> logger)
+    ILogger<SubagentRunner> logger,
+    ISkillResourceUsageStore? skillResourceUsageStore = null)
 {
     public async Task RunAsync(
         string taskId,
@@ -113,7 +114,7 @@ internal sealed class SubagentRunner(
         // tool-call discovery whose result is worth capturing as a typed asset; the main
         // agent reaches assets via skills the dream pass has already promoted.
         var skillTools = new SkillTools(skillStore, llmClient, logger, subagentSessionId,
-            enablePromote: true);
+            enablePromote: true, resourceUsageStore: skillResourceUsageStore);
 
         // Working memory tools scoped to this subagent's namespace
         var sessionWorkingMemoryTools = new WorkingMemoryTools(workingMemory, subagentNamespace, logger);

--- a/src/RockBot.Wisp/FileWispExecutionLog.cs
+++ b/src/RockBot.Wisp/FileWispExecutionLog.cs
@@ -68,6 +68,21 @@ internal sealed class FileWispExecutionLog : IWispExecutionLog
             .FirstOrDefault();
     }
 
+    public async Task<string?> GetCanonicalBodyAsync(string definitionHash, CancellationToken ct = default)
+    {
+        if (string.IsNullOrEmpty(definitionHash))
+            return null;
+
+        var records = await ReadAllAsync(ct);
+        return records
+            .Where(r => r.Succeeded
+                && r.DefinitionHash == definitionHash
+                && !string.IsNullOrEmpty(r.DefinitionBody))
+            .OrderBy(r => r.Timestamp)
+            .Select(r => r.DefinitionBody)
+            .FirstOrDefault();
+    }
+
     private async Task<IReadOnlyList<WispExecutionRecord>> ReadAllAsync(CancellationToken ct)
     {
         if (!File.Exists(_filePath))

--- a/src/RockBot.Wisp/SpawnWispsExecutor.cs
+++ b/src/RockBot.Wisp/SpawnWispsExecutor.cs
@@ -99,7 +99,7 @@ internal sealed class SpawnWispsExecutor(
             var result = await wispExecutor.ExecuteAsync(definition, wispId, ct);
 
             // Log execution (fire-and-forget, don't block the batch)
-            _ = LogExecutionAsync(result, defHash, batchId, sessionId, ct);
+            _ = LogExecutionAsync(result, defHash, defJson, batchId, sessionId, ct);
 
             return result;
         }
@@ -109,8 +109,16 @@ internal sealed class SpawnWispsExecutor(
         }
     }
 
+    /// <summary>
+    /// Maximum byte size of a step-definition body retained on a successful
+    /// wisp execution record. Bodies larger than this are dropped (with a
+    /// diagnostic flag) so the JSONL log does not bloat from oversize runs.
+    /// </summary>
+    internal const int DefinitionBodyMaxBytes = 8 * 1024;
+
     private async Task LogExecutionAsync(
-        WispExecutionResult result, string defHash, string batchId, string? sessionId, CancellationToken ct)
+        WispExecutionResult result, string defHash, string defJson,
+        string batchId, string? sessionId, CancellationToken ct)
     {
         if (executionLog is null)
             return;
@@ -153,6 +161,20 @@ internal sealed class SpawnWispsExecutor(
                 }
             }
 
+            // Retain the JSON step body only on successful runs, and only if it
+            // fits the cap. Failed runs leave Body=null (failure context lives on
+            // FailureCategory/ErrorMessage). Oversize successes set the diagnostic flag
+            // so the dream pass treats them as ineligible for promotion.
+            string? definitionBody = null;
+            bool bodyOmittedTooLarge = false;
+            if (result.IsSuccess)
+            {
+                if (Encoding.UTF8.GetByteCount(defJson) <= DefinitionBodyMaxBytes)
+                    definitionBody = defJson;
+                else
+                    bodyOmittedTooLarge = true;
+            }
+
             var failedStep = result.FailedStep;
             var record = new WispExecutionRecord
             {
@@ -171,7 +193,9 @@ internal sealed class SpawnWispsExecutor(
                 Timestamp = DateTimeOffset.UtcNow,
                 SessionId = sessionId,
                 RetryOf = retryOf,
-                BatchId = batchId
+                BatchId = batchId,
+                DefinitionBody = definitionBody,
+                BodyOmittedTooLarge = bodyOmittedTooLarge
             };
 
             await executionLog.AppendAsync(record, ct);

--- a/tests/RockBot.Agent.Tests/SkillToolsTests.cs
+++ b/tests/RockBot.Agent.Tests/SkillToolsTests.cs
@@ -325,6 +325,147 @@ public class SkillToolsTests
         Assert.IsFalse(tracker.TryMarkAsRecalled("session-2", "plan-meeting"));
     }
 
+    // ── PromoteSkillAsset (Phase 2b: skill-asset promotion) ──────────────────
+
+    [TestMethod]
+    public async Task SkillTools_DefaultCtor_DoesNotIncludePromote()
+    {
+        var tools = new SkillTools(new StubSkillStore(), new StubChatClient(), NullLogger<SkillTools>.Instance);
+
+        var names = tools.Tools.OfType<AIFunction>().Select(f => f.Name).ToList();
+        Assert.IsFalse(names.Any(n => n.Contains("promote", StringComparison.OrdinalIgnoreCase)),
+            "promote_skill_asset must not be in the main-agent tool list");
+    }
+
+    [TestMethod]
+    public async Task SkillTools_EnablePromote_IncludesPromoteTool()
+    {
+        var tools = new SkillTools(new StubSkillStore(), new StubChatClient(), NullLogger<SkillTools>.Instance,
+            enablePromote: true);
+
+        var names = tools.Tools.OfType<AIFunction>().Select(f => f.Name).ToList();
+        Assert.IsTrue(names.Any(n => n.Contains("promote", StringComparison.OrdinalIgnoreCase)),
+            $"promote_skill_asset should be in the subagent tool list. Got: {string.Join(", ", names)}");
+    }
+
+    [TestMethod]
+    public async Task PromoteSkillAsset_AttachesProvisionalManifestEntry()
+    {
+        var store = new StubSkillStore();
+        store.Add(new Skill("calendar/scan", "Scan", "# Scan", DateTimeOffset.UtcNow));
+
+        var tools = new SkillTools(store, new StubChatClient(), NullLogger<SkillTools>.Instance,
+            enablePromote: true);
+
+        var body = """{"description":"x","steps":[]}""";
+        var result = await tools.PromoteSkillAsset(
+            "calendar/scan", "fanout.json", SkillResourceType.Wisp,
+            "Per-account fan-out", body,
+            verifyHint: "exercises both accounts");
+
+        Assert.IsTrue(result.Contains("attached"), result);
+
+        var saved = await store.GetAsync("calendar/scan");
+        var entry = saved!.Manifest!.Single();
+        Assert.AreEqual("fanout.json", entry.Filename);
+        Assert.AreEqual(SkillResourceType.Wisp, entry.Type);
+        Assert.IsTrue(entry.Provisional);
+        Assert.IsNotNull(entry.CreatedAt);
+        Assert.AreEqual("exercises both accounts", entry.VerifyHint);
+        Assert.IsNotNull(entry.DefinitionHash);
+        Assert.AreEqual(16, entry.DefinitionHash!.Length);
+
+        // DefinitionHash should match SHA-256-hex16 of the body
+        var bytes = System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(body));
+        var expected = Convert.ToHexStringLower(bytes)[..16];
+        Assert.AreEqual(expected, entry.DefinitionHash);
+    }
+
+    [TestMethod]
+    public async Task PromoteSkillAsset_UnknownSkill_ReturnsHelpfulError()
+    {
+        var tools = new SkillTools(new StubSkillStore(), new StubChatClient(), NullLogger<SkillTools>.Instance,
+            enablePromote: true);
+
+        var result = await tools.PromoteSkillAsset(
+            "nope", "x.json", SkillResourceType.Wisp, "x", "{}");
+
+        Assert.IsTrue(result.Contains("not found"));
+        Assert.IsTrue(result.Contains("save_skill"));
+    }
+
+    [TestMethod]
+    public async Task PromoteSkillAsset_TwiceSameFilename_ReplacesPreservingOthers()
+    {
+        var store = new StubSkillStore();
+        store.Add(new Skill("calendar/scan", "Scan", "# Scan", DateTimeOffset.UtcNow));
+
+        var tools = new SkillTools(store, new StubChatClient(), NullLogger<SkillTools>.Instance,
+            enablePromote: true);
+
+        await tools.PromoteSkillAsset("calendar/scan", "a.json", SkillResourceType.Wisp, "first", "{\"v\":1}");
+        await tools.PromoteSkillAsset("calendar/scan", "b.py", SkillResourceType.Python, "second", "print('b')");
+        await tools.PromoteSkillAsset("calendar/scan", "a.json", SkillResourceType.Wisp, "first-v2", "{\"v\":2}");
+
+        var saved = await store.GetAsync("calendar/scan");
+        Assert.AreEqual(2, saved!.Manifest!.Count);
+        Assert.AreEqual("first-v2", saved.Manifest.Single(r => r.Filename == "a.json").Description);
+
+        // b.py is preserved
+        var bBody = await store.GetResourceAsync("calendar/scan", "b.py");
+        Assert.AreEqual("print('b')", bBody);
+    }
+
+    // ── FormatResourceTag — provisional asterisk ─────────────────────────────
+
+    [TestMethod]
+    public void FormatResourceTag_ProvisionalEntry_AppendsAsterisk()
+    {
+        var manifest = new List<SkillResource>
+        {
+            new("a.json", SkillResourceType.Wisp, "x", Provisional: true),
+        };
+        var tag = SkillTools.FormatResourceTag(manifest);
+        Assert.AreEqual(" [Wisp*]", tag);
+    }
+
+    [TestMethod]
+    public void FormatResourceTag_MixedProvisionalAndValidated_OnlyMarksAffectedTypes()
+    {
+        var manifest = new List<SkillResource>
+        {
+            new("a.json", SkillResourceType.Wisp, "x", Provisional: true),
+            new("script.py", SkillResourceType.Python, "y"),
+            new("schema.json", SkillResourceType.JsonSchema, "z"),
+        };
+        var tag = SkillTools.FormatResourceTag(manifest);
+        Assert.AreEqual(" [JsonSchema, Python, Wisp*]", tag);
+    }
+
+    [TestMethod]
+    public void FormatResourceTag_ProvisionalAndValidatedSameType_UsesAsterisk()
+    {
+        var manifest = new List<SkillResource>
+        {
+            new("a.json", SkillResourceType.Wisp, "x", Provisional: true),
+            new("b.json", SkillResourceType.Wisp, "y"),  // validated
+        };
+        var tag = SkillTools.FormatResourceTag(manifest);
+        Assert.AreEqual(" [Wisp*]", tag);
+    }
+
+    [TestMethod]
+    public void FormatResourceTag_AllValidated_NoAsterisk()
+    {
+        var manifest = new List<SkillResource>
+        {
+            new("a.json", SkillResourceType.Wisp, "x"),
+            new("b.py", SkillResourceType.Python, "y"),
+        };
+        var tag = SkillTools.FormatResourceTag(manifest);
+        Assert.AreEqual(" [Python, Wisp]", tag);
+    }
+
     // ── Stubs ─────────────────────────────────────────────────────────────────
 
     private sealed class StubSkillStore : ISkillStore
@@ -369,6 +510,88 @@ public class SkillToolsTests
             if (_resources.TryGetValue(skillName, out var files) && files.TryGetValue(filename, out var content))
                 return Task.FromResult<string?>(content);
             return Task.FromResult<string?>(null);
+        }
+
+        public Task<bool> AttachResourceAsync(string skillName, SkillResourceInput resource, SkillResource? manifestEntry = null)
+        {
+            if (!_skills.TryGetValue(skillName, out var existing))
+                return Task.FromResult(false);
+
+            if (!_resources.TryGetValue(skillName, out var files))
+                _resources[skillName] = files = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            files[resource.Filename] = resource.Content;
+
+            var entry = manifestEntry ?? new SkillResource(
+                resource.Filename, resource.Type, resource.Description,
+                Provisional: resource.Provisional,
+                CreatedAt: DateTimeOffset.UtcNow,
+                VerifyHint: resource.VerifyHint);
+
+            var oldManifest = existing.Manifest ?? [];
+            var newManifest = new List<SkillResource>(oldManifest.Count + 1);
+            var replaced = false;
+            foreach (var old in oldManifest)
+            {
+                if (string.Equals(old.Filename, resource.Filename, StringComparison.OrdinalIgnoreCase))
+                {
+                    newManifest.Add(entry);
+                    replaced = true;
+                }
+                else
+                {
+                    newManifest.Add(old);
+                }
+            }
+            if (!replaced)
+                newManifest.Add(entry);
+
+            _skills[skillName] = existing with { Manifest = newManifest };
+            return Task.FromResult(true);
+        }
+
+        public Task<bool> RemoveResourceAsync(string skillName, string filename)
+        {
+            if (!_skills.TryGetValue(skillName, out var existing) || existing.Manifest is null)
+                return Task.FromResult(false);
+
+            var oldManifest = existing.Manifest;
+            var newManifest = oldManifest
+                .Where(r => !string.Equals(r.Filename, filename, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+            if (newManifest.Count == oldManifest.Count)
+                return Task.FromResult(false);
+
+            if (_resources.TryGetValue(skillName, out var files))
+                files.Remove(filename);
+
+            _skills[skillName] = existing with { Manifest = newManifest.Count == 0 ? null : newManifest };
+            return Task.FromResult(true);
+        }
+
+        public Task<bool> UpdateResourceMetadataAsync(string skillName, SkillResource updated)
+        {
+            if (!_skills.TryGetValue(skillName, out var existing) || existing.Manifest is null)
+                return Task.FromResult(false);
+
+            var oldManifest = existing.Manifest;
+            var newManifest = new List<SkillResource>(oldManifest.Count);
+            var matched = false;
+            foreach (var old in oldManifest)
+            {
+                if (string.Equals(old.Filename, updated.Filename, StringComparison.OrdinalIgnoreCase))
+                {
+                    newManifest.Add(updated);
+                    matched = true;
+                }
+                else
+                {
+                    newManifest.Add(old);
+                }
+            }
+            if (!matched)
+                return Task.FromResult(false);
+            _skills[skillName] = existing with { Manifest = newManifest };
+            return Task.FromResult(true);
         }
     }
 

--- a/tests/RockBot.Host.Tests/DreamServiceWispSuccessTests.cs
+++ b/tests/RockBot.Host.Tests/DreamServiceWispSuccessTests.cs
@@ -1,0 +1,252 @@
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace RockBot.Host.Tests;
+
+/// <summary>
+/// Phase 3 (skill-asset promotion): exercise the apply loop of the success-shaped
+/// dream pass directly so we don't need to drive a real LLM. The pass's outer
+/// shape — query log → group by hash → resolve invokingSkill → call LLM → apply —
+/// is unit-tested at the apply boundary; the LLM-driven half is covered by the
+/// directive prompt itself.
+/// </summary>
+[TestClass]
+public class DreamServiceWispSuccessTests
+{
+    [TestMethod]
+    public async Task ApplyPromotions_AttachesNonProvisionalResourceToTargetSkill()
+    {
+        var store = new InMemorySkillStoreForSuccessTests();
+        await store.SaveAsync(new Skill("calendar/scan", "Scan", "# Scan", DateTimeOffset.UtcNow));
+
+        var body = """{"description":"x","steps":[]}""";
+        var candidate = new DreamService.WispSuccessCandidate(
+            DefinitionHash: "h-abc",
+            Frequency: 4,
+            DistinctSessions: 3,
+            Description: "Per-account fan-out",
+            InvokingSkill: "calendar/scan",
+            Body: body);
+
+        var promotion = new DreamService.WispSuccessPromotionDto
+        {
+            TargetSkill = "calendar/scan",
+            Filename = "fanout.json",
+            ResourceType = SkillResourceType.Wisp,
+            Description = "fan-out asset",
+            DefinitionHash = "h-abc"
+        };
+
+        var attached = await DreamService.ApplyWispSuccessPromotionsAsync(
+            store, [candidate], new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "calendar/scan" },
+            [promotion], NullLogger.Instance, CancellationToken.None);
+
+        Assert.AreEqual(1, attached);
+
+        var saved = await store.GetAsync("calendar/scan");
+        var entry = saved!.Manifest!.Single();
+        Assert.AreEqual("fanout.json", entry.Filename);
+        Assert.AreEqual(SkillResourceType.Wisp, entry.Type);
+        Assert.IsFalse(entry.Provisional, "Dream-pass promotions land non-provisional");
+        Assert.AreEqual("h-abc", entry.DefinitionHash);
+        Assert.IsNotNull(entry.CreatedAt);
+
+        // Body persisted verbatim from candidate
+        var written = await store.GetResourceAsync("calendar/scan", "fanout.json");
+        Assert.AreEqual(body, written);
+    }
+
+    [TestMethod]
+    public async Task ApplyPromotions_SkipsTargetSkillNotInExistingSet()
+    {
+        var store = new InMemorySkillStoreForSuccessTests();
+        await store.SaveAsync(new Skill("calendar/scan", "Scan", "# Scan", DateTimeOffset.UtcNow));
+
+        var candidate = new DreamService.WispSuccessCandidate(
+            "h-abc", 3, 2, "x", "calendar/scan", "{}");
+
+        var promotion = new DreamService.WispSuccessPromotionDto
+        {
+            TargetSkill = "non-existent-skill",
+            Filename = "x.json",
+            ResourceType = SkillResourceType.Wisp,
+            Description = "x",
+            DefinitionHash = "h-abc"
+        };
+
+        var attached = await DreamService.ApplyWispSuccessPromotionsAsync(
+            store, [candidate], new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "calendar/scan" },
+            [promotion], NullLogger.Instance, CancellationToken.None);
+
+        Assert.AreEqual(0, attached);
+    }
+
+    [TestMethod]
+    public async Task ApplyPromotions_SkipsPromotionForUnknownHash()
+    {
+        var store = new InMemorySkillStoreForSuccessTests();
+        await store.SaveAsync(new Skill("calendar/scan", "Scan", "# Scan", DateTimeOffset.UtcNow));
+
+        var candidate = new DreamService.WispSuccessCandidate(
+            "h-abc", 3, 2, "x", "calendar/scan", "{}");
+
+        var promotion = new DreamService.WispSuccessPromotionDto
+        {
+            TargetSkill = "calendar/scan",
+            Filename = "x.json",
+            ResourceType = SkillResourceType.Wisp,
+            Description = "x",
+            DefinitionHash = "h-totally-different"
+        };
+
+        var attached = await DreamService.ApplyWispSuccessPromotionsAsync(
+            store, [candidate], new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "calendar/scan" },
+            [promotion], NullLogger.Instance, CancellationToken.None);
+
+        Assert.AreEqual(0, attached);
+    }
+
+    [TestMethod]
+    public async Task ApplyPromotions_FillsDescriptionFromCandidateWhenLlmOmits()
+    {
+        var store = new InMemorySkillStoreForSuccessTests();
+        await store.SaveAsync(new Skill("calendar/scan", "Scan", "# Scan", DateTimeOffset.UtcNow));
+
+        var candidate = new DreamService.WispSuccessCandidate(
+            "h-abc", 3, 2, "candidate-description", "calendar/scan", "{}");
+
+        var promotion = new DreamService.WispSuccessPromotionDto
+        {
+            TargetSkill = "calendar/scan",
+            Filename = "x.json",
+            ResourceType = SkillResourceType.Wisp,
+            Description = null,  // LLM forgot to fill
+            DefinitionHash = "h-abc"
+        };
+
+        await DreamService.ApplyWispSuccessPromotionsAsync(
+            store, [candidate], new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "calendar/scan" },
+            [promotion], NullLogger.Instance, CancellationToken.None);
+
+        var saved = await store.GetAsync("calendar/scan");
+        Assert.AreEqual("candidate-description", saved!.Manifest!.Single().Description);
+    }
+
+    [TestMethod]
+    public async Task ApplyPromotions_NullPromotions_ReturnsZero()
+    {
+        var store = new InMemorySkillStoreForSuccessTests();
+        var attached = await DreamService.ApplyWispSuccessPromotionsAsync(
+            store, [], [], null, NullLogger.Instance, CancellationToken.None);
+        Assert.AreEqual(0, attached);
+    }
+
+    [TestMethod]
+    public async Task ApplyPromotions_EmptyOrMalformed_AreSkipped()
+    {
+        var store = new InMemorySkillStoreForSuccessTests();
+        await store.SaveAsync(new Skill("calendar/scan", "Scan", "# Scan", DateTimeOffset.UtcNow));
+
+        var candidate = new DreamService.WispSuccessCandidate(
+            "h-abc", 3, 2, "x", "calendar/scan", "{}");
+
+        // Various malformed promotions
+        var promotions = new[]
+        {
+            new DreamService.WispSuccessPromotionDto { TargetSkill = "", Filename = "x", DefinitionHash = "h-abc" },
+            new DreamService.WispSuccessPromotionDto { TargetSkill = "calendar/scan", Filename = "", DefinitionHash = "h-abc" },
+            new DreamService.WispSuccessPromotionDto { TargetSkill = "calendar/scan", Filename = "x", DefinitionHash = "" },
+        };
+
+        var attached = await DreamService.ApplyWispSuccessPromotionsAsync(
+            store, [candidate], new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "calendar/scan" },
+            promotions, NullLogger.Instance, CancellationToken.None);
+
+        Assert.AreEqual(0, attached);
+    }
+}
+
+/// <summary>
+/// Minimal in-memory <see cref="ISkillStore"/> sufficient to exercise the
+/// success-pass apply loop. Mirrors <see cref="FileSkillStore.AttachResourceAsync"/>
+/// semantics for the test surface only.
+/// </summary>
+internal sealed class InMemorySkillStoreForSuccessTests : ISkillStore
+{
+    private readonly Dictionary<string, Skill> _skills = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, Dictionary<string, string>> _resources = new(StringComparer.OrdinalIgnoreCase);
+
+    public Task SaveAsync(Skill skill)
+    {
+        _skills[skill.Name] = skill;
+        return Task.CompletedTask;
+    }
+
+    public Task SaveAsync(Skill skill, IReadOnlyList<SkillResourceInput>? resources)
+    {
+        _skills[skill.Name] = skill;
+        return Task.CompletedTask;
+    }
+
+    public Task<Skill?> GetAsync(string name) =>
+        Task.FromResult(_skills.GetValueOrDefault(name));
+
+    public Task<IReadOnlyList<Skill>> ListAsync() =>
+        Task.FromResult<IReadOnlyList<Skill>>(_skills.Values.OrderBy(s => s.Name).ToList());
+
+    public Task DeleteAsync(string name)
+    {
+        _skills.Remove(name);
+        _resources.Remove(name);
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<Skill>> SearchAsync(
+        string query, int maxResults, CancellationToken cancellationToken = default,
+        float[]? queryEmbedding = null) =>
+        Task.FromResult<IReadOnlyList<Skill>>([]);
+
+    public Task<string?> GetResourceAsync(string skillName, string filename)
+    {
+        if (_resources.TryGetValue(skillName, out var files) && files.TryGetValue(filename, out var content))
+            return Task.FromResult<string?>(content);
+        return Task.FromResult<string?>(null);
+    }
+
+    public Task<bool> AttachResourceAsync(
+        string skillName, SkillResourceInput resource, SkillResource? manifestEntry = null)
+    {
+        if (!_skills.TryGetValue(skillName, out var existing))
+            return Task.FromResult(false);
+
+        if (!_resources.TryGetValue(skillName, out var files))
+            _resources[skillName] = files = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        files[resource.Filename] = resource.Content;
+
+        var entry = manifestEntry ?? new SkillResource(
+            resource.Filename, resource.Type, resource.Description,
+            Provisional: resource.Provisional,
+            CreatedAt: DateTimeOffset.UtcNow,
+            VerifyHint: resource.VerifyHint);
+
+        var oldManifest = existing.Manifest ?? [];
+        var newManifest = new List<SkillResource>(oldManifest.Count + 1);
+        var replaced = false;
+        foreach (var old in oldManifest)
+        {
+            if (string.Equals(old.Filename, resource.Filename, StringComparison.OrdinalIgnoreCase))
+            {
+                newManifest.Add(entry);
+                replaced = true;
+            }
+            else
+            {
+                newManifest.Add(old);
+            }
+        }
+        if (!replaced)
+            newManifest.Add(entry);
+
+        _skills[skillName] = existing with { Manifest = newManifest };
+        return Task.FromResult(true);
+    }
+}

--- a/tests/RockBot.Host.Tests/FileSkillStoreTests.cs
+++ b/tests/RockBot.Host.Tests/FileSkillStoreTests.cs
@@ -627,6 +627,211 @@ public class FileSkillStoreTests
         Assert.AreEqual("/custom/skills", options.Value.BasePath);
     }
 
+    // ── AttachResourceAsync (Phase 2a: skill-asset promotion) ─────────────────
+
+    [TestMethod]
+    public async Task AttachResourceAsync_UnknownSkill_ReturnsFalse()
+    {
+        var store = CreateStore();
+        var ok = await store.AttachResourceAsync(
+            "nope",
+            new SkillResourceInput("a.json", SkillResourceType.Wisp, "x", "{}"));
+        Assert.IsFalse(ok);
+    }
+
+    [TestMethod]
+    public async Task AttachResourceAsync_AddsManifestEntryAndWritesFile()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(MakeSkill("research/scan", "Scan", "# Scan"));
+
+        var ok = await store.AttachResourceAsync(
+            "research/scan",
+            new SkillResourceInput(
+                "fanout.json",
+                SkillResourceType.Wisp,
+                "Per-account fan-out",
+                """{"description":"x","steps":[]}""",
+                Provisional: true,
+                VerifyHint: "exercises both accounts"));
+
+        Assert.IsTrue(ok);
+
+        // File on disk
+        var resourcePath = Path.Combine(_tempDir, "research", "scan.resources", "fanout.json");
+        Assert.IsTrue(File.Exists(resourcePath));
+
+        // Manifest entry has the new fields
+        var skill = await store.GetAsync("research/scan");
+        Assert.IsNotNull(skill);
+        Assert.IsNotNull(skill.Manifest);
+        Assert.AreEqual(1, skill.Manifest!.Count);
+        var entry = skill.Manifest[0];
+        Assert.AreEqual("fanout.json", entry.Filename);
+        Assert.IsTrue(entry.Provisional);
+        Assert.IsNotNull(entry.CreatedAt);
+        Assert.AreEqual("exercises both accounts", entry.VerifyHint);
+        Assert.IsNotNull(entry.DefinitionHash);
+        Assert.AreEqual(16, entry.DefinitionHash!.Length);
+    }
+
+    [TestMethod]
+    public async Task AttachResourceAsync_ReplacesByFilename_PreservesOtherEntries()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(MakeSkill("calendar/scan", "Scan", "# Scan"));
+
+        await store.AttachResourceAsync(
+            "calendar/scan",
+            new SkillResourceInput("a.json", SkillResourceType.Wisp, "first", "{\"v\":1}"));
+        await store.AttachResourceAsync(
+            "calendar/scan",
+            new SkillResourceInput("b.py", SkillResourceType.Python, "second", "print('b')"));
+
+        // Re-attach a.json with new content/description.
+        await store.AttachResourceAsync(
+            "calendar/scan",
+            new SkillResourceInput("a.json", SkillResourceType.Wisp, "first-v2", "{\"v\":2}"));
+
+        var skill = await store.GetAsync("calendar/scan");
+        Assert.IsNotNull(skill?.Manifest);
+        Assert.AreEqual(2, skill!.Manifest!.Count);
+
+        var aEntry = skill.Manifest.Single(r => r.Filename == "a.json");
+        Assert.AreEqual("first-v2", aEntry.Description);
+        var aBody = await store.GetResourceAsync("calendar/scan", "a.json");
+        Assert.AreEqual("{\"v\":2}", aBody);
+
+        // b.py untouched
+        var bEntry = skill.Manifest.Single(r => r.Filename == "b.py");
+        Assert.AreEqual("second", bEntry.Description);
+        var bBody = await store.GetResourceAsync("calendar/scan", "b.py");
+        Assert.AreEqual("print('b')", bBody);
+    }
+
+    [TestMethod]
+    public async Task AttachResourceAsync_PrebuiltManifestEntry_PersistsVerbatim()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(MakeSkill("calendar/scan", "Scan", "# Scan"));
+
+        var entry = new SkillResource(
+            "fanout.json",
+            SkillResourceType.Wisp,
+            "Per-account fan-out",
+            Provisional: false,
+            CreatedAt: new DateTimeOffset(2026, 1, 15, 12, 0, 0, TimeSpan.Zero),
+            VerifyHint: "exercises both accounts",
+            DefinitionHash: "deadbeefcafef00d");
+        await store.AttachResourceAsync(
+            "calendar/scan",
+            new SkillResourceInput("fanout.json", SkillResourceType.Wisp, "Per-account fan-out", "{}"),
+            manifestEntry: entry);
+
+        var skill = await store.GetAsync("calendar/scan");
+        var saved = skill!.Manifest!.Single();
+        Assert.IsFalse(saved.Provisional);
+        Assert.AreEqual(entry.CreatedAt, saved.CreatedAt);
+        Assert.AreEqual(entry.VerifyHint, saved.VerifyHint);
+        Assert.AreEqual(entry.DefinitionHash, saved.DefinitionHash);
+    }
+
+    [TestMethod]
+    public async Task RemoveResourceAsync_RemovesManifestEntryAndFile()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(MakeSkill("research/scan", "Scan", "# Scan"));
+        await store.AttachResourceAsync(
+            "research/scan",
+            new SkillResourceInput("a.json", SkillResourceType.Wisp, "x", "{}"));
+        await store.AttachResourceAsync(
+            "research/scan",
+            new SkillResourceInput("b.py", SkillResourceType.Python, "y", "print('y')"));
+
+        var ok = await store.RemoveResourceAsync("research/scan", "a.json");
+        Assert.IsTrue(ok);
+
+        var skill = await store.GetAsync("research/scan");
+        Assert.AreEqual(1, skill!.Manifest!.Count);
+        Assert.AreEqual("b.py", skill.Manifest[0].Filename);
+
+        var aPath = Path.Combine(_tempDir, "research", "scan.resources", "a.json");
+        Assert.IsFalse(File.Exists(aPath));
+    }
+
+    [TestMethod]
+    public async Task RemoveResourceAsync_UnknownEntry_ReturnsFalse()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(MakeSkill("s", "summary", "content"));
+
+        var ok = await store.RemoveResourceAsync("s", "missing.json");
+        Assert.IsFalse(ok);
+    }
+
+    [TestMethod]
+    public async Task UpdateResourceMetadataAsync_FlipsProvisionalAndPreservesContent()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(MakeSkill("calendar/scan", "Scan", "# Scan"));
+        await store.AttachResourceAsync(
+            "calendar/scan",
+            new SkillResourceInput("a.json", SkillResourceType.Wisp, "x", "{\"v\":1}",
+                Provisional: true,
+                VerifyHint: "hint"));
+
+        var initial = (await store.GetAsync("calendar/scan"))!.Manifest!.Single();
+        Assert.IsTrue(initial.Provisional);
+
+        // Validation pass would call this to flip Provisional=false while keeping VerifyHint.
+        var ok = await store.UpdateResourceMetadataAsync(
+            "calendar/scan",
+            initial with { Provisional = false });
+        Assert.IsTrue(ok);
+
+        var after = (await store.GetAsync("calendar/scan"))!.Manifest!.Single();
+        Assert.IsFalse(after.Provisional);
+        Assert.AreEqual("hint", after.VerifyHint);  // preserved per user pref
+        Assert.AreEqual(initial.CreatedAt, after.CreatedAt);
+        Assert.AreEqual(initial.DefinitionHash, after.DefinitionHash);
+
+        // File untouched
+        var body = await store.GetResourceAsync("calendar/scan", "a.json");
+        Assert.AreEqual("{\"v\":1}", body);
+    }
+
+    [TestMethod]
+    public async Task UpdateResourceMetadataAsync_UnknownEntry_ReturnsFalse()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(MakeSkill("s", "summary", "content"));
+
+        var ok = await store.UpdateResourceMetadataAsync(
+            "s",
+            new SkillResource("missing.json", SkillResourceType.Wisp, "x"));
+        Assert.IsFalse(ok);
+    }
+
+    [TestMethod]
+    public async Task SaveAsync_2Arg_PreservesProvisionalAndVerifyHintOnInput()
+    {
+        var store = CreateStore();
+        var skill = MakeSkill("calendar/scan", "Scan", "# Scan");
+        await store.SaveAsync(skill, new[]
+        {
+            new SkillResourceInput("a.json", SkillResourceType.Wisp, "x", "{\"v\":1}",
+                Provisional: true,
+                VerifyHint: "verify-A")
+        });
+
+        var saved = await store.GetAsync("calendar/scan");
+        var entry = saved!.Manifest!.Single();
+        Assert.IsTrue(entry.Provisional);
+        Assert.AreEqual("verify-A", entry.VerifyHint);
+        Assert.IsNotNull(entry.DefinitionHash);
+        Assert.IsNotNull(entry.CreatedAt);
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     private FileSkillStore CreateStore() =>

--- a/tests/RockBot.Host.Tests/ProvisionalValidationPassTests.cs
+++ b/tests/RockBot.Host.Tests/ProvisionalValidationPassTests.cs
@@ -1,0 +1,226 @@
+namespace RockBot.Host.Tests;
+
+[TestClass]
+public class ProvisionalValidationPassTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 5, 9, 12, 0, 0, TimeSpan.Zero);
+    private static readonly DateTimeOffset RecentlyCreated = Now.AddDays(-3);
+    private static readonly DateTimeOffset LongAgoCreated = Now.AddDays(-60);
+
+    private static SkillResource ProvWisp(string filename = "fanout.json", string hash = "h-abc",
+        DateTimeOffset? createdAt = null, SkillResourceType type = SkillResourceType.Wisp) =>
+        new(filename, type, "Per-account fan-out",
+            Provisional: true,
+            CreatedAt: createdAt ?? RecentlyCreated,
+            VerifyHint: "exercises both accounts",
+            DefinitionHash: hash);
+
+    private static WispExecutionRecord WispRecord(
+        bool succeeded, string sessionId, DateTimeOffset at, string hash = "h-abc") =>
+        new()
+        {
+            WispId = Guid.NewGuid().ToString("N")[..8],
+            Description = "x",
+            DefinitionHash = hash,
+            Succeeded = succeeded,
+            StepCount = 1,
+            StepsCompleted = succeeded ? 1 : 0,
+            DurationMs = 5,
+            Timestamp = at,
+            SessionId = sessionId,
+        };
+
+    [TestMethod]
+    public void Decide_ThreeDistinctSessionSuccesses_PromotesAndPreservesVerifyHint()
+    {
+        var records = new[]
+        {
+            WispRecord(true, "s1", Now.AddHours(-3)),
+            WispRecord(true, "s2", Now.AddHours(-2)),
+            WispRecord(true, "s3", Now.AddHours(-1)),
+        };
+
+        var decision = DreamService.DecideProvisionalAction(
+            ProvWisp(), records, [], Now,
+            successThreshold: 3, failureThreshold: 2, staleAfter: TimeSpan.FromDays(30));
+
+        Assert.AreEqual(DreamService.ProvisionalAction.Promote, decision.Action);
+        Assert.AreEqual(3, decision.SuccessCount);
+    }
+
+    [TestMethod]
+    public void Decide_ThreeSuccessesSameSession_DoesNotPromote()
+    {
+        var records = new[]
+        {
+            WispRecord(true, "s1", Now.AddHours(-3)),
+            WispRecord(true, "s1", Now.AddHours(-2)),
+            WispRecord(true, "s1", Now.AddHours(-1)),
+        };
+
+        var decision = DreamService.DecideProvisionalAction(
+            ProvWisp(), records, [], Now,
+            successThreshold: 3, failureThreshold: 2, staleAfter: TimeSpan.FromDays(30));
+
+        Assert.AreNotEqual(DreamService.ProvisionalAction.Promote, decision.Action);
+    }
+
+    [TestMethod]
+    public void Decide_TwoConsecutiveFailures_RemovesResource()
+    {
+        var records = new[]
+        {
+            WispRecord(true, "s1", Now.AddHours(-5)),
+            WispRecord(false, "s2", Now.AddHours(-2)),
+            WispRecord(false, "s3", Now.AddHours(-1)),
+        };
+
+        var decision = DreamService.DecideProvisionalAction(
+            ProvWisp(), records, [], Now,
+            successThreshold: 3, failureThreshold: 2, staleAfter: TimeSpan.FromDays(30));
+
+        Assert.AreEqual(DreamService.ProvisionalAction.Remove, decision.Action);
+        Assert.AreEqual(2, decision.ConsecutiveFailureCount);
+    }
+
+    [TestMethod]
+    public void Decide_FailureThenSuccess_DoesNotRemove()
+    {
+        var records = new[]
+        {
+            WispRecord(false, "s1", Now.AddHours(-3)),
+            WispRecord(false, "s2", Now.AddHours(-2)),
+            WispRecord(true, "s3", Now.AddHours(-1)),
+        };
+
+        var decision = DreamService.DecideProvisionalAction(
+            ProvWisp(), records, [], Now,
+            successThreshold: 3, failureThreshold: 2, staleAfter: TimeSpan.FromDays(30));
+
+        // Most-recent record is a success, so consecutive-failure rule does not trigger.
+        Assert.AreNotEqual(DreamService.ProvisionalAction.Remove, decision.Action);
+    }
+
+    [TestMethod]
+    public void Decide_OldResourceWithNoActivity_MarksStale()
+    {
+        var decision = DreamService.DecideProvisionalAction(
+            ProvWisp(createdAt: LongAgoCreated), [], [], Now,
+            successThreshold: 3, failureThreshold: 2, staleAfter: TimeSpan.FromDays(30));
+
+        Assert.AreEqual(DreamService.ProvisionalAction.MarkStale, decision.Action);
+    }
+
+    [TestMethod]
+    public void Decide_OldResourceWithActivity_NotStale()
+    {
+        var records = new[] { WispRecord(true, "s1", Now.AddDays(-1)) };
+
+        var decision = DreamService.DecideProvisionalAction(
+            ProvWisp(createdAt: LongAgoCreated), records, [], Now,
+            successThreshold: 10, failureThreshold: 5, staleAfter: TimeSpan.FromDays(30));
+
+        Assert.AreNotEqual(DreamService.ProvisionalAction.MarkStale, decision.Action);
+    }
+
+    [TestMethod]
+    public void Decide_FreshResourceNoActivity_Keeps()
+    {
+        var decision = DreamService.DecideProvisionalAction(
+            ProvWisp(createdAt: RecentlyCreated), [], [], Now,
+            successThreshold: 3, failureThreshold: 2, staleAfter: TimeSpan.FromDays(30));
+
+        Assert.AreEqual(DreamService.ProvisionalAction.Keep, decision.Action);
+    }
+
+    [TestMethod]
+    public void Decide_NonWispWithEnoughCheckouts_Promotes()
+    {
+        var pythonRes = ProvWisp(filename: "compute.py", hash: "h-py", type: SkillResourceType.Python);
+        var checkouts = new[]
+        {
+            new SkillResourceCheckoutEvent("calendar/scan", "compute.py", "s1", Now.AddHours(-3)),
+            new SkillResourceCheckoutEvent("calendar/scan", "compute.py", "s2", Now.AddHours(-2)),
+            new SkillResourceCheckoutEvent("calendar/scan", "compute.py", "s3", Now.AddHours(-1)),
+        };
+
+        var decision = DreamService.DecideProvisionalAction(
+            pythonRes, [], checkouts, Now,
+            successThreshold: 3, failureThreshold: 2, staleAfter: TimeSpan.FromDays(30));
+
+        Assert.AreEqual(DreamService.ProvisionalAction.Promote, decision.Action);
+        Assert.AreEqual(3, decision.SuccessCount);
+    }
+
+    [TestMethod]
+    public void Decide_NonWispCheckoutsSameSession_DoesNotPromote()
+    {
+        var pythonRes = ProvWisp(filename: "compute.py", type: SkillResourceType.Python);
+        var checkouts = new[]
+        {
+            new SkillResourceCheckoutEvent("calendar/scan", "compute.py", "s1", Now.AddHours(-3)),
+            new SkillResourceCheckoutEvent("calendar/scan", "compute.py", "s1", Now.AddHours(-2)),
+            new SkillResourceCheckoutEvent("calendar/scan", "compute.py", "s1", Now.AddHours(-1)),
+        };
+
+        var decision = DreamService.DecideProvisionalAction(
+            pythonRes, [], checkouts, Now,
+            successThreshold: 3, failureThreshold: 2, staleAfter: TimeSpan.FromDays(30));
+
+        Assert.AreNotEqual(DreamService.ProvisionalAction.Promote, decision.Action);
+    }
+
+    // ── FileSkillResourceUsageStore round-trip ───────────────────────────────
+
+    [TestMethod]
+    public async Task FileSkillResourceUsageStore_RecordAndQuery_RoundTrips()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "rb-skillres-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var opts = Microsoft.Extensions.Options.Options.Create(
+                new AgentProfileOptions { BasePath = tempDir });
+            var store = new FileSkillResourceUsageStore(opts,
+                Microsoft.Extensions.Logging.Abstractions.NullLogger<FileSkillResourceUsageStore>.Instance);
+
+            await store.RecordCheckoutAsync("calendar/scan", "compute.py", "s1", Now);
+            await store.RecordCheckoutAsync("calendar/scan", "compute.py", "s2", Now.AddMinutes(1));
+            await store.RecordCheckoutAsync("calendar/scan", "OTHER.py", "s3", Now);
+            await store.RecordCheckoutAsync("OTHER/skill", "compute.py", "s4", Now);
+
+            var results = await store.QueryCheckoutsAsync("calendar/scan", "compute.py", Now.AddMinutes(-10));
+            Assert.AreEqual(2, results.Count);
+            Assert.IsTrue(results.All(r => r.SkillName == "calendar/scan" && r.Filename == "compute.py"));
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+
+    [TestMethod]
+    public async Task FileSkillResourceUsageStore_FiltersBySinceTimestamp()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "rb-skillres-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var opts = Microsoft.Extensions.Options.Options.Create(
+                new AgentProfileOptions { BasePath = tempDir });
+            var store = new FileSkillResourceUsageStore(opts,
+                Microsoft.Extensions.Logging.Abstractions.NullLogger<FileSkillResourceUsageStore>.Instance);
+
+            await store.RecordCheckoutAsync("s", "f", "s1", Now.AddDays(-10));
+            await store.RecordCheckoutAsync("s", "f", "s2", Now.AddDays(-1));
+
+            var results = await store.QueryCheckoutsAsync("s", "f", Now.AddDays(-5));
+            Assert.AreEqual(1, results.Count);
+            Assert.AreEqual("s2", results[0].SessionId);
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+}

--- a/tests/RockBot.Host.Tests/SkillResourceApplierTests.cs
+++ b/tests/RockBot.Host.Tests/SkillResourceApplierTests.cs
@@ -1,0 +1,384 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace RockBot.Host.Tests;
+
+[TestClass]
+public class SkillResourceApplierTests
+{
+    [TestMethod]
+    public async Task Apply_Attach_AddsProvisionalResource()
+    {
+        var store = new InMemorySkillResourceStore();
+        await store.SaveAsync(new Skill("calendar/scan", "Scan", "# Scan", DateTimeOffset.UtcNow));
+
+        var applier = NewApplier(store);
+        var ticket = NewTicket("""
+            {
+              "skill": "calendar/scan",
+              "filename": "fanout.json",
+              "op": "attach",
+              "type": "Wisp",
+              "description": "Per-account fan-out",
+              "content": "{\"description\":\"x\",\"steps\":[]}",
+              "verifyHint": "exercises both accounts"
+            }
+            """);
+
+        var outcome = await applier.ApplyAsync(ticket, CancellationToken.None);
+
+        var saved = await store.GetAsync("calendar/scan");
+        var entry = saved!.Manifest!.Single();
+        Assert.AreEqual("fanout.json", entry.Filename);
+        Assert.IsTrue(entry.Provisional, "Self-repair attaches always land provisional");
+        Assert.AreEqual("exercises both accounts", entry.VerifyHint);
+
+        var diff = outcome.AppliedDiff;
+        Assert.AreEqual("attach", diff.GetProperty("op").GetString());
+        Assert.IsFalse(diff.GetProperty("replacedExisting").GetBoolean());
+        Assert.IsNotNull(outcome.Revert);
+    }
+
+    [TestMethod]
+    public async Task Apply_Attach_RevertRemovesNewlyAttachedResource()
+    {
+        var store = new InMemorySkillResourceStore();
+        await store.SaveAsync(new Skill("calendar/scan", "Scan", "# Scan", DateTimeOffset.UtcNow));
+
+        var applier = NewApplier(store);
+        var outcome = await applier.ApplyAsync(NewTicket("""
+            {
+              "skill": "calendar/scan",
+              "filename": "fanout.json",
+              "op": "attach",
+              "type": "Wisp",
+              "description": "x",
+              "content": "{\"v\":1}"
+            }
+            """), CancellationToken.None);
+
+        Assert.IsNotNull(outcome.Revert);
+        await outcome.Revert!(CancellationToken.None);
+
+        var saved = await store.GetAsync("calendar/scan");
+        Assert.IsTrue(saved!.Manifest is null || saved.Manifest.Count == 0);
+        var body = await store.GetResourceAsync("calendar/scan", "fanout.json");
+        Assert.IsNull(body);
+    }
+
+    [TestMethod]
+    public async Task Apply_Attach_RevertRestoresPriorBodyAndMetadata()
+    {
+        var store = new InMemorySkillResourceStore();
+        await store.SaveAsync(new Skill("calendar/scan", "Scan", "# Scan", DateTimeOffset.UtcNow));
+
+        // Pre-existing entry (validated)
+        await store.AttachResourceAsync(
+            "calendar/scan",
+            new SkillResourceInput("fanout.json", SkillResourceType.Wisp, "validated", "{\"v\":1}"),
+            new SkillResource(
+                "fanout.json", SkillResourceType.Wisp, "validated",
+                Provisional: false,
+                CreatedAt: new DateTimeOffset(2026, 1, 15, 0, 0, 0, TimeSpan.Zero),
+                VerifyHint: "validated-hint",
+                DefinitionHash: "old-hash-1234567"));
+
+        var applier = NewApplier(store);
+        var outcome = await applier.ApplyAsync(NewTicket("""
+            {
+              "skill": "calendar/scan",
+              "filename": "fanout.json",
+              "op": "attach",
+              "type": "Wisp",
+              "description": "self-repair-attempt",
+              "content": "{\"v\":2}"
+            }
+            """), CancellationToken.None);
+
+        // After apply: provisional, content v2
+        var afterApply = await store.GetAsync("calendar/scan");
+        Assert.IsTrue(afterApply!.Manifest!.Single().Provisional);
+        Assert.AreEqual("{\"v\":2}", await store.GetResourceAsync("calendar/scan", "fanout.json"));
+
+        await outcome.Revert!(CancellationToken.None);
+
+        // After revert: validated again, original body restored
+        var afterRevert = await store.GetAsync("calendar/scan");
+        var entry = afterRevert!.Manifest!.Single();
+        Assert.IsFalse(entry.Provisional);
+        Assert.AreEqual("validated", entry.Description);
+        Assert.AreEqual("validated-hint", entry.VerifyHint);
+        Assert.AreEqual("old-hash-1234567", entry.DefinitionHash);
+        Assert.AreEqual("{\"v\":1}", await store.GetResourceAsync("calendar/scan", "fanout.json"));
+    }
+
+    [TestMethod]
+    public async Task Apply_Delete_RemovesAndRevertRestores()
+    {
+        var store = new InMemorySkillResourceStore();
+        await store.SaveAsync(new Skill("calendar/scan", "Scan", "# Scan", DateTimeOffset.UtcNow));
+        await store.AttachResourceAsync(
+            "calendar/scan",
+            new SkillResourceInput("a.json", SkillResourceType.Wisp, "first", "{\"v\":1}",
+                Provisional: false,
+                VerifyHint: "h"));
+
+        var applier = NewApplier(store);
+        var outcome = await applier.ApplyAsync(NewTicket("""
+            { "skill": "calendar/scan", "filename": "a.json", "op": "delete" }
+            """), CancellationToken.None);
+
+        var afterApply = await store.GetAsync("calendar/scan");
+        Assert.IsTrue(afterApply!.Manifest is null || afterApply.Manifest.Count == 0);
+        Assert.IsNull(await store.GetResourceAsync("calendar/scan", "a.json"));
+
+        await outcome.Revert!(CancellationToken.None);
+
+        var afterRevert = await store.GetAsync("calendar/scan");
+        var entry = afterRevert!.Manifest!.Single();
+        Assert.AreEqual("a.json", entry.Filename);
+        Assert.AreEqual("first", entry.Description);
+        Assert.AreEqual("h", entry.VerifyHint);
+        Assert.AreEqual("{\"v\":1}", await store.GetResourceAsync("calendar/scan", "a.json"));
+    }
+
+    [TestMethod]
+    public async Task Apply_DemoteProvisional_FlipsProvisionalTrueAndRevertRestoresFalse()
+    {
+        var store = new InMemorySkillResourceStore();
+        await store.SaveAsync(new Skill("calendar/scan", "Scan", "# Scan", DateTimeOffset.UtcNow));
+        await store.AttachResourceAsync(
+            "calendar/scan",
+            new SkillResourceInput("a.json", SkillResourceType.Wisp, "x", "{}"),
+            new SkillResource("a.json", SkillResourceType.Wisp, "x",
+                Provisional: false,
+                CreatedAt: DateTimeOffset.UtcNow));
+
+        var applier = NewApplier(store);
+        var outcome = await applier.ApplyAsync(NewTicket("""
+            { "skill": "calendar/scan", "filename": "a.json", "op": "demote-provisional" }
+            """), CancellationToken.None);
+
+        Assert.IsTrue((await store.GetAsync("calendar/scan"))!.Manifest!.Single().Provisional);
+        await outcome.Revert!(CancellationToken.None);
+        Assert.IsFalse((await store.GetAsync("calendar/scan"))!.Manifest!.Single().Provisional);
+    }
+
+    [TestMethod]
+    public async Task Apply_DemoteProvisional_AlreadyProvisional_NoOp()
+    {
+        var store = new InMemorySkillResourceStore();
+        await store.SaveAsync(new Skill("calendar/scan", "Scan", "# Scan", DateTimeOffset.UtcNow));
+        await store.AttachResourceAsync(
+            "calendar/scan",
+            new SkillResourceInput("a.json", SkillResourceType.Wisp, "x", "{}",
+                Provisional: true));
+
+        var applier = NewApplier(store);
+        var outcome = await applier.ApplyAsync(NewTicket("""
+            { "skill": "calendar/scan", "filename": "a.json", "op": "demote-provisional" }
+            """), CancellationToken.None);
+
+        Assert.IsFalse(outcome.AppliedDiff.GetProperty("changed").GetBoolean());
+        Assert.IsNull(outcome.Revert);
+    }
+
+    [TestMethod]
+    public async Task Apply_UnknownOp_Throws()
+    {
+        var store = new InMemorySkillResourceStore();
+        await store.SaveAsync(new Skill("calendar/scan", "Scan", "# Scan", DateTimeOffset.UtcNow));
+
+        var applier = NewApplier(store);
+        await Assert.ThrowsExactlyAsync<ArgumentException>(async () =>
+            await applier.ApplyAsync(NewTicket("""
+                { "skill": "calendar/scan", "filename": "a.json", "op": "purge" }
+                """), CancellationToken.None));
+    }
+
+    [TestMethod]
+    public async Task Apply_AttachToMissingSkill_Throws()
+    {
+        var store = new InMemorySkillResourceStore();
+        var applier = NewApplier(store);
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(async () =>
+            await applier.ApplyAsync(NewTicket("""
+                {
+                  "skill": "missing",
+                  "filename": "a.json",
+                  "op": "attach",
+                  "type": "Wisp",
+                  "description": "x",
+                  "content": "{}"
+                }
+                """), CancellationToken.None));
+    }
+
+    [TestMethod]
+    public async Task Apply_DeleteMissingResource_Throws()
+    {
+        var store = new InMemorySkillResourceStore();
+        await store.SaveAsync(new Skill("calendar/scan", "Scan", "# Scan", DateTimeOffset.UtcNow));
+
+        var applier = NewApplier(store);
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(async () =>
+            await applier.ApplyAsync(NewTicket("""
+                { "skill": "calendar/scan", "filename": "missing.json", "op": "delete" }
+                """), CancellationToken.None));
+    }
+
+    [TestMethod]
+    public void Target_IsSkillResource()
+    {
+        var applier = NewApplier(new InMemorySkillResourceStore());
+        Assert.AreEqual(RepairTarget.SkillResource, applier.Target);
+    }
+
+    private static SkillResourceApplier NewApplier(ISkillStore store) =>
+        new(store, NullLogger<SkillResourceApplier>.Instance);
+
+    private static RepairTicket NewTicket(string changeJson)
+    {
+        var change = JsonDocument.Parse(changeJson).RootElement;
+        return new RepairTicket(
+            Id: "t-1",
+            PatternKey: "p|q|r",
+            Target: RepairTarget.SkillResource,
+            Change: change,
+            Verify: new VerifyShape("svr", "tool", JsonDocument.Parse("{}").RootElement,
+                new VerifyExpectation(VerifyExpectationKind.Success)),
+            Attempts: [],
+            Status: RepairStatus.Open,
+            CreatedAt: DateTimeOffset.UtcNow,
+            UpdatedAt: DateTimeOffset.UtcNow);
+    }
+}
+
+/// <summary>
+/// In-memory <see cref="ISkillStore"/> with full Phase-2/4/5 support
+/// (Attach + Remove + UpdateMetadata) — sufficient for SkillResourceApplier
+/// and Phase 5 validation-pass tests.
+/// </summary>
+internal sealed class InMemorySkillResourceStore : ISkillStore
+{
+    private readonly Dictionary<string, Skill> _skills = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, Dictionary<string, string>> _resources = new(StringComparer.OrdinalIgnoreCase);
+
+    public Task SaveAsync(Skill skill)
+    {
+        _skills[skill.Name] = skill;
+        return Task.CompletedTask;
+    }
+
+    public Task SaveAsync(Skill skill, IReadOnlyList<SkillResourceInput>? resources)
+    {
+        _skills[skill.Name] = skill;
+        return Task.CompletedTask;
+    }
+
+    public Task<Skill?> GetAsync(string name) =>
+        Task.FromResult(_skills.GetValueOrDefault(name));
+
+    public Task<IReadOnlyList<Skill>> ListAsync() =>
+        Task.FromResult<IReadOnlyList<Skill>>(_skills.Values.OrderBy(s => s.Name).ToList());
+
+    public Task DeleteAsync(string name)
+    {
+        _skills.Remove(name);
+        _resources.Remove(name);
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<Skill>> SearchAsync(
+        string query, int maxResults, CancellationToken cancellationToken = default,
+        float[]? queryEmbedding = null) =>
+        Task.FromResult<IReadOnlyList<Skill>>([]);
+
+    public Task<string?> GetResourceAsync(string skillName, string filename)
+    {
+        if (_resources.TryGetValue(skillName, out var files) && files.TryGetValue(filename, out var content))
+            return Task.FromResult<string?>(content);
+        return Task.FromResult<string?>(null);
+    }
+
+    public Task<bool> AttachResourceAsync(
+        string skillName, SkillResourceInput resource, SkillResource? manifestEntry = null)
+    {
+        if (!_skills.TryGetValue(skillName, out var existing))
+            return Task.FromResult(false);
+
+        if (!_resources.TryGetValue(skillName, out var files))
+            _resources[skillName] = files = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        files[resource.Filename] = resource.Content;
+
+        var entry = manifestEntry ?? new SkillResource(
+            resource.Filename, resource.Type, resource.Description,
+            Provisional: resource.Provisional,
+            CreatedAt: DateTimeOffset.UtcNow,
+            VerifyHint: resource.VerifyHint);
+
+        var oldManifest = existing.Manifest ?? [];
+        var newManifest = new List<SkillResource>(oldManifest.Count + 1);
+        var replaced = false;
+        foreach (var old in oldManifest)
+        {
+            if (string.Equals(old.Filename, resource.Filename, StringComparison.OrdinalIgnoreCase))
+            {
+                newManifest.Add(entry);
+                replaced = true;
+            }
+            else
+            {
+                newManifest.Add(old);
+            }
+        }
+        if (!replaced)
+            newManifest.Add(entry);
+
+        _skills[skillName] = existing with { Manifest = newManifest };
+        return Task.FromResult(true);
+    }
+
+    public Task<bool> RemoveResourceAsync(string skillName, string filename)
+    {
+        if (!_skills.TryGetValue(skillName, out var existing) || existing.Manifest is null)
+            return Task.FromResult(false);
+
+        var newManifest = existing.Manifest
+            .Where(r => !string.Equals(r.Filename, filename, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        if (newManifest.Count == existing.Manifest.Count)
+            return Task.FromResult(false);
+
+        if (_resources.TryGetValue(skillName, out var files))
+            files.Remove(filename);
+
+        _skills[skillName] = existing with { Manifest = newManifest.Count == 0 ? null : newManifest };
+        return Task.FromResult(true);
+    }
+
+    public Task<bool> UpdateResourceMetadataAsync(string skillName, SkillResource updated)
+    {
+        if (!_skills.TryGetValue(skillName, out var existing) || existing.Manifest is null)
+            return Task.FromResult(false);
+
+        var newManifest = new List<SkillResource>(existing.Manifest.Count);
+        var matched = false;
+        foreach (var old in existing.Manifest)
+        {
+            if (string.Equals(old.Filename, updated.Filename, StringComparison.OrdinalIgnoreCase))
+            {
+                newManifest.Add(updated);
+                matched = true;
+            }
+            else
+            {
+                newManifest.Add(old);
+            }
+        }
+        if (!matched)
+            return Task.FromResult(false);
+        _skills[skillName] = existing with { Manifest = newManifest };
+        return Task.FromResult(true);
+    }
+}

--- a/tests/RockBot.Wisp.Tests/WispExecutionLogTests.cs
+++ b/tests/RockBot.Wisp.Tests/WispExecutionLogTests.cs
@@ -336,6 +336,265 @@ public class WispExecutionLogTests
         Assert.AreNotEqual(hash1, hash2);
     }
 
+    // ── GetCanonicalBodyAsync (Phase 1: skill-asset promotion) ───────────────
+
+    [TestMethod]
+    public async Task GetCanonicalBodyAsync_SuccessfulRecord_ReturnsBody()
+    {
+        var tempDir = CreateTempDir();
+        try
+        {
+            var log = CreateLog(tempDir);
+            var body = """{"description":"x","steps":[]}""";
+
+            await log.AppendAsync(new WispExecutionRecord
+            {
+                WispId = "wisp-ok",
+                Description = "x",
+                DefinitionHash = "hash-ok",
+                Succeeded = true,
+                StepCount = 0,
+                StepsCompleted = 0,
+                DurationMs = 5,
+                Timestamp = DateTimeOffset.UtcNow,
+                DefinitionBody = body
+            });
+
+            var result = await log.GetCanonicalBodyAsync("hash-ok");
+            Assert.AreEqual(body, result);
+        }
+        finally
+        {
+            CleanupTempDir(tempDir);
+        }
+    }
+
+    [TestMethod]
+    public async Task GetCanonicalBodyAsync_FailedRecord_ReturnsNull()
+    {
+        var tempDir = CreateTempDir();
+        try
+        {
+            var log = CreateLog(tempDir);
+
+            // Failed record: even if a body were stored, it would be null per executor policy.
+            await log.AppendAsync(new WispExecutionRecord
+            {
+                WispId = "wisp-bad",
+                Description = "x",
+                DefinitionHash = "hash-bad",
+                Succeeded = false,
+                StepCount = 1,
+                StepsCompleted = 0,
+                DurationMs = 5,
+                Timestamp = DateTimeOffset.UtcNow,
+                DefinitionBody = null
+            });
+
+            var result = await log.GetCanonicalBodyAsync("hash-bad");
+            Assert.IsNull(result);
+        }
+        finally
+        {
+            CleanupTempDir(tempDir);
+        }
+    }
+
+    [TestMethod]
+    public async Task GetCanonicalBodyAsync_TwoSuccessesSameHash_ReturnsFirstBody()
+    {
+        var tempDir = CreateTempDir();
+        try
+        {
+            var log = CreateLog(tempDir);
+            var body = """{"description":"dup","steps":[]}""";
+            var earlier = DateTimeOffset.UtcNow.AddMinutes(-5);
+            var later = DateTimeOffset.UtcNow;
+
+            await log.AppendAsync(new WispExecutionRecord
+            {
+                WispId = "first",
+                Description = "dup",
+                DefinitionHash = "h-dup",
+                Succeeded = true,
+                StepCount = 0,
+                StepsCompleted = 0,
+                DurationMs = 5,
+                Timestamp = earlier,
+                DefinitionBody = body
+            });
+
+            // Second success of same hash — second-time executors may omit the body to dedup.
+            await log.AppendAsync(new WispExecutionRecord
+            {
+                WispId = "second",
+                Description = "dup",
+                DefinitionHash = "h-dup",
+                Succeeded = true,
+                StepCount = 0,
+                StepsCompleted = 0,
+                DurationMs = 6,
+                Timestamp = later,
+                DefinitionBody = null
+            });
+
+            var result = await log.GetCanonicalBodyAsync("h-dup");
+            Assert.AreEqual(body, result);
+        }
+        finally
+        {
+            CleanupTempDir(tempDir);
+        }
+    }
+
+    [TestMethod]
+    public async Task GetCanonicalBodyAsync_OversizeBodyOmittedFlag_ReturnsNull()
+    {
+        var tempDir = CreateTempDir();
+        try
+        {
+            var log = CreateLog(tempDir);
+
+            await log.AppendAsync(new WispExecutionRecord
+            {
+                WispId = "wisp-big",
+                Description = "big",
+                DefinitionHash = "h-big",
+                Succeeded = true,
+                StepCount = 1,
+                StepsCompleted = 1,
+                DurationMs = 5,
+                Timestamp = DateTimeOffset.UtcNow,
+                DefinitionBody = null,
+                BodyOmittedTooLarge = true
+            });
+
+            var result = await log.GetCanonicalBodyAsync("h-big");
+            Assert.IsNull(result);
+        }
+        finally
+        {
+            CleanupTempDir(tempDir);
+        }
+    }
+
+    [TestMethod]
+    public async Task GetCanonicalBodyAsync_UnknownHash_ReturnsNull()
+    {
+        var tempDir = CreateTempDir();
+        try
+        {
+            var log = CreateLog(tempDir);
+            var result = await log.GetCanonicalBodyAsync("nope");
+            Assert.IsNull(result);
+        }
+        finally
+        {
+            CleanupTempDir(tempDir);
+        }
+    }
+
+    // ── SpawnWispsExecutor body retention ────────────────────────────────────
+
+    [TestMethod]
+    public async Task SpawnWispsExecutor_SuccessfulRun_PersistsDefinitionBody()
+    {
+        var tempDir = CreateTempDir();
+        try
+        {
+            var executionLog = CreateLog(tempDir);
+            var registry = new FakeToolRegistry();
+            var memory = new FakeWorkingMemory();
+            var options = new WispOptions();
+            var wispExecutor = new WispExecutor(registry, memory, agentLoopRunner: null!, options,
+                NullLogger<WispExecutor>.Instance);
+            var spawnExecutor = new SpawnWispsExecutor(wispExecutor, executionLog, feedbackStore: null,
+                memory, options, NullLogger<SpawnWispsExecutor>.Instance);
+
+            registry.Register(
+                new ToolRegistration { Name = "web_search", Description = "ok", Source = "web" },
+                new ConditionalToolExecutor(() => ("done", false)));
+
+            var defJson = """
+            {
+              "definitions": [
+                {
+                  "description": "Smoke test",
+                  "steps": [{"id":"s1","mode":"Direct","gateway":"Web","tool":"web_search","params":{"query":"x"}}]
+                }
+              ]
+            }
+            """;
+
+            var req = new ToolInvokeRequest { ToolCallId = "tc", ToolName = "spawn_wisps", Arguments = defJson, SessionId = "sess" };
+            var resp = await spawnExecutor.ExecuteAsync(req, CancellationToken.None);
+            Assert.IsFalse(resp.IsError, resp.Content);
+
+            await Task.Delay(100);
+
+            var records = await executionLog.QueryRecentAsync(DateTimeOffset.UtcNow.AddMinutes(-1), 10);
+            Assert.AreEqual(1, records.Count);
+            Assert.IsTrue(records[0].Succeeded, $"record errored: {records[0].FailureCategory}: {records[0].ErrorMessage}");
+            Assert.IsNotNull(records[0].DefinitionBody);
+            Assert.IsFalse(records[0].BodyOmittedTooLarge);
+
+            // Body should round-trip back through GetCanonicalBodyAsync
+            var canonical = await executionLog.GetCanonicalBodyAsync(records[0].DefinitionHash);
+            Assert.AreEqual(records[0].DefinitionBody, canonical);
+        }
+        finally
+        {
+            CleanupTempDir(tempDir);
+        }
+    }
+
+    [TestMethod]
+    public async Task SpawnWispsExecutor_FailedRun_OmitsDefinitionBody()
+    {
+        var tempDir = CreateTempDir();
+        try
+        {
+            var executionLog = CreateLog(tempDir);
+            var registry = new FakeToolRegistry();
+            var memory = new FakeWorkingMemory();
+            var options = new WispOptions();
+            var wispExecutor = new WispExecutor(registry, memory, agentLoopRunner: null!, options,
+                NullLogger<WispExecutor>.Instance);
+            var spawnExecutor = new SpawnWispsExecutor(wispExecutor, executionLog, feedbackStore: null,
+                memory, options, NullLogger<SpawnWispsExecutor>.Instance);
+
+            registry.Register(
+                new ToolRegistration { Name = "web_search", Description = "fail", Source = "web" },
+                new ConditionalToolExecutor(() => ("boom", true)));
+
+            var defJson = """
+            {
+              "definitions": [
+                {
+                  "description": "Should fail",
+                  "steps": [{"id":"s1","mode":"Direct","gateway":"Web","tool":"web_search","params":{"query":"x"}}]
+                }
+              ]
+            }
+            """;
+
+            var req = new ToolInvokeRequest { ToolCallId = "tc", ToolName = "spawn_wisps", Arguments = defJson, SessionId = "sess" };
+            await spawnExecutor.ExecuteAsync(req, CancellationToken.None);
+
+            await Task.Delay(100);
+
+            var records = await executionLog.QueryRecentAsync(DateTimeOffset.UtcNow.AddMinutes(-1), 10);
+            Assert.AreEqual(1, records.Count);
+            Assert.IsFalse(records[0].Succeeded);
+            Assert.IsNull(records[0].DefinitionBody);
+            Assert.IsFalse(records[0].BodyOmittedTooLarge);
+        }
+        finally
+        {
+            CleanupTempDir(tempDir);
+        }
+    }
+
     // ── Helpers ──────────────────────────────────────────────────────────────
 
     private static FileWispExecutionLog CreateLog(string basePath)


### PR DESCRIPTION
Closes #370.

Implements the full design from `design/skill-asset-promotion.md` (PR #369). All five phases land in this PR per the plan; commits are split atomically per phase.

## Summary

The agent's self-improvement loop is no longer asymmetric. Subagents now capture the working artifacts they converge on (wisp definitions, scripts, schemas) as typed skill resources via a new `promote_skill_asset` tool. The dream cycle has a symmetric success-shaped pass that promotes repeating successful patterns autonomously. Provisional resources self-validate or self-evict based on observed use.

- **Phase 1** — `WispExecutionRecord.DefinitionBody` + `IWispExecutionLog.GetCanonicalBodyAsync` make a successful wisp's JSON recoverable for promotion. Bodies are size-capped at 8 KiB; failures and oversize runs record `null` with a diagnostic flag.
- **Phase 2a** — `SkillResource` gains `Provisional`, `CreatedAt`, `VerifyHint`, `DefinitionHash`. `ISkillStore` gains additive `AttachResourceAsync` / `RemoveResourceAsync` / `UpdateResourceMetadataAsync` so a single resource can be added or mutated without disturbing the rest of the manifest.
- **Phase 2b** — `SkillTools.PromoteSkillAsset` is gated behind a new `enablePromote` ctor flag, set only by `SubagentRunner`. The main agent does not see the tool. `subagent-directives.md` describes when to use it. `FormatResourceTag` shows `[Wisp*]` when any entry of that type is provisional.
- **Phase 3** — `RunWispSuccessAnalysisPassAsync` groups recent records by definition hash, keeps groups with `frequency >= 3 && successRate == 1.0`, resolves the invoking skill via `ISkillUsageStore`, fetches the canonical body via Phase 1, and asks the LLM to choose promotions. Promotions land **non-provisional** (observed-repetition validated). New `wisp-success-dream.md` directive plus a built-in fallback.
- **Phase 4a** — Removes the dead-end `promotionCandidates` log loop on the failure pass. The success pass is now the single source of truth for promotions.
- **Phase 4b** — `RepairTarget.SkillResource` + `SkillResourceApplier` extend self-repair to mutate skill manifests as a first-class target. Three ops (`attach`, `delete`, `demote-provisional`), each with a revert callback so verify failures roll back cleanly.
- **Phase 5** — `ISkillResourceUsageStore` records resource-checkout events. `RunProvisionalValidationPassAsync` uses both wisp-record cross-reference (by `DefinitionHash`) and checkout events to flip provisional resources to validated after distinct-session success, remove them after consecutive failure (with a `FailureClusterStore` entry), and prefix `[stale]` to old unused ones. Decision logic is extracted as `DreamService.DecideProvisionalAction` for testability.

## Test plan

- [x] `dotnet build RockBot.slnx` clean (no warnings on changed code)
- [x] `dotnet test RockBot.slnx` clean — 1808 tests pass, 0 fail (15 skipped: RabbitMQ + Scripts.Container integration)
- [x] Phase 1: `WispExecutionLogTests` — 16 tests, including new `GetCanonicalBodyAsync` round-trip and oversize-body handling
- [x] Phase 2a: `FileSkillStoreTests` — 57 tests, 8 new for `AttachResourceAsync` / `RemoveResourceAsync` / `UpdateResourceMetadataAsync`
- [x] Phase 2b: `SkillToolsTests` — 35 tests, 10 new for `PromoteSkillAsset`, `enablePromote` gating, and `FormatResourceTag` provisional marker
- [x] Phase 3: `DreamServiceWispSuccessTests` — 6 tests for `ApplyWispSuccessPromotionsAsync` decision boundaries
- [x] Phase 4b: `SkillResourceApplierTests` — 10 tests for attach / delete / demote-provisional + revert round-trips
- [x] Phase 5: `ProvisionalValidationPassTests` — 11 tests for `DecideProvisionalAction` thresholds + `FileSkillResourceUsageStore` round-trip
- [ ] Live cluster smoke test (deploy + watch one dream cycle) — recommended post-merge per the build-deploy workflow in `MEMORY.md`; not blocking the PR

## Notes

- The `BuiltInWispFailureDirective` constant in `DreamService.cs` and the on-disk `wisp-failure-dream.md` both have `promotionCandidates` removed — Phase 4a — so they stay in sync.
- The `WispPromotionCandidateDto` record is deleted (no consumers remain after Phase 4a).
- `FileSkillStore.SaveAsync(skill, resources)` (the bulk-replace path) now preserves `Provisional`, `VerifyHint`, and stamps `CreatedAt` + `DefinitionHash` on every entry it writes. This means the existing `patrol/wisp-mcp-params` skill — currently the only one with a populated manifest — will gain `CreatedAt` + `DefinitionHash` the next time it's resaved, with no migration required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)