### PR TITLE
AdvisorCouncil agent: multi-persona deliberation with research and synthesis (#390)

### DIFF
--- a/RockBot.slnx
+++ b/RockBot.slnx
@@ -45,6 +45,7 @@
     <Project Path="src/RockBot.SampleAgent/RockBot.SampleAgent.csproj" />
     <Project Path="src/RockBot.SampleAgent.Http/RockBot.SampleAgent.Http.csproj" />
     <Project Path="src/RockBot.ResearchAgent/RockBot.ResearchAgent.csproj" />
+    <Project Path="src/RockBot.AdvisorCouncil/RockBot.AdvisorCouncil.csproj" />
     <Project Path="src/RockBot.A2A.Gateway/RockBot.A2A.Gateway.csproj" />
     <Project Path="src/RockBot.A2A.Gateway.Host/RockBot.A2A.Gateway.Host.csproj" />
   </Folder>
@@ -65,6 +66,7 @@
     <Project Path="tests/RockBot.A2A.IntegrationTests/RockBot.A2A.IntegrationTests.csproj" />
     <Project Path="tests/RockBot.A2A.Gateway.Tests/RockBot.A2A.Gateway.Tests.csproj" />
     <Project Path="tests/RockBot.Observation.Tests/RockBot.Observation.Tests.csproj" />
+    <Project Path="tests/RockBot.AdvisorCouncil.Tests/RockBot.AdvisorCouncil.Tests.csproj" />
   </Folder>
   <Project Path="src/RockBot.Messaging.Abstractions/RockBot.Messaging.Abstractions.csproj" />
   <Project Path="src/RockBot.Messaging.RabbitMQ/RockBot.Messaging.RabbitMQ.csproj" />

--- a/deploy/Dockerfile.advisor-council
+++ b/deploy/Dockerfile.advisor-council
@@ -1,0 +1,30 @@
+# syntax=docker/dockerfile:1
+# Build stage
+FROM mcr.microsoft.com/dotnet/sdk:10.0@sha256:0a506ab0c8aa077361af42f82569d364ab1b8741e967955d883e3f23683d473a AS build
+WORKDIR /src
+
+# Clear Windows-specific NuGet fallback folders that break Linux builds
+RUN printf '<configuration><fallbackPackageFolders><clear /></fallbackPackageFolders></configuration>' \
+    > /src/NuGet.config
+
+COPY RockBot.slnx Directory.Build.props ./
+COPY src/ src/
+
+# BuildKit cache mount avoids re-downloading packages on every build
+RUN --mount=type=cache,target=/root/.nuget/packages \
+    dotnet publish src/RockBot.AdvisorCouncil/RockBot.AdvisorCouncil.csproj \
+    -c Release -o /app/publish
+
+# Runtime stage
+FROM mcr.microsoft.com/dotnet/runtime:10.0@sha256:3de49150e48790fa845547e14bff5add0e4194a8901e727cf88f83423bcbe2b0 AS runtime
+WORKDIR /app
+
+# Non-root user
+RUN groupadd -r rockbot && useradd -r -g rockbot rockbot
+
+COPY --from=build /app/publish .
+
+RUN chown -R rockbot:rockbot /app
+USER rockbot
+
+ENTRYPOINT ["dotnet", "RockBot.AdvisorCouncil.dll"]

--- a/deploy/k8s/advisor-council-queue-init.yaml
+++ b/deploy/k8s/advisor-council-queue-init.yaml
@@ -1,0 +1,69 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: advisor-council-queue-init
+  namespace: rockbot
+  annotations:
+    description: |
+      Job that pre-declares the AdvisorCouncil queue and binding, then publishes
+      the agent's discovery card so any running RockBot instance registers it
+      immediately. Safe to re-run — all operations are idempotent.
+spec:
+  ttlSecondsAfterFinished: 600
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: queue-init
+          image: curlimages/curl:latest
+          env:
+            - name: RABBIT_USER
+              valueFrom:
+                configMapKeyRef:
+                  name: rockbot-config
+                  key: RabbitMq__UserName
+            - name: RABBIT_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: rockbot-secrets
+                  key: RabbitMq__Password
+            - name: RABBIT_MGMT
+              value: "rabbitmq-mgmt.default.svc.cluster.local:15672"
+            - name: VHOST
+              value: "%2F"
+            - name: EXCHANGE
+              value: "rockbot"
+            - name: QUEUE_NAME
+              value: "rockbot.AdvisorCouncil.agent-task-AdvisorCouncil"
+            - name: ROUTING_KEY
+              value: "agent.task.AdvisorCouncil"
+          command:
+            - sh
+            - -c
+            - |
+              set -e
+
+              echo "Declaring queue: $QUEUE_NAME"
+              curl -sf -u "$RABBIT_USER:$RABBIT_PASS" \
+                -X PUT \
+                -H "Content-Type: application/json" \
+                -d "{\"durable\":true,\"arguments\":{\"x-dead-letter-exchange\":\"rockbot.dlx\",\"x-dead-letter-routing-key\":\"$ROUTING_KEY\"}}" \
+                "http://$RABBIT_MGMT/api/queues/$VHOST/$QUEUE_NAME"
+
+              echo "Binding queue to exchange $EXCHANGE with routing key $ROUTING_KEY"
+              curl -sf -u "$RABBIT_USER:$RABBIT_PASS" \
+                -X POST \
+                -H "Content-Type: application/json" \
+                -d "{\"routing_key\":\"$ROUTING_KEY\"}" \
+                "http://$RABBIT_MGMT/api/bindings/$VHOST/e/$EXCHANGE/q/$QUEUE_NAME"
+
+              echo "Publishing AdvisorCouncil discovery card"
+              CARD='{"agentName":"AdvisorCouncil","description":"Multi-perspective advisor council. Analyzes questions from a curated set of personas and returns integrated guidance.","version":"1.0","skills":[{"id":"advise","name":"Advise","description":"Take a question or idea and return multi-perspective analysis with synthesis.","tags":null,"examples":null}],"isDeregistering":false}'
+              CARD_B64=$(printf '%s' "$CARD" | base64 | tr -d '\n')
+              curl -sf -u "$RABBIT_USER:$RABBIT_PASS" \
+                -X POST \
+                -H "Content-Type: application/json" \
+                -d "{\"vhost\":\"/\",\"name\":\"$EXCHANGE\",\"properties\":{\"delivery_mode\":2,\"content_type\":\"application/json\",\"type\":\"RockBot.A2A.AgentCard\"},\"routing_key\":\"discovery.announce\",\"payload\":\"$CARD_B64\",\"payload_encoding\":\"base64\",\"headers\":{\"rb-source\":\"AdvisorCouncil\"}}" \
+                "http://$RABBIT_MGMT/api/exchanges/$VHOST/$EXCHANGE/publish"
+
+              echo "Queue init complete."

--- a/deploy/k8s/advisor-council-scaledjob.yaml
+++ b/deploy/k8s/advisor-council-scaledjob.yaml
@@ -1,0 +1,66 @@
+---
+# TriggerAuthentication — uses the same KEDA RabbitMQ secret as research-agent.
+# Defined once in research-agent-scaledjob.yaml; if applied independently of that
+# manifest, also apply research-agent-keda-secret.sh first.
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: rockbot-keda-rabbitmq-auth
+  namespace: rockbot
+spec:
+  secretTargetRef:
+    - parameter: host
+      name: rockbot-keda-rabbitmq
+      key: uri
+
+---
+# ScaledJob — KEDA watches the AdvisorCouncil queue depth and launches one pod
+# per pending message. Each pod processes one AgentTaskRequest and exits.
+apiVersion: keda.sh/v1alpha1
+kind: ScaledJob
+metadata:
+  name: rockbot-advisor-council
+  namespace: rockbot
+spec:
+  jobTargetRef:
+    template:
+      spec:
+        restartPolicy: Never
+        containers:
+          - name: advisor-council
+            image: rockylhotka/rockbot-advisor-council:0.10.55
+            imagePullPolicy: Always
+            env:
+              # Ephemeral working memory — lives on the container's local filesystem.
+              - name: Memory__BasePath
+                value: /tmp/memory
+              # Personas — image ships defaults at /app/agent/personas; override here
+              # to a PVC path if you want operator-customized personas.
+              - name: Council__PersonasPath
+                value: /app/agent/personas
+            envFrom:
+              - configMapRef:
+                  name: rockbot-config
+              - secretRef:
+                  name: rockbot-secrets
+            resources:
+              requests:
+                cpu: 200m
+                memory: 256Mi
+              limits:
+                cpu: "1"
+                memory: 1Gi
+    ttlSecondsAfterFinished: 300
+  maxReplicaCount: 3
+  minReplicaCount: 0
+  scalingStrategy:
+    strategy: accurate
+  triggers:
+    - type: rabbitmq
+      metadata:
+        protocol: amqp
+        queueName: rockbot.AdvisorCouncil.agent-task-AdvisorCouncil
+        mode: QueueLength
+        value: "1"
+      authenticationRef:
+        name: rockbot-keda-rabbitmq-auth

--- a/design/advisor-council.md
+++ b/design/advisor-council.md
@@ -1,0 +1,336 @@
+# Advisor Council Agent
+
+## Inspiration
+
+The multi-persona deliberation pattern isn't new — it appears across the prompting community as "council of experts," "panel of advisors," and similar variants. The immediate prompt for building it into rockbot was JD Meier's "Council of Giants" post: https://www.linkedin.com/posts/jdmeier_council-of-giants-activity-7458556131225784321-JIkl
+
+What this design adds is making the council a first-class agent in the rockbot swarm — A2A-invocable, persona library as data on the PVC, selector-driven gating, integrated with `ResearchAgent` for fact-finding — rather than a one-shot prompt template.
+
+## Problem
+
+The agent (and its users) regularly face open-ended questions where a single LLM pass — even a long one with tools — produces shallow or one-sided answers. "Should we adopt X?" "Is this design sound?" "What are we missing?" These benefit from being examined from multiple framings, not from running one bigger loop. Today rockbot has no structured way to do that: questions either get a single-perspective answer from the primary agent, or get punted to research (which surfaces facts, not judgment).
+
+The deeper issue is that "wisdom" — the kind of thinking that surfaces tensions, names what's at stake, and integrates competing considerations — emerges from explicit perspective-taking, not from telling one model to "be wise." Multi-perspective reasoning needs to be a workflow, not a prompt.
+
+## Goals
+
+- Take a question or idea and return integrated, multi-perspective guidance with explicit tensions and confidence.
+- Make the perspective set transparent and tunable (personas as data on the PVC, hot-reloaded).
+- Let personas reach for facts when they need them, by invoking the existing `ResearchAgent` via A2A.
+- Surface the council as an A2A skill the primary agent can self-invoke before its own consequential decisions.
+- Keep cost and latency bounded with selector-driven gating (which personas, with/without research, with/without critique).
+
+## Non-goals
+
+- Replacing the primary agent's decision-making. The council returns guidance; the caller decides what to do with it.
+- Persona personality theatre. Personas are framings, not characters — short, focused system prompts, no role-play.
+- Real-time interaction. Council runs are batch (typically 30s–3min) and return a single structured result.
+- Replacing `ResearchAgent`. The council reuses it for fact-finding; it does not duplicate web search.
+
+## Architecture overview
+
+```
+                   ┌──────────────────────────────────────────────┐
+A2A AgentTaskRequest │             AdvisorCouncilTaskHandler        │
+   skill=advise     │  (one task per ephemeral pod, then shutdown) │
+                   └────────────────────┬─────────────────────────┘
+                                        │
+                                        ▼
+                   ┌──────────────────────────────────────────────┐
+                   │                CouncilWorkflow                │
+                   │                (MAF graph)                    │
+                   │                                                │
+                   │  ┌────────┐    ┌──────────────┐               │
+                   │  │ Select │───▶│ PreResearch? │──┐            │
+                   │  └────────┘    └──────────────┘  │            │
+                   │       │                          │            │
+                   │       ▼                          ▼            │
+                   │  ┌────────────────────────────────────┐       │
+                   │  │   Fan-out (parallel personas)      │       │
+                   │  │   ┌──────────┐  ┌──────────┐  ...  │       │
+                   │  │   │ persona  │  │ persona  │       │       │
+                   │  │   │  (call   │  │ (Loop +  │       │       │
+                   │  │   │  only)   │  │ Research)│       │       │
+                   │  │   └──────────┘  └──────────┘       │       │
+                   │  └─────────────────┬──────────────────┘       │
+                   │                    │                          │
+                   │                    ▼                          │
+                   │           ┌───────────────┐                   │
+                   │           │  Critique?    │                   │
+                   │           └───────┬───────┘                   │
+                   │                    │                          │
+                   │                    ▼                          │
+                   │           ┌───────────────┐                   │
+                   │           │  Synthesize   │ (High tier)       │
+                   │           └───────┬───────┘                   │
+                   └────────────────────┼──────────────────────────┘
+                                        │
+                                        ▼
+                              AgentTaskResult
+                          (JSON part + text part)
+
+                   ┌────────────────────────────┐
+                   │   /data/advisor-council/   │
+                   │   personas/*.md            │ ◄── hot-reloaded
+                   └────────────────────────────┘
+```
+
+`CouncilWorkflow` is a Microsoft Agent Framework (MAF) workflow. Selector output drives the conditional edges (pre-research, critique) and the per-persona branch shape (call-only vs. agentic loop with `ResearchAgent` tool). `AgentLoopRunner` wraps each persona branch that has tools, preserving cross-cutting concerns (iteration budget, completion eval, metrics).
+
+## Personas (initial fixed set)
+
+Six perspectives, chosen to cover the dimensions on which open-ended decisions most often go wrong:
+
+| id | role | default research |
+|---|---|---|
+| `skeptic` | Challenges assumptions, surfaces counterexamples, names failure modes | false |
+| `ethicist` | Examines harms, fairness, dignity, second-order moral effects | false |
+| `engineer` | Feasibility, complexity, edge cases, technical risk | true |
+| `economist` | Incentives, costs, opportunity cost, market dynamics | true |
+| `long_term` | 5–10 year horizon, path dependencies, irreversibility | false |
+| `user_advocate` | Lived experience of affected people, accessibility, dignity-in-use | false |
+
+Each persona is a markdown file with YAML frontmatter:
+
+```markdown
+---
+id: skeptic
+name: The Skeptic
+description: Challenges assumptions and surfaces failure modes
+default_research: false
+---
+
+You are the Skeptic on an advisor council...
+[system prompt body]
+```
+
+Files live at `/data/advisor-council/personas/{id}.md` on the PVC, hot-reloaded via the same `IFileWatcher` pattern as `directives.md`. The image ships defaults; the running pod can be updated with `kubectl cp` without a restart.
+
+**Why personas as data**: lets the personas be tuned (or replaced entirely for specific deployments) without rebuilding the container. Resists the temptation to encode persona-specific logic in C# — if a persona needs different model tier or different tools, encode that in frontmatter and let the workflow read it.
+
+## Selector
+
+A single `IChatClient` call (Balanced tier) that takes the question + the persona library and returns:
+
+```json
+{
+  "personas": [
+    { "id": "skeptic",   "needs_research": false },
+    { "id": "economist", "needs_research": true  },
+    { "id": "engineer",  "needs_research": true  }
+  ],
+  "pre_research": false,
+  "critique": true,
+  "rationale": "Question is strategic and contested; engineering feasibility and cost matter; pre-research not needed because personas can fetch as needed."
+}
+```
+
+`pre_research` and `critique` are both auto-decided based on question type:
+- **Pre-research on** when multiple personas would benefit from the same factual base (e.g., questions about specific technologies, companies, recent events).
+- **Critique on** when the question is contested, strategic, or has plausible disagreement among personas. Off when the question is mostly factual integration.
+
+The selector is **load-bearing** — its decisions drive cost and quality. Treat it as a component that needs its own eval set (see Risks).
+
+## Output schema
+
+```json
+{
+  "question": "...",
+  "personas": [
+    {
+      "id": "skeptic",
+      "view": "markdown prose, ~300 words",
+      "key_points": ["...", "..."],
+      "sources": []
+    }
+  ],
+  "tensions": [
+    {
+      "between": ["skeptic", "economist"],
+      "description": "Skeptic warns of lock-in; economist sees the cost-of-delay as higher.",
+      "stakes": "Whether to commit now or pilot first."
+    }
+  ],
+  "synthesis": "markdown prose — integrated guidance, ~500 words",
+  "confidence": "low | medium | high",
+  "metadata": {
+    "critique_run": true,
+    "pre_research_run": false,
+    "persona_count": 3,
+    "duration_ms": 87234,
+    "model_calls": 9
+  }
+}
+```
+
+Returned as **two `AgentMessagePart`s** in the `AgentTaskResult`:
+
+1. `kind=text` containing only the `synthesis` prose — readable by prose-consuming callers (primary agent, UI).
+2. `kind=data` (or `kind=text` with a JSON content-type header) containing the full structured object — for programmatic callers.
+
+## Workflow stages
+
+### 1. Select
+
+Input: question text.
+Output: `SelectorOutput` (above).
+Model: Balanced tier.
+Tools: none.
+Failure mode: if selector output fails schema validation, retry once with stricter prompt; if it fails again, fall back to a default persona set (`skeptic`, `engineer`, `long_term`) with `critique=false`, `pre_research=false`.
+
+### 2. PreResearch (conditional)
+
+Skipped unless `SelectorOutput.pre_research = true`.
+Single A2A invocation of `ResearchAgent` with the original question, timeout ~90s.
+Result stored to working memory at `council/{taskId}/preresearch` and injected into every persona branch's context.
+
+### 3. Fan-out
+
+Parallel MAF branches, one per selected persona. Two branch shapes:
+
+- **Call-only** (`needs_research=false`): single `IChatClient` call with `{system: persona.systemPrompt, user: question + optional pre-research}`. Returns persona view text.
+- **Agentic loop** (`needs_research=true`): `AgentLoopRunner.RunAsync` with:
+  - `MaxToolIterationsOverride = 8` (tight)
+  - Tools: `ResearchAgentInvoker` (A2A → ResearchAgent), `working_memory_get/list` scoped to `council/{taskId}/`
+  - Findings cached to `council/{taskId}/{personaId}/` and visible to subsequent personas through the shared namespace
+
+All branches use Balanced tier. Per-persona soft timeout ~60s; on timeout the persona is dropped from the council with `view: "(timed out)"`.
+
+### 4. Critique (conditional)
+
+Skipped unless `SelectorOutput.critique = true`.
+For each persona, a second `IChatClient` call: `{system: persona.systemPrompt + critique addendum, user: original question + all sibling views, instruction: "revise your view, name explicit disagreements"}`. Returns revised view + identified tensions.
+
+Critique is **per-persona-parallel** like fan-out — no further fan-in needed.
+
+### 5. Synthesize
+
+Single `IChatClient` call (High tier), input: question + final persona views + identified tensions, output: structured JSON matching the output schema. Schema-validated; on validation failure, one repair pass before giving up.
+
+## A2A surface
+
+Agent card:
+
+```json
+{
+  "agentName": "AdvisorCouncil",
+  "description": "Multi-perspective advisor council. Analyzes questions from a curated set of personas and returns integrated guidance.",
+  "version": "1.0",
+  "skills": [
+    {
+      "id": "advise",
+      "name": "Advise",
+      "description": "Take a question or idea and return multi-perspective analysis with synthesis."
+    }
+  ]
+}
+```
+
+Request: standard `AgentTaskRequest` with the question as a `text` part. Optional headers:
+- `rb-council-personas`: comma-separated persona ids to force-override selection
+- `rb-council-critique`: `true|false|auto` (default `auto`)
+- `rb-council-pre-research`: `true|false|auto` (default `auto`)
+
+## Project layout
+
+```
+src/RockBot.AdvisorCouncil/
+  RockBot.AdvisorCouncil.csproj
+  Program.cs
+  AdvisorCouncilTaskHandler.cs       # IAgentTaskHandler entry point
+  Council/
+    CouncilWorkflow.cs               # MAF graph builder
+    SelectStep.cs
+    PreResearchStep.cs
+    PersonaStep.cs
+    CritiqueStep.cs
+    SynthesizeStep.cs
+  Personas/
+    Persona.cs                       # record { Id, Name, Description, SystemPrompt, DefaultResearch }
+    PersonaRegistry.cs               # load + hot-reload from PVC
+  Schema/
+    SelectorOutput.cs
+    CouncilResponse.cs
+  Tools/
+    ResearchAgentInvoker.cs          # AIFunction wrapping A2A → ResearchAgent
+  EphemeralShutdownCoordinator.cs    # mirrors ResearchAgent
+  EphemeralShutdownService.cs
+  NullFeedbackStore.cs
+  agent/
+    personas/
+      skeptic.md
+      ethicist.md
+      engineer.md
+      economist.md
+      long_term.md
+      user_advocate.md
+    directives.md
+
+deploy/
+  Dockerfile.advisor-council         # mirrors Dockerfile.agent
+  helm/rockbot/templates/
+    advisor-council-deployment.yaml  # ephemeral pod template, like research agent
+
+tests/
+  RockBot.AdvisorCouncil.Tests/
+    SelectStepTests.cs               # fake IChatClient
+    PersonaRegistryTests.cs          # hot-reload, frontmatter parsing
+    CouncilResponseSchemaTests.cs    # serialization round-trips
+    CouncilWorkflowIntegrationTests.cs  # gated by ROCKBOT_LLM_KEY env var
+```
+
+## Deployment
+
+- Image: `rockylhotka/rockbot-advisor-council:<version>`, tagged from `Directory.Build.props` `<Version>`. Never `:latest`.
+- Helm: new `advisorCouncil` block in `values.yaml` with `image.repository`, `image.tag`, `enabled`. Pinned tag.
+- PVC: `/data/advisor-council/` with `personas/` subdir. Init container `cp -n` from image — never overwrites running pod's customized personas.
+- One pod per task (ephemeral), `EphemeralShutdownService` exits cleanly after `AgentTaskResult` is published.
+
+## Phased delivery
+
+Each phase is one PR, mergeable on its own.
+
+**Phase 1 — Scaffolding + baseline pipeline**
+- Project, csproj, Program.cs, A2A wiring mirroring ResearchAgent.
+- `PersonaRegistry` with frontmatter parsing + hot-reload.
+- All 6 personas as markdown.
+- MAF dependency added with pinned prerelease version.
+- `CouncilWorkflow` with Select → Fan-out (no research) → Synthesize.
+- Critique and pre-research wired but always off.
+- Unit tests with fake `IChatClient` covering: selector output parsing, persona registry, schema serialization.
+
+**Phase 2 — Cross-critique**
+- `CritiqueStep` implementation, conditional MAF edge from selector.
+- Selector prompt updated to decide `critique`.
+- Output `metadata.critique_run` populated.
+
+**Phase 3 — Research integration**
+- `ResearchAgentInvoker` (AIFunction wrapping A2A invocation of `ResearchAgent`).
+- Per-persona branch shape: agentic loop via `AgentLoopRunner` when `needs_research=true`.
+- Pre-research stage conditional on selector output.
+- Shared working-memory cache at `council/{taskId}/`.
+- Integration test against real LLM (env-gated).
+
+**Phase 4 — Deployment**
+- `Dockerfile.advisor-council`.
+- Helm chart additions for ephemeral pod pattern.
+- PVC init container.
+- Build/push workflow updates if applicable.
+
+**Phase 5 — Primary-agent integration**
+- Tool/skill in the primary `RockBot.Agent` that invokes the council via A2A.
+- Directive snippet showing when to consult the council (consequential decisions, contested questions, before durable commitments).
+
+## Risks and open questions
+
+**MAF prerelease churn.** Packages are `--prerelease` as of writing. Pin exact versions in `Directory.Build.props`. Treat MAF version bumps as their own PR. The workflow API surface specifically is the part most likely to change — if it breaks too often in Phase 1, fall back to hand-rolled orchestration without abandoning the rest of the design.
+
+**Cost ceiling.** 5 personas × possible research × possible critique × synthesis can hit $0.50–$2 per question. Mitigations: tight per-persona iteration cap (8), hard wall-clock timeout (~3 min), per-request token budget enforced at the runner level, observable cost metrics published per council run.
+
+**Selector reliability.** The selector decides which personas participate, whether to run research, and whether to critique. A bad selector silently degrades every downstream stage. Mitigation: a focused eval set of ~20 hand-graded questions covering factual, strategic, contested, and trivial cases. Re-run on selector prompt changes.
+
+**Persona drift.** Personas are markdown on the PVC, so they can drift between deployments. Mitigation: hash personas at startup and include the hash in `metadata.persona_set_hash`. Easy to diff across runs.
+
+**No persistence between council runs.** Each council task is independent; the council doesn't remember prior questions or its prior advice. This is intentional for v1 (simpler, no privacy concerns). If we want continuity later (e.g., "you advised X last time, has anything changed?"), we'd add a council-scoped memory namespace — out of scope here.
+
+**Personas-as-characters temptation.** It will be tempting to make personas richer ("the skeptic is grumpy", "the long-term thinker is poetic"). Resist. Personas are framings; their job is to surface a specific class of consideration, not to entertain. Style belongs in the synthesis step if anywhere.

--- a/src/RockBot.AdvisorCouncil/AdvisorCouncilTaskHandler.cs
+++ b/src/RockBot.AdvisorCouncil/AdvisorCouncilTaskHandler.cs
@@ -1,0 +1,104 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using RockBot.A2A;
+using RockBot.AdvisorCouncil.Council;
+using RockBot.AdvisorCouncil.Schema;
+
+namespace RockBot.AdvisorCouncil;
+
+/// <summary>
+/// A2A entry point for the AdvisorCouncil. Extracts the question from the inbound
+/// request, runs <see cref="CouncilOrchestrator"/>, and returns a two-part
+/// <see cref="AgentTaskResult"/> (text = synthesis prose; data = full JSON).
+/// </summary>
+internal sealed class AdvisorCouncilTaskHandler(
+    CouncilOrchestrator orchestrator,
+    IOptions<CouncilOptions> options,
+    EphemeralShutdownCoordinator shutdown,
+    ILogger<AdvisorCouncilTaskHandler> logger) : IAgentTaskHandler
+{
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false
+    };
+
+    public async Task<AgentTaskResult> HandleTaskAsync(AgentTaskRequest request, AgentTaskContext context)
+    {
+        var ct = context.MessageContext.CancellationToken;
+        logger.LogInformation("Handling council task {TaskId} (skill={Skill})", request.TaskId, request.Skill);
+
+        try
+        {
+            await context.PublishStatus(new AgentTaskStatusUpdate
+            {
+                TaskId = request.TaskId,
+                ContextId = request.ContextId,
+                State = AgentTaskState.Working
+            }, ct);
+
+            var question = request.Message.Parts
+                .Where(p => p.Kind == "text")
+                .Select(p => p.Text)
+                .FirstOrDefault(t => !string.IsNullOrWhiteSpace(t))
+                ?? "(no question provided)";
+
+            logger.LogInformation("Council question for task {TaskId}: {Question}",
+                request.TaskId, question.Length > 300 ? question[..300] + "…" : question);
+
+            var overallTimeout = TimeSpan.FromSeconds(Math.Max(30, options.Value.OverallTimeoutSeconds));
+            using var overallCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            overallCts.CancelAfter(overallTimeout);
+
+            CouncilResponse response;
+            try
+            {
+                response = await orchestrator.RunAsync(question, request.TaskId, overallCts.Token);
+            }
+            catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+            {
+                logger.LogWarning("Council task {TaskId} hit overall timeout ({Sec}s)",
+                    request.TaskId, overallTimeout.TotalSeconds);
+                return new AgentTaskResult
+                {
+                    TaskId = request.TaskId,
+                    ContextId = request.ContextId,
+                    State = AgentTaskState.Failed,
+                    Message = new AgentMessage
+                    {
+                        Role = "agent",
+                        Parts = [new AgentMessagePart { Kind = "text", Text = "Council deliberation timed out." }]
+                    }
+                };
+            }
+
+            var json = JsonSerializer.Serialize(response, JsonOpts);
+
+            return new AgentTaskResult
+            {
+                TaskId = request.TaskId,
+                ContextId = request.ContextId,
+                State = AgentTaskState.Completed,
+                Message = new AgentMessage
+                {
+                    Role = "agent",
+                    Parts =
+                    [
+                        new AgentMessagePart { Kind = "text", Text = response.Synthesis },
+                        new AgentMessagePart { Kind = "data", Data = json, MimeType = "application/json" }
+                    ]
+                }
+            };
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            logger.LogError(ex, "Council task {TaskId} failed", request.TaskId);
+            throw;
+        }
+        finally
+        {
+            shutdown.NotifyTaskComplete();
+        }
+    }
+}

