### PR TITLE
Self-repair: close wisp pre-flight gap so it engages MCP recovery

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.10.53</Version>
+<Version>0.10.54</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.10.54</Version>
+<Version>0.10.55</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.Tools.Abstractions/IMcpPreflightRecovery.cs
+++ b/src/RockBot.Tools.Abstractions/IMcpPreflightRecovery.cs
@@ -35,6 +35,17 @@ public interface IMcpPreflightRecovery
         IReadOnlyDictionary<string, object?> existingArgs,
         string? parentSessionId,
         CancellationToken ct);
+
+    /// <summary>
+    /// Returns the JSON parameters schema for an MCP tool as a raw string, or null
+    /// when no schema source is available. Lets wisp pre-flight validation succeed
+    /// in bridge-mode agents (where per-server tool registrations don't live in the
+    /// local tool registry) without RockBot.Wisp taking a direct dependency on the
+    /// MCP schema cache. Implementations may transparently fetch from the MCP
+    /// bridge on first use and cache for subsequent calls.
+    /// </summary>
+    Task<string?> TryGetParametersSchemaAsync(
+        string serverName, string toolName, CancellationToken ct);
 }
 
 /// <summary>

--- a/src/RockBot.Tools.Abstractions/IMcpPreflightRecovery.cs
+++ b/src/RockBot.Tools.Abstractions/IMcpPreflightRecovery.cs
@@ -1,0 +1,56 @@
+namespace RockBot.Tools;
+
+/// <summary>
+/// Pre-flight recovery hook for callers that detect schema-mismatch problems
+/// before invoking an MCP tool — most notably wisp Direct MCP steps, whose
+/// schema validator catches missing required fields without going through the
+/// post-flight <c>McpRecoveryExecutor</c> path. Implementations resolve
+/// environmental defaults (time zone, current time, etc.) silently and build
+/// an enriched-error context string for fields they can't fill, so callers
+/// can pass the same schema/description/session-history hints to a downstream
+/// LLM correction step that the post-flight enricher would have provided.
+///
+/// See <c>design/self-repair.md</c> Amendment 1 and the wisp pre-flight gap
+/// addressed alongside it.
+/// </summary>
+public interface IMcpPreflightRecovery
+{
+    /// <summary>
+    /// Given a set of missing required fields for an MCP tool, returns any
+    /// values that environmental-default providers can fill silently plus an
+    /// optional enriched-error context (field schemas, tool-description hints,
+    /// recent same-session calls) for fields no provider could fill.
+    /// </summary>
+    /// <param name="serverName">MCP server name.</param>
+    /// <param name="toolName">Tool name on the server.</param>
+    /// <param name="missingFields">Required fields detected as missing by the caller.</param>
+    /// <param name="existingArgs">Arguments already supplied — passed to defaults providers
+    /// as resolution context.</param>
+    /// <param name="parentSessionId">Session id of the agent that initiated this call,
+    /// used by the enricher to surface recent same-session tool calls. May be null.</param>
+    Task<PreflightRecoveryResult> TryRecoverAsync(
+        string serverName,
+        string toolName,
+        IReadOnlyList<string> missingFields,
+        IReadOnlyDictionary<string, object?> existingArgs,
+        string? parentSessionId,
+        CancellationToken ct);
+}
+
+/// <summary>
+/// Result of <see cref="IMcpPreflightRecovery.TryRecoverAsync"/>.
+/// </summary>
+/// <param name="FilledDefaults">Field name → value pairs that an environmental-default
+/// provider could resolve. The caller merges these into the tool arguments before retrying.
+/// Empty when no provider matched.</param>
+/// <param name="UnresolvedFields">Subset of the input missing fields for which no provider
+/// could supply a value. The caller still has to surface these to a downstream LLM step
+/// (or fail the call) — they were not silently fixed.</param>
+/// <param name="EnrichedErrorContext">Optional multi-line context string produced by the
+/// schema-error enricher for the unresolved fields, suitable for inclusion in an LLM
+/// correction prompt. Null when no enrichment was available (e.g. schema lookup failed
+/// or every missing field was filled).</param>
+public sealed record PreflightRecoveryResult(
+    IReadOnlyDictionary<string, object?> FilledDefaults,
+    IReadOnlyList<string> UnresolvedFields,
+    string? EnrichedErrorContext);

--- a/src/RockBot.Tools.Mcp/McpServiceCollectionExtensions.cs
+++ b/src/RockBot.Tools.Mcp/McpServiceCollectionExtensions.cs
@@ -70,6 +70,12 @@ public static class McpServiceCollectionExtensions
 
         builder.Services.AddSingleton<McpRecoveryExecutor>();
 
+        // Pre-flight recovery: same providers + enricher exposed via a small abstraction
+        // so wisp Direct MCP steps can resolve environmental defaults and surface enriched
+        // errors before invoking the tool, without RockBot.Wisp taking a hard dependency
+        // on RockBot.Tools.Mcp.
+        builder.Services.AddSingleton<IMcpPreflightRecovery, McpPreflightRecovery>();
+
         builder.HandleMessage<McpServersIndexed, McpServersIndexedHandler>();
         builder.SubscribeTo($"tool.meta.mcp.{agentName}");
 

