### PR TITLE
A2ATaskResultHandler: preserve the data part of multi-part results (#392)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.10.55</Version>
+<Version>0.10.56</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/docs/a2a.md
+++ b/docs/a2a.md
@@ -26,7 +26,11 @@ result folded back into the conversation.
    `session/{sessionId}/a2a/{agentName}/{taskId}/result` (60-minute TTL) and
    injects a synthetic user turn into the conversation that contains the exact
    key. The primary agent calls `get_from_working_memory` with that key to
-   retrieve and present the result.
+   retrieve and present the result. If the response also carries a `data` part
+   (structured JSON), the bytes are preserved under a sibling key
+   `session/{sessionId}/a2a/{agentName}/{taskId}/result.data` with category
+   `a2a-result-data` and the same 60-minute TTL — the synthetic turn names this
+   key so the agent can fetch it on demand instead of having it inlined.
 
 The external agent does **not** need to be running at the moment `invoke_agent`
 is called — the message sits on the queue until the agent starts (e.g. a KEDA
@@ -71,6 +75,24 @@ skill handlers can read both parts from `AgentTaskRequest.Message.Parts`.
 
 `InputRequired` follow-ups remain text-only — only the initial `invoke_agent`
 call carries the structured payload.
+
+### Structured data in responses
+
+Skills can return a `data` part alongside their text synthesis — `AdvisorCouncil`
+does this, emitting `{ personas, tensions, confidence, metadata }` as
+`application/json` next to its prose. RockBot's primary-side handler preserves
+both parts:
+
+| Key | Category | Contents |
+|-----|----------|----------|
+| `…/{taskId}/result` | `a2a-result` | The `text` part (synthesis prose) |
+| `…/{taskId}/result.data` | `a2a-result-data` | The first `data` part's raw payload (typically JSON) |
+
+The `result.data` entry is only written when the response actually contains a
+`data` part with non-empty bytes — single-text-part results behave exactly as
+before. The data-key tag list includes the mime type, agent name, and task id
+for downstream filtering. The synthetic user turn that follows the result names
+both keys so the LLM can fetch the structured payload on demand.
 
 ---
 

--- a/src/RockBot.A2A/A2ATaskResultHandler.cs
+++ b/src/RockBot.A2A/A2ATaskResultHandler.cs
@@ -202,6 +202,9 @@ internal sealed class A2ATaskResultHandler(
             result.TaskId, pending.TargetAgent, pending.PrimarySessionId, result.State);
 
         var resultText = result.Message?.Parts.FirstOrDefault(p => p.Kind == "text")?.Text ?? "(no text output)";
+        var dataPart = result.Message?.Parts.FirstOrDefault(p => p.Kind == "data");
+        var dataJson = dataPart?.Data;
+        var dataMimeType = dataPart?.MimeType;
         string syntheticUserTurn;
 
         // PrimarySessionId is the full WM session namespace (e.g. "session/blazor-session"),
@@ -223,7 +226,8 @@ internal sealed class A2ATaskResultHandler(
         foreach (var entry in staleEntries)
         {
             if (entry.Key.Contains(staleAgentPattern, StringComparison.OrdinalIgnoreCase) &&
-                entry.Key.EndsWith("/result", StringComparison.OrdinalIgnoreCase))
+                (entry.Key.EndsWith("/result", StringComparison.OrdinalIgnoreCase) ||
+                 entry.Key.EndsWith("/result.data", StringComparison.OrdinalIgnoreCase)))
             {
                 logger.LogDebug("Purging stale A2A result entry '{Key}' before storing new result", entry.Key);
                 await workingMemory.DeleteAsync(entry.Key);
@@ -246,6 +250,27 @@ internal sealed class A2ATaskResultHandler(
             "A2A result for task {TaskId} ({Len:N0} chars) stored in working memory at key '{Key}'",
             result.TaskId, resultText.Length, memoryKey);
 
+        // Multi-part responses (text + data) preserve the structured data part under a
+        // sibling key so downstream consumers — the LLM's follow-up turn, subagent
+        // callers, observability tooling — can recover the structured fields. Without
+        // this, agents like AdvisorCouncil silently lose their JSON payload (per-persona
+        // views, tensions, confidence, metadata) on the receive side.
+        string? dataMemoryKey = null;
+        if (!string.IsNullOrWhiteSpace(dataJson))
+        {
+            dataMemoryKey = $"{sessionNamespace}/a2a/{pending.TargetAgent}/{result.TaskId}/result.data";
+            await workingMemory.SetAsync(
+                dataMemoryKey,
+                dataJson,
+                ttl: TimeSpan.FromMinutes(60),
+                category: "a2a-result-data",
+                tags: [pending.TargetAgent, result.TaskId, dataMimeType ?? "application/json"]);
+
+            logger.LogInformation(
+                "A2A data part for task {TaskId} ({Len:N0} chars, mime={Mime}) stored at key '{Key}'",
+                result.TaskId, dataJson.Length, dataMimeType ?? "application/json", dataMemoryKey);
+        }
+
         // If the A2A invocation didn't originate in a user session, the result must flow
         // back to the calling loop (subagent or wisp) via working memory — not as a
         // user-visible chat bubble. The caller will pull the result and incorporate it
@@ -264,6 +289,13 @@ internal sealed class A2ATaskResultHandler(
             $"[Agent '{pending.TargetAgent}' completed task {result.TaskId} (state={result.State})]: " +
             $"The result ({resultText.Length:N0} chars) is in working memory. " +
             $"Call get_from_working_memory with key '{memoryKey}' to read it before responding.";
+
+        if (dataMemoryKey is not null)
+        {
+            syntheticUserTurn +=
+                $" Structured JSON ({dataMimeType ?? "application/json"}) is also available " +
+                $"at key '{dataMemoryKey}' — fetch it only if the structured fields are needed.";
+        }
 
         // No separate preview bubble — the LLM synthesis below is the single
         // user-facing message. Publishing a preview AND a synthesis creates

--- a/tests/RockBot.A2A.Tests/A2ATaskResultHandlerTests.cs
+++ b/tests/RockBot.A2A.Tests/A2ATaskResultHandlerTests.cs
@@ -1,0 +1,172 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using RockBot.Host;
+using RockBot.Messaging;
+
+namespace RockBot.A2A.Tests;
+
+/// <summary>
+/// Tests for <see cref="A2ATaskResultHandler"/>'s working-memory side effects.
+///
+/// These exercise the non-user-session short-circuit (PrimarySessionId =
+/// "session/subagent-..."), where the handler writes to working memory and
+/// returns before touching the LLM, conversation memory, or publisher — so we
+/// can leave all the heavyweight dependencies as <c>null!</c> and still cover
+/// the data-part preservation path end-to-end.
+/// </summary>
+[TestClass]
+public class A2ATaskResultHandlerTests
+{
+    private const string TargetAgent = "AdvisorCouncil";
+    private const string TaskId = "task-42";
+    private const string SubagentSession = "session/subagent-test";
+
+    private readonly InMemoryWorkingMemory _memory = new();
+    private readonly A2ATaskTracker _tracker = new();
+    private readonly TrackingPublisher _publisher = new();
+    private readonly A2AOptions _options = new();
+    private readonly AgentIdentity _agent = new("primary-agent");
+    private readonly AgentNameHolder _nameHolder = new();
+
+    private A2ATaskResultHandler CreateHandler() =>
+        new(
+            agentLoopRunner: null!,
+            agentContextBuilder: null!,
+            llmClient: null!,
+            publisher: _publisher,
+            agent: _agent,
+            workingMemory: _memory,
+            memoryTools: null!,
+            skillStore: null!,
+            toolRegistry: null!,
+            rulesTools: null!,
+            toolGuideTools: null!,
+            conversationMemory: null!,
+            tracker: _tracker,
+            modelBehavior: null!,
+            agentNameHolder: _nameHolder,
+            inputRequiredHandler: null!,
+            a2aOptions: _options,
+            logger: NullLogger<A2ATaskResultHandler>.Instance);
+
+    private void TrackPending() =>
+        _tracker.Track(new PendingA2ATask
+        {
+            TaskId = TaskId,
+            TargetAgent = TargetAgent,
+            Skill = "deliberate",
+            PrimarySessionId = SubagentSession,
+            StartedAt = DateTimeOffset.UtcNow,
+            Cts = new CancellationTokenSource()
+        });
+
+    private static MessageHandlerContext CreateContext(MessageEnvelope envelope) =>
+        new()
+        {
+            Envelope = envelope,
+            Agent = new AgentIdentity("primary-agent"),
+            Services = null!,
+            CancellationToken = default
+        };
+
+    private static AgentTaskResult CreateResult(params AgentMessagePart[] parts) =>
+        new()
+        {
+            TaskId = TaskId,
+            State = AgentTaskState.Completed,
+            Message = new AgentMessage
+            {
+                Role = "agent",
+                Parts = parts
+            }
+        };
+
+    [TestMethod]
+    public async Task MultiPartResult_StoresDataPart_UnderSiblingKey()
+    {
+        const string dataJson = "{\"personas\":[\"a\",\"b\"],\"confidence\":\"high\"}";
+
+        TrackPending();
+        var result = CreateResult(
+            new AgentMessagePart { Kind = "text", Text = "Synthesis prose." },
+            new AgentMessagePart { Kind = "data", Data = dataJson, MimeType = "application/json" });
+        var envelope = TestEnvelopeHelper.CreateEnvelope(result, correlationId: TaskId);
+
+        await CreateHandler().HandleAsync(result, CreateContext(envelope));
+
+        Assert.AreEqual(2, _memory.Writes.Count, "expected text + data writes");
+
+        var textWrite = _memory.Writes[0];
+        Assert.AreEqual($"{SubagentSession}/a2a/{TargetAgent}/{TaskId}/result", textWrite.Key);
+        Assert.AreEqual("Synthesis prose.", textWrite.Value);
+        Assert.AreEqual("a2a-result", textWrite.Category);
+
+        var dataWrite = _memory.Writes[1];
+        Assert.AreEqual($"{SubagentSession}/a2a/{TargetAgent}/{TaskId}/result.data", dataWrite.Key);
+        Assert.AreEqual(dataJson, dataWrite.Value);
+        Assert.AreEqual("a2a-result-data", dataWrite.Category);
+        Assert.IsNotNull(dataWrite.Tags);
+        CollectionAssert.Contains((System.Collections.ICollection)dataWrite.Tags!, "application/json");
+        CollectionAssert.Contains((System.Collections.ICollection)dataWrite.Tags!, TargetAgent);
+        CollectionAssert.Contains((System.Collections.ICollection)dataWrite.Tags!, TaskId);
+    }
+
+    [TestMethod]
+    public async Task SingleTextResult_StoresOnlyResultKey()
+    {
+        TrackPending();
+        var result = CreateResult(
+            new AgentMessagePart { Kind = "text", Text = "Just prose." });
+        var envelope = TestEnvelopeHelper.CreateEnvelope(result, correlationId: TaskId);
+
+        await CreateHandler().HandleAsync(result, CreateContext(envelope));
+
+        Assert.AreEqual(1, _memory.Writes.Count, "single-text-part path must remain unchanged");
+        Assert.AreEqual($"{SubagentSession}/a2a/{TargetAgent}/{TaskId}/result", _memory.Writes[0].Key);
+        Assert.AreEqual("a2a-result", _memory.Writes[0].Category);
+    }
+
+    [TestMethod]
+    public async Task DataPartWithEmptyData_IsIgnored()
+    {
+        TrackPending();
+        var result = CreateResult(
+            new AgentMessagePart { Kind = "text", Text = "Prose." },
+            new AgentMessagePart { Kind = "data", Data = null, MimeType = "application/json" });
+        var envelope = TestEnvelopeHelper.CreateEnvelope(result, correlationId: TaskId);
+
+        await CreateHandler().HandleAsync(result, CreateContext(envelope));
+
+        Assert.AreEqual(1, _memory.Writes.Count, "data part with null Data should not create a .data entry");
+        Assert.IsFalse(_memory.Writes.Any(w => w.Key.EndsWith("/result.data")));
+    }
+}
+
+/// <summary>
+/// In-memory <see cref="IWorkingMemory"/> that records every <c>SetAsync</c>
+/// call for assertions. Read APIs return empty results — sufficient for the
+/// non-user-session path under test.
+/// </summary>
+internal sealed class InMemoryWorkingMemory : IWorkingMemory
+{
+    public List<(string Key, string Value, string? Category, IReadOnlyList<string>? Tags)> Writes { get; } = [];
+
+    public Task SetAsync(string key, string value, TimeSpan? ttl = null,
+        string? category = null, IReadOnlyList<string>? tags = null)
+    {
+        Writes.Add((key, value, category, tags));
+        return Task.CompletedTask;
+    }
+
+    public Task<string?> GetAsync(string key) => Task.FromResult<string?>(null);
+
+    public Task<IReadOnlyList<WorkingMemoryEntry>> ListAsync(string? prefix = null) =>
+        Task.FromResult<IReadOnlyList<WorkingMemoryEntry>>([]);
+
+    public Task DeleteAsync(string key) => Task.CompletedTask;
+
+    public Task ClearAsync(string? prefix = null) => Task.CompletedTask;
+
+    public Task<IReadOnlyList<WorkingMemoryEntry>> SearchAsync(
+        MemorySearchCriteria criteria, string? prefix = null) =>
+        Task.FromResult<IReadOnlyList<WorkingMemoryEntry>>([]);
+}


### PR DESCRIPTION
Closes #392.

## Summary
- When an A2A `AgentTaskResult` carries both a `text` part and a `data` part (e.g. `AdvisorCouncil`'s `CouncilResponse` JSON alongside the synthesis prose), the handler now stores the data bytes at a sibling working-memory key (`.../result.data`, category `a2a-result-data`, same 60-min TTL, tags include mime type) instead of silently dropping them.
- Single-text-part results behave exactly as before — no `result.data` write, no synthetic-turn change.
- For user sessions, the synthetic user turn fed into the follow-up LLM call names the data key so the model can fetch the structured payload on demand instead of having it inlined.
- Stale-entry purge broadened to also cover `/result.data` so a follow-up call doesn't leave the previous run's data lingering for 60 minutes.

## Test plan
- [x] `dotnet build RockBot.slnx` — 0 errors.
- [x] Three new tests in `tests/RockBot.A2A.Tests/A2ATaskResultHandlerTests.cs` cover multi-part preservation, single-text-part unchanged behavior, and a malformed `Kind=data` part with null `Data`.
- [x] Full A2A test suite: 152/152 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)