### PR TITLE
Enforce mcp/{server-name} naming for MCP server skills (#381)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.10.45</Version>
+<Version>0.10.51</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.Agent/agent/common-directives.md
+++ b/src/RockBot.Agent/agent/common-directives.md
@@ -224,6 +224,32 @@ If you complete a real task using a tool guide and no skill exists yet, save one
 Combine the guide's instructions with anything you discovered: edge cases, better
 argument patterns, pitfalls to avoid.
 
+### MCP server skill naming
+
+When you save a skill that documents a specific MCP server, the skill name MUST
+start with `mcp/{server-name}/`, using the exact `server_name` returned by
+`mcp_list_services` (lowercase, e.g. `mcp/ms365`, `mcp/calendar-mcp`,
+`mcp/github`). Either of these shapes is fine:
+
+- **Single per-server skill** — `mcp/{server-name}` covering all tools on the
+  server. Best fit for small or single-purpose servers.
+- **Sub-skills under the namespace** — `mcp/{server-name}/{area}` (e.g.
+  `mcp/ms365/email-tools`, `mcp/ms365/calendar-tools`). Use this when a server
+  is large enough that one document gets unwieldy. Group sub-skills by
+  functional area, not per-tool — don't create a separate sub-skill for every
+  individual tool when several tools share a workflow.
+
+Do NOT:
+
+- Save per-server skills at the top level (`calendar-mcp`, `routing-stats`)
+  or under topical folders that aren't `mcp/` (`calendar-mcp/...`,
+  `email/calendar-mcp-...`).
+- Substitute a display name, slug, or guess for the `server_name`.
+
+Topical workflow skills that genuinely span multiple servers
+(e.g. `email/mcp-search-send-drafts-and-verification`) stay topical and are
+NOT under the `mcp/` namespace — only per-server reference docs use it.
+
 ## Persistence When Facing Obstacles
 
 When a tool call returns an unexpected result, an error, or content that doesn't

--- a/src/RockBot.Agent/agent/skill-dream.md
+++ b/src/RockBot.Agent/agent/skill-dream.md
@@ -26,6 +26,25 @@ Review the skills and:
 
 3. **Leave everything else unchanged** — do not delete or modify skills that are not part of an overlap group.
 
+## Namespaced-singleton namespaces (e.g. `mcp/`)
+
+The user message may declare certain prefixes as **namespaced singletons** —
+prefixes where each immediate suffix is a 1:1 binding to a live external
+entity (e.g. `mcp/{server-name}` binds to a specific MCP server). For these:
+
+- **Across distinct singletons: do NOT merge.** Each `mcp/{server-name}` is a
+  unique binding. `mcp/calendar-mcp` and `mcp/ms365` must never be merged into
+  a parent guide or into each other, and a sub-skill of one
+  (e.g. `mcp/ms365/calendar-tools`) must never be merged with a sub-skill or
+  canonical entry of another.
+- **Within a single singleton's namespace: normal merge rules apply.** If two
+  skills under the same `mcp/{server-name}` prefix have genuine semantic
+  overlap (e.g. `mcp/calendar-mcp/send-email` and `mcp/calendar-mcp/email-send`
+  cover the same tool), merge them as you would any topical-cluster overlap.
+  Sub-skills that cover *different* parts of a large server (e.g.
+  `mcp/ms365/email-tools` vs `mcp/ms365/calendar-tools`) are NOT duplicates —
+  leave them alone.
+
 ## Critical rules
 
 - **Exhaustive deletion — this is the most important rule**: Every source skill you are replacing MUST appear in `toDelete`. If you produce one merged skill from sources A and B, then A and B both go in `toDelete`. No source survives a merge.