--- a/src/RockBot.Tools.Mcp/Recovery/McpPreflightRecovery.cs
+++ b/src/RockBot.Tools.Mcp/Recovery/McpPreflightRecovery.cs
@@ -16,9 +16,29 @@ namespace RockBot.Tools.Mcp.Recovery;
 public sealed class McpPreflightRecovery(
     IEnumerable<IToolArgumentDefaultsProvider> providers,
     SchemaErrorEnricher? enricher,
-    ILogger<McpPreflightRecovery> logger) : IMcpPreflightRecovery
+    ILogger<McpPreflightRecovery> logger,
+    ToolSchemaCache? schemas = null) : IMcpPreflightRecovery
 {
     private readonly IReadOnlyList<IToolArgumentDefaultsProvider> _providers = providers.ToList();
+
+    public async Task<string?> TryGetParametersSchemaAsync(
+        string serverName, string toolName, CancellationToken ct)
+    {
+        if (schemas is null) return null;
+        try
+        {
+            var def = await schemas.GetAsync(serverName, toolName, ct);
+            return def?.ParametersSchema;
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "Pre-flight schema lookup failed for {Server}/{Tool}; falling back to no validation",
+                serverName, toolName);
+            return null;
+        }
+    }
 
     public async Task<PreflightRecoveryResult> TryRecoverAsync(
         string serverName,

--- a/src/RockBot.Tools.Mcp/Recovery/McpPreflightRecovery.cs
+++ b/src/RockBot.Tools.Mcp/Recovery/McpPreflightRecovery.cs
@@ -1,0 +1,102 @@
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace RockBot.Tools.Mcp.Recovery;
+
+/// <summary>
+/// Default implementation of <see cref="IMcpPreflightRecovery"/>. Iterates the
+/// registered <see cref="IToolArgumentDefaultsProvider"/> set (same providers
+/// used by the post-flight <see cref="McpRecoveryExecutor"/>) to silently fill
+/// environmental defaults, and delegates per-field enrichment to
+/// <see cref="SchemaErrorEnricher"/> for fields no provider could resolve.
+/// This keeps wisp Direct MCP authoring failures on the same recovery rails as
+/// LLM-orchestrated calls — see <c>design/self-repair.md</c> Amendment 1 and
+/// the wisp pre-flight gap.
+/// </summary>
+public sealed class McpPreflightRecovery(
+    IEnumerable<IToolArgumentDefaultsProvider> providers,
+    SchemaErrorEnricher? enricher,
+    ILogger<McpPreflightRecovery> logger) : IMcpPreflightRecovery
+{
+    private readonly IReadOnlyList<IToolArgumentDefaultsProvider> _providers = providers.ToList();
+
+    public async Task<PreflightRecoveryResult> TryRecoverAsync(
+        string serverName,
+        string toolName,
+        IReadOnlyList<string> missingFields,
+        IReadOnlyDictionary<string, object?> existingArgs,
+        string? parentSessionId,
+        CancellationToken ct)
+    {
+        if (missingFields.Count == 0)
+            return new PreflightRecoveryResult(
+                new Dictionary<string, object?>(StringComparer.Ordinal), [], null);
+
+        var filled = new Dictionary<string, object?>(StringComparer.Ordinal);
+        var unresolved = new List<string>();
+
+        foreach (var fieldName in missingFields)
+        {
+            var value = await TryResolveAsync(serverName, toolName, fieldName, existingArgs, ct);
+            if (value is not null)
+                filled[fieldName] = value.Value;
+            else
+                unresolved.Add(fieldName);
+        }
+
+        string? enriched = null;
+        if (unresolved.Count > 0 && enricher is not null)
+        {
+            var sb = new StringBuilder();
+            foreach (var field in unresolved)
+            {
+                try
+                {
+                    var fragment = await enricher.EnrichAsync(
+                        serverName, toolName, field, parentSessionId,
+                        originalError: $"Missing required field '{field}' for {serverName}/{toolName}.",
+                        ct);
+                    if (sb.Length > 0) sb.AppendLine();
+                    sb.AppendLine(fragment);
+                }
+                catch (OperationCanceledException) { throw; }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(ex,
+                        "Pre-flight enrichment failed for {Server}/{Tool} field {Field}",
+                        serverName, toolName, field);
+                }
+            }
+            if (sb.Length > 0)
+                enriched = sb.ToString().TrimEnd();
+        }
+
+        return new PreflightRecoveryResult(filled, unresolved, enriched);
+    }
+
+    private async Task<ResolvedDefault?> TryResolveAsync(
+        string serverName, string toolName, string fieldName,
+        IReadOnlyDictionary<string, object?> existingArgs, CancellationToken ct)
+    {
+        var ctx = new ResolveContext(serverName, toolName, fieldName, existingArgs);
+        foreach (var provider in _providers)
+        {
+            if (!provider.CanResolve(serverName, toolName, fieldName)) continue;
+
+            try
+            {
+                var resolved = await provider.ResolveAsync(ctx, ct);
+                if (resolved is not null)
+                    return resolved;
+            }
+            catch (OperationCanceledException) { throw; }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex,
+                    "Pre-flight default provider {Provider} threw for {Server}/{Tool} field {Field}",
+                    provider.GetType().Name, serverName, toolName, fieldName);
+            }
+        }
+        return null;
+    }
+}

--- a/src/RockBot.Wisp/McpStepValidator.cs
+++ b/src/RockBot.Wisp/McpStepValidator.cs
@@ -40,29 +40,68 @@ internal static class McpStepValidator
     /// when required fields are missing or unknown fields are present under a
     /// closed schema.
     /// </summary>
-    public static WispStepError? Validate(WispStep step, IToolRegistry registry) =>
-        ValidateDetailed(step, registry).Error;
+    public static async Task<WispStepError?> ValidateAsync(
+        WispStep step, IToolRegistry registry,
+        IMcpPreflightRecovery? schemaSource, CancellationToken ct) =>
+        (await ValidateDetailedAsync(step, registry, schemaSource, ct)).Error;
 
     /// <summary>
-    /// Same as <see cref="Validate"/> but exposes the missing and unknown field lists
+    /// Same as <see cref="ValidateAsync"/> but exposes the missing and unknown field lists
     /// structurally so callers can route them through <see cref="IMcpPreflightRecovery"/>
     /// before falling back to LLM auto-correction.
     /// </summary>