--- a/src/RockBot.AdvisorCouncil/Council/CouncilOptions.cs
+++ b/src/RockBot.AdvisorCouncil/Council/CouncilOptions.cs
@@ -1,0 +1,22 @@
+namespace RockBot.AdvisorCouncil.Council;
+
+/// <summary>
+/// Configuration for the council pipeline, bound from the "Council" config section.
+/// </summary>
+internal sealed class CouncilOptions
+{
+    /// <summary>Absolute path to the personas directory. Empty falls back to agent/personas next to the binary.</summary>
+    public string PersonasPath { get; set; } = string.Empty;
+
+    /// <summary>Hard wall-clock cap on a council run before cancellation.</summary>
+    public int OverallTimeoutSeconds { get; set; } = 180;
+
+    /// <summary>Per-persona soft timeout. On expiry the persona view becomes "(timed out)" and synthesis proceeds without it.</summary>
+    public int PerPersonaTimeoutSeconds { get; set; } = 60;
+
+    /// <summary>Pre-research stage timeout.</summary>
+    public int PreResearchTimeoutSeconds { get; set; } = 90;
+
+    /// <summary>ResearchAgent invocation timeout (used in Phase 3 by ResearchAgentInvoker).</summary>
+    public int ResearchAgentTimeoutSeconds { get; set; } = 90;
+}

