### PR TITLE
Add DiagnosticLoggingChatClient watch for response duplication (#383)

### DIFF
--- a/src/RockBot.Host/DiagnosticLoggingChatClient.cs
+++ b/src/RockBot.Host/DiagnosticLoggingChatClient.cs
@@ -1,0 +1,111 @@
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+
+namespace RockBot.Host;
+
+/// <summary>
+/// Diagnostic wrapper that inspects assistant messages returned by the inner
+/// <see cref="IChatClient"/> and logs a warning when the response shows the
+/// fingerprint of duplicated content reported by users — either multiple
+/// <see cref="TextContent"/> items in one assistant message, or a single
+/// <see cref="TextContent"/> whose text contains a long substring repeated
+/// across a single newline boundary. Behaviour-neutral; only logs.
+/// </summary>
+public sealed class DiagnosticLoggingChatClient : DelegatingChatClient
+{
+    private readonly ILogger<DiagnosticLoggingChatClient> _logger;
+    private readonly string _tierLabel;
+
+    public DiagnosticLoggingChatClient(
+        IChatClient inner,
+        ILogger<DiagnosticLoggingChatClient> logger,
+        string tierLabel)
+        : base(inner)
+    {
+        _logger = logger;
+        _tierLabel = tierLabel;
+    }
+
+    public override async Task<ChatResponse> GetResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        var response = await base.GetResponseAsync(messages, options, cancellationToken);
+        Inspect(response);
+        return response;
+    }
+
+    public override async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        await foreach (var update in base.GetStreamingResponseAsync(messages, options, cancellationToken))
+            yield return update;
+    }
+
+    private void Inspect(ChatResponse response)
+    {
+        try
+        {
+            for (var i = 0; i < response.Messages.Count; i++)
+            {
+                var msg = response.Messages[i];
+                if (msg.Role != ChatRole.Assistant) continue;
+
+                var textContents = msg.Contents.OfType<TextContent>().ToList();
+
+                if (textContents.Count > 1)
+                {
+                    _logger.LogWarning(
+                        "Duplication-watch [{Tier}]: assistant message[{Idx}] has {Count} TextContent items " +
+                        "(lengths=[{Lengths}]); ChatMessage.Text concatenates without separators. " +
+                        "Contents types=[{Types}]",
+                        _tierLabel, i, textContents.Count,
+                        string.Join(",", textContents.Select(t => t.Text?.Length ?? 0)),
+                        string.Join(",", msg.Contents.Select(c => c.GetType().Name)));
+                }
+
+                if (textContents.Count >= 1
+                    && LooksDuplicated(textContents[textContents.Count - 1].Text, out var prefixLen, out var sample))
+                {
+                    _logger.LogWarning(
+                        "Duplication-watch [{Tier}]: assistant message[{Idx}] TextContent contains a repeated " +
+                        "{PrefixLen}-char prefix after a newline (totalLen={TotalLen}, contentsCount={ContentsCount}, " +
+                        "sample40=\"{Sample}\"). Source is the upstream provider, not RockBot middleware.",
+                        _tierLabel, i, prefixLen, textContents[textContents.Count - 1].Text!.Length,
+                        msg.Contents.Count, sample);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Duplication-watch inspection threw; ignoring");
+        }
+    }
+
+    /// <summary>
+    /// True when <paramref name="text"/> contains a substring of at least 40 characters
+    /// that appears once at the beginning and again immediately after a single newline.
+    /// Catches both exact "X\nX" duplication and partial "X.Y\nX" truncated repeats.
+    /// </summary>
+    internal static bool LooksDuplicated(string? text, out int prefixLen, out string sample)
+    {
+        prefixLen = 0;
+        sample = string.Empty;
+        if (string.IsNullOrEmpty(text) || text.Length < 80) return false;
+
+        const int probeLen = 40;
+        var probe = text.AsSpan(0, Math.Min(probeLen, text.Length));
+        var probeStr = probe.ToString();
+        var needle = "\n" + probeStr;
+        var idx = text.IndexOf(needle, StringComparison.Ordinal);
+        if (idx <= 0) return false;
+
+        prefixLen = probe.Length;
+        sample = probeStr;
+        return true;
+    }
+}

--- a/src/RockBot.Llm/ServiceCollectionExtensions.cs
+++ b/src/RockBot.Llm/ServiceCollectionExtensions.cs
@@ -81,18 +81,27 @@ public static class LlmServiceCollectionExtensions
         {
             var behavior = sp.GetRequiredService<ModelBehavior>();
             var logger = sp.GetRequiredService<ILogger<RockBotFunctionInvokingChatClient>>();
+            var diagLogger = sp.GetRequiredService<ILogger<DiagnosticLoggingChatClient>>();
             var progressNotifier = sp.GetService<IToolProgressNotifier>();
             var toolCallLog = sp.GetService<IToolCallLog>();
             var costEstimator = sp.GetRequiredService<LlmCostEstimator>();
 
-            IChatClient Wrap(IChatClient raw) =>
-                behavior.UseTextBasedToolCalling
-                    ? raw
-                    : new RockBotFunctionInvokingChatClient(raw, progressNotifier, toolCallLog, behavior,
+            IChatClient Wrap(IChatClient raw, string tierLabel)
+            {
+                // Diagnostic-watch sits between the OpenAI client and the function-invoking
+                // middleware so it sees each tool iteration's raw response, including the
+                // assistant message before any RockBot post-processing.
+                var watched = new DiagnosticLoggingChatClient(raw, diagLogger, tierLabel);
+                return behavior.UseTextBasedToolCalling
+                    ? watched
+                    : new RockBotFunctionInvokingChatClient(watched, progressNotifier, toolCallLog, behavior,
                         costEstimator, sp.GetRequiredService<IOptions<AgentHostOptions>>(), logger);
+            }
 
             return new TieredChatClientRegistry(
-                Wrap(lowInnerClient), Wrap(balancedInnerClient), Wrap(highInnerClient));
+                Wrap(lowInnerClient, "Low"),
+                Wrap(balancedInnerClient, "Balanced"),
+                Wrap(highInnerClient, "High"));
         });
 
         // Keep Balanced as the primary IChatClient singleton for consumers that