-    public static Result ValidateDetailed(WispStep step, IToolRegistry registry)
+    /// <param name="schemaSource">Optional fallback source for the parameters schema —
+    /// used in bridge-mode agents where per-server MCP tool registrations don't live
+    /// in the local tool registry. When non-null the validator consults this source
+    /// only if the registry lookup misses; resolution failures (timeout, no schema)
+    /// fall through to "validation skipped" rather than blocking the step.</param>
+    public static async Task<Result> ValidateDetailedAsync(
+        WispStep step, IToolRegistry registry,
+        IMcpPreflightRecovery? schemaSource, CancellationToken ct)
     {
         if (step.Gateway != GatewayType.Mcp)
             return EmptyResult;
         if (string.IsNullOrEmpty(step.Server) || string.IsNullOrEmpty(step.Tool))
             return EmptyResult;
 
-        var tool = FindMcpTool(registry, step.Server, step.Tool);
-        if (tool?.ParametersSchema is null)
+        var schemaJson = FindMcpTool(registry, step.Server, step.Tool)?.ParametersSchema;
+        if (schemaJson is null && schemaSource is not null)
+        {
+            schemaJson = await schemaSource.TryGetParametersSchemaAsync(
+                step.Server!, step.Tool!, ct);
+        }
+        return ValidateAgainstSchema(step, schemaJson);
+    }
+
+    /// <summary>
+    /// Registry-only synchronous validator, retained for unit tests and for callers
+    /// that don't have an <see cref="IMcpPreflightRecovery"/> available. Production
+    /// callers should prefer <see cref="ValidateAsync"/> so bridge-mode schemas
+    /// (cached via the MCP management proxy) are consulted too.
+    /// </summary>
+    public static WispStepError? Validate(WispStep step, IToolRegistry registry) =>
+        ValidateDetailed(step, registry).Error;
+
+    /// <inheritdoc cref="Validate"/>
+    public static Result ValidateDetailed(WispStep step, IToolRegistry registry)
+    {
+        if (step.Gateway != GatewayType.Mcp)
+            return EmptyResult;
+        if (string.IsNullOrEmpty(step.Server) || string.IsNullOrEmpty(step.Tool))
+            return EmptyResult;
+        return ValidateAgainstSchema(step,
+            FindMcpTool(registry, step.Server, step.Tool)?.ParametersSchema);
+    }
+
+    private static Result ValidateAgainstSchema(WispStep step, string? schemaJson)
+    {
+        if (schemaJson is null)
             return EmptyResult;
 
         JsonElement schema;
         try
         {
-            schema = JsonDocument.Parse(tool.ParametersSchema).RootElement;
+            schema = JsonDocument.Parse(schemaJson).RootElement;
         }
         catch (JsonException)
         {

--- a/src/RockBot.Wisp/McpStepValidator.cs
+++ b/src/RockBot.Wisp/McpStepValidator.cs
@@ -18,6 +18,20 @@ namespace RockBot.Wisp;
 internal static class McpStepValidator
 {
     /// <summary>
+    /// Structured validation outcome. <see cref="Error"/> is non-null exactly when
+    /// either <see cref="MissingFields"/> or <see cref="UnknownFields"/> is non-empty.
+    /// <see cref="MissingFields"/> is exposed so callers (e.g. wisp pre-flight recovery)
+    /// can hand the field list to <see cref="IMcpPreflightRecovery"/> for environmental
+    /// fills and schema-error enrichment.
+    /// </summary>
+    public sealed record Result(
+        IReadOnlyList<string> MissingFields,
+        IReadOnlyList<string> UnknownFields,
+        WispStepError? Error);
+
+    private static readonly Result EmptyResult = new([], [], null);
+
+    /// <summary>
     /// Validates an MCP-gateway step's resolved params against the target tool's
     /// schema. Returns <c>null</c> if valid, a schema-free step (non-MCP, or the
     /// tool is unregistered/unschematized), or if the params JSON is malformed —
@@ -26,16 +40,24 @@ internal static class McpStepValidator
     /// when required fields are missing or unknown fields are present under a
     /// closed schema.
     /// </summary>
-    public static WispStepError? Validate(WispStep step, IToolRegistry registry)
+    public static WispStepError? Validate(WispStep step, IToolRegistry registry) =>
+        ValidateDetailed(step, registry).Error;
+
+    /// <summary>
+    /// Same as <see cref="Validate"/> but exposes the missing and unknown field lists
+    /// structurally so callers can route them through <see cref="IMcpPreflightRecovery"/>
+    /// before falling back to LLM auto-correction.
+    /// </summary>
+    public static Result ValidateDetailed(WispStep step, IToolRegistry registry)
     {
         if (step.Gateway != GatewayType.Mcp)
-            return null;
+            return EmptyResult;
         if (string.IsNullOrEmpty(step.Server) || string.IsNullOrEmpty(step.Tool))
-            return null;
+            return EmptyResult;
 
         var tool = FindMcpTool(registry, step.Server, step.Tool);
         if (tool?.ParametersSchema is null)
-            return null;
+            return EmptyResult;
 
         JsonElement schema;
         try
@@ -44,7 +66,7 @@ internal static class McpStepValidator
         }
         catch (JsonException)
         {
-            return null;
+            return EmptyResult;
         }
 
         var paramsElement = step.ResolvedParams;
@@ -53,14 +75,15 @@ internal static class McpStepValidator
 
         var (missing, unknown) = Compare(schema, paramsElement.Value);
         if (missing.Count == 0 && unknown.Count == 0)
-            return null;
+            return EmptyResult;
 
-        return new WispStepError
+        var error = new WispStepError
         {
             Category = FailureCategory.Structural,
             Message = BuildErrorMessage(step.Server!, step.Tool!, missing, unknown, schema),
             ToolName = $"{step.Server}/{step.Tool}"
         };
+        return new Result(missing, unknown, error);
     }
 
     private static ToolRegistration? FindMcpTool(IToolRegistry registry, string server, string tool)

--- a/src/RockBot.Wisp/SpawnWispsExecutor.cs
+++ b/src/RockBot.Wisp/SpawnWispsExecutor.cs
@@ -96,7 +96,7 @@ internal sealed class SpawnWispsExecutor(
             var defJson = JsonSerializer.Serialize(definition, JsonOptions);
             var defHash = ComputeDefinitionHash(defJson);
 
-            var result = await wispExecutor.ExecuteAsync(definition, wispId, ct);
+            var result = await wispExecutor.ExecuteAsync(definition, wispId, parentSessionId: sessionId, ct);
 
             // Log execution (fire-and-forget, don't block the batch)
             _ = LogExecutionAsync(result, defHash, batchId, sessionId, ct);

--- a/src/RockBot.Wisp/WispExecutor.cs
+++ b/src/RockBot.Wisp/WispExecutor.cs
@@ -21,7 +21,8 @@ internal sealed class WispExecutor(
     WispOptions options,
     ILogger<WispExecutor> logger,
     ILlmClient? llmClient = null,
-    ISessionA2ACanceller? a2aCanceller = null)
+    ISessionA2ACanceller? a2aCanceller = null,
+    IMcpPreflightRecovery? preflightRecovery = null)
 {
     private const int DefaultLlmStepMaxIterations = 10;
     private const int InputChunkingThreshold = 8_000;
@@ -44,9 +45,22 @@ internal sealed class WispExecutor(
     /// <summary>
     /// Executes all steps in the wisp definition sequentially, returning a structured result.
     /// </summary>
+    /// <param name="parentSessionId">Session id of the agent that spawned this wisp.
+    /// Used as the <c>SessionId</c> on tool invocations so post-flight recovery enrichment
+    /// (and the pre-flight recovery hook, when wired) can surface recent same-session
+    /// tool calls. Falls back to <paramref name="wispId"/> when null — preserves
+    /// pre-existing behaviour for tests and callers that don't track a parent session.</param>
+    public Task<WispExecutionResult> ExecuteAsync(
+        WispDefinition definition,
+        string wispId,
+        CancellationToken ct) =>
+        ExecuteAsync(definition, wispId, parentSessionId: null, ct);
+
+    /// <inheritdoc cref="ExecuteAsync(WispDefinition, string, CancellationToken)"/>
     public async Task<WispExecutionResult> ExecuteAsync(
         WispDefinition definition,
         string wispId,
+        string? parentSessionId,
         CancellationToken ct)
     {
         logger.LogInformation("Wisp {WispId} starting: {Description} ({StepCount} steps)",
@@ -92,8 +106,8 @@ internal sealed class WispExecutor(
             {
                 stepResult = step.Mode switch
                 {
-                    StepMode.Direct => await ExecuteDirectStepAsync(step, i, wispId, wispNamespace, resultsByStepId, ct),
-                    StepMode.Llm => await ExecuteLlmStepAsync(step, i, definition, wispId, wispNamespace, resultsByStepId, ct),
+                    StepMode.Direct => await ExecuteDirectStepAsync(step, i, wispId, parentSessionId, wispNamespace, resultsByStepId, ct),
+                    StepMode.Llm => await ExecuteLlmStepAsync(step, i, definition, wispId, parentSessionId, wispNamespace, resultsByStepId, ct),
                     _ => new WispStepResult
                     {
                         StepId = step.Id,
@@ -228,6 +242,7 @@ internal sealed class WispExecutor(
         WispStep step,
         int index,
         string wispId,
+        string? parentSessionId,
         string wispNamespace,
         IReadOnlyDictionary<string, WispStepResult> priorResults,
         CancellationToken ct)
@@ -272,14 +287,61 @@ internal sealed class WispExecutor(
         // Pre-flight schema validation for MCP gateway steps. Catches authoring
         // mistakes (missing required fields, unknown fields under a closed schema)
         // before the tool is invoked, so a silent "empty result" can't be mistaken
-        // for a valid answer. On failure, attempt a single focused auto-correction
-        // LLM call — a tool-less one-shot that sees only the failing params and the
-        // schema summary. If the correction passes validation, the step proceeds
-        // with corrected params; otherwise the original error is surfaced.
-        var validationError = McpStepValidator.Validate(step, toolRegistry);
-        if (validationError is not null)
+        // for a valid answer. On failure, first delegate to IMcpPreflightRecovery —
+        // it can silently fill environmental defaults (timeZone, current time) and
+        // build an enriched-error context for fields no provider could supply, so
+        // the downstream auto-correction LLM call gets the same schema/description/
+        // session-history hints McpRecoveryExecutor would surface post-flight. If
+        // recovery resolves every missing field the step proceeds without an LLM
+        // round-trip; otherwise we fall through to a single focused LLM correction.
+        var validation = McpStepValidator.ValidateDetailed(step, toolRegistry);
+        if (validation.Error is { } validationError)
         {
-            var corrected = await TryAutoCorrectMcpParamsAsync(step, validationError, ct);
+            string? enrichedContext = null;
+
+            if (preflightRecovery is not null && validation.MissingFields.Count > 0)
+            {
+                var (filledStep, unresolved, enriched) =
+                    await TryFillPreflightDefaultsAsync(step, validation.MissingFields, parentSessionId, ct);
+                enrichedContext = enriched;
+
+                if (filledStep is not null)
+                {
+                    // Some (possibly all) missing fields filled silently — re-route +
+                    // re-validate against the merged params. A clean pass proceeds
+                    // to invocation; otherwise we keep filledStep as the new baseline
+                    // for the LLM correction so it doesn't have to re-derive defaults.
+                    step = filledStep;
+                    route = GatewayRouter.Route(step, wispId, priorResults);
+                    if (!route.IsSuccess)
+                    {
+                        return new WispStepResult
+                        {
+                            StepId = step.Id,
+                            StepIndex = index,
+                            IsSuccess = false,
+                            Error = new WispStepError
+                            {
+                                Category = route.ErrorCategory ?? FailureCategory.Structural,
+                                Message = route.ErrorMessage!
+                            },
+                            Duration = stepSw.Elapsed
+                        };
+                    }
+                    var afterFill = McpStepValidator.ValidateDetailed(step, toolRegistry);
+                    if (afterFill.Error is null)
+                    {
+                        logger.LogInformation(
+                            "Wisp {WispId} step {StepId}: pre-flight recovery filled environmental defaults for {Server}/{Tool}; proceeding without LLM correction",
+                            wispId, step.Id, step.Server, step.Tool);
+                        goto invoke;
+                    }
+                    // Still failing — carry the residual validation error into auto-correction.
+                    validationError = afterFill.Error;
+                }
+            }
+
+            var corrected = await TryAutoCorrectMcpParamsAsync(step, validationError, enrichedContext, ct);
             if (corrected is null)
             {
                 return new WispStepResult
@@ -329,6 +391,7 @@ internal sealed class WispExecutor(
                 wispId, step.Id, step.Server, step.Tool);
         }
 
+    invoke:
         // Resolve the executor from the registry
         var executor = toolRegistry.GetExecutor(route.ToolName!);
         if (executor is null)
@@ -348,13 +411,16 @@ internal sealed class WispExecutor(
             };
         }
 
-        // Invoke the tool
+        // Invoke the tool. Use the parent session id when available so
+        // McpRecoveryExecutor's enricher can surface recent same-session tool
+        // calls from the agent that spawned this wisp; fall back to wispId to
+        // preserve pre-existing behaviour for callers that don't track one.
         var request = new ToolInvokeRequest
         {
             ToolCallId = $"wisp-{wispId}-{step.Id}",
             ToolName = route.ToolName!,
             Arguments = route.Arguments,
-            SessionId = wispId
+            SessionId = parentSessionId ?? wispId
         };
 
         var response = await executor.ExecuteAsync(request, ct);
@@ -432,6 +498,7 @@ internal sealed class WispExecutor(
         int index,
         WispDefinition definition,
         string wispId,
+        string? parentSessionId,
         string wispNamespace,
         IReadOnlyDictionary<string, WispStepResult> priorResults,
         CancellationToken ct)
@@ -510,7 +577,7 @@ internal sealed class WispExecutor(
         chatMessages.Add(new ChatMessage(ChatRole.User, userPrompt));
 
         // Build scoped tool set for the LLM step
-        var scopedTools = BuildLlmStepTools(definition, wispNamespace);
+        var scopedTools = BuildLlmStepTools(definition, wispNamespace, parentSessionId);
 
         var chatOptions = new ChatOptions
         {
@@ -576,7 +643,7 @@ internal sealed class WispExecutor(
     /// - Tools listed in the top-level 'tools' array
     /// - Working memory tools (GetFromWorkingMemory, SearchWorkingMemory)
     /// </summary>
-    private List<AITool> BuildLlmStepTools(WispDefinition definition, string wispNamespace)
+    private List<AITool> BuildLlmStepTools(WispDefinition definition, string wispNamespace, string? parentSessionId)
     {
         var tools = new List<AITool>();
 
@@ -605,7 +672,8 @@ internal sealed class WispExecutor(
 
             if (registration is not null && executor is not null)
             {
-                tools.Add(new WispRegistryToolFunction(registration, executor, wispId: wispNamespace));
+                tools.Add(new WispRegistryToolFunction(registration, executor,
+                    wispId: wispNamespace, parentSessionId: parentSessionId));
             }
         }
 
@@ -828,33 +896,126 @@ internal sealed class WispExecutor(
     }
 
     /// <summary>
+    /// Delegates to <see cref="IMcpPreflightRecovery"/> to silently resolve any
+    /// missing required fields it can (environmental defaults like timeZone or
+    /// current time) and to build an enriched-error context for the rest. Returns
+    /// (filledStep, unresolved, enrichedContext): <c>filledStep</c> is non-null
+    /// only when at least one field was filled and is a copy of <paramref name="step"/>
+    /// with the resolved fields merged into its params; <c>unresolved</c> is the
+    /// subset of input fields that no provider could supply; <c>enrichedContext</c>
+    /// is the LLM-ready context string for those unresolved fields (null when the
+    /// enricher had nothing to contribute).
+    /// </summary>
+    private async Task<(WispStep? FilledStep, IReadOnlyList<string> Unresolved, string? EnrichedContext)>
+        TryFillPreflightDefaultsAsync(
+            WispStep step,
+            IReadOnlyList<string> missingFields,
+            string? parentSessionId,
+            CancellationToken ct)
+    {
+        if (preflightRecovery is null || string.IsNullOrEmpty(step.Server) || string.IsNullOrEmpty(step.Tool))
+            return (null, missingFields, null);
+
+        var existingArgs = ParseExistingArgs(step.ResolvedParams);
+
+        PreflightRecoveryResult result;
+        try
+        {
+            result = await preflightRecovery.TryRecoverAsync(
+                step.Server!, step.Tool!, missingFields, existingArgs, parentSessionId, ct);
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "Wisp pre-flight recovery threw for {Server}/{Tool}; falling back to LLM auto-correction",
+                step.Server, step.Tool);
+            return (null, missingFields, null);
+        }
+
+        if (result.FilledDefaults.Count == 0)
+            return (null, result.UnresolvedFields, result.EnrichedErrorContext);
+
+        // Merge filled defaults into the step's params and rebuild the JsonElement.
+        var merged = new Dictionary<string, object?>(existingArgs);
+        foreach (var (key, value) in result.FilledDefaults)
+            merged[key] = value;
+
+        JsonElement mergedParams;
+        try
+        {
+            mergedParams = JsonSerializer.SerializeToElement(merged);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "Failed to serialise merged params after pre-flight fill for {Server}/{Tool}",
+                step.Server, step.Tool);
+            return (null, result.UnresolvedFields, result.EnrichedErrorContext);
+        }
+
+        var filledStep = step with { Params = mergedParams, Input = null, Arguments = null };
+        return (filledStep, result.UnresolvedFields, result.EnrichedErrorContext);
+    }
+
+    private static Dictionary<string, object?> ParseExistingArgs(JsonElement? paramsEl)
+    {
+        if (paramsEl is null || paramsEl.Value.ValueKind != JsonValueKind.Object)
+            return new(StringComparer.Ordinal);
+
+        var dict = new Dictionary<string, object?>(StringComparer.Ordinal);
+        foreach (var p in paramsEl.Value.EnumerateObject())
+            dict[p.Name] = p.Value.ValueKind switch
+            {
+                JsonValueKind.String => p.Value.GetString(),
+                JsonValueKind.Number => p.Value.TryGetInt64(out var l) ? l : p.Value.GetDouble(),
+                JsonValueKind.True => true,
+                JsonValueKind.False => false,
+                JsonValueKind.Null => null,
+                _ => (object?)p.Value.Clone()
+            };
+        return dict;
+    }
+
+    /// <summary>
     /// Single-shot focused LLM call that rewrites the failing step's <c>params</c>
     /// to match the tool's schema. No tools available, narrow prompt, cheap tier.
     /// Returns a new <see cref="WispStep"/> with corrected params on success, or
     /// <c>null</c> if the correction attempt was skipped (no llm client wired up),
     /// threw, or produced something we couldn't parse as a JSON object.
+    /// <paramref name="enrichedContext"/>, when supplied by <see cref="IMcpPreflightRecovery"/>,
+    /// is appended to the prompt and carries the same schema/description/session-history
+    /// hints that <see cref="Recovery"/>'s post-flight enricher would have surfaced.
     /// The caller re-validates — we don't trust this output blindly.
     /// </summary>
     private async Task<WispStep?> TryAutoCorrectMcpParamsAsync(
-        WispStep step, WispStepError error, CancellationToken ct)
+        WispStep step, WispStepError error, string? enrichedContext, CancellationToken ct)
     {
         if (llmClient is null)
             return null;
 
         var currentParams = step.ResolvedParams?.GetRawText() ?? "{}";
+        var contextSection = string.IsNullOrEmpty(enrichedContext)
+            ? ""
+            : $"Recovery context (schema, tool-description hints, recent session calls):\n{enrichedContext}\n\n";
+
         var prompt =
             $"A wisp step's `params` failed schema validation. " +
             $"Rewrite the params to match the tool's schema.\n\n" +
             $"Tool: {step.Server}/{step.Tool}\n\n" +
             $"Current params:\n{currentParams}\n\n" +
             $"Validation error (includes the expected schema):\n{error.Message}\n\n" +
-            "Use ONLY values already present in the current params.\n" +
+            contextSection +
+            "Use ONLY values already present in the current params or values you can " +
+            "reasonably derive from the recovery context above (e.g. an emailId visible " +
+            "in a recent search_emails result listed in the context).\n" +
             "- If a required field matches a current param's meaning under a different " +
             "name (e.g. current `startDate` → schema `timeMin`, same value), remap it.\n" +
-            "- If a required field has NO semantic match in the current params, do NOT " +
-            $"invent one. Respond with exactly the word {NoCorrectionSentinel} and nothing " +
-            "else. The caller will surface the validation error so it can fetch the " +
-            "missing information itself.\n\n" +
+            "- If a required field has NO semantic match in the current params and the " +
+            "recovery context does not name a value to use, do NOT invent one. Respond " +
+            $"with exactly the word {NoCorrectionSentinel} and nothing else. The caller " +
+            "will surface the validation error so it can fetch the missing information " +
+            "itself.\n\n" +
             "Return ONLY a single JSON object (corrected params) or the exact string " +
             $"{NoCorrectionSentinel}. No code fences, no commentary, no prose.";
 

--- a/src/RockBot.Wisp/WispExecutor.cs
+++ b/src/RockBot.Wisp/WispExecutor.cs
@@ -294,7 +294,8 @@ internal sealed class WispExecutor(
         // session-history hints McpRecoveryExecutor would surface post-flight. If
         // recovery resolves every missing field the step proceeds without an LLM
         // round-trip; otherwise we fall through to a single focused LLM correction.
-        var validation = McpStepValidator.ValidateDetailed(step, toolRegistry);
+        var validation = await McpStepValidator.ValidateDetailedAsync(
+            step, toolRegistry, preflightRecovery, ct);
         if (validation.Error is { } validationError)
         {
             string? enrichedContext = null;
@@ -328,7 +329,8 @@ internal sealed class WispExecutor(
                             Duration = stepSw.Elapsed
                         };
                     }
-                    var afterFill = McpStepValidator.ValidateDetailed(step, toolRegistry);
+                    var afterFill = await McpStepValidator.ValidateDetailedAsync(
+                        step, toolRegistry, preflightRecovery, ct);
                     if (afterFill.Error is null)
                     {
                         logger.LogInformation(
@@ -374,7 +376,8 @@ internal sealed class WispExecutor(
                     Duration = stepSw.Elapsed
                 };
             }
-            var recheck = McpStepValidator.Validate(step, toolRegistry);
+            var recheck = await McpStepValidator.ValidateAsync(
+                step, toolRegistry, preflightRecovery, ct);
             if (recheck is not null)
             {
                 return new WispStepResult

--- a/src/RockBot.Wisp/WispRegistryToolFunction.cs
+++ b/src/RockBot.Wisp/WispRegistryToolFunction.cs
@@ -12,7 +12,8 @@ namespace RockBot.Wisp;
 internal sealed class WispRegistryToolFunction(
     ToolRegistration registration,
     IToolExecutor executor,
-    string wispId) : AIFunction
+    string wispId,
+    string? parentSessionId = null) : AIFunction
 {
     private static readonly JsonSerializerOptions SerializerOptions = new();
 
@@ -49,7 +50,7 @@ internal sealed class WispRegistryToolFunction(
             ToolCallId = $"wisp-{wispId}-{Guid.NewGuid():N}",
             ToolName = registration.Name,
             Arguments = argsJson,
-            SessionId = wispId
+            SessionId = parentSessionId ?? wispId
         };
 
         var response = await executor.ExecuteAsync(request, cancellationToken);

--- a/tests/RockBot.Tools.Tests/Recovery/McpPreflightRecoveryTests.cs
+++ b/tests/RockBot.Tools.Tests/Recovery/McpPreflightRecoveryTests.cs
@@ -1,0 +1,212 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using RockBot.Host;
+using RockBot.Tools.Mcp;
+using RockBot.Tools.Mcp.Recovery;
+
+namespace RockBot.Tools.Tests.Recovery;
+
+[TestClass]
+public class McpPreflightRecoveryTests
+{
+    [TestMethod]
+    public async Task NoMissingFields_ReturnsEmptyResult()
+    {
+        var recovery = new McpPreflightRecovery(
+            providers: [],
+            enricher: null,
+            logger: NullLogger<McpPreflightRecovery>.Instance);
+
+        var result = await recovery.TryRecoverAsync(
+            "srv", "do", missingFields: [],
+            existingArgs: new Dictionary<string, object?>(),
+            parentSessionId: null, CancellationToken.None);
+
+        Assert.AreEqual(0, result.FilledDefaults.Count);
+        Assert.AreEqual(0, result.UnresolvedFields.Count);
+        Assert.IsNull(result.EnrichedErrorContext);
+    }
+
+    [TestMethod]
+    public async Task EnvironmentalProvider_FillsField_SilentlyAndDropsFromUnresolved()
+    {
+        var provider = new StubProvider("timeZone", "America/Chicago");
+        var recovery = new McpPreflightRecovery(
+            providers: [provider],
+            enricher: null,
+            logger: NullLogger<McpPreflightRecovery>.Instance);
+
+        var result = await recovery.TryRecoverAsync(
+            "calendar-mcp", "get_calendar_events",
+            missingFields: ["timeZone"],
+            existingArgs: new Dictionary<string, object?>(),
+            parentSessionId: null, CancellationToken.None);
+
+        Assert.AreEqual(1, result.FilledDefaults.Count);
+        Assert.AreEqual("America/Chicago", result.FilledDefaults["timeZone"]);
+        Assert.AreEqual(0, result.UnresolvedFields.Count);
+        Assert.IsNull(result.EnrichedErrorContext);
+    }
+
+    [TestMethod]
+    public async Task UnfilledFields_AreEnriched()
+    {
+        // No provider for emailId — recovery should mark it unresolved and ask
+        // the enricher to build context for it.
+        var schemasByServer = new Dictionary<string, IReadOnlyList<McpToolDefinition>>
+        {
+            ["calendar-mcp"] = new[]
+            {
+                new McpToolDefinition
+                {
+                    Name = "get_email_details",
+                    Description = "Fetch full email content. Obtain emailId from search_emails results.",
+                    ParametersSchema = """{"type":"object","properties":{"emailId":{"type":"string","description":"Email id from a search result"}},"required":["emailId"]}"""
+                }
+            }
+        };
+        var enricher = new SchemaErrorEnricher(
+            new ToolSchemaCache((server, _) =>
+                Task.FromResult<IReadOnlyList<McpToolDefinition>?>(
+                    schemasByServer.TryGetValue(server, out var v) ? v : null)),
+            new EmptyToolCallLog());
+
+        var recovery = new McpPreflightRecovery(
+            providers: [],
+            enricher: enricher,
+            logger: NullLogger<McpPreflightRecovery>.Instance);
+
+        var result = await recovery.TryRecoverAsync(
+            "calendar-mcp", "get_email_details",
+            missingFields: ["emailId"],
+            existingArgs: new Dictionary<string, object?>(),
+            parentSessionId: null, CancellationToken.None);
+
+        Assert.AreEqual(0, result.FilledDefaults.Count);
+        CollectionAssert.AreEqual(new[] { "emailId" }, result.UnresolvedFields.ToArray());
+        Assert.IsNotNull(result.EnrichedErrorContext);
+        StringAssert.Contains(result.EnrichedErrorContext!, "Email id from a search result");
+        StringAssert.Contains(result.EnrichedErrorContext!, "search_emails");
+    }
+
+    [TestMethod]
+    public async Task PartialFill_OneFilledOneEnriched()
+    {
+        var schemasByServer = new Dictionary<string, IReadOnlyList<McpToolDefinition>>
+        {
+            ["calendar-mcp"] = new[]
+            {
+                new McpToolDefinition
+                {
+                    Name = "get_calendar_events",
+                    Description = "List events. accountId required. timeZone required.",
+                    ParametersSchema = """{"type":"object","properties":{"accountId":{"type":"string"},"timeZone":{"type":"string","description":"IANA tz"}},"required":["accountId","timeZone"]}"""
+                }
+            }
+        };
+        var enricher = new SchemaErrorEnricher(
+            new ToolSchemaCache((server, _) =>
+                Task.FromResult<IReadOnlyList<McpToolDefinition>?>(
+                    schemasByServer.TryGetValue(server, out var v) ? v : null)),
+            new EmptyToolCallLog());
+
+        var provider = new StubProvider("timeZone", "America/Chicago");
+        var recovery = new McpPreflightRecovery(
+            providers: [provider],
+            enricher: enricher,
+            logger: NullLogger<McpPreflightRecovery>.Instance);
+
+        var result = await recovery.TryRecoverAsync(
+            "calendar-mcp", "get_calendar_events",
+            missingFields: ["accountId", "timeZone"],
+            existingArgs: new Dictionary<string, object?>(),
+            parentSessionId: null, CancellationToken.None);
+
+        Assert.AreEqual(1, result.FilledDefaults.Count);
+        Assert.AreEqual("America/Chicago", result.FilledDefaults["timeZone"]);
+        CollectionAssert.AreEqual(new[] { "accountId" }, result.UnresolvedFields.ToArray());
+        Assert.IsNotNull(result.EnrichedErrorContext);
+        StringAssert.Contains(result.EnrichedErrorContext!, "accountId");
+    }
+
+    [TestMethod]
+    public async Task ProviderThrows_ContinuesToNextProvider()
+    {
+        var throwing = new ThrowingProvider("timeZone");
+        var working = new StubProvider("timeZone", "UTC");
+
+        var recovery = new McpPreflightRecovery(
+            providers: [throwing, working],
+            enricher: null,
+            logger: NullLogger<McpPreflightRecovery>.Instance);
+
+        var result = await recovery.TryRecoverAsync(
+            "srv", "tool", missingFields: ["timeZone"],
+            existingArgs: new Dictionary<string, object?>(),
+            parentSessionId: null, CancellationToken.None);
+
+        Assert.AreEqual("UTC", result.FilledDefaults["timeZone"]);
+    }
+
+    [TestMethod]
+    public async Task ParentSessionId_FlowsToEnricher()
+    {
+        var captured = new List<string?>();
+        var enricher = new SchemaErrorEnricher(
+            new ToolSchemaCache((_, _) => Task.FromResult<IReadOnlyList<McpToolDefinition>?>(null)),
+            new CapturingToolCallLog(captured));
+
+        var recovery = new McpPreflightRecovery(
+            providers: [],
+            enricher: enricher,
+            logger: NullLogger<McpPreflightRecovery>.Instance);
+
+        await recovery.TryRecoverAsync(
+            "srv", "tool", missingFields: ["x"],
+            existingArgs: new Dictionary<string, object?>(),
+            parentSessionId: "session-42", CancellationToken.None);
+
+        CollectionAssert.Contains(captured, "session-42",
+            "enricher must be queried with the parent session id");
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private sealed class StubProvider(string field, object value) : IToolArgumentDefaultsProvider
+    {
+        public bool CanResolve(string serverName, string toolName, string fieldName) =>
+            string.Equals(fieldName, field, StringComparison.Ordinal);
+
+        public Task<ResolvedDefault?> ResolveAsync(ResolveContext ctx, CancellationToken ct) =>
+            Task.FromResult<ResolvedDefault?>(new ResolvedDefault(value));
+    }
+
+    private sealed class ThrowingProvider(string field) : IToolArgumentDefaultsProvider
+    {
+        public bool CanResolve(string serverName, string toolName, string fieldName) =>
+            string.Equals(fieldName, field, StringComparison.Ordinal);
+
+        public Task<ResolvedDefault?> ResolveAsync(ResolveContext ctx, CancellationToken ct) =>
+            throw new InvalidOperationException("boom");
+    }
+
+    private sealed class EmptyToolCallLog : IToolCallLog
+    {
+        public Task AppendAsync(ToolCallEvent evt, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<IReadOnlyList<ToolCallEvent>> GetBySessionAsync(string sessionId, CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<ToolCallEvent>>([]);
+        public Task<IReadOnlyList<ToolCallEvent>> QueryRecentAsync(DateTimeOffset since, int maxResults, CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<ToolCallEvent>>([]);
+    }
+
+    private sealed class CapturingToolCallLog(List<string?> captured) : IToolCallLog
+    {
+        public Task AppendAsync(ToolCallEvent evt, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<IReadOnlyList<ToolCallEvent>> GetBySessionAsync(string sessionId, CancellationToken ct = default)
+        {
+            captured.Add(sessionId);
+            return Task.FromResult<IReadOnlyList<ToolCallEvent>>([]);
+        }
+        public Task<IReadOnlyList<ToolCallEvent>> QueryRecentAsync(DateTimeOffset since, int maxResults, CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<ToolCallEvent>>([]);
+    }
+}

--- a/tests/RockBot.Wisp.Tests/WispAutoCorrectTests.cs
+++ b/tests/RockBot.Wisp.Tests/WispAutoCorrectTests.cs
@@ -131,6 +131,91 @@ public class WispAutoCorrectTests
     }
 
     [TestMethod]
+    public async Task PreflightRecovery_FillsEnvDefault_NoLlmCallNeeded()
+    {
+        // When preflight recovery can silently fill every missing field from an
+        // environmental default, the step proceeds without an LLM round-trip.
+        var llm = new ScriptedLlmClient("UNUSED");
+        var preflight = new StubPreflightRecovery(
+            filledDefaults: new Dictionary<string, object?> { ["calendarId"] = "primary" },
+            unresolved: [],
+            enrichedContext: null);
+
+        var (executor, registry, captured) = CreateExecutor(llm, preflight);
+        RegisterCalendarMcp(registry, captured);
+
+        // Missing calendarId — preflight will fill it.
+        var definition = MakeCalendarWisp(
+            """{"accountId":"a","timeMin":"t1","timeMax":"t2"}""");
+
+        var result = await executor.ExecuteAsync(definition, "wisp-pf-1", parentSessionId: "parent-42", CancellationToken.None);
+
+        Assert.IsTrue(result.IsSuccess, "Step should succeed after preflight env fill");
+        Assert.AreEqual(0, llm.CallCount, "LLM auto-correct must not run when preflight filled every missing field");
+
+        // Verify the filled value flowed through to the executor.
+        Assert.AreEqual(1, captured.Count);
+        var args = JsonDocument.Parse(captured[0]).RootElement;
+        var innerArgs = args.GetProperty("arguments");
+        Assert.AreEqual("primary", innerArgs.GetProperty("calendarId").GetString());
+
+        // Verify the wisp threaded parent session id to preflight recovery.
+        Assert.AreEqual("parent-42", preflight.LastParentSessionId);
+    }
+
+    [TestMethod]
+    public async Task PreflightRecovery_PartialFill_EnrichmentInjectedIntoLlmPrompt()
+    {
+        // Preflight fills one missing field, leaves another unresolved with an
+        // enriched-error context. The auto-correct LLM gets the enriched context
+        // appended to its prompt, then supplies the final value.
+        var llm = new CapturingScriptedLlmClient("""
+            {"accountId":"acct-from-enriched","calendarId":"primary","timeMin":"t1","timeMax":"t2"}
+            """);
+        var preflight = new StubPreflightRecovery(
+            filledDefaults: new Dictionary<string, object?> { ["calendarId"] = "primary" },
+            unresolved: ["accountId"],
+            enrichedContext: "Field schema: accountId. Recent successful calls in this session: list_accounts");
+
+        var (executor, registry, captured) = CreateExecutor(llm, preflight);
+        RegisterCalendarMcp(registry, captured);
+
+        var definition = MakeCalendarWisp(
+            """{"timeMin":"t1","timeMax":"t2"}""");
+
+        var result = await executor.ExecuteAsync(definition, "wisp-pf-2", CancellationToken.None);
+
+        Assert.IsTrue(result.IsSuccess, "Step should succeed after partial fill + LLM completion");
+        Assert.AreEqual(1, llm.CallCount);
+        StringAssert.Contains(llm.LastPrompt!, "Recent successful calls in this session: list_accounts",
+            "Enriched context from preflight recovery must appear in the LLM correction prompt");
+        StringAssert.Contains(llm.LastPrompt!, "Recovery context",
+            "The prompt must introduce the recovery-context block so the LLM knows to use it");
+    }
+
+    [TestMethod]
+    public async Task PreflightRecovery_NotWired_FallsBackToBareAutoCorrect()
+    {
+        // Without an IMcpPreflightRecovery in DI the wisp keeps its prior
+        // behaviour: bare LLM auto-correct with just the validation error.
+        var llm = new CapturingScriptedLlmClient("""
+            {"accountId":"a","calendarId":"c","timeMin":"2026-04-23T00:00:00","timeMax":"2026-04-23T23:59:59"}
+            """);
+        var (executor, registry, captured) = CreateExecutor(llm, preflightRecovery: null);
+        RegisterCalendarMcp(registry, captured);
+
+        var definition = MakeCalendarWisp(
+            """{"accountId":"a","calendarId":"c","startDate":"2026-04-23","endDate":"2026-04-23"}""");
+
+        var result = await executor.ExecuteAsync(definition, "wisp-pf-3", CancellationToken.None);
+
+        Assert.IsTrue(result.IsSuccess);
+        Assert.IsNotNull(llm.LastPrompt);
+        Assert.IsFalse(llm.LastPrompt!.Contains("Recovery context"),
+            "Recovery context block must be absent when no preflight recovery is wired");
+    }
+
+    [TestMethod]
     public async Task ValidationFailure_LlmWrapsResponseInCodeFences_StillParsed()
     {
         var llm = new ScriptedLlmClient("""
@@ -152,15 +237,63 @@ public class WispAutoCorrectTests
     // ── Fixture ──────────────────────────────────────────────────────────────
 
     private static (WispExecutor Executor, FakeToolRegistry Registry, List<string> CapturedArgs)
-        CreateExecutor(ILlmClient? llmClient)
+        CreateExecutor(ILlmClient? llmClient,
+                       IMcpPreflightRecovery? preflightRecovery = null)
     {
         var registry = new FakeToolRegistry();
         var memory = new FakeWorkingMemory();
         var options = new WispOptions { SharedVolumePath = null };
         var captured = new List<string>();
         var executor = new WispExecutor(registry, memory, agentLoopRunner: null!, options,
-            NullLogger<WispExecutor>.Instance, llmClient);
+            NullLogger<WispExecutor>.Instance, llmClient,
+            a2aCanceller: null, preflightRecovery: preflightRecovery);
         return (executor, registry, captured);
+    }
+
+    private sealed class StubPreflightRecovery(
+        IReadOnlyDictionary<string, object?> filledDefaults,
+        IReadOnlyList<string> unresolved,
+        string? enrichedContext) : IMcpPreflightRecovery
+    {
+        public string? LastParentSessionId { get; private set; }
+        public IReadOnlyList<string>? LastMissingFields { get; private set; }
+
+        public Task<PreflightRecoveryResult> TryRecoverAsync(
+            string serverName,
+            string toolName,
+            IReadOnlyList<string> missingFields,
+            IReadOnlyDictionary<string, object?> existingArgs,
+            string? parentSessionId,
+            CancellationToken ct)
+        {
+            LastParentSessionId = parentSessionId;
+            LastMissingFields = missingFields;
+            return Task.FromResult(
+                new PreflightRecoveryResult(filledDefaults, unresolved, enrichedContext));
+        }
+    }
+
+    private sealed class CapturingScriptedLlmClient(string responseText) : ILlmClient
+    {
+        public int CallCount { get; private set; }
+        public string? LastPrompt { get; private set; }
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options = null,
+            CancellationToken cancellationToken = default) =>
+            Respond(messages);
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages, ModelTier tier,
+            ChatOptions? options = null, CancellationToken cancellationToken = default) =>
+            Respond(messages);
+
+        private Task<ChatResponse> Respond(IEnumerable<ChatMessage> messages)
+        {
+            CallCount++;
+            LastPrompt = messages.LastOrDefault()?.Text ?? "";
+            return Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, responseText)));
+        }
     }
 
     private static void RegisterCalendarMcp(FakeToolRegistry registry, List<string>? capturedArgs)

--- a/tests/RockBot.Wisp.Tests/WispAutoCorrectTests.cs
+++ b/tests/RockBot.Wisp.Tests/WispAutoCorrectTests.cs
@@ -193,6 +193,69 @@ public class WispAutoCorrectTests
             "The prompt must introduce the recovery-context block so the LLM knows to use it");
     }
 
+    private const string CalendarSchemaWithTimeZone = """
+        {
+          "type": "object",
+          "properties": {
+            "accountId":  { "type": "string" },
+            "calendarId": { "type": "string" },
+            "timeMin":    { "type": "string" },
+            "timeMax":    { "type": "string" },
+            "timeZone":   { "type": "string" }
+          },
+          "required": ["accountId", "calendarId", "timeMin", "timeMax", "timeZone"],
+          "additionalProperties": false
+        }
+        """;
+
+    [TestMethod]
+    public async Task PreflightRecovery_SchemaFromRecoveryHook_BridgeModeFill()
+    {
+        // Regression: in bridge-mode agents the per-server MCP tool registrations
+        // don't live in the local tool registry, so McpStepValidator.Validate would
+        // historically return null (skip validation) and the wisp would only recover
+        // via the slower post-flight path. ValidateDetailedAsync now consults the
+        // IMcpPreflightRecovery hook for the schema as a fallback — verify that path
+        // engages, the env-default fill fires, and the LLM is never called.
+        var llm = new ScriptedLlmClient("UNUSED");
+        var preflight = new StubPreflightRecovery(
+            filledDefaults: new Dictionary<string, object?> { ["timeZone"] = "America/Chicago" },
+            unresolved: [],
+            enrichedContext: null,
+            schemaJson: CalendarSchemaWithTimeZone);
+
+        var (executor, registry, captured) = CreateExecutor(llm, preflight);
+
+        // Register ONLY mcp_invoke_tool (the bridge-mode case) — NO mcp:calendar-mcp
+        // tool registration, so McpStepValidator.FindMcpTool returns null and the
+        // validator has to lean on the preflight hook for the schema.
+        registry.Register(
+            new ToolRegistration
+            {
+                Name = "mcp_invoke_tool",
+                Description = "",
+                Source = "mcp:management"
+            },
+            new CapturingToolExecutor(r => captured.Add(r.Arguments ?? ""), "{\"events\":[]}"));
+
+        // Schema requires timeZone but the wisp omits it.
+        var definition = MakeCalendarWisp(
+            """{"accountId":"a","calendarId":"c","timeMin":"t1","timeMax":"t2"}""");
+
+        var result = await executor.ExecuteAsync(definition, "wisp-bridge-1", CancellationToken.None);
+
+        Assert.IsTrue(result.IsSuccess, "Step should succeed via bridge-mode schema fallback");
+        Assert.AreEqual(0, llm.CallCount, "LLM auto-correct must not run");
+        Assert.IsTrue(preflight.SchemaLookupCount >= 1,
+            "Validator must have consulted the schema source");
+
+        // Verify the env default landed in the wire call.
+        Assert.AreEqual(1, captured.Count, $"captured args: {string.Join(" | ", captured)}");
+        var args = JsonDocument.Parse(captured[0]).RootElement;
+        var innerArgs = args.GetProperty("arguments");
+        Assert.AreEqual("America/Chicago", innerArgs.GetProperty("timeZone").GetString());
+    }
+
     [TestMethod]
     public async Task PreflightRecovery_NotWired_FallsBackToBareAutoCorrect()
     {
@@ -253,10 +316,12 @@ public class WispAutoCorrectTests
     private sealed class StubPreflightRecovery(
         IReadOnlyDictionary<string, object?> filledDefaults,
         IReadOnlyList<string> unresolved,
-        string? enrichedContext) : IMcpPreflightRecovery
+        string? enrichedContext,
+        string? schemaJson = null) : IMcpPreflightRecovery
     {
         public string? LastParentSessionId { get; private set; }
         public IReadOnlyList<string>? LastMissingFields { get; private set; }
+        public int SchemaLookupCount { get; private set; }
 
         public Task<PreflightRecoveryResult> TryRecoverAsync(
             string serverName,
@@ -270,6 +335,13 @@ public class WispAutoCorrectTests
             LastMissingFields = missingFields;
             return Task.FromResult(
                 new PreflightRecoveryResult(filledDefaults, unresolved, enrichedContext));
+        }
+
+        public Task<string?> TryGetParametersSchemaAsync(
+            string serverName, string toolName, CancellationToken ct)
+        {
+            SchemaLookupCount++;
+            return Task.FromResult(schemaJson);
         }
     }
 


### PR DESCRIPTION
## Summary

Wisp Direct MCP steps had two error-handling layers:

- **Pre-flight** — `McpStepValidator` + a bare one-shot LLM auto-correct that saw only the validation error.
- **Post-flight** — invocation through `McpManagementExecutor` → `McpRecoveryExecutor`, which already engages environmental defaults + `SchemaErrorEnricher`.

The pre-flight path bypassed the recovery infrastructure: no `IToolArgumentDefaultsProvider`, no field schemas, no description hints, no recent same-session calls. The design doc claimed wisps "benefit from the same recovery" — aspiration, not implementation. This PR closes that gap.

## Changes

- **New** `IMcpPreflightRecovery` in `RockBot.Tools.Abstractions` plus a concrete `McpPreflightRecovery` in `RockBot.Tools.Mcp.Recovery` that walks the same provider set as `McpRecoveryExecutor` and delegates per-field to `SchemaErrorEnricher`.
- `WispExecutor` accepts the optional hook. On `McpStepValidator` failure it asks the hook to silently fill what it can (`timeZone`, current time, …), re-validates against merged params, and only falls back to the LLM auto-correct for fields no provider could supply. The auto-correct prompt now carries an enriched **Recovery context** block when the hook produced one — matching what the post-flight path surfaces.
- `WispExecutor.ExecuteAsync` gains an optional `parentSessionId`. `SpawnWispsExecutor` passes the calling agent's session id so the enricher's "recent same-session calls" actually finds the parent's tool-call history; `WispRegistryToolFunction` threads it through LLM-step tool invocations so the post-flight enricher sees the parent session too.
- `McpStepValidator.ValidateDetailed` exposes `MissingFields` structurally so callers can route them through `IMcpPreflightRecovery`.

## Behaviour after this PR

- Wisp Direct MCP step missing `timeZone` → silently filled, no LLM round-trip.
- Wisp Direct MCP step missing `emailId` → enriched context (field schema, tool-description hint, recent same-session calls from the *parent* agent's session log) gets appended to the auto-correct prompt under a "Recovery context" block.
- Post-flight `McpRecoveryExecutor` also sees the parent session id via `ToolInvokeRequest.SessionId`.
- Fully backward-compatible: existing `ExecuteAsync(definition, wispId, ct)` overload preserved; `IMcpPreflightRecovery` and `parentSessionId` are both optional.

## Test plan

- [x] `RockBot.Tools.Tests` — 6 new tests in `McpPreflightRecoveryTests` covering empty-input, silent env-default fill, enrichment for unfilled fields, partial fill, provider-throws fallthrough, and parent-session-id flow.
- [x] `RockBot.Wisp.Tests` — 3 new tests in `WispAutoCorrectTests` covering env-default silent fill (no LLM call), partial fill + enriched LLM prompt, and the no-hook fallback path.
- [x] Full solution test run: **1,868 pass, 0 fail** across 16 test projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)