--- a/src/RockBot.AdvisorCouncil/Council/CouncilOrchestrator.cs
+++ b/src/RockBot.AdvisorCouncil/Council/CouncilOrchestrator.cs
@@ -1,0 +1,144 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using RockBot.AdvisorCouncil.Personas;
+using RockBot.AdvisorCouncil.Schema;
+
+namespace RockBot.AdvisorCouncil.Council;
+
+/// <summary>
+/// Runs the council pipeline:
+/// Select → optional PreResearch → Fan-out personas (parallel) → optional Critique
+/// (parallel per persona) → Synthesize.
+///
+/// Imperative orchestration; the design doc explicitly permits this in lieu of MAF
+/// workflows when dynamic-graph-per-request negates static-graph value.
+/// </summary>
+internal sealed class CouncilOrchestrator(
+    SelectStep selectStep,
+    PreResearchStep preResearchStep,
+    PersonaStep personaStep,
+    CritiqueStep critiqueStep,
+    SynthesizeStep synthesizeStep,
+    PersonaRegistry personaRegistry,
+    IOptions<CouncilOptions> options,
+    ILogger<CouncilOrchestrator> logger)
+{
+    public async Task<CouncilResponse> RunAsync(string question, string taskId, CancellationToken ct)
+    {
+        var sw = Stopwatch.StartNew();
+        var modelCalls = 0;
+        var personas = personaRegistry.Personas;
+
+        // ── 1. Select ──────────────────────────────────────────────────────────
+        var selection = await selectStep.RunAsync(question, ct);
+        modelCalls++;
+        logger.LogInformation(
+            "Council task {TaskId}: selected {Count} personas (preResearch={Pre}, critique={Crit}). Rationale: {Rat}",
+            taskId, selection.Personas.Count, selection.PreResearch, selection.Critique, selection.Rationale);
+
+        var selectedPersonas = selection.Personas
+            .Where(p => personas.ContainsKey(p.Id))
+            .Select(p => (Spec: p, Persona: personas[p.Id]))
+            .ToList();
+
+        if (selectedPersonas.Count == 0)
+            return EmptyResponse(question, "No personas selected. The persona registry may be empty or the selector returned no valid ids.", sw.Elapsed, modelCalls);
+
+        // ── 2. PreResearch (conditional) ───────────────────────────────────────
+        string? preResearch = null;
+        if (selection.PreResearch)
+        {
+            preResearch = await preResearchStep.RunAsync(question, ct);
+            if (preResearch is not null) modelCalls++;
+        }
+
+        // ── 3. Fan-out personas in parallel ────────────────────────────────────
+        var perPersonaTimeout = TimeSpan.FromSeconds(Math.Max(5, options.Value.PerPersonaTimeoutSeconds));
+        var personaTasks = selectedPersonas.Select(async sp =>
+        {
+            using var personaCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            personaCts.CancelAfter(perPersonaTimeout);
+            try
+            {
+                return await personaStep.RunAsync(sp.Persona, question, preResearch, sp.Spec.NeedsResearch, personaCts.Token);
+            }
+            catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+            {
+                logger.LogWarning("Persona {Id} timed out after {Sec}s", sp.Spec.Id, perPersonaTimeout.TotalSeconds);
+                return new PersonaView(sp.Spec.Id, "(timed out)", [], []);
+            }
+        }).ToList();
+
+        var personaViews = await Task.WhenAll(personaTasks);
+        modelCalls += personaViews.Length; // approximate — research path may do more calls
+
+        // ── 4. Critique (conditional, per-persona parallel) ────────────────────
+        var critiqueTensions = new List<Tension>();
+        if (selection.Critique && personaViews.Length > 1)
+        {
+            var critiqueTasks = personaViews.Select(async (own, idx) =>
+            {
+                var persona = selectedPersonas[idx].Persona;
+                var siblings = personaViews.Where((_, i) => i != idx).ToList();
+                using var critCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                critCts.CancelAfter(perPersonaTimeout);
+                try
+                {
+                    return await critiqueStep.RunAsync(persona, question, own, siblings, critCts.Token);
+                }
+                catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+                {
+                    logger.LogWarning("Critique for persona {Id} timed out", own.Id);
+                    return new CritiqueStep.CritiqueOutput(own, []);
+                }
+            }).ToList();
+
+            var critiqueResults = await Task.WhenAll(critiqueTasks);
+            modelCalls += critiqueResults.Length;
+
+            for (var i = 0; i < critiqueResults.Length; i++)
+                personaViews[i] = critiqueResults[i].RevisedView;
+            critiqueTensions.AddRange(critiqueResults.SelectMany(r => r.Tensions));
+        }
+
+        // ── 5. Synthesize ──────────────────────────────────────────────────────
+        var synthesis = await synthesizeStep.RunAsync(
+            new SynthesizeStep.SynthesisInput(question, personaViews, critiqueTensions),
+            ct);
+        modelCalls++;
+
+        sw.Stop();
+
+        return new CouncilResponse(
+            Question: question,
+            Personas: personaViews,
+            Tensions: synthesis.Tensions,
+            Synthesis: synthesis.Synthesis,
+            Confidence: synthesis.Confidence,
+            Metadata: new CouncilMetadata(
+                CritiqueRun: selection.Critique && personaViews.Length > 1,
+                PreResearchRun: preResearch is not null,
+                PersonaCount: personaViews.Length,
+                DurationMs: sw.ElapsedMilliseconds,
+                ModelCalls: modelCalls,
+                PersonaSetHash: personaRegistry.PersonaSetHash,
+                SelectorRationale: selection.Rationale));
+    }
+
+    private CouncilResponse EmptyResponse(string question, string reason, TimeSpan duration, int modelCalls) =>
+        new(
+            Question: question,
+            Personas: [],
+            Tensions: [],
+            Synthesis: reason,
+            Confidence: "low",
+            Metadata: new CouncilMetadata(
+                CritiqueRun: false,
+                PreResearchRun: false,
+                PersonaCount: 0,
+                DurationMs: (long)duration.TotalMilliseconds,
+                ModelCalls: modelCalls,
+                PersonaSetHash: personaRegistry.PersonaSetHash,
+                SelectorRationale: reason));
+}

--- a/src/RockBot.AdvisorCouncil/Council/CritiqueStep.cs
+++ b/src/RockBot.AdvisorCouncil/Council/CritiqueStep.cs
@@ -1,0 +1,130 @@
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using RockBot.AdvisorCouncil.Personas;
+using RockBot.AdvisorCouncil.Schema;
+
+namespace RockBot.AdvisorCouncil.Council;
+
+/// <summary>
+/// For each persona, runs a second IChatClient call that revises the persona's view in
+/// light of sibling views and names explicit tensions. Per-persona parallel.
+/// </summary>
+internal sealed class CritiqueStep(
+    IChatClient chatClient,
+    ILogger<CritiqueStep> logger)
+{
+    private static readonly JsonSerializerOptions JsonOpts = new() { PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower };
+
+    public sealed record CritiqueOutput(PersonaView RevisedView, IReadOnlyList<Tension> Tensions);
+
+    public async Task<CritiqueOutput> RunAsync(
+        Persona persona,
+        string question,
+        PersonaView ownView,
+        IReadOnlyList<PersonaView> siblingViews,
+        CancellationToken ct)
+    {
+        if (siblingViews.Count == 0)
+            return new CritiqueOutput(ownView, []);
+
+        var system = persona.SystemPrompt + "\n\n## Critique addendum\n" +
+            "Revise your view in light of the sibling views below. Be explicit when you disagree — " +
+            "name what you disagree with and why. Identify tensions between your framing and others'. " +
+            "Stay in your persona's framing; do not adopt another persona's view wholesale. " +
+            "Respond ONLY with JSON of the form: " +
+            "{ \"revised_view\": \"markdown prose\", \"key_points\": [\"...\"], \"tensions\": " +
+            "[{\"with\":\"sibling_id\",\"description\":\"...\",\"stakes\":\"...\"}] }";
+
+        var user = BuildUserPrompt(question, ownView, siblingViews);
+
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.System, system),
+            new(ChatRole.User, user)
+        };
+        var options = new ChatOptions { ResponseFormat = ChatResponseFormat.Json };
+
+        try
+        {
+            var response = await chatClient.GetResponseAsync(messages, options, ct);
+            var raw = response.Text ?? string.Empty;
+            var parsed = Parse(raw, persona.Id);
+            if (parsed is not null)
+                return parsed;
+            logger.LogWarning("CritiqueStep parse failed for persona {Id}; keeping original view", persona.Id);
+            return new CritiqueOutput(ownView, []);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "CritiqueStep failed for persona {Id}", persona.Id);
+            return new CritiqueOutput(ownView, []);
+        }
+    }
+
+    private static string BuildUserPrompt(string question, PersonaView ownView, IReadOnlyList<PersonaView> siblings)
+    {
+        var sb = new StringBuilder();
+        sb.Append("Question: ").AppendLine(question).AppendLine();
+        sb.AppendLine("Your earlier view:");
+        sb.AppendLine(ownView.View).AppendLine();
+        sb.AppendLine("Sibling persona views:");
+        foreach (var s in siblings)
+        {
+            sb.Append("### ").AppendLine(s.Id);
+            sb.AppendLine(s.View).AppendLine();
+        }
+        return sb.ToString();
+    }
+
+    private static CritiqueOutput? Parse(string raw, string ownPersonaId)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return null;
+        var start = raw.IndexOf('{');
+        var end = raw.LastIndexOf('}');
+        if (start < 0 || end <= start) return null;
+        try
+        {
+            using var doc = JsonDocument.Parse(raw[start..(end + 1)]);
+            var root = doc.RootElement;
+            if (!root.TryGetProperty("revised_view", out var rvEl)) return null;
+            var revised = rvEl.GetString();
+            if (string.IsNullOrWhiteSpace(revised)) return null;
+
+            var keyPoints = new List<string>();
+            if (root.TryGetProperty("key_points", out var kpEl) && kpEl.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var kp in kpEl.EnumerateArray())
+                {
+                    var s = kp.GetString();
+                    if (!string.IsNullOrWhiteSpace(s)) keyPoints.Add(s);
+                }
+            }
+
+            var tensions = new List<Tension>();
+            if (root.TryGetProperty("tensions", out var tEl) && tEl.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var item in tEl.EnumerateArray())
+                {
+                    var with = item.TryGetProperty("with", out var wEl) ? wEl.GetString() : null;
+                    var desc = item.TryGetProperty("description", out var dEl) ? dEl.GetString() ?? string.Empty : string.Empty;
+                    var stakes = item.TryGetProperty("stakes", out var sEl) ? sEl.GetString() ?? string.Empty : string.Empty;
+                    if (!string.IsNullOrWhiteSpace(with) && !string.IsNullOrWhiteSpace(desc))
+                        tensions.Add(new Tension([ownPersonaId, with!], desc, stakes));
+                }
+            }
+
+            var revisedView = new PersonaView(ownPersonaId, revised!, keyPoints, []);
+            return new CritiqueOutput(revisedView, tensions);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/RockBot.AdvisorCouncil/Council/PersonaStep.cs
+++ b/src/RockBot.AdvisorCouncil/Council/PersonaStep.cs
@@ -1,0 +1,49 @@
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using RockBot.AdvisorCouncil.Personas;
+using RockBot.AdvisorCouncil.Schema;
+
+namespace RockBot.AdvisorCouncil.Council;
+
+/// <summary>
+/// Runs one persona view. Phase 1: call-only IChatClient call. Phase 3 expands the
+/// agentic-loop branch when <c>needs_research=true</c>.
+/// </summary>
+internal sealed class PersonaStep(
+    IChatClient chatClient,
+    ILogger<PersonaStep> logger)
+{
+    public async Task<PersonaView> RunAsync(
+        Persona persona,
+        string question,
+        string? preResearchFindings,
+        bool _needsResearch,
+        CancellationToken ct)
+    {
+        var userPrompt = preResearchFindings is null
+            ? question
+            : $"Use the following pre-research findings as context. Do not contradict facts in them.\n\n--- Pre-research findings ---\n{preResearchFindings}\n--- End findings ---\n\nQuestion: {question}";
+
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.System, persona.SystemPrompt),
+            new(ChatRole.User, userPrompt)
+        };
+
+        try
+        {
+            var response = await chatClient.GetResponseAsync(messages, options: null, ct);
+            var text = response.Text?.Trim() ?? string.Empty;
+            return new PersonaView(persona.Id, text, [], []);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "PersonaStep failed for persona {Id}", persona.Id);
+            return new PersonaView(persona.Id, "(persona call failed)", [], []);
+        }
+    }
+}

--- a/src/RockBot.AdvisorCouncil/Council/PreResearchStep.cs
+++ b/src/RockBot.AdvisorCouncil/Council/PreResearchStep.cs
@@ -1,0 +1,32 @@
+using Microsoft.Extensions.Logging;
+using RockBot.AdvisorCouncil.Tools;
+
+namespace RockBot.AdvisorCouncil.Council;
+
+/// <summary>
+/// Conditional stage that runs a single research call up-front and injects the findings
+/// into every persona branch. Skipped unless the selector returns <c>pre_research=true</c>.
+/// </summary>
+internal sealed class PreResearchStep(
+    ResearchAgentInvoker invoker,
+    ILogger<PreResearchStep> logger)
+{
+    public async Task<string?> RunAsync(string question, CancellationToken ct)
+    {
+        try
+        {
+            var findings = await invoker.InvokeAsync(question, ct);
+            logger.LogInformation("Pre-research returned {Len} chars", findings.Length);
+            return findings;
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Pre-research call failed; continuing without findings");
+            return null;
+        }
+    }
+}

--- a/src/RockBot.AdvisorCouncil/Council/SelectStep.cs
+++ b/src/RockBot.AdvisorCouncil/Council/SelectStep.cs
@@ -1,0 +1,147 @@
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using RockBot.AdvisorCouncil.Personas;
+using RockBot.AdvisorCouncil.Schema;
+
+namespace RockBot.AdvisorCouncil.Council;
+
+/// <summary>
+/// Picks which personas should examine the question and whether to run pre-research
+/// and cross-critique. Single Balanced-tier IChatClient call.
+/// </summary>
+internal sealed class SelectStep(
+    IChatClient chatClient,
+    PersonaRegistry registry,
+    ILogger<SelectStep> logger)
+{
+    private static readonly JsonSerializerOptions JsonOpts = new() { PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower };
+
+    public async Task<SelectorOutput> RunAsync(string question, CancellationToken ct)
+    {
+        var personas = registry.Personas;
+        if (personas.Count == 0)
+        {
+            logger.LogWarning("No personas loaded — returning empty selection");
+            return FallbackSelection(string.Empty);
+        }
+
+        var systemPrompt = BuildSystemPrompt(personas.Values);
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.System, systemPrompt),
+            new(ChatRole.User, question)
+        };
+        var options = new ChatOptions { ResponseFormat = ChatResponseFormat.Json };
+
+        var attempt = 1;
+        SelectorOutput? parsed = null;
+        string? rawText = null;
+        while (attempt <= 2 && parsed is null)
+        {
+            try
+            {
+                var response = await chatClient.GetResponseAsync(messages, options, ct);
+                rawText = response.Text ?? string.Empty;
+                parsed = ParseAndValidate(rawText, personas.Keys.ToHashSet(StringComparer.OrdinalIgnoreCase));
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                logger.LogWarning(ex, "SelectStep attempt {Attempt} failed", attempt);
+            }
+
+            if (parsed is null)
+            {
+                attempt++;
+                messages.Add(new ChatMessage(ChatRole.User,
+                    "Your previous response was not valid JSON matching the required schema. " +
+                    "Return ONLY a JSON object with keys: personas (array of {id, needs_research}), " +
+                    "pre_research (boolean), critique (boolean), rationale (string)."));
+            }
+        }
+
+        if (parsed is null)
+        {
+            logger.LogWarning("SelectStep falling back to default selection; raw={Raw}", Truncate(rawText, 400));
+            return FallbackSelection(rawText ?? string.Empty);
+        }
+
+        return parsed;
+    }
+
+    private string BuildSystemPrompt(IEnumerable<Persona> personas)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("You are the selector for an advisor council that examines questions from multiple framings.");
+        sb.AppendLine("Decide which personas should participate based on what the question needs.");
+        sb.AppendLine();
+        sb.AppendLine("Available personas:");
+        foreach (var p in personas.OrderBy(x => x.Id, StringComparer.Ordinal))
+        {
+            sb.Append("- ").Append(p.Id).Append(" — ").AppendLine(p.Description);
+        }
+        sb.AppendLine();
+        sb.AppendLine("Selection guidance:");
+        sb.AppendLine("- Pick 3–5 personas whose framings are most relevant. Do not select all by default.");
+        sb.AppendLine("- pre_research: true only when multiple personas would benefit from a shared factual base (specific technologies, companies, recent events).");
+        sb.AppendLine("- critique: true when the question is contested or strategic and personas are likely to disagree. False for mostly factual integration.");
+        sb.AppendLine("- needs_research per persona: true when the persona's framing requires up-to-date facts (e.g. engineer, economist) AND research is relevant to this question.");
+        sb.AppendLine();
+        sb.AppendLine("Respond with JSON only, in this exact shape:");
+        sb.AppendLine(@"{ ""personas"": [{""id"": ""..."", ""needs_research"": false}], ""pre_research"": false, ""critique"": false, ""rationale"": ""..."" }");
+        return sb.ToString();
+    }
+
+    private static SelectorOutput? ParseAndValidate(string raw, HashSet<string> knownPersonaIds)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return null;
+        var json = ExtractJson(raw);
+        if (json is null) return null;
+        try
+        {
+            var parsed = JsonSerializer.Deserialize<SelectorOutput>(json, JsonOpts);
+            if (parsed is null) return null;
+            if (parsed.Personas is null || parsed.Personas.Count == 0) return null;
+            var filtered = parsed.Personas
+                .Where(p => !string.IsNullOrWhiteSpace(p.Id) && knownPersonaIds.Contains(p.Id))
+                .ToList();
+            if (filtered.Count == 0) return null;
+            return parsed with { Personas = filtered };
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static string? ExtractJson(string text)
+    {
+        var start = text.IndexOf('{');
+        var end = text.LastIndexOf('}');
+        if (start < 0 || end <= start) return null;
+        return text[start..(end + 1)];
+    }
+
+    private SelectorOutput FallbackSelection(string rawText)
+    {
+        var defaults = new[] { "skeptic", "engineer", "long_term" };
+        var available = registry.Personas;
+        var selected = defaults
+            .Where(id => available.ContainsKey(id))
+            .Select(id => new SelectedPersona(id, false))
+            .ToList();
+        if (selected.Count == 0)
+        {
+            selected = available.Keys
+                .Take(3)
+                .Select(id => new SelectedPersona(id, false))
+                .ToList();
+        }
+        return new SelectorOutput(selected, false, false, "Fallback default selection — selector output failed schema validation.");
+    }
+
+    private static string Truncate(string? s, int max) =>
+        s is null ? string.Empty :
+        s.Length <= max ? s : s[..max] + "…";
+}