--- a/src/RockBot.Host/AgentContextBuilder.cs
+++ b/src/RockBot.Host/AgentContextBuilder.cs
@@ -34,6 +34,12 @@ public sealed class AgentContextBuilder(
     ICapabilityClaimVerifier? capabilityClaimVerifier = null)
 {
     private const int MaxLlmContextTurns = 20;
+
+    // Below this length, the user message is treated as a low-signal follow-up: BM25
+    // searches over its text return noise that drowns out the recent conversation
+    // thread, leading the LLM to summarise injected memory instead of replying to
+    // what was actually said. See issue #383.
+    private const int ShortMessageThreshold = 30;
     private readonly IServiceSearchIndex? _serviceSearchIndex = serviceSearchIndexProviders.FirstOrDefault();
     private readonly IKnowledgeGraph? _knowledgeGraph = knowledgeGraphProviders.FirstOrDefault();
     private readonly KnowledgeGraphOptions _graphOptions = knowledgeGraphOptions.Value;
@@ -101,12 +107,27 @@ public sealed class AgentContextBuilder(
             logger.LogInformation("No AdditionalSystemPrompt configured for this model");
         }
 
+        // Short low-signal messages ("ok", "I'll find out soon", "any idea why?")
+        // produce noisy BM25 hits that drown out the recent conversation thread.
+        // When the message is below the threshold, skip per-turn topic searches
+        // (long-term memory, episodic, skill recall, service hints) and the
+        // embedding generation that backs them. Conversation history, rules,
+        // identity, and working memory still flow — those are session grounding,
+        // not topic-search. See issue #383.
+        var isShortMessage = !string.IsNullOrWhiteSpace(currentUserContent)
+            && currentUserContent.Length <= ShortMessageThreshold;
+        if (isShortMessage)
+            logger.LogInformation(
+                "Short user message ({Len} chars ≤ {Threshold}) — skipping per-turn topic search injection",
+                currentUserContent.Length, ShortMessageThreshold);
+
         // ── Wave 0: generate the query embedding once, shared across all searches ──
         // Avoids redundant calls to the embedding endpoint — each store would otherwise
-        // generate its own query embedding for the same user message text.
+        // generate its own query embedding for the same user message text. Skipped
+        // for short messages since none of the gated searches will run.
 
         float[]? sharedQueryEmbedding = null;
-        if (_embeddingGenerator is not null && !string.IsNullOrWhiteSpace(currentUserContent))
+        if (_embeddingGenerator is not null && !string.IsNullOrWhiteSpace(currentUserContent) && !isShortMessage)
         {
             try
             {
@@ -133,16 +154,22 @@ public sealed class AgentContextBuilder(
         var shouldInjectSkillIndex = skillIndexTracker.TryMarkAsInjected(sessionId);
 
         var historyTask = conversationMemory.GetTurnsAsync(sessionId, ct);
-        var ltmTask = longTermMemory.SearchAsync(
-            new MemorySearchCriteria(Query: currentUserContent, MaxResults: 8, QueryEmbedding: sharedQueryEmbedding));
-        var episodicTask = longTermMemory.SearchAsync(
-            new MemorySearchCriteria(Query: currentUserContent, Category: "episodic", MaxResults: 5, QueryEmbedding: sharedQueryEmbedding));
+        var ltmTask = isShortMessage
+            ? Task.FromResult<IReadOnlyList<MemoryEntry>>([])
+            : longTermMemory.SearchAsync(
+                new MemorySearchCriteria(Query: currentUserContent, MaxResults: 8, QueryEmbedding: sharedQueryEmbedding));
+        var episodicTask = isShortMessage
+            ? Task.FromResult<IReadOnlyList<MemoryEntry>>([])
+            : longTermMemory.SearchAsync(
+                new MemorySearchCriteria(Query: currentUserContent, Category: "episodic", MaxResults: 5, QueryEmbedding: sharedQueryEmbedding));
         var identityTask = longTermMemory.SearchAsync(
             new MemorySearchCriteria(Category: AgentIdentityCategories.Prefix, MaxResults: 20));
         var skillListTask = shouldInjectSkillIndex
             ? skillStore.ListAsync()
             : Task.FromResult<IReadOnlyList<Skill>>([]);
-        var skillSearchTask = skillStore.SearchAsync(currentUserContent, maxResults: 5, ct, queryEmbedding: sharedQueryEmbedding);
+        var skillSearchTask = isShortMessage
+            ? Task.FromResult<IReadOnlyList<Skill>>([])
+            : skillStore.SearchAsync(currentUserContent, maxResults: 5, ct, queryEmbedding: sharedQueryEmbedding);
         var wmTask = workingMemory.ListAsync(wmNamespace);
         var graphTask = _knowledgeGraph?.FindEntitiesByNameAsync(currentUserContent);
         var patrolTask = isUserSession
@@ -458,8 +485,10 @@ public sealed class AgentContextBuilder(
             }
         }
 
-        // Per-turn service search hints (A2A agents + MCP servers)
-        if (_serviceSearchIndex is not null && !string.IsNullOrWhiteSpace(currentUserContent))
+        // Per-turn service search hints (A2A agents + MCP servers).
+        // Gated on isShortMessage to match the BM25-search injections above —
+        // a 2-3-word query produces noisy hits regardless of which index runs it.
+        if (_serviceSearchIndex is not null && !string.IsNullOrWhiteSpace(currentUserContent) && !isShortMessage)
         {
             var candidates = _serviceSearchIndex.Search(currentUserContent, maxResults: 2);
             if (candidates.Count > 0)

--- a/src/RockBot.Host/DiagnosticLoggingChatClient.cs
+++ b/src/RockBot.Host/DiagnosticLoggingChatClient.cs
@@ -1,0 +1,111 @@
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+
+namespace RockBot.Host;
+
+/// <summary>
+/// Diagnostic wrapper that inspects assistant messages returned by the inner
+/// <see cref="IChatClient"/> and logs a warning when the response shows the
+/// fingerprint of duplicated content reported by users — either multiple
+/// <see cref="TextContent"/> items in one assistant message, or a single
+/// <see cref="TextContent"/> whose text contains a long substring repeated
+/// across a single newline boundary. Behaviour-neutral; only logs.
+/// </summary>
+public sealed class DiagnosticLoggingChatClient : DelegatingChatClient
+{
+    private readonly ILogger<DiagnosticLoggingChatClient> _logger;
+    private readonly string _tierLabel;
+
+    public DiagnosticLoggingChatClient(
+        IChatClient inner,
+        ILogger<DiagnosticLoggingChatClient> logger,
+        string tierLabel)
+        : base(inner)
+    {
+        _logger = logger;
+        _tierLabel = tierLabel;
+    }
+
+    public override async Task<ChatResponse> GetResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        var response = await base.GetResponseAsync(messages, options, cancellationToken);
+        Inspect(response);
+        return response;
+    }
+
+    public override async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        await foreach (var update in base.GetStreamingResponseAsync(messages, options, cancellationToken))
+            yield return update;
+    }
+
+    private void Inspect(ChatResponse response)
+    {
+        try
+        {
+            for (var i = 0; i < response.Messages.Count; i++)
+            {
+                var msg = response.Messages[i];
+                if (msg.Role != ChatRole.Assistant) continue;
+
+                var textContents = msg.Contents.OfType<TextContent>().ToList();
+
+                if (textContents.Count > 1)
+                {
+                    _logger.LogWarning(
+                        "Duplication-watch [{Tier}]: assistant message[{Idx}] has {Count} TextContent items " +
+                        "(lengths=[{Lengths}]); ChatMessage.Text concatenates without separators. " +
+                        "Contents types=[{Types}]",
+                        _tierLabel, i, textContents.Count,
+                        string.Join(",", textContents.Select(t => t.Text?.Length ?? 0)),
+                        string.Join(",", msg.Contents.Select(c => c.GetType().Name)));
+                }
+
+                if (textContents.Count >= 1
+                    && LooksDuplicated(textContents[textContents.Count - 1].Text, out var prefixLen, out var sample))
+                {
+                    _logger.LogWarning(
+                        "Duplication-watch [{Tier}]: assistant message[{Idx}] TextContent contains a repeated " +
+                        "{PrefixLen}-char prefix after a newline (totalLen={TotalLen}, contentsCount={ContentsCount}, " +
+                        "sample40=\"{Sample}\"). Source is the upstream provider, not RockBot middleware.",
+                        _tierLabel, i, prefixLen, textContents[textContents.Count - 1].Text!.Length,
+                        msg.Contents.Count, sample);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Duplication-watch inspection threw; ignoring");
+        }
+    }
+
+    /// <summary>
+    /// True when <paramref name="text"/> contains a substring of at least 40 characters
+    /// that appears once at the beginning and again immediately after a single newline.
+    /// Catches both exact "X\nX" duplication and partial "X.Y\nX" truncated repeats.
+    /// </summary>
+    internal static bool LooksDuplicated(string? text, out int prefixLen, out string sample)
+    {
+        prefixLen = 0;
+        sample = string.Empty;
+        if (string.IsNullOrEmpty(text) || text.Length < 80) return false;
+
+        const int probeLen = 40;
+        var probe = text.AsSpan(0, Math.Min(probeLen, text.Length));
+        var probeStr = probe.ToString();
+        var needle = "\n" + probeStr;
+        var idx = text.IndexOf(needle, StringComparison.Ordinal);
+        if (idx <= 0) return false;
+
+        prefixLen = probe.Length;
+        sample = probeStr;
+        return true;
+    }
+}

--- a/src/RockBot.Host/DreamService.cs
+++ b/src/RockBot.Host/DreamService.cs
@@ -3369,9 +3369,13 @@ internal sealed class DreamService : IHostedService, IDisposable
             userMessage.AppendLine(
                 $"The following skill name prefix(es) are namespaced bindings to live external entities: " +
                 $"{string.Join(", ", singletonPrefixes.Select(p => $"'{p}*'"))}. " +
-                "Each suffix is a 1:1 binding (e.g. 'mcp/{server-name}' refers to a specific MCP server). " +
-                "Do NOT merge skills across these prefixes, replace them with an abstract parent guide, " +
-                "or delete them as duplicates of one another. They may only be improved or kept as-is.");
+                "Each immediate suffix is a 1:1 binding (e.g. 'mcp/{server-name}' refers to a specific MCP server). " +
+                "Do NOT merge skills across distinct suffixes — 'mcp/calendar-mcp' and 'mcp/ms365' must remain separate, " +
+                "and a sub-skill of one ('mcp/ms365/calendar-tools') must never be merged with a sub-skill or canonical entry of another. " +
+                "Do NOT replace these prefixes with an abstract parent guide. " +
+                "Within a single suffix's namespace (e.g. 'mcp/calendar-mcp/*'), normal semantic-overlap merging applies — " +
+                "duplicate sub-skills covering the same tool may be merged, " +
+                "but sub-skills covering distinct functional areas of a large server should be left alone.");
         }
 
         return userMessage.ToString();

--- a/src/RockBot.Llm/ServiceCollectionExtensions.cs
+++ b/src/RockBot.Llm/ServiceCollectionExtensions.cs
@@ -81,18 +81,27 @@ public static class LlmServiceCollectionExtensions
         {
             var behavior = sp.GetRequiredService<ModelBehavior>();
             var logger = sp.GetRequiredService<ILogger<RockBotFunctionInvokingChatClient>>();
+            var diagLogger = sp.GetRequiredService<ILogger<DiagnosticLoggingChatClient>>();
             var progressNotifier = sp.GetService<IToolProgressNotifier>();
             var toolCallLog = sp.GetService<IToolCallLog>();
             var costEstimator = sp.GetRequiredService<LlmCostEstimator>();
 
-            IChatClient Wrap(IChatClient raw) =>
-                behavior.UseTextBasedToolCalling
-                    ? raw
-                    : new RockBotFunctionInvokingChatClient(raw, progressNotifier, toolCallLog, behavior,
+            IChatClient Wrap(IChatClient raw, string tierLabel)
+            {
+                // Diagnostic-watch sits between the OpenAI client and the function-invoking
+                // middleware so it sees each tool iteration's raw response, including the
+                // assistant message before any RockBot post-processing.
+                var watched = new DiagnosticLoggingChatClient(raw, diagLogger, tierLabel);
+                return behavior.UseTextBasedToolCalling
+                    ? watched
+                    : new RockBotFunctionInvokingChatClient(watched, progressNotifier, toolCallLog, behavior,
                         costEstimator, sp.GetRequiredService<IOptions<AgentHostOptions>>(), logger);
+            }
 
             return new TieredChatClientRegistry(
-                Wrap(lowInnerClient), Wrap(balancedInnerClient), Wrap(highInnerClient));
+                Wrap(lowInnerClient, "Low"),
+                Wrap(balancedInnerClient, "Balanced"),
+                Wrap(highInnerClient, "High"));
         });
 
         // Keep Balanced as the primary IChatClient singleton for consumers that

--- a/src/RockBot.Tools.Mcp/McpServiceCollectionExtensions.cs
+++ b/src/RockBot.Tools.Mcp/McpServiceCollectionExtensions.cs
@@ -43,6 +43,7 @@ public static class McpServiceCollectionExtensions
         builder.Services.AddSingleton<McpServerIndex>();
         builder.Services.AddSingleton<McpManagementExecutor>();
         builder.Services.AddHostedService<McpStartupProbeService>();
+        builder.Services.AddHostedService<McpSkillNameMigrationService>();
         builder.Services.AddSingleton<IToolSkillProvider, McpToolSkillProvider>();
 
         // Self-repair Phase 1: mechanical recovery for missing required parameters.

--- a/src/RockBot.Tools.Mcp/McpSkillNameMigrationService.cs
+++ b/src/RockBot.Tools.Mcp/McpSkillNameMigrationService.cs
@@ -1,0 +1,155 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using RockBot.Host;
+
+namespace RockBot.Tools.Mcp;
+
+/// <summary>
+/// One-shot startup migration that renames legacy top-level skills matching a
+/// known MCP <c>server_name</c> to <c>mcp/{server-name}</c>. Cleans up drift
+/// from before the naming convention was reinforced (issue #381).
+///
+/// The service waits for <see cref="McpServerIndex"/> to be populated by the
+/// bridge — up to <see cref="WaitForIndex"/> total — and then enumerates the
+/// skill store. Idempotent on subsequent runs: skills already namespaced are
+/// left alone; if both old and new names exist, the legacy top-level entry is
+/// removed and the namespaced entry is preserved.
+/// </summary>
+/// <remarks>
+/// REMOVE AFTER MIGRATION: this service exists to clean up pre-#381 drift in
+/// the maintainer's live cluster — RockBot has a single production instance
+/// today. Once the live skill store has been migrated and verified (no more
+/// top-level skills matching MCP server names), delete this file along with
+/// its registration in <c>McpServiceCollectionExtensions.AddMcpToolProxy</c>
+/// and the matching tests in <c>McpSkillNameMigrationServiceTests</c>.
+/// The naming convention itself is enforced going forward by directives, so
+/// the migration step is not load-bearing once the one-time cleanup is done.
+/// </remarks>
+internal sealed class McpSkillNameMigrationService : IHostedService
+{
+    private static readonly TimeSpan WaitForIndex = TimeSpan.FromSeconds(60);
+    private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(2);
+
+    private readonly ISkillStore _skillStore;
+    private readonly McpServerIndex _index;
+    private readonly ILogger<McpSkillNameMigrationService> _logger;
+
+    private CancellationTokenSource? _cts;
+
+    public McpSkillNameMigrationService(
+        ISkillStore skillStore,
+        McpServerIndex index,
+        ILogger<McpSkillNameMigrationService> logger)
+    {
+        _skillStore = skillStore;
+        _index = index;
+        _logger = logger;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        _ = RunInBackgroundAsync(_cts.Token);
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _cts?.Cancel();
+        return Task.CompletedTask;
+    }
+
+    private async Task RunInBackgroundAsync(CancellationToken ct)
+    {
+        try
+        {
+            var deadline = DateTime.UtcNow.Add(WaitForIndex);
+            while (DateTime.UtcNow < deadline && _index.Servers.Count == 0)
+            {
+                try { await Task.Delay(PollInterval, ct); }
+                catch (OperationCanceledException) { return; }
+            }
+
+            var servers = _index.Servers;
+            if (servers.Count == 0)
+            {
+                _logger.LogInformation(
+                    "MCP server index did not populate within {Timeout}s; skipping skill name migration",
+                    WaitForIndex.TotalSeconds);
+                return;
+            }
+
+            await MigrateAsync(servers, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "MCP skill name migration failed");
+        }
+    }
+
+    /// <summary>
+    /// Renames top-level skills whose name matches a known <paramref name="servers"/>
+    /// entry's <c>server_name</c> (case-insensitive) to <c>mcp/{server-name}</c>.
+    /// </summary>
+    /// <remarks>
+    /// Exposed at <c>internal</c> so tests can drive migration directly without
+    /// waiting on the index-population polling path.
+    /// </remarks>
+    internal async Task<MigrationSummary> MigrateAsync(
+        IReadOnlyList<McpServerSummary> servers,
+        CancellationToken ct)
+    {
+        var serverNames = new HashSet<string>(
+            servers.Select(s => s.ServerName),
+            StringComparer.OrdinalIgnoreCase);
+
+        var skills = await _skillStore.ListAsync();
+
+        int renamed = 0, removedDuplicate = 0;
+        foreach (var skill in skills)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            // Only flat top-level names are candidates. Skills already nested
+            // anywhere (including under mcp/) are ignored.
+            if (skill.Name.Contains('/')) continue;
+            if (!serverNames.Contains(skill.Name)) continue;
+
+            var newName = $"mcp/{skill.Name.ToLowerInvariant()}";
+
+            var existing = await _skillStore.GetAsync(newName);
+            if (existing is not null)
+            {
+                await _skillStore.DeleteAsync(skill.Name);
+                removedDuplicate++;
+                _logger.LogInformation(
+                    "Removed duplicate top-level skill '{Old}' (already migrated to '{New}')",
+                    skill.Name, newName);
+                continue;
+            }
+
+            var migrated = skill with
+            {
+                Name = newName,
+                UpdatedAt = DateTimeOffset.UtcNow
+            };
+            await _skillStore.SaveAsync(migrated);
+            await _skillStore.DeleteAsync(skill.Name);
+            renamed++;
+            _logger.LogInformation(
+                "Migrated MCP server skill '{Old}' to '{New}'",
+                skill.Name, newName);
+        }
+
+        if (renamed > 0 || removedDuplicate > 0)
+        {
+            _logger.LogInformation(
+                "MCP skill name migration: {Renamed} renamed, {RemovedDuplicate} duplicate(s) removed",
+                renamed, removedDuplicate);
+        }
+
+        return new MigrationSummary(renamed, removedDuplicate);
+    }
+
+    internal readonly record struct MigrationSummary(int Renamed, int RemovedDuplicate);
+}

