### PR TITLE
Task directives + convention-aware skill consolidation (#377)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.10.44</Version>
+<Version>0.10.45</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.Agent/ScheduledTaskHandler.cs
+++ b/src/RockBot.Agent/ScheduledTaskHandler.cs
@@ -29,6 +29,7 @@ internal sealed class ScheduledTaskHandler(
     AgentLoopRunner agentLoopRunner,
     AgentContextBuilder agentContextBuilder,
     IOptions<AgentProfileOptions> profileOptions,
+    IScheduledTaskStore scheduledTaskStore,
     ILogger<ScheduledTaskHandler> logger,
     ISkillUsageStore? skillUsageStore = null) : IMessageHandler<ScheduledTaskMessage>
 {
@@ -49,11 +50,25 @@ internal sealed class ScheduledTaskHandler(
         // as a system message immediately after the main system prompt (index 1).
         var basePath = profileOptions.Value.BasePath;
         var directivePath = Path.Combine(basePath, $"{message.TaskName}.md");
+        var nextSystemInsertIndex = 1;
         if (File.Exists(directivePath))
         {
             var directiveContent = await File.ReadAllTextAsync(directivePath, ct);
-            chatMessages.Insert(1, new ChatMessage(ChatRole.System, directiveContent));
+            chatMessages.Insert(nextSystemInsertIndex, new ChatMessage(ChatRole.System, directiveContent));
+            nextSystemInsertIndex++;
             logger.LogInformation("Injected task directive from '{Path}'", directivePath);
+        }
+
+        // If the scheduled task carries an evolving Directive body (the agent's running checklist
+        // updated via update_task_directive), inject it as the next system message so it sits
+        // immediately after the static framing on every fire.
+        var taskRecord = await scheduledTaskStore.GetAsync(message.TaskName);
+        if (!string.IsNullOrWhiteSpace(taskRecord?.Directive))
+        {
+            chatMessages.Insert(nextSystemInsertIndex, new ChatMessage(ChatRole.System, taskRecord.Directive));
+            logger.LogInformation(
+                "Injected evolving task directive for '{Task}' ({Length} chars)",
+                message.TaskName, taskRecord.Directive.Length);
         }
 
         // Add the task description as the user turn (context builder doesn't add it;
@@ -63,6 +78,7 @@ internal sealed class ScheduledTaskHandler(
         // Per-session tools — same set the user handler builds (sessionId already is "patrol/name")
         var sessionWorkingMemoryTools = new WorkingMemoryTools(workingMemory, sessionId, logger);
         var sessionSkillTools = new SkillTools(skillStore, llmClient, logger, sessionId, skillUsageStore);
+        var taskDirectiveTools = new TaskDirectiveTools(scheduledTaskStore, message.TaskName, logger);
 
         var batchId = Guid.NewGuid().ToString("N")[..12];
         var spawnedSubagent = false;
@@ -77,6 +93,7 @@ internal sealed class ScheduledTaskHandler(
         var allTools = memoryTools.Tools
             .Concat(sessionWorkingMemoryTools.Tools)
             .Concat(sessionSkillTools.Tools)
+            .Concat(taskDirectiveTools.Tools)
             .Concat(rulesTools.Tools)
             .Concat(toolGuideTools.Tools)
             .Concat(registryTools)

--- a/src/RockBot.Agent/agent/heartbeat-patrol.md
+++ b/src/RockBot.Agent/agent/heartbeat-patrol.md
@@ -47,24 +47,26 @@ until TTLs expire. Put the run timestamp inside the value if you need traceabili
 
 ## Execution
 
-Load and execute your patrol checklist:
+Your evolving patrol checklist is delivered to you automatically as part of the system
+prompt for this run — there is nothing to load. **Execute everything in it.**
+
+If no checklist has been delivered (first run, post-migration), build a sensible starting
+checklist covering: active plans, upcoming calendar, recent email, scheduled task health,
+and pending work queues. Save it with:
 
 ```
-get_skill("patrol/proactive-actions")
+update_task_directive(content: "<your starting checklist as markdown>")
 ```
 
-**Execute everything in it.**
-
-If the skill does not exist yet, create a sensible starting checklist via
-`save_skill("patrol/proactive-actions", ...)` covering: active plans, upcoming
-calendar, recent email, scheduled task health, and pending work queues. Then execute it.
+Then execute it.
 
 ---
 
 ## After the Patrol
 
 If you discovered a new recurring pattern or check that belongs in future patrols,
-update `patrol/proactive-actions` via `save_skill`. Only add patterns that recur —
-not one-offs.
+call `update_task_directive` with the revised checklist body — it replaces the entire
+directive, so include the existing items plus your additions. Only add patterns that
+recur — not one-offs.
 
 **Produce no text output. End the response.**

--- a/src/RockBot.Agent/agent/skill-dream.md
+++ b/src/RockBot.Agent/agent/skill-dream.md
@@ -34,6 +34,7 @@ Review the skills and:
 - **Never delete without replacement**: Do not delete a skill unless its content is fully covered by a merged skill in `toSave`.
 - **Do not hallucinate**: Only work with the content provided. Do not invent procedures, tool names, or steps not present in the source skills.
 - **Preserve specificity**: Merged skills must retain all specific tool names, parameter names, account identifiers, and nuances from all sources.
+- **Search-keyword preservation**: When merging, the new summary must preserve search-relevant keywords from each original source — tool names, service names, and other distinguishing terms — so BM25 recall on any original query still surfaces the merged skill. A merged skill that drops the keywords its sources used is unreachable.
 
 ## Output format
 

--- a/src/RockBot.Host.Abstractions/DreamOptions.cs
+++ b/src/RockBot.Host.Abstractions/DreamOptions.cs
@@ -110,15 +110,6 @@ public sealed class DreamOptions
     /// </summary>
     public string GraphConsolidationDirectivePath { get; set; } = "graph-consolidation-dream.md";
 
-    /// <summary>
-    /// Skill name prefixes that are protected from deletion by dream consolidation and
-    /// optimization passes. Skills whose names start with any of these prefixes (case-insensitive)
-    /// will never be deleted, even if the LLM proposes merging or removing them.
-    /// Default: <c>["patrol/"]</c> — protects the patrol checklist skills that are referenced
-    /// by system directives.
-    /// </summary>
-    public List<string> ProtectedSkillPrefixes { get; set; } = ["patrol/"];
-
     /// <summary>Whether the narrative identity reflection pass is enabled.</summary>
     public bool IdentityReflectionEnabled { get; set; } = true;
 

--- a/src/RockBot.Host.Abstractions/IScheduledTaskStore.cs
+++ b/src/RockBot.Host.Abstractions/IScheduledTaskStore.cs
@@ -19,4 +19,11 @@ public interface IScheduledTaskStore
 
     /// <summary>Updates the LastFiredAt timestamp for an existing task. No-op if not found.</summary>
     Task UpdateLastFiredAsync(string name, DateTimeOffset firedAt);
+
+    /// <summary>
+    /// Replaces the <see cref="ScheduledTask.Directive"/> body for an existing task.
+    /// No-op if the task does not exist. Other fields (cron, description, timestamps,
+    /// system/runOnce flags) are left unchanged.
+    /// </summary>
+    Task UpdateDirectiveAsync(string name, string directive);
 }

--- a/src/RockBot.Host.Abstractions/ScheduledTask.cs
+++ b/src/RockBot.Host.Abstractions/ScheduledTask.cs
@@ -16,6 +16,13 @@ namespace RockBot.Host;
 /// When true the task is a system-internal background task (e.g. heartbeat patrol)
 /// whose results are collapsed in the UI. User-created tasks default to false.
 /// </param>
+/// <param name="Directive">
+/// Optional, evolving free-form directive content the agent maintains for itself across runs of
+/// this task (e.g. the heartbeat patrol's running checklist). When non-null the content is
+/// injected as a system message immediately after the task's static framing on every fire,
+/// and the agent updates it via the <c>update_task_directive</c> tool. Distinct from
+/// <see cref="Description"/>, which is the user-facing prompt the task fires with.
+/// </param>
 public sealed record ScheduledTask(
     string Name,
     string CronExpression,
@@ -23,4 +30,5 @@ public sealed record ScheduledTask(
     DateTimeOffset CreatedAt,
     DateTimeOffset? LastFiredAt = null,
     bool RunOnce = false,
-    bool IsSystemTask = false);
+    bool IsSystemTask = false,
+    string? Directive = null);

--- a/src/RockBot.Host/AgentContextBuilder.cs
+++ b/src/RockBot.Host/AgentContextBuilder.cs
@@ -524,8 +524,9 @@ public sealed class AgentContextBuilder(
                 "- To read a finding: call get_from_working_memory with the full key.\n" +
                 "- To dismiss a resolved finding: call delete_from_working_memory with the full key. " +
                 "Do this when the user confirms something is resolved or not a real issue — dismissed entries stop being re-surfaced.\n" +
-                "- To change what the patrol checks and reports: edit the 'patrol/proactive-actions' skill via save_skill. " +
-                "The patrol runs on a schedule and loads that skill as its directive each run.";
+                "- The patrol updates its own checklist each run based on what it learns. " +
+                "If you want the patrol to check or report something differently, ask in this session " +
+                "and the change can be made — patrol updates take effect on the next scheduled run.";
             chatMessages.Add(new ChatMessage(ChatRole.System, patrolContext));
             logger.LogInformation("Injected {Count} patrol working memory entries into context", patrolEntries.Count);
         }

--- a/src/RockBot.Host/DreamService.cs
+++ b/src/RockBot.Host/DreamService.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using RockBot.Messaging;
+using RockBot.Tools;
 
 namespace RockBot.Host;
 
@@ -47,6 +48,7 @@ internal sealed class DreamService : IHostedService, IDisposable
     private readonly IReadOnlyDictionary<RepairTarget, IRepairTargetApplier>? _repairAppliers;
     private readonly IRepairTicketVerifier? _repairTicketVerifier;
     private readonly RepairTicketOptions? _repairOptions;
+    private readonly IReadOnlyList<IToolSkillProvider> _toolSkillProviders;
     private Timer? _timer;
     private CronExpression? _cron;
     private string? _dreamDirective;
@@ -93,7 +95,8 @@ internal sealed class DreamService : IHostedService, IDisposable
         IRepairTicketStore? repairTicketStore = null,
         IEnumerable<IRepairTargetApplier>? repairAppliers = null,
         IRepairTicketVerifier? repairTicketVerifier = null,
-        IOptions<RepairTicketOptions>? repairOptions = null)
+        IOptions<RepairTicketOptions>? repairOptions = null,
+        IEnumerable<IToolSkillProvider>? toolSkillProviders = null)
     {
         _memory = memory;
         _skillStore = skillStores.FirstOrDefault();
@@ -127,6 +130,7 @@ internal sealed class DreamService : IHostedService, IDisposable
                 map[applier.Target] = applier;
             _repairAppliers = map;
         }
+        _toolSkillProviders = toolSkillProviders?.ToList() ?? (IReadOnlyList<IToolSkillProvider>)Array.Empty<IToolSkillProvider>();
     }
 
     public Task StartAsync(CancellationToken cancellationToken)
@@ -632,14 +636,11 @@ internal sealed class DreamService : IHostedService, IDisposable
     {
         var all = await _skillStore!.ListAsync();
 
-        // Prune skills that have not been used in 18 months (skip protected skills)
+        // Prune skills that have not been used in 18 months
         var threshold = DateTimeOffset.UtcNow.AddMonths(-18);
         var pruned = 0;
         foreach (var skill in all)
         {
-            if (IsProtectedSkill(skill.Name))
-                continue;
-
             var lastActivity = skill.LastUsedAt ?? skill.UpdatedAt ?? skill.CreatedAt;
             if (lastActivity < threshold)
             {
@@ -702,68 +703,15 @@ internal sealed class DreamService : IHostedService, IDisposable
             coUsed[parts[1]].Add(parts[0]);
         }
 
-        var userMessage = new StringBuilder();
-        userMessage.AppendLine($"The agent currently has {all.Count} skills. Consolidate them:");
-        userMessage.AppendLine();
+        var singletonPrefixes = GetSingletonPrefixes(_toolSkillProviders);
 
-        var sparseThreshold = DateTimeOffset.UtcNow.AddDays(-7);
-        for (var i = 0; i < all.Count; i++)
-        {
-            var s = all[i];
-            var count = usageCount.TryGetValue(s.Name, out var c) ? c : 0;
-            var usageAnnotation = $" [usage: {count}x in last 30d]";
-            var coUsedAnnotation = coUsed.TryGetValue(s.Name, out var coSkills) && coSkills.Count > 0
-                ? $" [co-used with: {string.Join(", ", coSkills.Take(3))}]"
-                : string.Empty;
-            var isSparse = s.Content.Length < 200 && s.CreatedAt < sparseThreshold;
-            var sparseAnnotation = isSparse ? " [sparse-content: may need examples or steps]" : string.Empty;
-            userMessage.AppendLine($"{i + 1}. [NAME:{s.Name}]{usageAnnotation}{coUsedAnnotation}{sparseAnnotation} summary: {s.Summary}");
-            // Cap content at 800 chars so the LLM doesn't reproduce long markdown verbatim
-            // (long content with inline double-quotes breaks JSON encoding in the response).
-            const int ContentCap = 800;
-            var displayContent = s.Content.Length > ContentCap
-                ? s.Content[..ContentCap] + "\n[... truncated for consolidation pass ...]"
-                : s.Content;
-            userMessage.AppendLine(displayContent);
-            userMessage.AppendLine();
-        }
-
-        // Append co-occurrence section for the top pairs
-        var topPairs = coOccurrences.OrderByDescending(p => p.Value).Take(10).ToList();
-        if (topPairs.Count > 0)
-        {
-            userMessage.AppendLine();
-            userMessage.AppendLine("Frequently co-used skill pairs (across sessions in last 30 days):");
-            foreach (var (pair, cnt) in topPairs)
-            {
-                var parts = pair.Split('|');
-                userMessage.AppendLine($"- {parts[0]} + {parts[1]}: {cnt} session(s)");
-            }
-        }
-
-        // Append prefix cluster section for abstract parent guide detection
-        var prefixClusters = all
-            .Where(s => s.Name.Contains('/'))
-            .GroupBy(s => s.Name[..s.Name.IndexOf('/')])
-            .Where(g => g.Count() >= 2)
-            .OrderByDescending(g => g.Count())
-            .ToList();
-
-        if (prefixClusters.Count > 0)
-        {
-            userMessage.AppendLine();
-            userMessage.AppendLine("Skill name-prefix clusters (consider whether each cluster warrants an abstract parent guide skill):");
-            foreach (var cluster in prefixClusters)
-            {
-                var names = cluster.OrderBy(s => s.Name).Select(s => s.Name).ToList();
-                userMessage.AppendLine($"- '{cluster.Key}/*': {string.Join(", ", names)}");
-            }
-        }
+        var userMessage = BuildSkillConsolidationUserMessage(
+            all, usageCount, coUsed, coOccurrences, singletonPrefixes, DateTimeOffset.UtcNow);
 
         var result = await InvokeDreamPassAsync<SkillDreamResultDto>(
             "skill consolidation",
             _skillDreamDirective!,
-            userMessage.ToString(),
+            userMessage,
             ct);
         if (result is null) return;
 
@@ -779,17 +727,6 @@ internal sealed class DreamService : IHostedService, IDisposable
         foreach (var dto in result.ToSave ?? [])
             foreach (var srcName in dto.SourceNames ?? [])
                 allToDelete.Add(srcName);
-
-        // Guard: never delete skills whose names match a protected prefix (e.g. patrol/).
-        // These skills are referenced by system directives and must not be removed by dream passes.
-        var protectedNames = allToDelete.Where(IsProtectedSkill).ToList();
-        foreach (var name in protectedNames)
-        {
-            allToDelete.Remove(name);
-            _logger.LogWarning(
-                "DreamService: skill consolidation LLM proposed deleting protected skill '{Name}' — skipping",
-                name);
-        }
 
         // Safety guard: refuse to delete skills when nothing is being saved in return.
         // The directive says "never delete without replacement" — enforce it in code so an
@@ -1053,16 +990,6 @@ internal sealed class DreamService : IHostedService, IDisposable
         foreach (var dto in result.ToSave ?? [])
             foreach (var srcName in dto.SourceNames ?? [])
                 allToDelete.Add(srcName);
-
-        // Guard: never delete skills whose names match a protected prefix (e.g. patrol/).
-        var protectedOptNames = allToDelete.Where(IsProtectedSkill).ToList();
-        foreach (var name in protectedOptNames)
-        {
-            allToDelete.Remove(name);
-            _logger.LogWarning(
-                "DreamService: skill optimization LLM proposed deleting protected skill '{Name}' — skipping",
-                name);
-        }
 
         foreach (var name in allToDelete)
         {
@@ -3337,14 +3264,130 @@ internal sealed class DreamService : IHostedService, IDisposable
         }
     }
 
-    private bool IsProtectedSkill(string name)
+    /// <summary>
+    /// Collects every prefix declared by an <see cref="IToolSkillProvider"/> with
+    /// <see cref="ConsolidationPolicy.NamespacedSingleton"/>. Prefix strings are returned
+    /// verbatim (e.g. <c>"mcp/"</c> including the trailing slash).
+    /// </summary>
+    internal static IReadOnlyList<string> GetSingletonPrefixes(
+        IEnumerable<IToolSkillProvider>? providers)
     {
-        foreach (var prefix in _options.ProtectedSkillPrefixes)
+        if (providers is null) return Array.Empty<string>();
+
+        var prefixes = new List<string>();
+        foreach (var p in providers)
         {
-            if (name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
-                return true;
+            var policy = p.ConsolidationPolicy;
+            if (policy is { Policy: ConsolidationPolicy.NamespacedSingleton } && !string.IsNullOrWhiteSpace(policy.Value.Prefix))
+                prefixes.Add(policy.Value.Prefix);
+        }
+        return prefixes;
+    }
+
+    /// <summary>
+    /// Builds the user-message text submitted to the LLM during the skill consolidation pass.
+    /// Extracted from <see cref="ConsolidateSkillsAsync"/> for unit-testing without invoking the LLM.
+    /// </summary>
+    /// <remarks>
+    /// Singleton-prefixed skill names (those whose name starts with a prefix declared as
+    /// <see cref="ConsolidationPolicy.NamespacedSingleton"/>) are excluded from the prefix-cluster
+    /// section and a constraints paragraph is appended naming each such prefix so the LLM does not
+    /// propose merging across them.
+    /// </remarks>
+    internal static string BuildSkillConsolidationUserMessage(
+        IReadOnlyList<Skill> all,
+        IReadOnlyDictionary<string, int> usageCount,
+        IReadOnlyDictionary<string, List<string>> coUsed,
+        IReadOnlyDictionary<string, int> coOccurrences,
+        IReadOnlyCollection<string> singletonPrefixes,
+        DateTimeOffset now)
+    {
+        var userMessage = new StringBuilder();
+        userMessage.AppendLine($"The agent currently has {all.Count} skills. Consolidate them:");
+        userMessage.AppendLine();
+
+        var sparseThreshold = now.AddDays(-7);
+        for (var i = 0; i < all.Count; i++)
+        {
+            var s = all[i];
+            var count = usageCount.TryGetValue(s.Name, out var c) ? c : 0;
+            var usageAnnotation = $" [usage: {count}x in last 30d]";
+            var coUsedAnnotation = coUsed.TryGetValue(s.Name, out var coSkills) && coSkills.Count > 0
+                ? $" [co-used with: {string.Join(", ", coSkills.Take(3))}]"
+                : string.Empty;
+            var isSparse = s.Content.Length < 200 && s.CreatedAt < sparseThreshold;
+            var sparseAnnotation = isSparse ? " [sparse-content: may need examples or steps]" : string.Empty;
+            userMessage.AppendLine($"{i + 1}. [NAME:{s.Name}]{usageAnnotation}{coUsedAnnotation}{sparseAnnotation} summary: {s.Summary}");
+            // Cap content at 800 chars so the LLM doesn't reproduce long markdown verbatim
+            // (long content with inline double-quotes breaks JSON encoding in the response).
+            const int ContentCap = 800;
+            var displayContent = s.Content.Length > ContentCap
+                ? s.Content[..ContentCap] + "\n[... truncated for consolidation pass ...]"
+                : s.Content;
+            userMessage.AppendLine(displayContent);
+            userMessage.AppendLine();
         }
 
+        // Append co-occurrence section for the top pairs
+        var topPairs = coOccurrences.OrderByDescending(p => p.Value).Take(10).ToList();
+        if (topPairs.Count > 0)
+        {
+            userMessage.AppendLine();
+            userMessage.AppendLine("Frequently co-used skill pairs (across sessions in last 30 days):");
+            foreach (var (pair, cnt) in topPairs)
+            {
+                var parts = pair.Split('|');
+                userMessage.AppendLine($"- {parts[0]} + {parts[1]}: {cnt} session(s)");
+            }
+        }
+
+        // Append prefix cluster section for abstract parent guide detection,
+        // omitting any cluster whose key matches a namespaced-singleton prefix.
+        var prefixClusters = all
+            .Where(s => s.Name.Contains('/'))
+            .GroupBy(s => s.Name[..s.Name.IndexOf('/')])
+            .Where(g => g.Count() >= 2)
+            .Where(g => !IsSingletonClusterKey(g.Key, singletonPrefixes))
+            .OrderByDescending(g => g.Count())
+            .ToList();
+
+        if (prefixClusters.Count > 0)
+        {
+            userMessage.AppendLine();
+            userMessage.AppendLine("Skill name-prefix clusters (consider whether each cluster warrants an abstract parent guide skill):");
+            foreach (var cluster in prefixClusters)
+            {
+                var names = cluster.OrderBy(s => s.Name).Select(s => s.Name).ToList();
+                userMessage.AppendLine($"- '{cluster.Key}/*': {string.Join(", ", names)}");
+            }
+        }
+
+        if (singletonPrefixes.Count > 0)
+        {
+            userMessage.AppendLine();
+            userMessage.AppendLine("Constraints — namespaced-singleton prefixes:");
+            userMessage.AppendLine(
+                $"The following skill name prefix(es) are namespaced bindings to live external entities: " +
+                $"{string.Join(", ", singletonPrefixes.Select(p => $"'{p}*'"))}. " +
+                "Each suffix is a 1:1 binding (e.g. 'mcp/{server-name}' refers to a specific MCP server). " +
+                "Do NOT merge skills across these prefixes, replace them with an abstract parent guide, " +
+                "or delete them as duplicates of one another. They may only be improved or kept as-is.");
+        }
+
+        return userMessage.ToString();
+    }
+
+    private static bool IsSingletonClusterKey(string clusterKey, IReadOnlyCollection<string> singletonPrefixes)
+    {
+        foreach (var prefix in singletonPrefixes)
+        {
+            // Cluster keys do not include the trailing slash; prefixes do (e.g. "mcp/").
+            if (prefix.Length > 0 && prefix[^1] == '/' &&
+                string.Equals(clusterKey, prefix[..^1], StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
         return false;
     }
 

--- a/src/RockBot.Host/FileScheduledTaskStore.cs
+++ b/src/RockBot.Host/FileScheduledTaskStore.cs
@@ -128,6 +128,25 @@ internal sealed class FileScheduledTaskStore : IScheduledTaskStore
         }
     }
 
+    public async Task UpdateDirectiveAsync(string name, string directive)
+    {
+        await _lock.WaitAsync();
+        try
+        {
+            var tasks = await ReadAllAsync();
+            if (!tasks.TryGetValue(name, out var existing))
+                return;
+
+            tasks[name] = existing with { Directive = directive };
+            await WriteAllAsync(tasks);
+            _logger.LogDebug("Updated directive for scheduled task '{Name}' ({Length} chars)", name, directive.Length);
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
     // ── Internal ─────────────────────────────────────────────────────────────
 
     private async Task<Dictionary<string, ScheduledTask>> ReadAllAsync()

--- a/src/RockBot.Host/HeartbeatBootstrapService.cs
+++ b/src/RockBot.Host/HeartbeatBootstrapService.cs
@@ -7,12 +7,23 @@ namespace RockBot.Host;
 /// <summary>
 /// Registers the heartbeat-patrol scheduled task on startup if it does not
 /// already exist. Idempotent — safe to run on every pod restart.
+///
+/// Also performs a one-time migration: if a legacy <c>patrol/proactive-actions</c> skill
+/// exists in the skill store (the previous home for the patrol's evolving checklist), its
+/// content is copied into the heartbeat-patrol task's <see cref="ScheduledTask.Directive"/>
+/// and the skill is removed. After migration the heartbeat patrol updates itself via the
+/// <c>update_task_directive</c> tool instead of the skill store.
 /// </summary>
 internal sealed class HeartbeatBootstrapService(
     ISchedulerService scheduler,
+    IScheduledTaskStore taskStore,
+    ISkillStore skillStore,
     IOptions<HeartbeatBootstrapOptions> options,
     ILogger<HeartbeatBootstrapService> logger) : IHostedService
 {
+    private const string TaskName = "heartbeat-patrol";
+    private const string LegacySkillName = "patrol/proactive-actions";
+
     public async Task StartAsync(CancellationToken ct)
     {
         if (!options.Value.Enabled)
@@ -22,24 +33,55 @@ internal sealed class HeartbeatBootstrapService(
         }
 
         var existing = await scheduler.ListAsync(ct);
-        var patrol = existing.FirstOrDefault(t => t.Name == "heartbeat-patrol");
+        var patrol = existing.FirstOrDefault(t => t.Name == TaskName);
 
-        if (patrol is not null && patrol.CronExpression == options.Value.CronExpression)
+        // Migration: if the legacy skill exists, fold its content into the task's Directive.
+        // Prefer any directive that's already on the task — the agent has likely refined it
+        // beyond the skill's contents.
+        var legacySkill = await skillStore.GetAsync(LegacySkillName);
+        var directiveSeed = patrol?.Directive ?? legacySkill?.Content;
+
+        var cronUnchanged = patrol is not null && patrol.CronExpression == options.Value.CronExpression;
+        var directiveSeedDiffers = !string.Equals(patrol?.Directive, directiveSeed, StringComparison.Ordinal);
+
+        if (cronUnchanged && !directiveSeedDiffers)
         {
-            logger.LogInformation("Heartbeat patrol already registered with cron '{Cron}'; skipping", patrol.CronExpression);
-            return;
+            logger.LogInformation(
+                "Heartbeat patrol already registered with cron '{Cron}' and directive in place; skipping",
+                patrol!.CronExpression);
+        }
+        else if (cronUnchanged)
+        {
+            // Same cron, but the directive is missing — only the legacy skill's content needs
+            // to be folded in. UpdateDirectiveAsync preserves CreatedAt/LastFiredAt.
+            await taskStore.UpdateDirectiveAsync(TaskName, directiveSeed!);
+            logger.LogInformation(
+                "Seeded heartbeat patrol directive from legacy skill '{Skill}' ({Length} chars)",
+                LegacySkillName, directiveSeed!.Length);
+        }
+        else
+        {
+            await scheduler.ScheduleAsync(new ScheduledTask(
+                Name: TaskName,
+                CronExpression: options.Value.CronExpression,
+                Description: "Run the heartbeat patrol: check calendar, email, active plans, and scheduled task health.",
+                CreatedAt: patrol?.CreatedAt ?? DateTimeOffset.UtcNow,
+                RunOnce: false,
+                IsSystemTask: true,
+                Directive: directiveSeed), ct);
+
+            var action = patrol is null ? "Registered" : "Updated";
+            logger.LogInformation("{Action} heartbeat patrol (cron: {Cron})", action, options.Value.CronExpression);
         }
 
-        await scheduler.ScheduleAsync(new ScheduledTask(
-            Name: "heartbeat-patrol",
-            CronExpression: options.Value.CronExpression,
-            Description: "Run the heartbeat patrol: check calendar, email, active plans, and scheduled task health.",
-            CreatedAt: patrol?.CreatedAt ?? DateTimeOffset.UtcNow,
-            RunOnce: false,
-            IsSystemTask: true), ct);
-
-        var action = patrol is null ? "Registered" : "Updated";
-        logger.LogInformation("{Action} heartbeat patrol (cron: {Cron})", action, options.Value.CronExpression);
+        // Migration: drop the legacy skill once its content has reached the task.
+        if (legacySkill is not null)
+        {
+            await skillStore.DeleteAsync(LegacySkillName);
+            logger.LogInformation(
+                "Migrated legacy skill '{Skill}' into '{Task}' directive and removed the skill",
+                LegacySkillName, TaskName);
+        }
     }
 
     public Task StopAsync(CancellationToken ct) => Task.CompletedTask;

--- a/src/RockBot.Host/TaskDirectiveTools.cs
+++ b/src/RockBot.Host/TaskDirectiveTools.cs
@@ -1,0 +1,54 @@
+using System.ComponentModel;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+
+namespace RockBot.Host;
+
+/// <summary>
+/// Per-scheduled-task tool surface that lets the executing agent rewrite the task's evolving
+/// directive body. The directive is injected as a system message on every fire of the task
+/// (see <c>ScheduledTaskHandler</c>) — this is how a recurring task accumulates and refines
+/// its own checklist over time without parking the content in the skill store.
+///
+/// Constructed per-fire so the task name is baked in and a tool call cannot accidentally
+/// mutate a different task's directive.
+/// </summary>
+public sealed class TaskDirectiveTools
+{
+    private readonly IScheduledTaskStore _store;
+    private readonly string _taskName;
+    private readonly ILogger _logger;
+
+    public TaskDirectiveTools(IScheduledTaskStore store, string taskName, ILogger logger)
+    {
+        _store = store;
+        _taskName = taskName;
+        _logger = logger;
+
+        Tools =
+        [
+            AIFunctionFactory.Create(UpdateTaskDirective)
+        ];
+    }
+
+    public IList<AITool> Tools { get; }
+
+    [Description(
+        "Replace the entire body of the current scheduled task's evolving directive — the running " +
+        "checklist or notes the agent maintains across runs of this task. The new content " +
+        "becomes part of the system prompt on the next fire of this task. " +
+        "Use this to record what to look for, what was just learned, or what to watch next time. " +
+        "This tool is only available inside a scheduled-task execution and only edits the " +
+        "directive of the task that is currently running.")]
+    public async Task<string> UpdateTaskDirective(
+        [Description("The new directive content. Replaces the existing directive entirely.")] string content)
+    {
+        _logger.LogInformation(
+            "Tool call: UpdateTaskDirective(task={Task}, length={Length})",
+            _taskName, content?.Length ?? 0);
+
+        await _store.UpdateDirectiveAsync(_taskName, content ?? string.Empty);
+        return $"Directive for task '{_taskName}' updated ({(content ?? string.Empty).Length} chars). " +
+               "It will be part of the system prompt on the next fire.";
+    }
+}

--- a/src/RockBot.Tools.Abstractions/IToolSkillProvider.cs
+++ b/src/RockBot.Tools.Abstractions/IToolSkillProvider.cs
@@ -1,6 +1,25 @@
 namespace RockBot.Tools;
 
 /// <summary>
+/// How the dream service should treat skills under a given name prefix during consolidation.
+/// </summary>
+public enum ConsolidationPolicy
+{
+    /// <summary>
+    /// Suffixes under the prefix are topical variants and may be merged together or under
+    /// an abstract parent guide. This is the default treatment for any prefix cluster.
+    /// </summary>
+    TopicalCluster,
+
+    /// <summary>
+    /// Each suffix is a 1:1 binding to a live external entity (e.g. an MCP server name).
+    /// Skills under such a prefix must not be merged across or replaced by a parent guide —
+    /// doing so destroys the binding the agent will rebuild on its next encounter.
+    /// </summary>
+    NamespacedSingleton
+}
+
+/// <summary>
 /// Implemented by tool services (web, MCP, scripts, etc.) to publish a usage guide
 /// that the agent can retrieve on-demand via the <c>get_tool_guide</c> tool.
 ///
@@ -29,4 +48,18 @@ public interface IToolSkillProvider
     /// Called only when the agent explicitly requests the guide by name.
     /// </summary>
     string GetDocument();
+
+    /// <summary>
+    /// Optional declaration that skills under a given name prefix should be treated by
+    /// the dream consolidation pass with a non-default <see cref="ConsolidationPolicy"/>.
+    /// Return <c>null</c> (the default) to accept the standard topical-cluster treatment.
+    /// </summary>
+    /// <example>
+    /// MCP server skills are namespaced singletons:
+    /// <code>
+    /// public (string Prefix, ConsolidationPolicy Policy)? ConsolidationPolicy
+    ///     =&gt; ("mcp/", ConsolidationPolicy.NamespacedSingleton);
+    /// </code>
+    /// </example>
+    (string Prefix, ConsolidationPolicy Policy)? ConsolidationPolicy => null;
 }

--- a/src/RockBot.Tools.Mcp/McpToolSkillProvider.cs
+++ b/src/RockBot.Tools.Mcp/McpToolSkillProvider.cs
@@ -11,6 +11,9 @@ internal sealed class McpToolSkillProvider : IToolSkillProvider
     public string Name => "mcp";
     public string Summary => "MCP server discovery and tool invocation (mcp_list_services, mcp_get_service_details, mcp_invoke_tool).";
 
+    public (string Prefix, ConsolidationPolicy Policy)? ConsolidationPolicy
+        => ("mcp/", RockBot.Tools.ConsolidationPolicy.NamespacedSingleton);
+
     public string GetDocument() =>
         """
         # MCP Server Discovery and Invocation Guide

--- a/tests/RockBot.Host.Tests/DreamServicePromptBuilderTests.cs
+++ b/tests/RockBot.Host.Tests/DreamServicePromptBuilderTests.cs
@@ -1,0 +1,113 @@
+using RockBot.Tools;
+
+namespace RockBot.Host.Tests;
+
+/// <summary>
+/// Verifies that <see cref="DreamService.BuildSkillConsolidationUserMessage"/> respects the
+/// <see cref="ConsolidationPolicy.NamespacedSingleton"/> hint advertised by an
+/// <see cref="IToolSkillProvider"/>: clusters under such prefixes must not appear in the
+/// "consider an abstract parent guide" section, and a constraints paragraph must name
+/// each prefix so the LLM does not propose merging across them.
+/// </summary>
+[TestClass]
+public class DreamServicePromptBuilderTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 5, 9, 12, 0, 0, TimeSpan.Zero);
+
+    [TestMethod]
+    public void GetSingletonPrefixes_NullProviders_ReturnsEmpty()
+    {
+        var prefixes = DreamService.GetSingletonPrefixes(null);
+        Assert.AreEqual(0, prefixes.Count);
+    }
+
+    [TestMethod]
+    public void GetSingletonPrefixes_FiltersOutTopicalAndUnsetProviders()
+    {
+        var providers = new IToolSkillProvider[]
+        {
+            new StubProvider("mcp", ("mcp/", ConsolidationPolicy.NamespacedSingleton)),
+            new StubProvider("web", null),
+            new StubProvider("scripts", ("scripts/", ConsolidationPolicy.TopicalCluster))
+        };
+
+        var prefixes = DreamService.GetSingletonPrefixes(providers);
+
+        CollectionAssert.AreEqual(new[] { "mcp/" }, prefixes.ToArray());
+    }
+
+    [TestMethod]
+    public void BuildSkillConsolidationUserMessage_NoSingletonPrefix_OmitsConstraintsAndIncludesAllClusters()
+    {
+        var skills = new[]
+        {
+            MakeSkill("mcp/ms365"),
+            MakeSkill("mcp/calendar-mcp"),
+            MakeSkill("coding/dotnet"),
+            MakeSkill("coding/python")
+        };
+
+        var msg = DreamService.BuildSkillConsolidationUserMessage(
+            skills,
+            usageCount: new Dictionary<string, int>(),
+            coUsed: new Dictionary<string, List<string>>(),
+            coOccurrences: new Dictionary<string, int>(),
+            singletonPrefixes: Array.Empty<string>(),
+            now: Now);
+
+        StringAssert.Contains(msg, "'mcp/*': mcp/calendar-mcp, mcp/ms365");
+        StringAssert.Contains(msg, "'coding/*': coding/dotnet, coding/python");
+        Assert.IsFalse(msg.Contains("Constraints — namespaced-singleton prefixes"),
+            "Without singleton prefixes the constraints block must not appear.");
+    }
+
+    [TestMethod]
+    public void BuildSkillConsolidationUserMessage_WithMcpSingleton_ExcludesMcpClusterAndAppendsConstraints()
+    {
+        var skills = new[]
+        {
+            MakeSkill("mcp/ms365"),
+            MakeSkill("mcp/calendar-mcp"),
+            MakeSkill("coding/dotnet"),
+            MakeSkill("coding/python")
+        };
+
+        var msg = DreamService.BuildSkillConsolidationUserMessage(
+            skills,
+            usageCount: new Dictionary<string, int>(),
+            coUsed: new Dictionary<string, List<string>>(),
+            coOccurrences: new Dictionary<string, int>(),
+            singletonPrefixes: new[] { "mcp/" },
+            now: Now);
+
+        Assert.IsFalse(msg.Contains("'mcp/*':"),
+            "mcp/* cluster must NOT appear in the abstract-parent-guide section.");
+        StringAssert.Contains(msg, "'coding/*': coding/dotnet, coding/python");
+
+        StringAssert.Contains(msg, "Constraints — namespaced-singleton prefixes");
+        StringAssert.Contains(msg, "'mcp/*'");
+        StringAssert.Contains(msg, "Do NOT merge skills");
+    }
+
+    private static Skill MakeSkill(string name) => new(
+        Name: name,
+        Summary: $"summary for {name}",
+        Content: $"content for {name}",
+        CreatedAt: Now.AddDays(-30));
+
+    private sealed class StubProvider : IToolSkillProvider
+    {
+        private readonly (string Prefix, ConsolidationPolicy Policy)? _policy;
+
+        public StubProvider(string name, (string Prefix, ConsolidationPolicy Policy)? policy)
+        {
+            Name = name;
+            _policy = policy;
+        }
+
+        public string Name { get; }
+        public string Summary => $"stub {Name}";
+        public string GetDocument() => string.Empty;
+        public (string Prefix, ConsolidationPolicy Policy)? ConsolidationPolicy => _policy;
+    }
+}

--- a/tests/RockBot.Host.Tests/FileScheduledTaskStoreTests.cs
+++ b/tests/RockBot.Host.Tests/FileScheduledTaskStoreTests.cs
@@ -156,6 +156,51 @@ public sealed class FileScheduledTaskStoreTests
         await store.UpdateLastFiredAsync("nonexistent", DateTimeOffset.UtcNow);
     }
 
+    // ── Directive ─────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task SaveAsync_WithDirective_RoundTripsAcrossRestarts()
+    {
+        var filePath = Path.Combine(_tempDir, "scheduled-tasks.json");
+        var store1 = new FileScheduledTaskStore(filePath, NullLogger<FileScheduledTaskStore>.Instance);
+
+        var task = MakeTask("with-directive") with { Directive = "## Checklist\n- one\n- two" };
+        await store1.SaveAsync(task);
+
+        var store2 = new FileScheduledTaskStore(filePath, NullLogger<FileScheduledTaskStore>.Instance);
+        var retrieved = await store2.GetAsync("with-directive");
+
+        Assert.IsNotNull(retrieved);
+        Assert.AreEqual("## Checklist\n- one\n- two", retrieved.Directive);
+    }
+
+    [TestMethod]
+    public async Task UpdateDirectiveAsync_SetsDirectiveAndPreservesOtherFields()
+    {
+        var store = CreateStore();
+        var firedAt = new DateTimeOffset(2026, 2, 19, 8, 0, 0, TimeSpan.Zero);
+        await store.SaveAsync(MakeTask("patrol", cron: "0 8 * * *", description: "Patrol"));
+        await store.UpdateLastFiredAsync("patrol", firedAt);
+
+        await store.UpdateDirectiveAsync("patrol", "new directive body");
+
+        var retrieved = await store.GetAsync("patrol");
+        Assert.IsNotNull(retrieved);
+        Assert.AreEqual("new directive body", retrieved.Directive);
+        Assert.AreEqual("0 8 * * *", retrieved.CronExpression, "Cron must be preserved.");
+        Assert.AreEqual("Patrol", retrieved.Description, "Description must be preserved.");
+        Assert.AreEqual(firedAt, retrieved.LastFiredAt, "LastFiredAt must be preserved.");
+    }
+
+    [TestMethod]
+    public async Task UpdateDirectiveAsync_UnknownTask_IsNoOp()
+    {
+        var store = CreateStore();
+        // Should not throw
+        await store.UpdateDirectiveAsync("nonexistent", "body");
+        Assert.IsNull(await store.GetAsync("nonexistent"));
+    }
+
     // ── Persistence ───────────────────────────────────────────────────────────
 
     [TestMethod]

--- a/tests/RockBot.Host.Tests/RockBot.Host.Tests.csproj
+++ b/tests/RockBot.Host.Tests/RockBot.Host.Tests.csproj
@@ -24,6 +24,7 @@
     <ProjectReference Include="..\..\src\RockBot.Host\RockBot.Host.csproj" />
     <ProjectReference Include="..\..\src\RockBot.Messaging.Abstractions\RockBot.Messaging.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\RockBot.Observation\RockBot.Observation.csproj" />
+    <ProjectReference Include="..\..\src\RockBot.Tools.Abstractions\RockBot.Tools.Abstractions.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/RockBot.Host.Tests/SchedulerServiceTests.cs
+++ b/tests/RockBot.Host.Tests/SchedulerServiceTests.cs
@@ -188,6 +188,13 @@ public sealed class SchedulerServiceTests
                 _tasks[name] = existing with { LastFiredAt = firedAt };
             return Task.CompletedTask;
         }
+
+        public Task UpdateDirectiveAsync(string name, string directive)
+        {
+            if (_tasks.TryGetValue(name, out var existing))
+                _tasks[name] = existing with { Directive = directive };
+            return Task.CompletedTask;
+        }
     }
 
     private sealed class NullPipeline : IMessagePipeline

--- a/tests/RockBot.Host.Tests/TaskDirectiveToolsTests.cs
+++ b/tests/RockBot.Host.Tests/TaskDirectiveToolsTests.cs
@@ -1,0 +1,80 @@
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace RockBot.Host.Tests;
+
+/// <summary>
+/// Verifies <see cref="TaskDirectiveTools.UpdateTaskDirective"/> writes through to the store
+/// for the task it was constructed against, and surfaces the new body on subsequent reads —
+/// the round-trip the next fire of the scheduled task depends on.
+/// </summary>
+[TestClass]
+public sealed class TaskDirectiveToolsTests
+{
+    private string _tempDir = string.Empty;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"rockbot-task-dir-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    [TestMethod]
+    public async Task UpdateTaskDirective_WritesContentVisibleOnNextRead()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(new ScheduledTask(
+            "patrol", "0 8 * * *", "do stuff", DateTimeOffset.UtcNow, IsSystemTask: true));
+
+        var tools = new TaskDirectiveTools(store, "patrol", NullLogger<TaskDirectiveTools>.Instance);
+
+        var result = await tools.UpdateTaskDirective("- check email\n- check calendar");
+
+        var retrieved = await store.GetAsync("patrol");
+        Assert.IsNotNull(retrieved);
+        Assert.AreEqual("- check email\n- check calendar", retrieved.Directive);
+        StringAssert.Contains(result, "patrol");
+    }
+
+    [TestMethod]
+    public async Task UpdateTaskDirective_OnlyAffectsTheBoundTask()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(new ScheduledTask(
+            "patrol", "0 8 * * *", "do stuff", DateTimeOffset.UtcNow, IsSystemTask: true));
+        await store.SaveAsync(new ScheduledTask(
+            "weekly-report", "0 9 * * 1", "report", DateTimeOffset.UtcNow));
+
+        var tools = new TaskDirectiveTools(store, "patrol", NullLogger<TaskDirectiveTools>.Instance);
+        await tools.UpdateTaskDirective("patrol body");
+
+        Assert.AreEqual("patrol body", (await store.GetAsync("patrol"))!.Directive);
+        Assert.IsNull((await store.GetAsync("weekly-report"))!.Directive,
+            "Updating one task's directive must not bleed into a sibling task.");
+    }
+
+    [TestMethod]
+    public async Task UpdateTaskDirective_UnknownTask_DoesNotThrow()
+    {
+        var store = CreateStore();
+        var tools = new TaskDirectiveTools(store, "missing", NullLogger<TaskDirectiveTools>.Instance);
+
+        var result = await tools.UpdateTaskDirective("ignored");
+
+        // Underlying UpdateDirectiveAsync is a no-op; the tool returns its acknowledgement
+        // string but no task was written.
+        Assert.IsNull(await store.GetAsync("missing"));
+        StringAssert.Contains(result, "missing");
+    }
+
+    private FileScheduledTaskStore CreateStore() =>
+        new(Path.Combine(_tempDir, "scheduled-tasks.json"),
+            NullLogger<FileScheduledTaskStore>.Instance);
+}


### PR DESCRIPTION
Closes #377. Implements the design at `design/skill-name-stability.md`.

## Summary

Two design errors made the dream's skill consolidation pass fight the patrol on every cycle:

1. The patrol's evolving checklist lived in the skill store as `patrol/proactive-actions` even though it's a task directive. `ProtectedSkillPrefixes = ["patrol/"]` (PR #275) protected it but over-shot, keeping ~19 unrelated `patrol/*` drift skills alive against consolidation forever.
2. The consolidation prompt asked the wrong question of `mcp/*` skills — those suffixes are 1:1 bindings to live MCP servers, not topical variants. Merging across them destroys a binding the agent rebuilds on its next encounter.

## What changed

**Part A — task directives as first-class persistence**
- `ScheduledTask` gains an optional `Directive` field; `IScheduledTaskStore` gains `UpdateDirectiveAsync`.
- New `TaskDirectiveTools` registers `update_task_directive(content)` per scheduled-task fire, scoped to the task that's running.
- `ScheduledTaskHandler` injects the task's `Directive` as a system message immediately after the static `{taskName}.md` framing.
- `HeartbeatBootstrapService` migrates the legacy `patrol/proactive-actions` skill into the heartbeat-patrol task's `Directive` and deletes the skill (idempotent).
- `heartbeat-patrol.md` and the patrol-context wording in `AgentContextBuilder` updated.

**Part B — convention-aware consolidation policy**
- `IToolSkillProvider` gains an optional `ConsolidationPolicy` hook (`TopicalCluster` | `NamespacedSingleton`).
- `McpToolSkillProvider` declares `("mcp/", NamespacedSingleton)`.
- `DreamService` consumes `IEnumerable<IToolSkillProvider>?`, omits singleton prefixes from the prefix-cluster prompt section, and appends a constraints paragraph naming each singleton prefix.
- Prompt construction extracted to `internal static BuildSkillConsolidationUserMessage` for unit testing.
- `skill-dream.md` gains a Search-keyword preservation rule for merges.

**Part C — cleanup**
- `DreamOptions.ProtectedSkillPrefixes` removed along with `IsProtectedSkill` and its three call sites in `DreamService`. The patrol skill no longer exists, and `mcp/*` skills are protected by policy rather than by name.

## Test plan

- [x] `dotnet build RockBot.slnx` — clean (only pre-existing NU1902/NU1903/CA1416)
- [x] `dotnet test RockBot.slnx` — all 826 Host tests + ~1900 across other suites pass
- [x] New: `DreamServicePromptBuilderTests` (singleton prefix filter + constraints block)
- [x] New: `FileScheduledTaskStoreTests` (Directive round-trip, `UpdateDirectiveAsync` preserves other fields, no-op on missing)
- [x] New: `TaskDirectiveToolsTests` (round-trip + bound-task isolation)
- [ ] Post-deploy: confirm migration runs once on a host with the legacy `patrol/proactive-actions` skill, and is a no-op on subsequent restarts.
- [ ] Post-deploy: trigger a heartbeat patrol; confirm system prompt carries the directive body and `update_task_directive` writes through to the next fire.
- [ ] Post-deploy: observe a dream cycle in K8s logs; confirm the "consolidation LLM proposed deleting protected skill" warning storm has stopped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)