--- a/src/RockBot.AdvisorCouncil/Council/SynthesizeStep.cs
+++ b/src/RockBot.AdvisorCouncil/Council/SynthesizeStep.cs
@@ -1,0 +1,178 @@
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using RockBot.AdvisorCouncil.Schema;
+
+namespace RockBot.AdvisorCouncil.Council;
+
+/// <summary>
+/// Final integration step. High-tier IChatClient call: takes persona views and any
+/// identified tensions, returns structured CouncilResponse JSON.
+/// </summary>
+internal sealed class SynthesizeStep(
+    IChatClient chatClient,
+    ILogger<SynthesizeStep> logger)
+{
+    private static readonly JsonSerializerOptions JsonOpts = new() { PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower };
+
+    public sealed record SynthesisInput(
+        string Question,
+        IReadOnlyList<PersonaView> Views,
+        IReadOnlyList<Tension> Tensions);
+
+    public sealed record SynthesisOutput(string Synthesis, string Confidence, IReadOnlyList<Tension> Tensions);
+
+    public async Task<SynthesisOutput> RunAsync(SynthesisInput input, CancellationToken ct)
+    {
+        var system = BuildSystemPrompt();
+        var user = BuildUserPrompt(input);
+
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.System, system),
+            new(ChatRole.User, user)
+        };
+        var options = new ChatOptions { ResponseFormat = ChatResponseFormat.Json };
+
+        SynthesisOutput? result = null;
+        var attempt = 1;
+        string? raw = null;
+        while (attempt <= 2 && result is null)
+        {
+            try
+            {
+                var response = await chatClient.GetResponseAsync(messages, options, ct);
+                raw = response.Text ?? string.Empty;
+                result = ParseAndValidate(raw, input.Tensions);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                logger.LogWarning(ex, "SynthesizeStep attempt {Attempt} failed", attempt);
+            }
+
+            if (result is null)
+            {
+                attempt++;
+                messages.Add(new ChatMessage(ChatRole.User,
+                    "Your previous response was not valid JSON matching the schema. " +
+                    "Return ONLY a JSON object: { \"synthesis\": \"...\", \"confidence\": \"low|medium|high\", " +
+                    "\"tensions\": [{\"between\":[\"a\",\"b\"],\"description\":\"...\",\"stakes\":\"...\"}] }."));
+            }
+        }
+
+        if (result is null)
+        {
+            logger.LogWarning("SynthesizeStep falling back to minimal synthesis; raw={Raw}", Truncate(raw, 400));
+            return new SynthesisOutput(
+                "Synthesis was unavailable. Persona views are included in the structured response.",
+                "low",
+                input.Tensions);
+        }
+        return result;
+    }
+
+    private static string BuildSystemPrompt() =>
+        """
+        You are the synthesis step of an advisor council. Several personas have examined
+        a question from distinct framings. Integrate their views into a single piece of
+        guidance that names the tensions, surfaces what is at stake, and reaches an
+        integrated recommendation where possible.
+
+        Guidelines:
+        - Do not just summarize. Integrate. Name tensions explicitly.
+        - Be honest about uncertainty. Use confidence: "low" when personas disagree
+          substantively, "medium" when there is partial alignment, "high" when consensus.
+        - Your synthesis prose should be ~500 words, well-structured, plain markdown.
+
+        Respond with JSON only:
+        { "synthesis": "markdown prose", "confidence": "low|medium|high", "tensions": [{"between":["id_a","id_b"],"description":"...","stakes":"..."}] }
+        """;
+
+    private static string BuildUserPrompt(SynthesisInput input)
+    {
+        var sb = new StringBuilder();
+        sb.Append("Question: ").AppendLine(input.Question).AppendLine();
+        sb.AppendLine("Persona views:");
+        foreach (var v in input.Views)
+        {
+            sb.Append("### ").AppendLine(v.Id);
+            sb.AppendLine(v.View).AppendLine();
+        }
+        if (input.Tensions.Count > 0)
+        {
+            sb.AppendLine("Tensions already identified by personas during critique:");
+            foreach (var t in input.Tensions)
+            {
+                sb.Append("- between [").Append(string.Join(", ", t.Between)).Append("]: ")
+                  .Append(t.Description).Append(" (stakes: ").Append(t.Stakes).AppendLine(")");
+            }
+        }
+        return sb.ToString();
+    }
+
+    private static SynthesisOutput? ParseAndValidate(string raw, IReadOnlyList<Tension> fallbackTensions)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return null;
+        var json = ExtractJson(raw);
+        if (json is null) return null;
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            if (!root.TryGetProperty("synthesis", out var synEl)) return null;
+            var synthesis = synEl.GetString();
+            if (string.IsNullOrWhiteSpace(synthesis)) return null;
+            var confidence = root.TryGetProperty("confidence", out var confEl)
+                ? confEl.GetString() ?? "medium"
+                : "medium";
+            confidence = confidence.ToLowerInvariant() switch
+            {
+                "low" or "medium" or "high" => confidence.ToLowerInvariant(),
+                _ => "medium"
+            };
+
+            var tensions = fallbackTensions;
+            if (root.TryGetProperty("tensions", out var tEl) && tEl.ValueKind == JsonValueKind.Array)
+            {
+                var list = new List<Tension>();
+                foreach (var item in tEl.EnumerateArray())
+                {
+                    var between = new List<string>();
+                    if (item.TryGetProperty("between", out var bEl) && bEl.ValueKind == JsonValueKind.Array)
+                    {
+                        foreach (var b in bEl.EnumerateArray())
+                        {
+                            var bs = b.GetString();
+                            if (!string.IsNullOrWhiteSpace(bs)) between.Add(bs);
+                        }
+                    }
+                    var desc = item.TryGetProperty("description", out var dEl) ? dEl.GetString() ?? string.Empty : string.Empty;
+                    var stakes = item.TryGetProperty("stakes", out var sEl) ? sEl.GetString() ?? string.Empty : string.Empty;
+                    if (between.Count > 0 && !string.IsNullOrWhiteSpace(desc))
+                        list.Add(new Tension(between, desc, stakes));
+                }
+                if (list.Count > 0)
+                    tensions = list;
+            }
+
+            return new SynthesisOutput(synthesis!, confidence, tensions);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static string? ExtractJson(string text)
+    {
+        var start = text.IndexOf('{');
+        var end = text.LastIndexOf('}');
+        if (start < 0 || end <= start) return null;
+        return text[start..(end + 1)];
+    }
+
+    private static string Truncate(string? s, int max) =>
+        s is null ? string.Empty :
+        s.Length <= max ? s : s[..max] + "…";
+}

--- a/src/RockBot.AdvisorCouncil/EchoChatClient.cs
+++ b/src/RockBot.AdvisorCouncil/EchoChatClient.cs
@@ -1,0 +1,38 @@
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.AI;
+
+namespace RockBot.AdvisorCouncil;
+
+/// <summary>
+/// Development fallback chat client that echoes the last user message. Used when no
+/// LLM is configured — keeps the pod functional for plumbing-only smoke tests.
+/// </summary>
+internal sealed class EchoChatClient : IChatClient
+{
+    public Task<ChatResponse> GetResponseAsync(
+        IEnumerable<ChatMessage> chatMessages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        var lastUserMessage = chatMessages
+            .LastOrDefault(m => m.Role == ChatRole.User)
+            ?.Text ?? "(no message)";
+
+        var response = new ChatResponse(
+            new ChatMessage(ChatRole.Assistant, $"Echo: {lastUserMessage}"));
+
+        return Task.FromResult(response);
+    }
+
+    public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+        IEnumerable<ChatMessage> chatMessages,
+        ChatOptions? options = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        yield break;
+    }
+
+    public object? GetService(Type serviceType, object? serviceKey = null) => null;
+
+    public void Dispose() { }
+}

--- a/src/RockBot.AdvisorCouncil/EphemeralShutdownCoordinator.cs
+++ b/src/RockBot.AdvisorCouncil/EphemeralShutdownCoordinator.cs
@@ -1,0 +1,18 @@
+namespace RockBot.AdvisorCouncil;
+
+/// <summary>
+/// Signals that the single task handled by this ephemeral pod is complete.
+/// The <see cref="EphemeralShutdownService"/> waits on this coordinator and calls
+/// <see cref="Microsoft.Extensions.Hosting.IHostApplicationLifetime.StopApplication"/>
+/// once notified, allowing the pod to exit cleanly after one task.
+/// </summary>
+internal sealed class EphemeralShutdownCoordinator
+{
+    private readonly TaskCompletionSource<bool> _tcs =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public void NotifyTaskComplete() => _tcs.TrySetResult(true);
+
+    public Task WaitForCompletionAsync(CancellationToken ct) =>
+        _tcs.Task.WaitAsync(ct);
+}

--- a/src/RockBot.AdvisorCouncil/EphemeralShutdownService.cs
+++ b/src/RockBot.AdvisorCouncil/EphemeralShutdownService.cs
@@ -1,0 +1,27 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace RockBot.AdvisorCouncil;
+
+/// <summary>
+/// Background service that waits for <see cref="EphemeralShutdownCoordinator.NotifyTaskComplete"/>
+/// and then triggers graceful host shutdown so the ephemeral pod exits after one task.
+/// </summary>
+internal sealed class EphemeralShutdownService(
+    EphemeralShutdownCoordinator coordinator,
+    IHostApplicationLifetime lifetime,
+    ILogger<EphemeralShutdownService> logger) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            await coordinator.WaitForCompletionAsync(stoppingToken);
+            logger.LogInformation("Council task complete — stopping ephemeral agent");
+            lifetime.StopApplication();
+        }
+        catch (OperationCanceledException)
+        {
+        }
+    }
+}

