### PR TITLE
Skip BM25 topic injection on short user messages (#383)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.10.45</Version>
+<Version>0.10.51</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.Host/AgentContextBuilder.cs
+++ b/src/RockBot.Host/AgentContextBuilder.cs
@@ -34,6 +34,12 @@ public sealed class AgentContextBuilder(
     ICapabilityClaimVerifier? capabilityClaimVerifier = null)
 {
     private const int MaxLlmContextTurns = 20;
+
+    // Below this length, the user message is treated as a low-signal follow-up: BM25
+    // searches over its text return noise that drowns out the recent conversation
+    // thread, leading the LLM to summarise injected memory instead of replying to
+    // what was actually said. See issue #383.
+    private const int ShortMessageThreshold = 30;
     private readonly IServiceSearchIndex? _serviceSearchIndex = serviceSearchIndexProviders.FirstOrDefault();
     private readonly IKnowledgeGraph? _knowledgeGraph = knowledgeGraphProviders.FirstOrDefault();
     private readonly KnowledgeGraphOptions _graphOptions = knowledgeGraphOptions.Value;
@@ -101,12 +107,27 @@ public sealed class AgentContextBuilder(
             logger.LogInformation("No AdditionalSystemPrompt configured for this model");
         }
 
+        // Short low-signal messages ("ok", "I'll find out soon", "any idea why?")
+        // produce noisy BM25 hits that drown out the recent conversation thread.
+        // When the message is below the threshold, skip per-turn topic searches
+        // (long-term memory, episodic, skill recall, service hints) and the
+        // embedding generation that backs them. Conversation history, rules,
+        // identity, and working memory still flow — those are session grounding,
+        // not topic-search. See issue #383.
+        var isShortMessage = !string.IsNullOrWhiteSpace(currentUserContent)
+            && currentUserContent.Length <= ShortMessageThreshold;
+        if (isShortMessage)
+            logger.LogInformation(
+                "Short user message ({Len} chars ≤ {Threshold}) — skipping per-turn topic search injection",
+                currentUserContent.Length, ShortMessageThreshold);
+
         // ── Wave 0: generate the query embedding once, shared across all searches ──
         // Avoids redundant calls to the embedding endpoint — each store would otherwise
-        // generate its own query embedding for the same user message text.
+        // generate its own query embedding for the same user message text. Skipped
+        // for short messages since none of the gated searches will run.
 
         float[]? sharedQueryEmbedding = null;
-        if (_embeddingGenerator is not null && !string.IsNullOrWhiteSpace(currentUserContent))
+        if (_embeddingGenerator is not null && !string.IsNullOrWhiteSpace(currentUserContent) && !isShortMessage)
         {
             try
             {
@@ -133,16 +154,22 @@ public sealed class AgentContextBuilder(
         var shouldInjectSkillIndex = skillIndexTracker.TryMarkAsInjected(sessionId);
 
         var historyTask = conversationMemory.GetTurnsAsync(sessionId, ct);
-        var ltmTask = longTermMemory.SearchAsync(
-            new MemorySearchCriteria(Query: currentUserContent, MaxResults: 8, QueryEmbedding: sharedQueryEmbedding));
-        var episodicTask = longTermMemory.SearchAsync(
-            new MemorySearchCriteria(Query: currentUserContent, Category: "episodic", MaxResults: 5, QueryEmbedding: sharedQueryEmbedding));
+        var ltmTask = isShortMessage
+            ? Task.FromResult<IReadOnlyList<MemoryEntry>>([])
+            : longTermMemory.SearchAsync(
+                new MemorySearchCriteria(Query: currentUserContent, MaxResults: 8, QueryEmbedding: sharedQueryEmbedding));
+        var episodicTask = isShortMessage
+            ? Task.FromResult<IReadOnlyList<MemoryEntry>>([])
+            : longTermMemory.SearchAsync(
+                new MemorySearchCriteria(Query: currentUserContent, Category: "episodic", MaxResults: 5, QueryEmbedding: sharedQueryEmbedding));
         var identityTask = longTermMemory.SearchAsync(
             new MemorySearchCriteria(Category: AgentIdentityCategories.Prefix, MaxResults: 20));
         var skillListTask = shouldInjectSkillIndex
             ? skillStore.ListAsync()
             : Task.FromResult<IReadOnlyList<Skill>>([]);
-        var skillSearchTask = skillStore.SearchAsync(currentUserContent, maxResults: 5, ct, queryEmbedding: sharedQueryEmbedding);
+        var skillSearchTask = isShortMessage
+            ? Task.FromResult<IReadOnlyList<Skill>>([])
+            : skillStore.SearchAsync(currentUserContent, maxResults: 5, ct, queryEmbedding: sharedQueryEmbedding);
         var wmTask = workingMemory.ListAsync(wmNamespace);
         var graphTask = _knowledgeGraph?.FindEntitiesByNameAsync(currentUserContent);
         var patrolTask = isUserSession
@@ -458,8 +485,10 @@ public sealed class AgentContextBuilder(
             }
         }
 
-        // Per-turn service search hints (A2A agents + MCP servers)
-        if (_serviceSearchIndex is not null && !string.IsNullOrWhiteSpace(currentUserContent))
+        // Per-turn service search hints (A2A agents + MCP servers).
+        // Gated on isShortMessage to match the BM25-search injections above —
+        // a 2-3-word query produces noisy hits regardless of which index runs it.
+        if (_serviceSearchIndex is not null && !string.IsNullOrWhiteSpace(currentUserContent) && !isShortMessage)
         {
             var candidates = _serviceSearchIndex.Search(currentUserContent, maxResults: 2);
             if (candidates.Count > 0)

--- a/tests/RockBot.Host.Tests/AgentContextBuilderCapabilityClaimTests.cs
+++ b/tests/RockBot.Host.Tests/AgentContextBuilderCapabilityClaimTests.cs
@@ -19,6 +19,11 @@ namespace RockBot.Host.Tests;
 [TestClass]
 public class AgentContextBuilderCapabilityClaimTests
 {
+    // BuildAsync skips long-term-memory injection for user messages ≤30 chars (see #383).
+    // Capability-claim filtering runs inside the LTM injection path, so tests use a
+    // message above that threshold to keep the path engaged.
+    private const string LongMessage = "tell me what you remember about this topic";
+
     [TestMethod]
     public async Task BuildAsync_PredicateSucceeded_EvictsClaimAndSkipsInjection()
     {
@@ -27,7 +32,7 @@ public class AgentContextBuilderCapabilityClaimTests
         var verifier = new StubVerifier(VerifyOutcome.PredicateSucceeded);
         var builder = NewBuilder(ltm, verifier);
 
-        var messages = await builder.BuildAsync("session-1", "anything", CancellationToken.None);
+        var messages = await builder.BuildAsync("session-1", LongMessage, CancellationToken.None);
 
         Assert.AreEqual(1, ltm.DeletedIds.Count, "Falsified claim must be evicted from LTM.");
         Assert.AreEqual("claim-a", ltm.DeletedIds[0]);
@@ -43,7 +48,7 @@ public class AgentContextBuilderCapabilityClaimTests
         var verifier = new StubVerifier(VerifyOutcome.PredicateFailed);
         var builder = NewBuilder(ltm, verifier);
 
-        var messages = await builder.BuildAsync("session-1", "anything", CancellationToken.None);
+        var messages = await builder.BuildAsync("session-1", LongMessage, CancellationToken.None);
 
         Assert.AreEqual(0, ltm.DeletedIds.Count, "Predicate-failed claim must NOT be evicted.");
         var injected = messages.FirstOrDefault(m => m.Text?.Contains("claim-b") == true);
@@ -60,7 +65,7 @@ public class AgentContextBuilderCapabilityClaimTests
         var verifier = new StubVerifier(VerifyOutcome.Uncertain, detail: "budget exceeded");
         var builder = NewBuilder(ltm, verifier);
 
-        var messages = await builder.BuildAsync("session-1", "anything", CancellationToken.None);
+        var messages = await builder.BuildAsync("session-1", LongMessage, CancellationToken.None);
 
         Assert.AreEqual(0, ltm.DeletedIds.Count, "Uncertain claim must NOT be evicted.");
         var injected = messages.FirstOrDefault(m => m.Text?.Contains("claim-c") == true);
@@ -77,7 +82,7 @@ public class AgentContextBuilderCapabilityClaimTests
         var verifier = new StubVerifier(VerifyOutcome.PredicateSucceeded); // would evict if it ran
         var builder = NewBuilder(ltm, verifier);
 
-        var messages = await builder.BuildAsync("session-1", "anything", CancellationToken.None);
+        var messages = await builder.BuildAsync("session-1", LongMessage, CancellationToken.None);
 
         Assert.AreEqual(0, ltm.DeletedIds.Count, "Non-claim entries must not be evicted.");
         Assert.AreEqual(0, verifier.CallCount, "Verifier must not be invoked for non-claim entries.");
@@ -92,7 +97,7 @@ public class AgentContextBuilderCapabilityClaimTests
         var ltm = new RecordingMemory([claim]);
         var builder = NewBuilder(ltm, verifier: null);
 
-        var messages = await builder.BuildAsync("session-1", "anything", CancellationToken.None);
+        var messages = await builder.BuildAsync("session-1", LongMessage, CancellationToken.None);
 
         Assert.AreEqual(0, ltm.DeletedIds.Count);
         Assert.IsTrue(messages.Any(m => m.Text?.Contains("claim-d") == true),
@@ -110,7 +115,7 @@ public class AgentContextBuilderCapabilityClaimTests
         };
         var builder = NewBuilder(ltm, verifier);
 
-        var messages = await builder.BuildAsync("session-1", "anything", CancellationToken.None);
+        var messages = await builder.BuildAsync("session-1", LongMessage, CancellationToken.None);
 
         Assert.AreEqual(0, ltm.DeletedIds.Count, "Verifier exceptions must not cause eviction.");
         var injected = messages.FirstOrDefault(m => m.Text?.Contains("claim-e") == true);

--- a/tests/RockBot.Host.Tests/AgentContextBuilderKnowledgeGraphTests.cs
+++ b/tests/RockBot.Host.Tests/AgentContextBuilderKnowledgeGraphTests.cs
@@ -100,7 +100,10 @@ public class AgentContextBuilderKnowledgeGraphTests
 
         var (builder, _) = BuildBuilder(graph, ltm);
 
-        await builder.BuildAsync("session-3", "what did Alice think?", CancellationToken.None);
+        // Long enough to bypass short-message dampening (#383) so LTM-seeded graph
+        // expansion still runs. The literal text doesn't matter — graph stub returns
+        // Alice regardless of the query.
+        await builder.BuildAsync("session-3", "what did Alice think about the recent meeting", CancellationToken.None);
 
         // FindEntitiesByNameAsync is called once for the user message and once per top memory
         // (K=2 by default, but only 1 memory is in the store here, so just 1 memory call).

--- a/tests/RockBot.Host.Tests/CapabilityClaimEndToEndTests.cs
+++ b/tests/RockBot.Host.Tests/CapabilityClaimEndToEndTests.cs
@@ -82,13 +82,13 @@ public class CapabilityClaimEndToEndTests
 
         // Use a query that BM25 will match against the claim content so the recall path
         // surfaces the entry; otherwise the entry wouldn't reach the read-side filter.
-        var messages = await builder.BuildAsync("session-1", "wrapper cannot pass arguments", CancellationToken.None);
+        var messages = await builder.BuildAsync("session-1", "wrapper cannot pass arguments to the function", CancellationToken.None);
 
         // 5. Claim must be evicted from disk and absent from the chat context.
         var afterSearch = await ltm.SearchAsync(new MemorySearchCriteria(
             Category: CapabilityClaimCategories.Prefix, MaxResults: 10));
         Assert.AreEqual(0, afterSearch.Count, "Falsified claim was not evicted from long-term memory.");
-        Assert.IsFalse(messages.Any(m => m.Text?.Contains("wrapper cannot pass arguments") == true),
+        Assert.IsFalse(messages.Any(m => m.Text?.Contains("get_calendar_events") == true),
             "Falsified claim leaked into injected context.");
 
         Assert.AreEqual(1, verifier.CallCount, "Verifier was not invoked exactly once for the claim.");
@@ -123,7 +123,7 @@ public class CapabilityClaimEndToEndTests
         var verifier = new AlwaysFailingVerifier();
         var builder = NewBuilder(ltm, verifier, profileOpts);
 
-        await builder.BuildAsync("session-1", "wrapper cannot pass arguments", CancellationToken.None);
+        await builder.BuildAsync("session-1", "wrapper cannot pass arguments to the function", CancellationToken.None);
 
         // Claim is preserved on disk.
         var search = await ltm.SearchAsync(new MemorySearchCriteria(


### PR DESCRIPTION
## Summary

When the user message is ≤30 characters, `AgentContextBuilder` skips per-turn BM25 long-term memory recall, episodic memory recall, skill recall, and service-hint injection — and the embedding generation that backs them. Conversation history, active rules, identity entries, and working memory still flow.

Knowledge-graph memory-seed triples drop out as a consequence since the seed list collapses to empty; user-seed triples (entity name match) still run unchanged.

## Why

Tracked in #383. On short low-signal turns, BM25 over the user message returns lexically-noisy hits that drown out the recent conversation thread. `gpt-5.4-mini` (Low tier) then summarises the injected memory instead of replying to what was said — typically by issuing a `SaveMemory` call and writing *"Noted, I saved X."* as the reply.

Two production incidents in `blazor-session`:

| user message | length | bad reply |
| --- | --- | --- |
| "I'll find out soon" | 18 | "Noted. The Cathedral City trip is on the board for this coming winter, and the health note is now saved with it." |
| "Hopefully we can go this coming winter…" | 67 | "Noted. I've got that on the travel ledger: hoping for Cathedral City this coming winter…" (also duplicated; tracked separately) |

The 30-char threshold catches the 18-char case cleanly. Longer-message variants of the same wrong-context pattern are not addressed here — left as a follow-up under #383.

## Behaviour after the change

- Single new log line when the gate fires:
  `AgentContextBuilder: Short user message (N chars ≤ 30) — skipping per-turn topic search injection`
- Long messages: unchanged.
- First-turn fallback (`recalled.Count == 0 && history.Count == 1`) still runs, so a brand-new session with a short opening message still gets a small memory injection.

## Version

Bumped `Directory.Build.props` to `0.10.51` to match the image already deployed to the maintainer's cluster.

## Test plan

- [x] `dotnet build` clean
- [ ] Live verification — running pod on `0.10.51` for ~25h, gate fired twice on short turns, no wrong-topic SaveMemory→summary replies observed since deploy
- [ ] Unit tests for the gate (follow-up; existing `AgentContextBuilderKnowledgeGraphTests` scaffolding is the natural home)

## Related

- Stacked on top of #382 (target branch).
- Companion diagnostic PR for the duplicated-text symptom: separate PR — different code path, different problem, observability only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)