### PR TITLE
Bump version to 0.10.57

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.10.56</Version>
+<Version>0.10.57</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->


### PR DESCRIPTION
## Summary
- Aligns source with the agent image (`rockylhotka/rockbot-agent:0.10.57`) deployed to the cluster as part of the PR #376 (skill asset promotion) rollout.

## Test plan
- [x] No code changes; build/test unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)