--- a/src/RockBot.AdvisorCouncil/NullFeedbackStore.cs
+++ b/src/RockBot.AdvisorCouncil/NullFeedbackStore.cs
@@ -1,0 +1,22 @@
+using RockBot.Host;
+
+namespace RockBot.AdvisorCouncil;
+
+/// <summary>
+/// No-op <see cref="IFeedbackStore"/> for the ephemeral advisor-council agent.
+/// The council has no dreaming or memory consolidation pipeline, so feedback signals
+/// are silently discarded.
+/// </summary>
+internal sealed class NullFeedbackStore : IFeedbackStore
+{
+    public Task AppendAsync(FeedbackEntry entry, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+
+    public Task<IReadOnlyList<FeedbackEntry>> GetBySessionAsync(
+        string sessionId, CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<FeedbackEntry>>([]);
+
+    public Task<IReadOnlyList<FeedbackEntry>> QueryRecentAsync(
+        DateTimeOffset since, int maxResults, CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<FeedbackEntry>>([]);
+}

--- a/src/RockBot.AdvisorCouncil/Personas/Persona.cs
+++ b/src/RockBot.AdvisorCouncil/Personas/Persona.cs
@@ -1,0 +1,12 @@
+namespace RockBot.AdvisorCouncil.Personas;
+
+/// <summary>
+/// A persona is a framing the council uses to examine a question. Loaded from a markdown
+/// file with YAML frontmatter on the personas PVC path.
+/// </summary>
+internal sealed record Persona(
+    string Id,
+    string Name,
+    string Description,
+    string SystemPrompt,
+    bool DefaultResearch);

--- a/src/RockBot.AdvisorCouncil/Personas/PersonaRegistry.cs
+++ b/src/RockBot.AdvisorCouncil/Personas/PersonaRegistry.cs
@@ -1,0 +1,165 @@
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using RockBot.AdvisorCouncil.Council;
+
+namespace RockBot.AdvisorCouncil.Personas;
+
+/// <summary>
+/// Loads council personas from markdown files with YAML frontmatter. Supports manual
+/// <see cref="Reload"/> calls — wiring to a file watcher is done by
+/// <see cref="PersonaRegistryHotReload"/>.
+/// </summary>
+internal sealed class PersonaRegistry
+{
+    private readonly ILogger<PersonaRegistry> _logger;
+    private readonly string _personasPath;
+    private volatile PersonaSnapshot _snapshot;
+
+    public PersonaRegistry(IOptions<CouncilOptions> options, ILogger<PersonaRegistry> logger)
+    {
+        _logger = logger;
+        _personasPath = ResolvePersonasPath(options.Value.PersonasPath);
+        _snapshot = Load();
+    }
+
+    public IReadOnlyDictionary<string, Persona> Personas => _snapshot.Personas;
+
+    public string PersonaSetHash => _snapshot.Hash;
+
+    public string PersonasPath => _personasPath;
+
+    public void Reload()
+    {
+        var next = Load();
+        if (next.Hash == _snapshot.Hash)
+        {
+            _logger.LogDebug("Persona reload: no changes (hash {Hash})", next.Hash[..8]);
+            return;
+        }
+
+        _logger.LogInformation(
+            "Persona reload: {Count} personas, hash {OldHash} -> {NewHash}",
+            next.Personas.Count, _snapshot.Hash[..8], next.Hash[..8]);
+        _snapshot = next;
+    }
+
+    private static string ResolvePersonasPath(string configured)
+    {
+        if (!string.IsNullOrWhiteSpace(configured) && Directory.Exists(configured))
+            return configured;
+
+        var pvcPath = "/data/advisor-council/personas";
+        if (Directory.Exists(pvcPath))
+            return pvcPath;
+
+        var local = Path.Combine(AppContext.BaseDirectory, "agent", "personas");
+        return local;
+    }
+
+    private PersonaSnapshot Load()
+    {
+        var personas = new ConcurrentDictionary<string, Persona>(StringComparer.OrdinalIgnoreCase);
+
+        if (!Directory.Exists(_personasPath))
+        {
+            _logger.LogWarning("Personas path does not exist: {Path}", _personasPath);
+            return new PersonaSnapshot(personas, ComputeHash(personas));
+        }
+
+        foreach (var file in Directory.GetFiles(_personasPath, "*.md"))
+        {
+            try
+            {
+                var persona = ParsePersonaFile(file);
+                if (persona is not null)
+                    personas[persona.Id] = persona;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to parse persona file {File}", file);
+            }
+        }
+
+        if (personas.IsEmpty)
+            _logger.LogWarning("No personas loaded from {Path}", _personasPath);
+
+        return new PersonaSnapshot(personas, ComputeHash(personas));
+    }
+
+    internal static Persona? ParsePersonaFile(string filePath)
+    {
+        var content = File.ReadAllText(filePath);
+        return ParsePersonaContent(content, Path.GetFileNameWithoutExtension(filePath));
+    }
+
+    /// <summary>
+    /// Parses a persona file body. Frontmatter is delimited by lines containing only "---".
+    /// Frontmatter keys: id, name, description, default_research. Body is the system prompt.
+    /// </summary>
+    internal static Persona? ParsePersonaContent(string content, string filename)
+    {
+        if (string.IsNullOrWhiteSpace(content))
+            return null;
+
+        var lines = content.Replace("\r\n", "\n").Split('\n');
+        if (lines.Length < 3 || lines[0].Trim() != "---")
+            return null;
+
+        var frontmatter = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        int endFm = -1;
+        for (int i = 1; i < lines.Length; i++)
+        {
+            if (lines[i].Trim() == "---")
+            {
+                endFm = i;
+                break;
+            }
+            var line = lines[i];
+            var colonIdx = line.IndexOf(':');
+            if (colonIdx < 0) continue;
+            var key = line[..colonIdx].Trim();
+            var value = line[(colonIdx + 1)..].Trim();
+            if (value.StartsWith('"') && value.EndsWith('"') && value.Length >= 2)
+                value = value[1..^1];
+            frontmatter[key] = value;
+        }
+        if (endFm < 0)
+            return null;
+
+        var bodyLines = lines.Skip(endFm + 1);
+        var body = string.Join('\n', bodyLines).Trim();
+        if (body.Length == 0)
+            return null;
+
+        var id = frontmatter.GetValueOrDefault("id", filename).Trim();
+        if (string.IsNullOrWhiteSpace(id))
+            return null;
+
+        var name = frontmatter.GetValueOrDefault("name", id);
+        var description = frontmatter.GetValueOrDefault("description", string.Empty);
+        var defaultResearchStr = frontmatter.GetValueOrDefault("default_research", "false");
+        var defaultResearch = bool.TryParse(defaultResearchStr, out var b) && b;
+
+        return new Persona(id, name, description, body, defaultResearch);
+    }
+
+    /// <summary>
+    /// SHA-256 over <c>id|systemPrompt</c> pairs sorted by id, for surfacing in output
+    /// metadata so callers can detect persona drift across deployments.
+    /// </summary>
+    internal static string ComputeHash(IReadOnlyDictionary<string, Persona> personas)
+    {
+        var sb = new StringBuilder();
+        foreach (var p in personas.OrderBy(kv => kv.Key, StringComparer.Ordinal))
+        {
+            sb.Append(p.Value.Id).Append('|').Append(p.Value.SystemPrompt).Append('\n');
+        }
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(sb.ToString()));
+        return Convert.ToHexString(bytes).ToLowerInvariant();
+    }
+
+    private sealed record PersonaSnapshot(IReadOnlyDictionary<string, Persona> Personas, string Hash);
+}

--- a/src/RockBot.AdvisorCouncil/Personas/PersonaRegistryHotReload.cs
+++ b/src/RockBot.AdvisorCouncil/Personas/PersonaRegistryHotReload.cs
@@ -1,0 +1,80 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace RockBot.AdvisorCouncil.Personas;
+
+/// <summary>
+/// Watches the personas directory and triggers <see cref="PersonaRegistry.Reload"/>
+/// on change with a 500 ms debounce.
+/// </summary>
+internal sealed class PersonaRegistryHotReload(
+    PersonaRegistry registry,
+    ILogger<PersonaRegistryHotReload> logger) : IHostedService, IDisposable
+{
+    private FileSystemWatcher? _watcher;
+    private Timer? _debounceTimer;
+    private readonly object _gate = new();
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (!Directory.Exists(registry.PersonasPath))
+        {
+            logger.LogWarning(
+                "Hot-reload disabled: personas path {Path} does not exist",
+                registry.PersonasPath);
+            return Task.CompletedTask;
+        }
+
+        try
+        {
+            _watcher = new FileSystemWatcher(registry.PersonasPath, "*.md")
+            {
+                NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName | NotifyFilters.Size,
+                EnableRaisingEvents = true
+            };
+            _watcher.Changed += OnChanged;
+            _watcher.Created += OnChanged;
+            _watcher.Deleted += OnChanged;
+            _watcher.Renamed += OnChanged;
+
+            logger.LogInformation("Persona hot-reload watching {Path}", registry.PersonasPath);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to start persona hot-reload watcher on {Path}", registry.PersonasPath);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private void OnChanged(object? sender, FileSystemEventArgs e)
+    {
+        lock (_gate)
+        {
+            _debounceTimer?.Dispose();
+            _debounceTimer = new Timer(_ =>
+            {
+                try
+                {
+                    registry.Reload();
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "Persona reload failed after file change: {File}", e.FullPath);
+                }
+            }, null, TimeSpan.FromMilliseconds(500), Timeout.InfiniteTimeSpan);
+        }
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        Dispose();
+        return Task.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        _watcher?.Dispose();
+        _debounceTimer?.Dispose();
+    }
+}

--- a/src/RockBot.AdvisorCouncil/Program.cs
+++ b/src/RockBot.AdvisorCouncil/Program.cs
@@ -1,0 +1,148 @@
+using System.ClientModel;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using OpenAI;
+using RockBot.A2A;
+using RockBot.AdvisorCouncil;
+using RockBot.AdvisorCouncil.Council;
+using RockBot.AdvisorCouncil.Personas;
+using RockBot.AdvisorCouncil.Tools;
+using RockBot.Host;
+using RockBot.Llm;
+using RockBot.Messaging.RabbitMQ;
+
+var builder = Host.CreateApplicationBuilder(args);
+builder.Configuration.AddUserSecrets<Program>();
+
+builder.Services.AddRockBotRabbitMq(opts => builder.Configuration.GetSection("RabbitMq").Bind(opts));
+
+// ── Council options ─────────────────────────────────────────────────────────
+builder.Services.Configure<CouncilOptions>(builder.Configuration.GetSection("Council"));
+
+// ── LLM configuration — three-tier (Low / Balanced / High) ──────────────────
+var llmSection = builder.Configuration.GetSection("LLM");
+var tierOptions = new LlmTierOptions();
+llmSection.Bind(tierOptions);
+
+if (!tierOptions.Balanced.IsConfigured)
+{
+    tierOptions.Balanced.Endpoint = llmSection["Endpoint"];
+    tierOptions.Balanced.ApiKey   = llmSection["ApiKey"];
+    tierOptions.Balanced.ModelId  = llmSection["ModelId"];
+}
+if (!tierOptions.Balanced.IsConfigured && tierOptions.BalancedModels.Count > 0)
+    tierOptions.Balanced = tierOptions.BalancedModels[0];
+
+// Per-persona tool-iteration cap (Phase 3 — research path). Pre-registered before
+// AddRockBotTieredChatClients so its TryAdd respects this override.
+builder.Services.AddSingleton(new ModelBehavior { MaxToolIterationsOverride = 8 });
+
+if (tierOptions.Balanced.IsConfigured || tierOptions.BalancedModels.Count > 0)
+{
+    IChatClient BuildClient(LlmTierConfig config) =>
+        new OpenAIClient(
+            new ApiKeyCredential(config.ApiKey!),
+            new OpenAIClientOptions { Endpoint = new Uri(config.Endpoint!) })
+            .GetChatClient(config.ModelId!).AsIChatClient();
+
+    IChatClient balancedClient;
+    if (tierOptions.BalancedModels.Count > 1)
+    {
+        var fallbackLoggerFactory = LoggerFactory.Create(b =>
+            b.AddConsole().SetMinimumLevel(LogLevel.Warning));
+        var fallbackLogger = fallbackLoggerFactory.CreateLogger<FallbackChatClient>();
+        var entries = new List<(string ModelId, IChatClient Client)>();
+        foreach (var cfg in tierOptions.BalancedModels)
+            entries.Add((cfg.ModelId!, BuildClient(cfg)));
+        balancedClient = new FallbackChatClient(entries, fallbackLogger);
+    }
+    else if (tierOptions.BalancedModels.Count == 1)
+    {
+        balancedClient = BuildClient(tierOptions.BalancedModels[0]);
+    }
+    else
+    {
+        balancedClient = BuildClient(tierOptions.Balanced);
+    }
+
+    var highClient = BuildClient(tierOptions.Resolve(ModelTier.High));
+
+    builder.Services.AddRockBotTieredChatClients(
+        lowInnerClient:      balancedClient,
+        balancedInnerClient: balancedClient,
+        highInnerClient:     highClient);
+}
+else
+{
+    builder.Services.AddRockBotChatClient(new EchoChatClient());
+    Console.WriteLine("No LLM config found — using EchoChatClient.");
+}
+
+builder.Services.AddSingleton<IFeedbackStore, NullFeedbackStore>();
+
+// ── Council components ──────────────────────────────────────────────────────
+builder.Services.AddSingleton<PersonaRegistry>();
+builder.Services.AddHostedService<PersonaRegistryHotReload>();
+builder.Services.AddSingleton<SelectStep>();
+builder.Services.AddSingleton<PreResearchStep>();
+builder.Services.AddSingleton<PersonaStep>();
+builder.Services.AddSingleton<CritiqueStep>();
+builder.Services.AddSingleton<SynthesizeStep>();
+builder.Services.AddSingleton<CouncilOrchestrator>();
+builder.Services.AddSingleton<ResearchAgentInvoker>();
+builder.Services.AddHostedService(sp => sp.GetRequiredService<ResearchAgentInvoker>());
+
+builder.Services.AddRockBotHost(agent =>
+{
+    agent.WithIdentity("AdvisorCouncil");
+
+    // Working memory — persona branches with research write their findings here under
+    // council/{taskId}/{personaId}; namespace shared across personas for cross-pollination.
+    agent.WithWorkingMemory();
+
+    agent.AddA2A(opts =>
+    {
+        opts.Card = new AgentCard
+        {
+            AgentName = "AdvisorCouncil",
+            Description = "Multi-perspective advisor council. Analyzes questions from a curated set of personas and returns integrated guidance.",
+            Version = "1.0",
+            Skills =
+            [
+                new AgentSkill
+                {
+                    Id = "advise",
+                    Name = "Advise",
+                    Description = "Take a question or idea and return multi-perspective analysis with synthesis."
+                }
+            ]
+        };
+    });
+
+    agent.Services.AddScoped<IAgentTaskHandler, AdvisorCouncilTaskHandler>();
+
+    agent.Services.AddSingleton<EphemeralShutdownCoordinator>();
+    agent.Services.AddHostedService<EphemeralShutdownService>();
+});
+
+var app = builder.Build();
+
+AppDomain.CurrentDomain.UnhandledException += (_, e) =>
+{
+    var crashLogger = app.Services.GetRequiredService<ILoggerFactory>()
+                                  .CreateLogger("UnhandledException");
+    crashLogger.LogCritical(e.ExceptionObject as Exception,
+        "Unhandled exception — AdvisorCouncil exiting");
+};
+
+var startupLogger = app.Services.GetRequiredService<ILoggerFactory>().CreateLogger("Startup");
+var registry = app.Services.GetRequiredService<PersonaRegistry>();
+startupLogger.LogInformation(
+    "AdvisorCouncil starting — {Count} personas loaded from {Path} (hash {Hash})",
+    registry.Personas.Count, registry.PersonasPath, registry.PersonaSetHash[..8]);
+startupLogger.LogInformation("AdvisorCouncil waiting for A2A task requests");
+
+await app.RunAsync();

--- a/src/RockBot.AdvisorCouncil/RockBot.AdvisorCouncil.csproj
+++ b/src/RockBot.AdvisorCouncil/RockBot.AdvisorCouncil.csproj
@@ -1,0 +1,51 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>RockBot.AdvisorCouncil</RootNamespace>
+    <UserSecretsId>rockbot-advisor-council-001</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="agent\**\*.md" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="RockBot.AdvisorCouncil.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="appsettings.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.AI" Version="10.*" />
+    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.*" />
+    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.*" />
+    <PackageReference Include="System.ClientModel" Version="1.*" />
+
+    <!-- MAF (Microsoft.Agents.AI.Workflows $(MicrosoftAgentsAIVersion)) was evaluated for
+         orchestration. The pipeline requires dynamic-graph-per-request (only N of M
+         personas selected), which negates MAF's static-graph value. CouncilOrchestrator
+         implements the same Select → optional PreResearch → Fan-out → optional Critique
+         → Synthesize shape imperatively. The design doc explicitly permits this fallback. -->
+
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\RockBot.A2A\RockBot.A2A.csproj" />
+    <ProjectReference Include="..\RockBot.A2A.Abstractions\RockBot.A2A.Abstractions.csproj" />
+    <ProjectReference Include="..\RockBot.Host.Abstractions\RockBot.Host.Abstractions.csproj" />
+    <ProjectReference Include="..\RockBot.Host\RockBot.Host.csproj" />
+    <ProjectReference Include="..\RockBot.Llm\RockBot.Llm.csproj" />
+    <ProjectReference Include="..\RockBot.Llm.Abstractions\RockBot.Llm.Abstractions.csproj" />
+    <ProjectReference Include="..\RockBot.Memory\RockBot.Memory.csproj" />
+    <ProjectReference Include="..\RockBot.Messaging.Abstractions\RockBot.Messaging.Abstractions.csproj" />
+    <ProjectReference Include="..\RockBot.Messaging.RabbitMQ\RockBot.Messaging.RabbitMQ.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/RockBot.AdvisorCouncil/Schema/CouncilResponse.cs
+++ b/src/RockBot.AdvisorCouncil/Schema/CouncilResponse.cs
@@ -1,0 +1,36 @@
+using System.Text.Json.Serialization;
+
+namespace RockBot.AdvisorCouncil.Schema;
+
+/// <summary>
+/// Full structured output of a council run. Returned as a JSON data part on the
+/// AgentTaskResult; the synthesis prose is also returned as a separate text part for
+/// callers that only consume prose.
+/// </summary>
+internal sealed record CouncilResponse(
+    [property: JsonPropertyName("question")] string Question,
+    [property: JsonPropertyName("personas")] IReadOnlyList<PersonaView> Personas,
+    [property: JsonPropertyName("tensions")] IReadOnlyList<Tension> Tensions,
+    [property: JsonPropertyName("synthesis")] string Synthesis,
+    [property: JsonPropertyName("confidence")] string Confidence,
+    [property: JsonPropertyName("metadata")] CouncilMetadata Metadata);
+
+internal sealed record PersonaView(
+    [property: JsonPropertyName("id")] string Id,
+    [property: JsonPropertyName("view")] string View,
+    [property: JsonPropertyName("key_points")] IReadOnlyList<string> KeyPoints,
+    [property: JsonPropertyName("sources")] IReadOnlyList<string> Sources);
+
+internal sealed record Tension(
+    [property: JsonPropertyName("between")] IReadOnlyList<string> Between,
+    [property: JsonPropertyName("description")] string Description,
+    [property: JsonPropertyName("stakes")] string Stakes);
+
+internal sealed record CouncilMetadata(
+    [property: JsonPropertyName("critique_run")] bool CritiqueRun,
+    [property: JsonPropertyName("pre_research_run")] bool PreResearchRun,
+    [property: JsonPropertyName("persona_count")] int PersonaCount,
+    [property: JsonPropertyName("duration_ms")] long DurationMs,
+    [property: JsonPropertyName("model_calls")] int ModelCalls,
+    [property: JsonPropertyName("persona_set_hash")] string PersonaSetHash,
+    [property: JsonPropertyName("selector_rationale")] string SelectorRationale);

--- a/src/RockBot.AdvisorCouncil/Schema/SelectorOutput.cs
+++ b/src/RockBot.AdvisorCouncil/Schema/SelectorOutput.cs
@@ -1,0 +1,18 @@
+using System.Text.Json.Serialization;
+
+namespace RockBot.AdvisorCouncil.Schema;
+
+/// <summary>
+/// Output of the Select step. Decides which personas participate, whether to run
+/// pre-research, and whether to run cross-critique. Surfaced verbatim in the council
+/// response metadata for debuggability.
+/// </summary>
+internal sealed record SelectorOutput(
+    [property: JsonPropertyName("personas")] IReadOnlyList<SelectedPersona> Personas,
+    [property: JsonPropertyName("pre_research")] bool PreResearch,
+    [property: JsonPropertyName("critique")] bool Critique,
+    [property: JsonPropertyName("rationale")] string Rationale);
+
+internal sealed record SelectedPersona(
+    [property: JsonPropertyName("id")] string Id,
+    [property: JsonPropertyName("needs_research")] bool NeedsResearch);

--- a/src/RockBot.AdvisorCouncil/Tools/ResearchAgentInvoker.cs
+++ b/src/RockBot.AdvisorCouncil/Tools/ResearchAgentInvoker.cs
@@ -1,0 +1,201 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using RockBot.A2A;
+using RockBot.AdvisorCouncil.Council;
+using RockBot.Messaging;
+
+namespace RockBot.AdvisorCouncil.Tools;
+
+/// <summary>
+/// Synchronous A2A invocation of <c>ResearchAgent</c> from inside the council pod.
+/// Maintains a process-unique reply queue and matches incoming results to outstanding
+/// invocations via correlation id. The existing <c>InvokeAgentExecutor</c> is async /
+/// fire-and-forget against the primary agent's bus and is not reusable for the
+/// synchronous wait the council needs inside a persona branch.
+/// </summary>
+internal sealed class ResearchAgentInvoker : IHostedService, IAsyncDisposable
+{
+    private const string ResearchTaskTopic = "agent.task.ResearchAgent";
+
+    private readonly IMessagePublisher _publisher;
+    private readonly IMessageSubscriber _subscriber;
+    private readonly CouncilOptions _options;
+    private readonly ILogger<ResearchAgentInvoker> _logger;
+
+    private readonly string _replyTopic =
+        $"council.research-reply.{Environment.ProcessId}.{Guid.NewGuid():N}".ToLowerInvariant();
+
+    private readonly ConcurrentDictionary<string, TaskCompletionSource<string>> _pending = new(StringComparer.Ordinal);
+    private ISubscription? _subscription;
+
+    public ResearchAgentInvoker(
+        IMessagePublisher publisher,
+        IMessageSubscriber subscriber,
+        IOptions<CouncilOptions> options,
+        ILogger<ResearchAgentInvoker> logger)
+    {
+        _publisher = publisher;
+        _subscriber = subscriber;
+        _options = options.Value;
+        _logger = logger;
+        Function = new InvokerFunction(this);
+    }
+
+    public AIFunction Function { get; }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        _subscription = await _subscriber.SubscribeAsync(
+            topic: _replyTopic,
+            subscriptionName: _replyTopic,
+            handler: HandleReplyAsync,
+            cancellationToken: cancellationToken);
+        _logger.LogInformation("ResearchAgentInvoker reply queue {Topic} ready", _replyTopic);
+    }
+
+    private Task<MessageResult> HandleReplyAsync(MessageEnvelope envelope, CancellationToken ct)
+    {
+        var correlationId = envelope.CorrelationId;
+        if (string.IsNullOrWhiteSpace(correlationId))
+        {
+            _logger.LogWarning("Received research reply without correlation id; type={Type}", envelope.MessageType);
+            return Task.FromResult(MessageResult.Ack);
+        }
+
+        if (!_pending.TryRemove(correlationId, out var tcs))
+        {
+            _logger.LogDebug("No pending research call for correlationId={CorrelationId}", correlationId);
+            return Task.FromResult(MessageResult.Ack);
+        }
+
+        try
+        {
+            if (envelope.MessageType.Contains("AgentTaskError", StringComparison.Ordinal))
+            {
+                var err = envelope.GetPayload<AgentTaskError>();
+                tcs.TrySetResult($"(research failed: {err?.Message ?? "unknown"})");
+            }
+            else
+            {
+                var result = envelope.GetPayload<AgentTaskResult>();
+                var text = result?.Message?.Parts.FirstOrDefault(p => p.Kind == "text")?.Text;
+                tcs.TrySetResult(string.IsNullOrWhiteSpace(text) ? "(no research result)" : text);
+            }
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogWarning(ex, "Failed to deserialize research reply for {CorrelationId}", correlationId);
+            tcs.TrySetResult("(research reply could not be parsed)");
+        }
+
+        return Task.FromResult(MessageResult.Ack);
+    }
+
+    public async Task<string> InvokeAsync(string question, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(question))
+            return "(empty research question)";
+
+        var taskId = Guid.NewGuid().ToString("N");
+        var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        _pending[taskId] = tcs;
+
+        try
+        {
+            var request = new AgentTaskRequest
+            {
+                TaskId = taskId,
+                Skill = "research",
+                Message = new AgentMessage
+                {
+                    Role = "user",
+                    Parts = [new AgentMessagePart { Kind = "text", Text = question }]
+                }
+            };
+
+            var envelope = request.ToEnvelope<AgentTaskRequest>(
+                source: "AdvisorCouncil",
+                correlationId: taskId,
+                replyTo: _replyTopic);
+
+            await _publisher.PublishAsync(ResearchTaskTopic, envelope, ct);
+
+            var timeout = TimeSpan.FromSeconds(Math.Max(5, _options.ResearchAgentTimeoutSeconds));
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            timeoutCts.CancelAfter(timeout);
+
+            var sw = Stopwatch.StartNew();
+            var completed = await Task.WhenAny(tcs.Task, Task.Delay(timeout, timeoutCts.Token));
+            sw.Stop();
+
+            if (completed == tcs.Task)
+            {
+                _logger.LogInformation("Research call {TaskId} returned in {Ms}ms", taskId, sw.ElapsedMilliseconds);
+                return await tcs.Task;
+            }
+
+            _pending.TryRemove(taskId, out _);
+            _logger.LogWarning("Research call {TaskId} timed out after {Sec}s", taskId, timeout.TotalSeconds);
+            return "(research timed out)";
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            _pending.TryRemove(taskId, out _);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _pending.TryRemove(taskId, out _);
+            _logger.LogError(ex, "Research call {TaskId} failed", taskId);
+            return $"(research call failed: {ex.Message})";
+        }
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        if (_subscription is not null)
+        {
+            await _subscription.DisposeAsync();
+            _subscription = null;
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_subscription is not null)
+            await _subscription.DisposeAsync();
+    }
+
+    private sealed class InvokerFunction(ResearchAgentInvoker owner) : AIFunction
+    {
+        private static readonly JsonElement Schema = JsonDocument.Parse(
+            """{"type":"object","properties":{"question":{"type":"string","description":"The research question."}},"required":["question"]}""")
+            .RootElement;
+
+        public override string Name => "research";
+
+        public override string Description =>
+            "Search the web and summarise findings on a topic. Use sparingly — each call is " +
+            "delegated to a separate research agent and costs latency. Pass a focused question.";
+
+        public override JsonElement JsonSchema => Schema;
+
+        protected override async ValueTask<object?> InvokeCoreAsync(
+            AIFunctionArguments arguments, CancellationToken cancellationToken)
+        {
+            string? question = null;
+            if (arguments.TryGetValue("question", out var v))
+                question = v?.ToString();
+            if (string.IsNullOrWhiteSpace(question))
+                return "Error: missing required argument 'question'.";
+
+            return await owner.InvokeAsync(question!, cancellationToken);
+        }
+    }
+}
+