### PR DESCRIPTION
## Summary

Adds a behaviour-neutral `DelegatingChatClient` that inspects assistant messages returned by the inner `IChatClient` and warns when the response shows the fingerprint of duplicated content reported by users:

- **Multiple `TextContent` items** in a single assistant message — would prove adapter or middleware splitting.
- **A single `TextContent` whose first 40-char prefix repeats after a newline** — catches both exact `X\nX` and truncated `X.Y\nX` patterns.

Wired in via `AddRockBotTieredChatClients` so each tier (Low/Balanced/High) gets the watch between its raw OpenAI client and `RockBotFunctionInvokingChatClient`. Tier label included in every warning.

## Why

Tracked in #383. Three production duplications observed against `gpt-5.4-mini` on Azure Foundry (Low tier), all `\n`-separated:

| time (UTC) | user message | reply pattern |
| --- | --- | --- |
| 02:43:48 | "On the way to AMS, then Brussels" | truncated dup of "On the way to AMS, then Brussels. The travel plan…" |
| 02:53:19 | "Hopefully we can go this coming winter…" | exact dup of "Noted. I've got that on the travel ledger…" |
| 04:28:21 | "Well, not quite yet, but they lowered the gear" | exact dup of "Gear down. Still airborne enough…" |

The 3rd incident was on-topic and 47 chars long — eliminating both the wrong-context hypothesis and the short-message hypothesis, so this is a separate bug from #383's primary fix.

`Microsoft.Extensions.AI` 10.5.x source analysis rules out adapter/middleware as sources:

- `Contents.ConcatText()` joins `TextContent` items with **no separator** — two TextContents would produce `X.X.`, not `X.\nX.`.
- `FunctionInvokingChatClient` does not merge messages across iterations.
- `ExtractAssistantText` returns a single message's `.Text`.
- `M.E.AI.OpenAI` 10.3.0 maps reasoning content to `TextReasoningContent` (a separate AIContent type), which `ConcatText` does not include.

The likely remaining explanation: Azure Foundry's `gpt-5.4-mini` is returning literal `X\nX` in `choices[0].message.content`. This wrapper captures the structure on the next occurrence so we can confirm and decide where to fix.

## What the warning looks like

Two paths the inspector covers:

```
warn: RockBot.Host.DiagnosticLoggingChatClient[0]
      Duplication-watch [Low]: assistant message[2] has 2 TextContent items (lengths=[X,Y]); …
```

```
warn: RockBot.Host.DiagnosticLoggingChatClient[0]
      Duplication-watch [Low]: assistant message[2] TextContent contains a repeated 40-char prefix
      after a newline (totalLen=X, contentsCount=1, sample40="…"). Source is the upstream provider,
      not RockBot middleware.
```

## What this does not do

- No sanitiser. Users still see the duplication until we add one. Investigation order is intentional — we want to know whether the fix belongs in our code or upstream before adding the dedup.
- No version bump. The companion PR (short-message dampening, #384) carries the bump.

## Test plan

- [x] `dotnet build` clean
- [x] Live: running pod on `0.10.51` for ~25h, 0 hits so far (sample size still modest, dups were sporadic)

## Related

- Stacked on top of #382 (target branch).
- Companion behaviour-change PR for the wrong-context bug on short messages: #384.

🤖 Generated with [Claude Code](https://claude.com/claude-code)