--- a/tests/RockBot.Host.Tests/AgentContextBuilderCapabilityClaimTests.cs
+++ b/tests/RockBot.Host.Tests/AgentContextBuilderCapabilityClaimTests.cs
@@ -19,6 +19,11 @@ namespace RockBot.Host.Tests;
 [TestClass]
 public class AgentContextBuilderCapabilityClaimTests
 {
+    // BuildAsync skips long-term-memory injection for user messages ≤30 chars (see #383).
+    // Capability-claim filtering runs inside the LTM injection path, so tests use a
+    // message above that threshold to keep the path engaged.
+    private const string LongMessage = "tell me what you remember about this topic";
+
     [TestMethod]
     public async Task BuildAsync_PredicateSucceeded_EvictsClaimAndSkipsInjection()
     {
@@ -27,7 +32,7 @@ public class AgentContextBuilderCapabilityClaimTests
         var verifier = new StubVerifier(VerifyOutcome.PredicateSucceeded);
         var builder = NewBuilder(ltm, verifier);
 
-        var messages = await builder.BuildAsync("session-1", "anything", CancellationToken.None);
+        var messages = await builder.BuildAsync("session-1", LongMessage, CancellationToken.None);
 
         Assert.AreEqual(1, ltm.DeletedIds.Count, "Falsified claim must be evicted from LTM.");
         Assert.AreEqual("claim-a", ltm.DeletedIds[0]);
@@ -43,7 +48,7 @@ public class AgentContextBuilderCapabilityClaimTests
         var verifier = new StubVerifier(VerifyOutcome.PredicateFailed);
         var builder = NewBuilder(ltm, verifier);
 
-        var messages = await builder.BuildAsync("session-1", "anything", CancellationToken.None);
+        var messages = await builder.BuildAsync("session-1", LongMessage, CancellationToken.None);
 
         Assert.AreEqual(0, ltm.DeletedIds.Count, "Predicate-failed claim must NOT be evicted.");
         var injected = messages.FirstOrDefault(m => m.Text?.Contains("claim-b") == true);
@@ -60,7 +65,7 @@ public class AgentContextBuilderCapabilityClaimTests
         var verifier = new StubVerifier(VerifyOutcome.Uncertain, detail: "budget exceeded");
         var builder = NewBuilder(ltm, verifier);
 
-        var messages = await builder.BuildAsync("session-1", "anything", CancellationToken.None);
+        var messages = await builder.BuildAsync("session-1", LongMessage, CancellationToken.None);
 
         Assert.AreEqual(0, ltm.DeletedIds.Count, "Uncertain claim must NOT be evicted.");
         var injected = messages.FirstOrDefault(m => m.Text?.Contains("claim-c") == true);
@@ -77,7 +82,7 @@ public class AgentContextBuilderCapabilityClaimTests
         var verifier = new StubVerifier(VerifyOutcome.PredicateSucceeded); // would evict if it ran
         var builder = NewBuilder(ltm, verifier);
 
-        var messages = await builder.BuildAsync("session-1", "anything", CancellationToken.None);
+        var messages = await builder.BuildAsync("session-1", LongMessage, CancellationToken.None);
 
         Assert.AreEqual(0, ltm.DeletedIds.Count, "Non-claim entries must not be evicted.");
         Assert.AreEqual(0, verifier.CallCount, "Verifier must not be invoked for non-claim entries.");
@@ -92,7 +97,7 @@ public class AgentContextBuilderCapabilityClaimTests
         var ltm = new RecordingMemory([claim]);
         var builder = NewBuilder(ltm, verifier: null);
 
-        var messages = await builder.BuildAsync("session-1", "anything", CancellationToken.None);
+        var messages = await builder.BuildAsync("session-1", LongMessage, CancellationToken.None);
 
         Assert.AreEqual(0, ltm.DeletedIds.Count);
         Assert.IsTrue(messages.Any(m => m.Text?.Contains("claim-d") == true),
@@ -110,7 +115,7 @@ public class AgentContextBuilderCapabilityClaimTests
         };
         var builder = NewBuilder(ltm, verifier);
 
-        var messages = await builder.BuildAsync("session-1", "anything", CancellationToken.None);
+        var messages = await builder.BuildAsync("session-1", LongMessage, CancellationToken.None);
 
         Assert.AreEqual(0, ltm.DeletedIds.Count, "Verifier exceptions must not cause eviction.");
         var injected = messages.FirstOrDefault(m => m.Text?.Contains("claim-e") == true);

--- a/tests/RockBot.Host.Tests/AgentContextBuilderKnowledgeGraphTests.cs
+++ b/tests/RockBot.Host.Tests/AgentContextBuilderKnowledgeGraphTests.cs
@@ -100,7 +100,10 @@ public class AgentContextBuilderKnowledgeGraphTests
 
         var (builder, _) = BuildBuilder(graph, ltm);
 
-        await builder.BuildAsync("session-3", "what did Alice think?", CancellationToken.None);
+        // Long enough to bypass short-message dampening (#383) so LTM-seeded graph
+        // expansion still runs. The literal text doesn't matter — graph stub returns
+        // Alice regardless of the query.
+        await builder.BuildAsync("session-3", "what did Alice think about the recent meeting", CancellationToken.None);
 
         // FindEntitiesByNameAsync is called once for the user message and once per top memory
         // (K=2 by default, but only 1 memory is in the store here, so just 1 memory call).

--- a/tests/RockBot.Host.Tests/CapabilityClaimEndToEndTests.cs
+++ b/tests/RockBot.Host.Tests/CapabilityClaimEndToEndTests.cs
@@ -82,13 +82,13 @@ public class CapabilityClaimEndToEndTests
 
         // Use a query that BM25 will match against the claim content so the recall path
         // surfaces the entry; otherwise the entry wouldn't reach the read-side filter.
-        var messages = await builder.BuildAsync("session-1", "wrapper cannot pass arguments", CancellationToken.None);
+        var messages = await builder.BuildAsync("session-1", "wrapper cannot pass arguments to the function", CancellationToken.None);
 
         // 5. Claim must be evicted from disk and absent from the chat context.
         var afterSearch = await ltm.SearchAsync(new MemorySearchCriteria(
             Category: CapabilityClaimCategories.Prefix, MaxResults: 10));
         Assert.AreEqual(0, afterSearch.Count, "Falsified claim was not evicted from long-term memory.");
-        Assert.IsFalse(messages.Any(m => m.Text?.Contains("wrapper cannot pass arguments") == true),
+        Assert.IsFalse(messages.Any(m => m.Text?.Contains("get_calendar_events") == true),
             "Falsified claim leaked into injected context.");
 
         Assert.AreEqual(1, verifier.CallCount, "Verifier was not invoked exactly once for the claim.");
@@ -123,7 +123,7 @@ public class CapabilityClaimEndToEndTests
         var verifier = new AlwaysFailingVerifier();
         var builder = NewBuilder(ltm, verifier, profileOpts);
 
-        await builder.BuildAsync("session-1", "wrapper cannot pass arguments", CancellationToken.None);
+        await builder.BuildAsync("session-1", "wrapper cannot pass arguments to the function", CancellationToken.None);
 
         // Claim is preserved on disk.
         var search = await ltm.SearchAsync(new MemorySearchCriteria(

--- a/tests/RockBot.Host.Tests/DreamServicePromptBuilderTests.cs
+++ b/tests/RockBot.Host.Tests/DreamServicePromptBuilderTests.cs
@@ -86,7 +86,42 @@ public class DreamServicePromptBuilderTests
 
         StringAssert.Contains(msg, "Constraints — namespaced-singleton prefixes");
         StringAssert.Contains(msg, "'mcp/*'");
-        StringAssert.Contains(msg, "Do NOT merge skills");
+        StringAssert.Contains(msg, "Do NOT merge skills across distinct suffixes");
+    }
+
+    [TestMethod]
+    public void BuildSkillConsolidationUserMessage_WithMcpSingleton_AllowsWithinNamespaceMerging()
+    {
+        // The constraint message must explicitly permit merging duplicate sub-skills
+        // within a single mcp/{server} namespace, while still forbidding cross-suffix merges.
+        var skills = new[]
+        {
+            MakeSkill("mcp/calendar-mcp"),
+            MakeSkill("mcp/calendar-mcp/send-email"),
+            MakeSkill("mcp/calendar-mcp/email-send"),
+            MakeSkill("mcp/ms365"),
+            MakeSkill("mcp/ms365/calendar-tools"),
+        };
+
+        var msg = DreamService.BuildSkillConsolidationUserMessage(
+            skills,
+            usageCount: new Dictionary<string, int>(),
+            coUsed: new Dictionary<string, List<string>>(),
+            coOccurrences: new Dictionary<string, int>(),
+            singletonPrefixes: new[] { "mcp/" },
+            now: Now);
+
+        // Within-namespace merging is explicitly permitted.
+        StringAssert.Contains(msg, "Within a single suffix's namespace");
+        StringAssert.Contains(msg, "normal semantic-overlap merging applies");
+
+        // Cross-suffix merging is explicitly forbidden, including across sub-skills.
+        StringAssert.Contains(msg, "must remain separate");
+        StringAssert.Contains(msg, "must never be merged with a sub-skill or canonical entry of another");
+
+        // Top-level mcp/* still excluded from abstract-parent-guide suggestions.
+        Assert.IsFalse(msg.Contains("'mcp/*':"),
+            "mcp/* cluster must NOT appear in the abstract-parent-guide section.");
     }
 
     private static Skill MakeSkill(string name) => new(

--- a/tests/RockBot.Tools.Tests/McpSkillNameMigrationServiceTests.cs
+++ b/tests/RockBot.Tools.Tests/McpSkillNameMigrationServiceTests.cs
@@ -1,0 +1,197 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using RockBot.Host;
+using RockBot.Tools.Mcp;
+
+namespace RockBot.Tools.Tests;
+
+/// <summary>
+/// Verifies <see cref="McpSkillNameMigrationService.MigrateAsync"/> behavior. Drives
+/// the migration entry point directly (bypassing the index-population polling path)
+/// against an in-memory <see cref="ISkillStore"/>.
+/// </summary>
+[TestClass]
+public class McpSkillNameMigrationServiceTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 5, 9, 12, 0, 0, TimeSpan.Zero);
+
+    [TestMethod]
+    public async Task MigrateAsync_RenamesTopLevelMatchingSkillToMcpNamespace()
+    {
+        var store = new InMemorySkillStore();
+        await store.SaveAsync(MakeSkill("calendar-mcp", "calendar content"));
+
+        var service = CreateService(store);
+        var summary = await service.MigrateAsync(
+            new[] { Server("calendar-mcp") },
+            CancellationToken.None);
+
+        Assert.AreEqual(1, summary.Renamed);
+        Assert.AreEqual(0, summary.RemovedDuplicate);
+
+        Assert.IsNull(await store.GetAsync("calendar-mcp"),
+            "The legacy top-level entry should be deleted after rename.");
+
+        var migrated = await store.GetAsync("mcp/calendar-mcp");
+        Assert.IsNotNull(migrated);
+        Assert.AreEqual("calendar content", migrated!.Content,
+            "Migration must preserve content verbatim.");
+        Assert.IsNotNull(migrated.UpdatedAt);
+    }
+
+    [TestMethod]
+    public async Task MigrateAsync_LowercasesNewName()
+    {
+        var store = new InMemorySkillStore();
+        await store.SaveAsync(MakeSkill("Calendar-MCP", "mixed case"));
+
+        var service = CreateService(store);
+        var summary = await service.MigrateAsync(
+            new[] { Server("calendar-mcp") },
+            CancellationToken.None);
+
+        Assert.AreEqual(1, summary.Renamed);
+        Assert.IsNotNull(await store.GetAsync("mcp/calendar-mcp"));
+        Assert.IsNull(await store.GetAsync("Calendar-MCP"));
+    }
+
+    [TestMethod]
+    public async Task MigrateAsync_LeavesAlreadyNamespacedSkillsUntouched()
+    {
+        var store = new InMemorySkillStore();
+        await store.SaveAsync(MakeSkill("mcp/calendar-mcp", "already migrated"));
+        // Sub-skills under the namespace are also valid (large-server pattern) and
+        // must not be touched by the migration.
+        await store.SaveAsync(MakeSkill("mcp/ms365/email-tools", "sub-skill"));
+
+        var service = CreateService(store);
+        var summary = await service.MigrateAsync(
+            new[] { Server("calendar-mcp"), Server("ms365") },
+            CancellationToken.None);
+
+        Assert.AreEqual(0, summary.Renamed);
+        Assert.AreEqual(0, summary.RemovedDuplicate);
+
+        Assert.IsNotNull(await store.GetAsync("mcp/calendar-mcp"));
+        Assert.IsNotNull(await store.GetAsync("mcp/ms365/email-tools"));
+    }
+
+    [TestMethod]
+    public async Task MigrateAsync_DropsLegacyEntryWhenNamespacedTargetAlreadyExists()
+    {
+        var store = new InMemorySkillStore();
+        await store.SaveAsync(MakeSkill("calendar-mcp", "stale duplicate"));
+        await store.SaveAsync(MakeSkill("mcp/calendar-mcp", "canonical"));
+
+        var service = CreateService(store);
+        var summary = await service.MigrateAsync(
+            new[] { Server("calendar-mcp") },
+            CancellationToken.None);
+
+        Assert.AreEqual(0, summary.Renamed);
+        Assert.AreEqual(1, summary.RemovedDuplicate);
+
+        Assert.IsNull(await store.GetAsync("calendar-mcp"),
+            "The duplicate top-level entry should be removed.");
+
+        var preserved = await store.GetAsync("mcp/calendar-mcp");
+        Assert.IsNotNull(preserved);
+        Assert.AreEqual("canonical", preserved!.Content,
+            "The pre-existing namespaced entry must be preserved unchanged.");
+    }
+
+    [TestMethod]
+    public async Task MigrateAsync_LeavesNonMatchingTopLevelSkillUntouched()
+    {
+        var store = new InMemorySkillStore();
+        await store.SaveAsync(MakeSkill("plan-meeting", "unrelated topical skill"));
+        await store.SaveAsync(MakeSkill("research-summary", "another unrelated skill"));
+
+        var service = CreateService(store);
+        var summary = await service.MigrateAsync(
+            new[] { Server("calendar-mcp"), Server("ms365") },
+            CancellationToken.None);
+
+        Assert.AreEqual(0, summary.Renamed);
+        Assert.AreEqual(0, summary.RemovedDuplicate);
+
+        Assert.IsNotNull(await store.GetAsync("plan-meeting"));
+        Assert.IsNotNull(await store.GetAsync("research-summary"));
+    }
+
+    [TestMethod]
+    public async Task MigrateAsync_NoServers_DoesNothing()
+    {
+        var store = new InMemorySkillStore();
+        await store.SaveAsync(MakeSkill("calendar-mcp", "content"));
+
+        var service = CreateService(store);
+        var summary = await service.MigrateAsync(
+            Array.Empty<McpServerSummary>(),
+            CancellationToken.None);
+
+        Assert.AreEqual(0, summary.Renamed);
+        Assert.AreEqual(0, summary.RemovedDuplicate);
+        Assert.IsNotNull(await store.GetAsync("calendar-mcp"));
+    }
+
+    private static McpSkillNameMigrationService CreateService(ISkillStore store)
+    {
+        return new McpSkillNameMigrationService(
+            store,
+            new McpServerIndex(),
+            NullLogger<McpSkillNameMigrationService>.Instance);
+    }
+
+    private static Skill MakeSkill(string name, string content) => new(
+        Name: name,
+        Summary: $"summary for {name}",
+        Content: content,
+        CreatedAt: Now);
+
+    private static McpServerSummary Server(string name) =>
+        new() { ServerName = name };
+
+    /// <summary>
+    /// In-memory <see cref="ISkillStore"/> fake: covers the subset of the API the
+    /// migration service exercises (Save / Get / List / Delete).
+    /// </summary>
+    private sealed class InMemorySkillStore : ISkillStore
+    {
+        private readonly Dictionary<string, Skill> _skills = new(StringComparer.Ordinal);
+
+        public Task SaveAsync(Skill skill)
+        {
+            _skills[skill.Name] = skill;
+            return Task.CompletedTask;
+        }
+
+        public Task<Skill?> GetAsync(string name)
+        {
+            _skills.TryGetValue(name, out var skill);
+            return Task.FromResult<Skill?>(skill);
+        }
+
+        public Task<IReadOnlyList<Skill>> ListAsync()
+        {
+            IReadOnlyList<Skill> list = _skills.Values
+                .OrderBy(s => s.Name, StringComparer.Ordinal)
+                .ToList();
+            return Task.FromResult(list);
+        }
+
+        public Task DeleteAsync(string name)
+        {
+            _skills.Remove(name);
+            return Task.CompletedTask;
+        }
+
+        public Task<IReadOnlyList<Skill>> SearchAsync(
+            string query,
+            int maxResults,
+            CancellationToken cancellationToken = default,
+            float[]? queryEmbedding = null)
+        {
+            return ListAsync();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #381.

Reinforces the `mcp/{server-name}` skill naming convention so per-server skills land in the protected namespace, the MCP guide's Step 0 fast-path actually works, and the singleton-policy protection from #380 covers what it was designed to cover.

Three reinforcing changes plus a temporary one-shot migration:

- **`common-directives.md`** — adds an "MCP server skill naming" rule. Skills documenting a specific MCP server MUST live under `mcp/{server-name}/`. Either shape is fine: a single per-server skill (small servers) or sub-skills under the namespace grouped by functional area (large servers like `mcp/ms365/email-tools`, `mcp/ms365/calendar-tools`). Top-level / topical bindings are forbidden.
- **`skill-dream.md` + `DreamService.BuildSkillConsolidationUserMessage`** — narrows the namespaced-singleton constraint. Cross-suffix merges remain forbidden (including across sub-skills of distinct servers); WITHIN a single `mcp/{server}/*` namespace, normal semantic-overlap merging applies. Net effect: duplicate sub-skills covering the same tool can self-heal; distinct functional areas of a large server are preserved.
- **`McpSkillNameMigrationService`** — one-shot startup `IHostedService` that polls `McpServerIndex` up to 60s, then renames legacy top-level skills matching a known `server_name` to `mcp/{server-name}` (lowercase). Idempotent; carries a `REMOVE AFTER MIGRATION` doc-comment listing exactly the files to delete in a follow-up PR once the live cluster is migrated.

## Test plan

- [x] `dotnet build RockBot.slnx` — clean build
- [x] `dotnet test RockBot.slnx` — full suite passes (1500+ tests). New: 6 migration tests + 1 new dream prompt-builder test; updated: 1 existing dream constraint-wording assertion.
- [ ] Deploy to live cluster, observe migration log lines, verify legacy top-level skills (`calendar-mcp`, `routing-stats`, etc.) renamed to `mcp/{server}`.
- [ ] After verification, open a follow-up PR removing `McpSkillNameMigrationService.cs`, its registration in `McpServiceCollectionExtensions.AddMcpToolProxy`, and `McpSkillNameMigrationServiceTests.cs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)