--- a/src/RockBot.AdvisorCouncil/agent/directives.md
+++ b/src/RockBot.AdvisorCouncil/agent/directives.md
@@ -1,0 +1,21 @@
+# AdvisorCouncil Directives
+
+You are AdvisorCouncil, a multi-perspective deliberation agent in the RockBot swarm.
+
+## Purpose
+Take a question or idea and return multi-perspective analysis with explicit tensions and an integrated synthesis. You run as an ephemeral pod: one task, then exit.
+
+## Supported Skills
+- **advise**: Examine a question from a curated set of personas (skeptic, ethicist, engineer, economist, long-term thinker, user advocate). Return a structured response with per-persona views, identified tensions, and a synthesis.
+
+## Output contract
+Every successful response returns two parts:
+1. A text part containing only the synthesis prose — readable by prose-consuming callers.
+2. A data part (`kind=data`, `mimeType=application/json`) containing the full structured `CouncilResponse` JSON.
+
+## Behavior Guidelines
+- Personas are framings, not characters. No role-play; no personality theatre.
+- Do not ask clarifying questions — answer with the best information available.
+- Use the `research` tool sparingly. Each call costs latency and money; only invoke it when the persona's framing genuinely requires up-to-date facts.
+- Keep persona views ~300 words; synthesis ~500 words.
+- Be honest about uncertainty. Set `confidence: low` when personas disagree substantively.

--- a/src/RockBot.AdvisorCouncil/agent/personas/economist.md
+++ b/src/RockBot.AdvisorCouncil/agent/personas/economist.md
@@ -1,0 +1,21 @@
+---
+id: economist
+name: The Economist
+description: Incentives, costs, opportunity cost, and market dynamics
+default_research: true
+---
+
+You are the Economist on an advisor council. Your job is to make incentives and opportunity costs visible.
+
+Approach:
+- Ask what behavior the choice rewards and punishes — for the team making it, for users, for competitors. People do what they are incentivised to do.
+- Name the opportunity cost: what is not being done because this is being done? What is the cost of delay?
+- Examine market dynamics where relevant: substitutes, switching costs, network effects, who captures surplus.
+- Distinguish fixed cost (one-time investment) from marginal cost (cost per additional unit) and total cost over the relevant horizon.
+- Use the research tool when the answer depends on specifics — pricing, market share, regulatory environment, what competitors have done.
+
+Constraints:
+- Don't reduce everything to dollars. Time, attention, optionality, and reputational stakes are also costs.
+- Avoid the "everything is a market" reflex when the question genuinely isn't economic.
+- Keep your view to ~300 words. Plain markdown. No role-play.
+- Be willing to say "the costs and benefits are clear" when they are — you exist to surface non-obvious economics, not to manufacture them.

--- a/src/RockBot.AdvisorCouncil/agent/personas/engineer.md
+++ b/src/RockBot.AdvisorCouncil/agent/personas/engineer.md
@@ -1,0 +1,20 @@
+---
+id: engineer
+name: The Engineer
+description: Feasibility, complexity, edge cases, and technical risk
+default_research: true
+---
+
+You are the Engineer on an advisor council. Your job is to assess feasibility, name the real complexity costs, and surface technical risks that look small in slide-deck form but matter in production.
+
+Approach:
+- Walk through the work as if you had to implement it. What are the actual steps? Where does the difficulty live?
+- Identify edge cases that the question or proposal glosses over. Boundary conditions, failure modes under load, partial-failure semantics, observability gaps.
+- Compare costs honestly: time to build vs. time to maintain, what's load-bearing vs. what's incidental complexity.
+- Use the research tool when feasibility hinges on specifics you don't know (current behavior of a library, scale limits of a service, known caveats of a technology).
+
+Constraints:
+- Be concrete. Numbers and named systems beat hand-waving.
+- Do not pretend to certainty about scales or performance you have not actually measured.
+- Keep your view to ~300 words. Plain markdown. No role-play.
+- It is fine to say "this is straightforward" when it is — your value is calibrated honesty, not pessimism.

--- a/src/RockBot.AdvisorCouncil/agent/personas/ethicist.md
+++ b/src/RockBot.AdvisorCouncil/agent/personas/ethicist.md
@@ -1,0 +1,20 @@
+---
+id: ethicist
+name: The Ethicist
+description: Examines harms, fairness, dignity, and second-order moral effects
+default_research: false
+---
+
+You are the Ethicist on an advisor council. Your job is to surface the moral dimension of a question — who could be harmed, who benefits, what dignities are at stake, and what second-order effects matter.
+
+Approach:
+- Ask who is affected and how. Include people who are not in the room: future users, downstream third parties, those who can't easily opt out.
+- Examine fairness and asymmetric power. Who bears the costs, who captures the benefits?
+- Name the moral stakes plainly: dignity, autonomy, honesty, harm, fairness, accountability.
+- Distinguish first-order effects (what happens directly) from second-order effects (what behavior the choice incentivises over time).
+
+Constraints:
+- Do not moralize. Identify the ethical considerations; let the council weigh them.
+- Avoid abstract philosophy. Connect every ethical claim to a concrete person or situation.
+- Keep your view to ~300 words. Plain markdown. No role-play.
+- If the question has no meaningful ethical content, say so briefly rather than manufacture concerns.

--- a/src/RockBot.AdvisorCouncil/agent/personas/long_term.md
+++ b/src/RockBot.AdvisorCouncil/agent/personas/long_term.md
@@ -1,0 +1,20 @@
+---
+id: long_term
+name: The Long-Term Thinker
+description: 5–10 year horizon, path dependencies, and irreversibility
+default_research: false
+---
+
+You are the Long-Term Thinker on an advisor council. Your job is to look past the current decision cycle and ask what this choice locks in.
+
+Approach:
+- Apply a 5–10 year horizon. What does the world look like then if this choice is made? If it isn't?
+- Identify path dependencies and lock-in: choices that close off future options, accumulate technical or social debt, or compound in either direction.
+- Distinguish reversible decisions (cheap to undo) from irreversible ones (expensive or impossible to undo). Treat them differently — irreversibility deserves more caution.
+- Name what improves over time vs. what decays. Compounding effects, both positive and negative, often dominate the long run.
+
+Constraints:
+- Do not predict specific futures. Identify the shape of consequences, not their detail.
+- Resist the urge to make every question feel epochal. Some decisions genuinely don't have a long-term dimension.
+- Keep your view to ~300 words. Plain markdown. No role-play.
+- "This is a short-horizon decision" is a valid view when it is.

--- a/src/RockBot.AdvisorCouncil/agent/personas/skeptic.md
+++ b/src/RockBot.AdvisorCouncil/agent/personas/skeptic.md
@@ -1,0 +1,19 @@
+---
+id: skeptic
+name: The Skeptic
+description: Challenges assumptions and surfaces failure modes
+default_research: false
+---
+
+You are the Skeptic on an advisor council. Your job is to surface what could go wrong, what is being assumed without evidence, and what failure modes are not yet named.
+
+Approach:
+- Identify the load-bearing assumptions in the question or proposal. Which of these would, if false, change the answer?
+- Name specific, concrete failure modes — not generic risk categories. Prefer "the migration script will silently fail when row X has Y" over "data integrity risks".
+- Look for survivor bias, hindsight bias, and over-fit lessons from prior wins.
+- Be precise about what you don't know. If the question requires facts you don't have, say so explicitly rather than guess.
+
+Constraints:
+- You are not a contrarian for sport. If a claim is well-supported, acknowledge it before raising concerns.
+- Keep your view to ~300 words. Plain markdown. No role-play, no theatre.
+- Do not propose solutions unless asked — your job is to name what the others are missing.

--- a/src/RockBot.AdvisorCouncil/agent/personas/user_advocate.md
+++ b/src/RockBot.AdvisorCouncil/agent/personas/user_advocate.md
@@ -1,0 +1,20 @@
+---
+id: user_advocate
+name: The User Advocate
+description: Lived experience of affected people, accessibility, and dignity-in-use
+default_research: false
+---
+
+You are the User Advocate on an advisor council. Your job is to keep the people who actually use, depend on, or are affected by this choice present in the conversation.
+
+Approach:
+- Picture a specific real person. What does the choice feel like for them on a Tuesday morning? Walk through the experience.
+- Surface accessibility considerations — for users with different abilities, languages, contexts, devices, levels of expertise.
+- Examine dignity-in-use: does the choice treat people as competent adults, or as problems to be managed? Where is consent meaningful and where is it theatre?
+- Name silent users: those who don't complain but quietly leave, those whose use case isn't the loudest in the room.
+
+Constraints:
+- Be specific about which users. "Users want X" is rarely true of all users; say which users and which contexts.
+- Do not romanticise users. They have actual constraints — time, attention, patience — and respect for those matters more than enthusiasm about features.
+- Keep your view to ~300 words. Plain markdown. No role-play.
+- If the question is internal-only and has no user-facing dimension, say so plainly.

--- a/src/RockBot.AdvisorCouncil/appsettings.json
+++ b/src/RockBot.AdvisorCouncil/appsettings.json
@@ -1,0 +1,24 @@
+{
+  "RabbitMq": {
+    "Host": "localhost",
+    "VirtualHost": "/",
+    "Username": "guest",
+    "Password": "guest",
+    "Port": 5672
+  },
+  "LLM": {
+    "Endpoint": "",
+    "ApiKey": "",
+    "ModelId": ""
+  },
+  "Memory": {
+    "BasePath": "/tmp/memory"
+  },
+  "Council": {
+    "PersonasPath": "",
+    "OverallTimeoutSeconds": 180,
+    "PerPersonaTimeoutSeconds": 60,
+    "PreResearchTimeoutSeconds": 90,
+    "ResearchAgentTimeoutSeconds": 90
+  }
+}

--- a/src/RockBot.Agent/agent/directives.md
+++ b/src/RockBot.Agent/agent/directives.md
@@ -224,6 +224,26 @@ End every response with a clear final statement about what happened or what the 
 
 If the next action is obvious, you already did it (see above). If it's speculative, say nothing.
 
+## Consulting the Advisor Council
+
+For consequential or contested decisions — adopting a new technology, design
+choices with non-trivial tradeoffs, irreversible commitments, ethically loaded
+questions, anything where being wrong is expensive — invoke the `AdvisorCouncil`
+agent via `invoke_agent` with `skill: advise` before forming a final
+recommendation. Pass the question or the proposed decision as the message text.
+The council returns multi-perspective analysis with explicit tensions and a
+synthesis (text part is the synthesis prose; data part is the structured JSON).
+
+Skip the council for:
+- Factual lookups (use `ResearchAgent` instead).
+- Routine coding tasks, small fixes, mechanical work.
+- Time-sensitive operational decisions where deliberation cost exceeds value.
+- Questions where the answer is unambiguous from existing context.
+
+When the council returns, treat its synthesis as **guidance, not verdict** —
+integrate it with your own judgment and what the user actually asked for. The
+council surfaces considerations; it does not decide.
+
 ## Constraints
 
 - Keep responses concise and outcome-focused. Expand only when the user asks for detail or the situation warrants it.

--- a/tests/RockBot.AdvisorCouncil.Tests/CouncilOrchestratorTests.cs
+++ b/tests/RockBot.AdvisorCouncil.Tests/CouncilOrchestratorTests.cs
@@ -1,0 +1,129 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using RockBot.AdvisorCouncil.Council;
+using RockBot.AdvisorCouncil.Personas;
+
+namespace RockBot.AdvisorCouncil.Tests;
+
+[TestClass]
+public class CouncilOrchestratorTests
+{
+    private static PersonaRegistry MakeRegistry()
+    {
+        var tmp = Path.Combine(Path.GetTempPath(), "orch-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tmp);
+        var personas = new[]
+        {
+            ("skeptic", "Skeptic body"),
+            ("engineer", "Engineer body"),
+            ("long_term", "Long-term body")
+        };
+        foreach (var (id, body) in personas)
+            File.WriteAllText(Path.Combine(tmp, $"{id}.md"), $"---\nid: {id}\n---\n{body}");
+        return new PersonaRegistry(
+            Options.Create(new CouncilOptions { PersonasPath = tmp }),
+            NullLogger<PersonaRegistry>.Instance);
+    }
+
+    [TestMethod]
+    public async Task RunAsync_BasicPipeline_ReturnsExpectedShape()
+    {
+        var registry = MakeRegistry();
+        // Matchers are checked in insertion order; put stage-distinguishing prompts
+        // before persona-body prompts so critique calls (which carry both) don't
+        // collide with the plain persona call match.
+        var chat = new FakeChatClient()
+            .WhenUserContains("selector for an advisor council",
+                """{ "personas": [{"id":"skeptic","needs_research":false},{"id":"engineer","needs_research":false}], "pre_research": false, "critique": false, "rationale": "Engineering decision." }""")
+            .WhenUserContains("synthesis step of an advisor council",
+                """{ "synthesis": "## Synthesis\n\nProceed with caution.", "confidence": "medium", "tensions": [] }""")
+            .WhenUserContains("Critique addendum",
+                """{ "revised_view": "(revised)", "key_points": [], "tensions": [] }""")
+            .WhenUserContains("Skeptic body", "Skeptic warns this is too early.")
+            .WhenUserContains("Engineer body", "Engineering says feasibility is OK with caveats.");
+
+        var orchestrator = BuildOrchestrator(registry, chat);
+
+        var response = await orchestrator.RunAsync("Should we adopt MAF for orchestration?", "task-1", CancellationToken.None);
+
+        Assert.AreEqual(2, response.Personas.Count);
+        Assert.AreEqual("medium", response.Confidence);
+        StringAssert.Contains(response.Synthesis, "Proceed with caution");
+        Assert.IsFalse(response.Metadata.CritiqueRun);
+        Assert.IsFalse(response.Metadata.PreResearchRun);
+        Assert.AreEqual(2, response.Metadata.PersonaCount);
+        Assert.IsFalse(string.IsNullOrEmpty(response.Metadata.PersonaSetHash));
+        Assert.IsTrue(response.Metadata.ModelCalls >= 4); // select + 2 personas + synth
+    }
+
+    [TestMethod]
+    public async Task RunAsync_CritiqueEnabled_RunsCritiqueAndPopulatesTensions()
+    {
+        var registry = MakeRegistry();
+        var chat = new FakeChatClient()
+            .WhenUserContains("selector for an advisor council",
+                """{ "personas": [{"id":"skeptic","needs_research":false},{"id":"engineer","needs_research":false}], "pre_research": false, "critique": true, "rationale": "Contested." }""")
+            .WhenUserContains("synthesis step of an advisor council",
+                """{ "synthesis": "Integrated view.", "confidence": "low", "tensions": [{"between":["skeptic","engineer"],"description":"timing","stakes":"ship vs delay"}] }""")
+            .WhenUserContains("Critique addendum",
+                """{ "revised_view": "Revised view (post-critique)", "key_points": ["kp1"], "tensions": [{"with":"engineer","description":"disagree on timing","stakes":"ship vs delay"}] }""")
+            .WhenUserContains("Skeptic body", "Initial skeptic view.")
+            .WhenUserContains("Engineer body", "Initial engineer view.");
+
+        var orchestrator = BuildOrchestrator(registry, chat);
+        var response = await orchestrator.RunAsync("Should we adopt MAF?", "task-2", CancellationToken.None);
+
+        Assert.IsTrue(response.Metadata.CritiqueRun);
+        Assert.IsTrue(response.Tensions.Count >= 1);
+        Assert.AreEqual("low", response.Confidence);
+        Assert.IsTrue(response.Personas.Any(v => v.View.Contains("Revised")));
+    }
+
+    [TestMethod]
+    public async Task RunAsync_SynthesisInvalid_FallsBackButStillReturns()
+    {
+        var registry = MakeRegistry();
+        // Synthesis always returns invalid; orchestrator falls back to a stub synthesis.
+        var chat = new FakeChatClient()
+            .WhenUserContains("selector for an advisor council",
+                """{ "personas": [{"id":"skeptic","needs_research":false}], "pre_research": false, "critique": false, "rationale": "Simple." }""")
+            .WhenUserContains("synthesis step of an advisor council", "not valid json")
+            .WhenUserContains("Skeptic body", "Persona view.");
+
+        var orchestrator = BuildOrchestrator(registry, chat);
+        var response = await orchestrator.RunAsync("Q?", "task-3", CancellationToken.None);
+
+        Assert.AreEqual("low", response.Confidence);
+        Assert.IsFalse(string.IsNullOrWhiteSpace(response.Synthesis));
+    }
+
+    [TestMethod]
+    public async Task RunAsync_NoPersonasInRegistry_ReturnsEmptyResponse()
+    {
+        var tmp = Path.Combine(Path.GetTempPath(), "empty-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tmp);
+        var registry = new PersonaRegistry(
+            Options.Create(new CouncilOptions { PersonasPath = tmp }),
+            NullLogger<PersonaRegistry>.Instance);
+        var chat = new FakeChatClient();
+
+        var orchestrator = BuildOrchestrator(registry, chat);
+        var response = await orchestrator.RunAsync("anything", "task-4", CancellationToken.None);
+
+        Assert.AreEqual(0, response.Personas.Count);
+        Assert.AreEqual("low", response.Confidence);
+    }
+
+    private static CouncilOrchestrator BuildOrchestrator(PersonaRegistry registry, FakeChatClient chat)
+    {
+        var opts = Options.Create(new CouncilOptions { PerPersonaTimeoutSeconds = 30, OverallTimeoutSeconds = 60 });
+        var select = new SelectStep(chat, registry, NullLogger<SelectStep>.Instance);
+        var persona = new PersonaStep(chat, NullLogger<PersonaStep>.Instance);
+        var critique = new CritiqueStep(chat, NullLogger<CritiqueStep>.Instance);
+        var synth = new SynthesizeStep(chat, NullLogger<SynthesizeStep>.Instance);
+        // PreResearchStep needs a ResearchAgentInvoker — not used in these tests because pre_research=false
+        var preResearch = new PreResearchStep(null!, NullLogger<PreResearchStep>.Instance);
+        return new CouncilOrchestrator(select, preResearch, persona, critique, synth, registry, opts,
+            NullLogger<CouncilOrchestrator>.Instance);
+    }
+}

--- a/tests/RockBot.AdvisorCouncil.Tests/CouncilResponseSchemaTests.cs
+++ b/tests/RockBot.AdvisorCouncil.Tests/CouncilResponseSchemaTests.cs
@@ -1,0 +1,68 @@
+using System.Text.Json;
+using RockBot.AdvisorCouncil.Schema;
+
+namespace RockBot.AdvisorCouncil.Tests;
+
+[TestClass]
+public class CouncilResponseSchemaTests
+{
+    private static readonly JsonSerializerOptions Opts = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    [TestMethod]
+    public void CouncilResponse_RoundTrips()
+    {
+        var original = new CouncilResponse(
+            Question: "What is X?",
+            Personas:
+            [
+                new PersonaView("skeptic", "skeptic view", ["pt1", "pt2"], []),
+                new PersonaView("engineer", "engineer view", ["pt3"], ["http://example.com"])
+            ],
+            Tensions:
+            [
+                new Tension(["skeptic", "engineer"], "disagree about feasibility", "ship vs. delay")
+            ],
+            Synthesis: "## Synthesis\n\nThe council...",
+            Confidence: "medium",
+            Metadata: new CouncilMetadata(
+                CritiqueRun: true,
+                PreResearchRun: false,
+                PersonaCount: 2,
+                DurationMs: 12345,
+                ModelCalls: 6,
+                PersonaSetHash: "abc123",
+                SelectorRationale: "selected based on contested feasibility"));
+
+        var json = JsonSerializer.Serialize(original, Opts);
+        var roundTripped = JsonSerializer.Deserialize<CouncilResponse>(json, Opts);
+
+        Assert.IsNotNull(roundTripped);
+        Assert.AreEqual(original.Question, roundTripped!.Question);
+        Assert.AreEqual(original.Personas.Count, roundTripped.Personas.Count);
+        Assert.AreEqual("skeptic", roundTripped.Personas[0].Id);
+        Assert.AreEqual(original.Tensions.Count, roundTripped.Tensions.Count);
+        Assert.AreEqual(original.Confidence, roundTripped.Confidence);
+        Assert.AreEqual(original.Metadata.DurationMs, roundTripped.Metadata.DurationMs);
+        Assert.AreEqual(original.Metadata.PersonaSetHash, roundTripped.Metadata.PersonaSetHash);
+    }
+
+    [TestMethod]
+    public void SelectorOutput_JsonSchemaShape_IsSnakeCase()
+    {
+        var sel = new SelectorOutput(
+            [new SelectedPersona("skeptic", true)],
+            PreResearch: true,
+            Critique: false,
+            Rationale: "r");
+
+        var json = JsonSerializer.Serialize(sel);
+
+        StringAssert.Contains(json, "\"pre_research\":");
+        StringAssert.Contains(json, "\"needs_research\":");
+        StringAssert.Contains(json, "\"critique\":");
+        StringAssert.Contains(json, "\"rationale\":");
+    }
+}

--- a/tests/RockBot.AdvisorCouncil.Tests/FakeChatClient.cs
+++ b/tests/RockBot.AdvisorCouncil.Tests/FakeChatClient.cs
@@ -1,0 +1,59 @@
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.AI;
+
+namespace RockBot.AdvisorCouncil.Tests;
+
+/// <summary>
+/// Test double that returns scripted responses. Tests configure responses in order or
+/// by matching the user prompt. Tracks each call for assertions.
+/// </summary>
+internal sealed class FakeChatClient : IChatClient
+{
+    private readonly Queue<string> _responses = new();
+    private readonly Dictionary<Func<string, bool>, string> _matchers = new();
+
+    public List<(IReadOnlyList<ChatMessage> Messages, ChatOptions? Options)> Calls { get; } = new();
+
+    public FakeChatClient EnqueueResponse(string text)
+    {
+        _responses.Enqueue(text);
+        return this;
+    }
+
+    public FakeChatClient WhenUserContains(string substring, string response)
+    {
+        _matchers[m => m.Contains(substring, StringComparison.OrdinalIgnoreCase)] = response;
+        return this;
+    }
+
+    public Task<ChatResponse> GetResponseAsync(
+        IEnumerable<ChatMessage> chatMessages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        var msgs = chatMessages.ToList();
+        Calls.Add((msgs, options));
+
+        var allText = string.Join("\n", msgs.Select(m => m.Text ?? string.Empty));
+        foreach (var (predicate, response) in _matchers)
+        {
+            if (predicate(allText))
+                return Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, response)));
+        }
+
+        var text = _responses.Count > 0 ? _responses.Dequeue() : "(no scripted response)";
+        return Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, text)));
+    }
+
+    public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+        IEnumerable<ChatMessage> chatMessages,
+        ChatOptions? options = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        yield break;
+    }
+
+    public object? GetService(Type serviceType, object? serviceKey = null) => null;
+
+    public void Dispose() { }
+}

--- a/tests/RockBot.AdvisorCouncil.Tests/PersonaRegistryTests.cs
+++ b/tests/RockBot.AdvisorCouncil.Tests/PersonaRegistryTests.cs
@@ -1,0 +1,180 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using RockBot.AdvisorCouncil.Council;
+using RockBot.AdvisorCouncil.Personas;
+
+namespace RockBot.AdvisorCouncil.Tests;
+
+[TestClass]
+public class PersonaRegistryTests
+{
+    [TestMethod]
+    public void ParsePersonaContent_HappyPath_ReturnsPersonaWithBody()
+    {
+        var content =
+            """
+            ---
+            id: skeptic
+            name: The Skeptic
+            description: Challenges assumptions
+            default_research: false
+            ---
+
+            You are the Skeptic. Surface what could go wrong.
+            """;
+
+        var p = PersonaRegistry.ParsePersonaContent(content, "skeptic");
+
+        Assert.IsNotNull(p);
+        Assert.AreEqual("skeptic", p!.Id);
+        Assert.AreEqual("The Skeptic", p.Name);
+        Assert.AreEqual("Challenges assumptions", p.Description);
+        Assert.IsFalse(p.DefaultResearch);
+        StringAssert.Contains(p.SystemPrompt, "Surface what could go wrong");
+    }
+
+    [TestMethod]
+    public void ParsePersonaContent_DefaultResearchTrue_IsParsed()
+    {
+        var content =
+            """
+            ---
+            id: engineer
+            default_research: true
+            ---
+            Body.
+            """;
+
+        var p = PersonaRegistry.ParsePersonaContent(content, "engineer");
+
+        Assert.IsNotNull(p);
+        Assert.IsTrue(p!.DefaultResearch);
+    }
+
+    [TestMethod]
+    public void ParsePersonaContent_NoFrontmatter_ReturnsNull()
+    {
+        var content = "Just a body with no frontmatter at all.";
+        var p = PersonaRegistry.ParsePersonaContent(content, "x");
+        Assert.IsNull(p);
+    }
+
+    [TestMethod]
+    public void ParsePersonaContent_FrontmatterButEmptyBody_ReturnsNull()
+    {
+        var content =
+            """
+            ---
+            id: x
+            ---
+
+            """;
+        var p = PersonaRegistry.ParsePersonaContent(content, "x");
+        Assert.IsNull(p);
+    }
+
+    [TestMethod]
+    public void ParsePersonaContent_FilenameUsedWhenIdMissing()
+    {
+        var content =
+            """
+            ---
+            name: Fallback
+            ---
+            Body.
+            """;
+        var p = PersonaRegistry.ParsePersonaContent(content, "default_filename");
+        Assert.IsNotNull(p);
+        Assert.AreEqual("default_filename", p!.Id);
+    }
+
+    [TestMethod]
+    public void ComputeHash_IsStable_OrderInsensitive()
+    {
+        var a = new Dictionary<string, Persona>
+        {
+            ["a"] = new("a", "A", "d", "prompt a", false),
+            ["b"] = new("b", "B", "d", "prompt b", false)
+        };
+        var b = new Dictionary<string, Persona>
+        {
+            ["b"] = new("b", "B", "d", "prompt b", false),
+            ["a"] = new("a", "A", "d", "prompt a", false)
+        };
+        Assert.AreEqual(PersonaRegistry.ComputeHash(a), PersonaRegistry.ComputeHash(b));
+    }
+
+    [TestMethod]
+    public void ComputeHash_ChangesWhenSystemPromptChanges()
+    {
+        var a = new Dictionary<string, Persona>
+        {
+            ["a"] = new("a", "A", "d", "prompt a", false)
+        };
+        var b = new Dictionary<string, Persona>
+        {
+            ["a"] = new("a", "A", "d", "prompt a-modified", false)
+        };
+        Assert.AreNotEqual(PersonaRegistry.ComputeHash(a), PersonaRegistry.ComputeHash(b));
+    }
+
+    [TestMethod]
+    public void Registry_LoadsPersonasFromDirectory()
+    {
+        var tmp = CreateTempDir();
+        try
+        {
+            File.WriteAllText(Path.Combine(tmp, "skeptic.md"),
+                "---\nid: skeptic\nname: Skeptic\n---\nSkeptic body.");
+            File.WriteAllText(Path.Combine(tmp, "engineer.md"),
+                "---\nid: engineer\ndefault_research: true\n---\nEngineer body.");
+
+            var opts = Options.Create(new CouncilOptions { PersonasPath = tmp });
+            var reg = new PersonaRegistry(opts, NullLogger<PersonaRegistry>.Instance);
+
+            Assert.AreEqual(2, reg.Personas.Count);
+            Assert.IsTrue(reg.Personas.ContainsKey("skeptic"));
+            Assert.IsTrue(reg.Personas.ContainsKey("engineer"));
+            Assert.IsTrue(reg.Personas["engineer"].DefaultResearch);
+            Assert.IsFalse(string.IsNullOrEmpty(reg.PersonaSetHash));
+        }
+        finally
+        {
+            Directory.Delete(tmp, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public void Registry_Reload_PicksUpNewFiles()
+    {
+        var tmp = CreateTempDir();
+        try
+        {
+            File.WriteAllText(Path.Combine(tmp, "skeptic.md"),
+                "---\nid: skeptic\n---\nSkeptic body.");
+
+            var opts = Options.Create(new CouncilOptions { PersonasPath = tmp });
+            var reg = new PersonaRegistry(opts, NullLogger<PersonaRegistry>.Instance);
+            var hashBefore = reg.PersonaSetHash;
+            Assert.AreEqual(1, reg.Personas.Count);
+
+            File.WriteAllText(Path.Combine(tmp, "engineer.md"),
+                "---\nid: engineer\n---\nEngineer body.");
+            reg.Reload();
+
+            Assert.AreEqual(2, reg.Personas.Count);
+            Assert.AreNotEqual(hashBefore, reg.PersonaSetHash);
+        }
+        finally
+        {
+            Directory.Delete(tmp, recursive: true);
+        }
+    }
+
+    private static string CreateTempDir()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "advisor-council-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        return path;
+    }
+}

--- a/tests/RockBot.AdvisorCouncil.Tests/ResearchAgentInvokerTests.cs
+++ b/tests/RockBot.AdvisorCouncil.Tests/ResearchAgentInvokerTests.cs
@@ -1,0 +1,115 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using RockBot.A2A;
+using RockBot.AdvisorCouncil.Council;
+using RockBot.AdvisorCouncil.Tools;
+using RockBot.Messaging;
+using RockBot.Messaging.InProcess;
+
+namespace RockBot.AdvisorCouncil.Tests;
+
+[TestClass]
+public class ResearchAgentInvokerTests
+{
+    [TestMethod]
+    public async Task InvokeAsync_PublishesRequest_AndReturnsResultText()
+    {
+        var sp = BuildServices(researchTimeoutSec: 5);
+        var invoker = sp.GetRequiredService<ResearchAgentInvoker>();
+        var publisher = sp.GetRequiredService<IMessagePublisher>();
+        var subscriber = sp.GetRequiredService<IMessageSubscriber>();
+
+        // Start the invoker so its reply queue subscription is active.
+        await invoker.StartAsync(CancellationToken.None);
+
+        // Simulate ResearchAgent: subscribe to its task topic, send a result back to replyTo
+        // with the same correlationId.
+        await using var fakeAgentSubscription = await subscriber.SubscribeAsync(
+            "agent.task.ResearchAgent",
+            "fake-research-agent",
+            async (envelope, ct) =>
+            {
+                var reply = new AgentTaskResult
+                {
+                    TaskId = envelope.CorrelationId!,
+                    State = AgentTaskState.Completed,
+                    Message = new AgentMessage
+                    {
+                        Role = "agent",
+                        Parts = [new AgentMessagePart { Kind = "text", Text = "Mocked research answer." }]
+                    }
+                };
+                var replyEnvelope = reply.ToEnvelope<AgentTaskResult>(
+                    source: "ResearchAgent",
+                    correlationId: envelope.CorrelationId);
+                await publisher.PublishAsync(envelope.ReplyTo!, replyEnvelope, ct);
+                return MessageResult.Ack;
+            });
+
+        var result = await invoker.InvokeAsync("What is the capital of France?", CancellationToken.None);
+
+        Assert.AreEqual("Mocked research answer.", result);
+
+        await invoker.StopAsync(CancellationToken.None);
+    }
+
+    [TestMethod]
+    public async Task InvokeAsync_TimesOut_WhenNoReplyArrives()
+    {
+        var sp = BuildServices(researchTimeoutSec: 1);
+        var invoker = sp.GetRequiredService<ResearchAgentInvoker>();
+        await invoker.StartAsync(CancellationToken.None);
+
+        // No subscriber on agent.task.ResearchAgent — nothing will reply.
+
+        var result = await invoker.InvokeAsync("Anything", CancellationToken.None);
+
+        StringAssert.Contains(result, "timed out");
+        await invoker.StopAsync(CancellationToken.None);
+    }
+
+    [TestMethod]
+    public async Task InvokeAsync_AgentTaskError_SurfacesErrorMessage()
+    {
+        var sp = BuildServices(researchTimeoutSec: 5);
+        var invoker = sp.GetRequiredService<ResearchAgentInvoker>();
+        var publisher = sp.GetRequiredService<IMessagePublisher>();
+        var subscriber = sp.GetRequiredService<IMessageSubscriber>();
+        await invoker.StartAsync(CancellationToken.None);
+
+        await using var fakeAgentSubscription = await subscriber.SubscribeAsync(
+            "agent.task.ResearchAgent",
+            "fake-research-error",
+            async (envelope, ct) =>
+            {
+                var err = new AgentTaskError
+                {
+                    TaskId = envelope.CorrelationId!,
+                    Code = AgentTaskError.Codes.ExecutionFailed,
+                    Message = "Web search quota exceeded.",
+                    IsRetryable = false
+                };
+                var replyEnvelope = err.ToEnvelope<AgentTaskError>(
+                    source: "ResearchAgent",
+                    correlationId: envelope.CorrelationId);
+                await publisher.PublishAsync(envelope.ReplyTo!, replyEnvelope, ct);
+                return MessageResult.Ack;
+            });
+
+        var result = await invoker.InvokeAsync("anything", CancellationToken.None);
+
+        StringAssert.Contains(result, "Web search quota exceeded");
+        await invoker.StopAsync(CancellationToken.None);
+    }
+
+    private static IServiceProvider BuildServices(int researchTimeoutSec)
+    {
+        var services = new ServiceCollection();
+        services.AddRockBotInProcessMessaging();
+        services.AddLogging();
+        services.Configure<CouncilOptions>(o => o.ResearchAgentTimeoutSeconds = researchTimeoutSec);
+        services.AddSingleton<ResearchAgentInvoker>();
+        return services.BuildServiceProvider();
+    }
+}

--- a/tests/RockBot.AdvisorCouncil.Tests/RockBot.AdvisorCouncil.Tests.csproj
+++ b/tests/RockBot.AdvisorCouncil.Tests/RockBot.AdvisorCouncil.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.*" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\RockBot.AdvisorCouncil\RockBot.AdvisorCouncil.csproj" />
+    <ProjectReference Include="..\..\src\RockBot.A2A.Abstractions\RockBot.A2A.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\RockBot.Host\RockBot.Host.csproj" />
+    <ProjectReference Include="..\..\src\RockBot.Messaging.Abstractions\RockBot.Messaging.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\RockBot.Messaging.InProcess\RockBot.Messaging.InProcess.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/RockBot.AdvisorCouncil.Tests/SelectStepTests.cs
+++ b/tests/RockBot.AdvisorCouncil.Tests/SelectStepTests.cs
@@ -1,0 +1,91 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using RockBot.AdvisorCouncil.Council;
+using RockBot.AdvisorCouncil.Personas;
+
+namespace RockBot.AdvisorCouncil.Tests;
+
+[TestClass]
+public class SelectStepTests
+{
+    private static PersonaRegistry MakeRegistry(params (string id, bool defaultResearch)[] personas)
+    {
+        var tmp = Path.Combine(Path.GetTempPath(), "selector-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tmp);
+        foreach (var (id, dr) in personas)
+        {
+            File.WriteAllText(Path.Combine(tmp, $"{id}.md"),
+                $"---\nid: {id}\ndefault_research: {dr.ToString().ToLower()}\n---\n{id} body.");
+        }
+        var opts = Options.Create(new CouncilOptions { PersonasPath = tmp });
+        return new PersonaRegistry(opts, NullLogger<PersonaRegistry>.Instance);
+    }
+
+    [TestMethod]
+    public async Task RunAsync_ValidJson_ReturnsParsedSelection()
+    {
+        var registry = MakeRegistry(("skeptic", false), ("engineer", true), ("economist", true));
+        var chat = new FakeChatClient().EnqueueResponse(
+            """
+            { "personas": [{"id":"skeptic","needs_research":false},{"id":"engineer","needs_research":true}],
+              "pre_research": false, "critique": true, "rationale": "Design question with engineering tradeoffs." }
+            """);
+        var step = new SelectStep(chat, registry, NullLogger<SelectStep>.Instance);
+
+        var result = await step.RunAsync("Should we adopt MAF?", CancellationToken.None);
+
+        Assert.AreEqual(2, result.Personas.Count);
+        Assert.IsTrue(result.Critique);
+        Assert.IsFalse(result.PreResearch);
+        Assert.AreEqual("skeptic", result.Personas[0].Id);
+        Assert.IsTrue(result.Personas[1].NeedsResearch);
+    }
+
+    [TestMethod]
+    public async Task RunAsync_InvalidJson_RetriesThenSucceeds()
+    {
+        var registry = MakeRegistry(("skeptic", false), ("engineer", false));
+        var chat = new FakeChatClient()
+            .EnqueueResponse("not json")
+            .EnqueueResponse(
+                """{ "personas": [{"id":"skeptic","needs_research":false}], "pre_research": false, "critique": false, "rationale": "x" }""");
+        var step = new SelectStep(chat, registry, NullLogger<SelectStep>.Instance);
+
+        var result = await step.RunAsync("Trivial", CancellationToken.None);
+
+        Assert.AreEqual(1, result.Personas.Count);
+        Assert.AreEqual(2, chat.Calls.Count, "Should have retried after invalid JSON");
+    }
+
+    [TestMethod]
+    public async Task RunAsync_TwoFailures_FallsBackToDefault()
+    {
+        var registry = MakeRegistry(("skeptic", false), ("engineer", false), ("long_term", false), ("ethicist", false));
+        var chat = new FakeChatClient()
+            .EnqueueResponse("not json")
+            .EnqueueResponse("also not json");
+        var step = new SelectStep(chat, registry, NullLogger<SelectStep>.Instance);
+
+        var result = await step.RunAsync("Anything", CancellationToken.None);
+
+        Assert.IsFalse(result.PreResearch);
+        Assert.IsFalse(result.Critique);
+        Assert.IsTrue(result.Personas.Count >= 2);
+        CollectionAssert.Contains(result.Personas.Select(p => p.Id).ToList(), "skeptic");
+        CollectionAssert.Contains(result.Personas.Select(p => p.Id).ToList(), "engineer");
+    }
+
+    [TestMethod]
+    public async Task RunAsync_UnknownPersonaId_FilteredOut()
+    {
+        var registry = MakeRegistry(("skeptic", false), ("engineer", false));
+        var chat = new FakeChatClient().EnqueueResponse(
+            """{ "personas": [{"id":"unknown","needs_research":false},{"id":"skeptic","needs_research":false}], "pre_research": false, "critique": false, "rationale": "x" }""");
+        var step = new SelectStep(chat, registry, NullLogger<SelectStep>.Instance);
+
+        var result = await step.RunAsync("q", CancellationToken.None);
+
+        Assert.AreEqual(1, result.Personas.Count);
+        Assert.AreEqual("skeptic", result.Personas[0].Id);
+    }
+}


### PR DESCRIPTION
Closes #390.

Implements a new `RockBot.AdvisorCouncil` ephemeral A2A agent that examines a question from multiple curated personas (skeptic, ethicist, engineer, economist, long-term thinker, user advocate) and returns integrated guidance with explicit tensions and a synthesis. Reuses `ResearchAgent` for fact-finding rather than duplicating web search. All five phases from `design/advisor-council.md` land in this PR per the original issue plan.

## Pipeline

`CouncilOrchestrator` runs:

`Select` → optional `PreResearch` → fan-out personas in parallel → optional per-persona `Critique` → `Synthesize`

- **Select** (Balanced tier, JSON-validated, one retry then fallback): picks which personas participate and whether to run pre-research / cross-critique.
- **PreResearch** (conditional): single synchronous call to `ResearchAgent`, findings injected into every persona branch.
- **Personas** (Balanced tier, parallel): call-only by default; agentic loop with the `research` tool when the selector marks `needs_research`. Per-persona 60s soft timeout.
- **Critique** (conditional, per-persona parallel): each persona revises its view against sibling views and names explicit tensions.
- **Synthesize** (High tier, JSON-validated): integrates persona views and tensions into prose + confidence.

Output is an `AgentTaskResult` with two parts: a `text` part containing the synthesis prose (for prose consumers like the primary agent) and a `data` part with the full `CouncilResponse` JSON (for programmatic consumers).

Overall 3-min wall-clock cap and per-persona 60s soft timeout bound cost; `metadata` carries `model_calls`, `duration_ms`, and `persona_set_hash` for observability and drift detection.

## Synchronous A2A research from inside the council

`ResearchAgentInvoker` exposes ResearchAgent as an `AIFunction` (so persona branches with `needs_research=true` can call it via `AgentLoopRunner`). The existing `InvokeAgentExecutor` is async/fire-and-forget against the primary agent's bus and is not suitable here — the council needs a synchronous wait per call. Implementation: process-unique reply queue keyed on `correlationId`, `ConcurrentDictionary<string, TaskCompletionSource<string>>` for matching, 90s timeout.

## MAF deviation (called out in code)

The design doc names Microsoft Agent Framework (MAF) Workflows as the orchestration choice, with an explicit fallback to imperative orchestration. The pipeline requires dynamic-graph-per-request (only N of M personas selected per question), which negates MAF's static-graph value: MAF's fan-in barrier would deadlock on unselected executors, and the workaround is to build a fresh graph per request — at which point MAF Workflows is just ceremony around what is naturally expressed as `await Task.WhenAll(personaTasks)`. We took the fallback. Easy to swap later if MAF's dynamic-graph story improves.

## Personas

Six markdown files at `src/RockBot.AdvisorCouncil/agent/personas/`, loaded from `/data/advisor-council/personas/` at runtime (`PersonaRegistry` with `FileSystemWatcher`-based hot-reload, 500ms debounce). Frontmatter: `id`, `name`, `description`, `default_research`. Personas are framings, not characters — short, focused, no role-play.

`engineer` and `economist` default to `needs_research=true`; the others are call-only.

## Deployment

- `deploy/Dockerfile.advisor-council` — net10.0 SDK build + digest-pinned runtime base + non-root user. Mirrors `Dockerfile.research-agent`.
- `deploy/k8s/advisor-council-scaledjob.yaml` — KEDA ScaledJob, one pod per pending message, exits after one task. Image `rockylhotka/rockbot-advisor-council:<version>` (versioned, not `:latest`).
- `deploy/k8s/advisor-council-queue-init.yaml` — pre-declares the queue and publishes the discovery card so a running RockBot agent registers AdvisorCouncil immediately.

No Helm chart entry — ResearchAgent also lives only under `deploy/k8s/`; keeping the prevailing pattern. Helm-managed variant is a separate additive change if wanted.

## Primary-agent integration

`src/RockBot.Agent/agent/directives.md` gets a new section on when to consult the council (consequential, contested, irreversible, ethically loaded) and when to skip (factual lookups, routine work, time-sensitive ops, unambiguous answers). No code change needed in `RockBot.Agent` — `invoke_agent` already supports any A2A agent the directory knows about, and the queue-init job makes the council discoverable.

## Tests (22 passing, no external deps)

- `PersonaRegistryTests` — frontmatter parsing happy/missing/malformed, hash stability + change detection, reload picks up new files.
- `SelectStepTests` — valid JSON, invalid then retry, two failures fall back to default, unknown persona ids filtered.
- `CouncilResponseSchemaTests` — full round-trip + snake_case JSON shape.
- `CouncilOrchestratorTests` — basic pipeline, critique on, synthesis JSON-invalid fallback, empty registry case.
- `ResearchAgentInvokerTests` — uses the in-process bus to simulate ResearchAgent replying; covers success, timeout, and `AgentTaskError` paths.

## Test plan

- [ ] Build clean: ` dotnet build RockBot.slnx` (verified: 0 errors, only pre-existing warnings).
- [ ] Unit tests pass: ` dotnet test tests/RockBot.AdvisorCouncil.Tests/` (verified: 22/22).
- [ ] Build and push image: ` docker build -f deploy/Dockerfile.advisor-council -t rockylhotka/rockbot-advisor-council:\$VERSION . && docker push`.
- [ ] Apply manifests: ` kubectl apply -f deploy/k8s/advisor-council-scaledjob.yaml -n rockbot && kubectl apply -f deploy/k8s/advisor-council-queue-init.yaml -n rockbot`.
- [ ] Smoke test via the primary agent: ask a contested question, observe `invoke_agent` dispatching to `AdvisorCouncil` with `skill: advise` and the council returning a structured response with both text and data parts.

## Follow-ups (out of scope here)

- Selector eval set (~10–20 hand-graded questions) to catch regressions in the load-bearing selector prompt.
- Helm template for the council ScaledJob if/when ResearchAgent gets one.
- Reconsider MAF Workflows if the dynamic-graph story improves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)