### PR TITLE
Recognize ClientResultException in FallbackChatClient; degrade safely

### DIFF
--- a/src/RockBot.Agent/ScheduledTaskHandler.cs
+++ b/src/RockBot.Agent/ScheduledTaskHandler.cs
@@ -113,6 +113,7 @@ internal sealed class ScheduledTaskHandler(
         var replySessionId = message.IsSystemTask ? "scheduled-system" : "scheduled";
 
         string finalText;
+        bool succeeded;
         try
         {
             using var progressCtx = ToolProgressNotifier.SetContext(new ToolProgressContext
@@ -125,6 +126,7 @@ internal sealed class ScheduledTaskHandler(
             finalText = await agentLoopRunner.RunAsync(
                 chatMessages, chatOptions, sessionId: sessionId,
                 enableFollowUp: false, cancellationToken: ct);
+            succeeded = true;
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
@@ -139,9 +141,13 @@ internal sealed class ScheduledTaskHandler(
         {
             logger.LogError(ex, "Scheduled task '{TaskName}' failed", message.TaskName);
             finalText = $"I encountered an error while executing the scheduled task: {ex.Message}";
+            succeeded = false;
         }
 
-        logger.LogInformation("Scheduled task '{TaskName}' completed", message.TaskName);
+        if (succeeded)
+            logger.LogInformation("Scheduled task '{TaskName}' completed", message.TaskName);
+        else
+            logger.LogInformation("Scheduled task '{TaskName}' finished with error reply", message.TaskName);
 
         // Patrol tasks may produce no output when there is nothing to report — that is correct.
         if (string.IsNullOrWhiteSpace(finalText))

--- a/src/RockBot.Llm/FallbackChatClient.cs
+++ b/src/RockBot.Llm/FallbackChatClient.cs
@@ -1,3 +1,4 @@
+using System.ClientModel;
 using System.Net;
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.AI;
@@ -249,15 +250,16 @@ public sealed class FallbackChatClient : IChatClient
 
         if (ex is HttpRequestException { StatusCode: { } status })
         {
-            return status switch
-            {
-                HttpStatusCode.TooManyRequests => FallbackErrorCategory.Transient,
-                HttpStatusCode.PaymentRequired  => FallbackErrorCategory.QuotaExhausted,
-                HttpStatusCode.Unauthorized     => FallbackErrorCategory.HardError,
-                HttpStatusCode.Forbidden        => FallbackErrorCategory.HardError,
-                HttpStatusCode.NotFound         => FallbackErrorCategory.HardError,
-                _                               => FallbackErrorCategory.Unknown
-            };
+            return ClassifyStatusCode((int)status);
+        }
+
+        // OpenAI SDK (and other System.ClientModel-based SDKs) surface HTTP failures
+        // as ClientResultException rather than HttpRequestException. Without this branch
+        // a 503 from the LLM provider falls through to message-string inspection,
+        // gets classified as Unknown, and is re-thrown without retry or fallback.
+        if (ex is ClientResultException cre)
+        {
+            return ClassifyStatusCode(cre.Status);
         }
 
         var msg = ex.Message;
@@ -271,4 +273,17 @@ public sealed class FallbackChatClient : IChatClient
 
     private static bool ContainsAny(string text, params string[] values) =>
         values.Any(v => text.Contains(v, StringComparison.OrdinalIgnoreCase));
+
+    private static FallbackErrorCategory ClassifyStatusCode(int status) => status switch
+    {
+        408 => FallbackErrorCategory.Transient,        // Request Timeout
+        429 => FallbackErrorCategory.Transient,        // Too Many Requests
+        500 => FallbackErrorCategory.Transient,        // Internal Server Error
+        502 => FallbackErrorCategory.Transient,        // Bad Gateway
+        503 => FallbackErrorCategory.Transient,        // Service Unavailable
+        504 => FallbackErrorCategory.Transient,        // Gateway Timeout
+        402 => FallbackErrorCategory.QuotaExhausted,   // Payment Required
+        401 or 403 or 404 => FallbackErrorCategory.HardError,
+        _   => FallbackErrorCategory.Unknown
+    };
 }

--- a/src/RockBot.Subagent/SubagentResultHandler.cs
+++ b/src/RockBot.Subagent/SubagentResultHandler.cs
@@ -226,11 +226,79 @@ internal sealed class SubagentResultHandler(
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            logger.LogError(ex, "Failed to handle subagent result consolidation for session {SessionId}",
+            logger.LogError(ex,
+                "Failed to handle subagent result consolidation for session {SessionId} — emitting degraded reply",
                 rawSessionId);
+
+            await PublishDegradedReplyAsync(rawSessionId, batchedResults, ex, ct);
         }
         // Note: subagent working memory entries ("subagent/{taskId}/...") are intentionally NOT
         // deleted here. They persist until their TTL expires so the primary agent can reference
         // them across multiple follow-up turns.
+    }
+
+    /// <summary>
+    /// Synthesis LLM call failed (e.g. all providers 503'd). The per-subagent outputs are still
+    /// in working memory and conversation memory — stitch them into a plain reply so the user
+    /// receives the work that did succeed instead of silent failure.
+    /// </summary>
+    private async Task PublishDegradedReplyAsync(
+        string rawSessionId,
+        IReadOnlyList<SubagentResultMessage> batchedResults,
+        Exception synthesisError,
+        CancellationToken ct)
+    {
+        try
+        {
+            var content = BuildDegradedReplyContent(batchedResults, synthesisError);
+
+            await conversationMemory.AddTurnAsync(
+                rawSessionId,
+                new ConversationTurn("assistant", content, DateTimeOffset.UtcNow)
+                { AgentName = agent.Name },
+                ct);
+
+            var reply = new AgentReply
+            {
+                Content = content,
+                SessionId = rawSessionId,
+                AgentName = agent.Name,
+                IsFinal = true
+            };
+            var envelope = reply.ToEnvelope<AgentReply>(source: agent.Name);
+            await publisher.PublishAsync($"{UserProxyTopics.UserResponse}.{agent.Name}", envelope, ct);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            logger.LogError(ex,
+                "Degraded subagent consolidation reply also failed for session {SessionId}",
+                rawSessionId);
+        }
+    }
+
+    internal static string BuildDegradedReplyContent(
+        IReadOnlyList<SubagentResultMessage> batchedResults,
+        Exception synthesisError)
+    {
+        var successCount = batchedResults.Count(r => r.IsSuccess);
+        var failCount = batchedResults.Count - successCount;
+
+        var sb = new System.Text.StringBuilder();
+        sb.AppendLine(
+            $"I couldn't synthesize a unified summary — the synthesis step itself failed ({synthesisError.Message.Trim()}). " +
+            $"Here are the raw subagent results ({successCount} succeeded, {failCount} failed):");
+        sb.AppendLine();
+
+        foreach (var r in batchedResults)
+        {
+            sb.AppendLine($"### Subagent {r.TaskId} — {(r.IsSuccess ? "succeeded" : "failed")}");
+            if (!r.IsSuccess && !string.IsNullOrWhiteSpace(r.Error))
+                sb.AppendLine($"_Error: {r.Error}_");
+            sb.AppendLine();
+            sb.AppendLine(string.IsNullOrWhiteSpace(r.Output) ? "_(no output)_" : r.Output);
+            sb.AppendLine();
+        }
+
+        return sb.ToString().TrimEnd();
     }
 }

--- a/tests/RockBot.Llm.Tests/FallbackChatClientTests.cs
+++ b/tests/RockBot.Llm.Tests/FallbackChatClientTests.cs
@@ -1,3 +1,5 @@
+using System.ClientModel;
+using System.ClientModel.Primitives;
 using System.Net;
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.AI;
@@ -21,6 +23,13 @@ public class FallbackChatClientTests
 
     private static HttpRequestException HttpEx(HttpStatusCode status) =>
         new("err", null, status);
+
+    /// <summary>
+    /// Constructs a <see cref="ClientResultException"/> with the given HTTP status,
+    /// matching what the OpenAI SDK throws on a failed request.
+    /// </summary>
+    private static ClientResultException ClientResultEx(int status) =>
+        new("Service request failed.", new StatusOnlyPipelineResponse(status));
 
     // ── test stubs ───────────────────────────────────────────────────────────
 
@@ -302,6 +311,56 @@ public class FallbackChatClientTests
     }
 
     [TestMethod]
+    public async Task ClientResultException_503_RetriesAndFallsBack()
+    {
+        // Regression: a 503 from the OpenAI SDK surfaces as ClientResultException, not
+        // HttpRequestException. Before the fix it was classified Unknown and re-thrown
+        // immediately, bypassing both retry and the fallback chain.
+        var first  = new SequentialStub();
+        first.Enqueue(ClientResultEx(503)); // attempt 0: 503
+        first.Enqueue(ClientResultEx(503)); // attempt 1 (retry): still 503
+        var second = new FixedStub(response: OkResponse("from-second"));
+
+        var client = Build([("m1", first), ("m2", second)], maxRetries: 1);
+
+        var response = await client.GetResponseAsync([]);
+
+        Assert.AreEqual("from-second", response.Messages[^1].Text);
+        Assert.AreEqual(2, first.CallCount, "503 should be retried once on the same model");
+        Assert.AreEqual(1, second.CallCount);
+    }
+
+    [TestMethod]
+    public async Task ClientResultException_TransientStatuses_FallBack()
+    {
+        foreach (var status in new[] { 408, 429, 500, 502, 503, 504 })
+        {
+            var first  = new FixedStub(ex: ClientResultEx(status));
+            var second = new FixedStub(response: OkResponse($"fallback-{status}"));
+            var client = Build([("m1", first), ("m2", second)], maxRetries: 0);
+
+            var response = await client.GetResponseAsync([]);
+
+            Assert.AreEqual($"fallback-{status}", response.Messages[^1].Text,
+                $"Status {status} should fall back to the next model");
+        }
+    }
+
+    [TestMethod]
+    public async Task ClientResultException_HardErrorStatus_FallsBackAndDegrades()
+    {
+        var first  = new FixedStub(ex: ClientResultEx(401));
+        var second = new FixedStub(response: OkResponse());
+        var client = Build([("m1", first), ("m2", second)], maxRetries: 0);
+
+        await client.GetResponseAsync([]);
+        await client.GetResponseAsync([]);
+
+        Assert.AreEqual(1, first.CallCount, "401 should mark model degraded; second call must skip it");
+        Assert.AreEqual(2, second.CallCount);
+    }
+
+    [TestMethod]
     public async Task PerAttemptTimeout_UserCancellation_PropagatesImmediately()
     {
         var slow = new SlowStub(delay: TimeSpan.FromSeconds(30));
@@ -324,6 +383,23 @@ public class FallbackChatClientTests
     }
 
     // ── additional stubs ────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Minimal PipelineResponse that only carries an HTTP status — enough to construct
+    /// a ClientResultException whose Status property the classifier can read.
+    /// </summary>
+    private sealed class StatusOnlyPipelineResponse(int status) : PipelineResponse
+    {
+        public override int Status { get; } = status;
+        public override string ReasonPhrase => string.Empty;
+        public override Stream? ContentStream { get => null; set { } }
+        public override BinaryData Content => BinaryData.Empty;
+        protected override PipelineResponseHeaders HeadersCore => throw new NotImplementedException();
+        public override BinaryData BufferContent(CancellationToken cancellationToken = default) => BinaryData.Empty;
+        public override ValueTask<BinaryData> BufferContentAsync(CancellationToken cancellationToken = default) =>
+            new(BinaryData.Empty);
+        public override void Dispose() { }
+    }
 
     /// <summary>Delays for a configurable period before responding (simulates a stalled model).</summary>
     private sealed class SlowStub(TimeSpan delay) : IChatClient

--- a/tests/RockBot.Subagent.Tests/SubagentResultHandlerDegradedReplyTests.cs
+++ b/tests/RockBot.Subagent.Tests/SubagentResultHandlerDegradedReplyTests.cs
@@ -1,0 +1,55 @@
+using RockBot.Host;
+
+namespace RockBot.Subagent.Tests;
+
+[TestClass]
+public class SubagentResultHandlerDegradedReplyTests
+{
+    private static SubagentResultMessage MakeResult(
+        string taskId, bool isSuccess, string output, string? error = null) => new()
+    {
+        TaskId = taskId,
+        SubagentSessionId = $"subagent-{taskId}",
+        PrimarySessionId = "session/s1",
+        Output = output,
+        IsSuccess = isSuccess,
+        Error = error,
+        Timestamp = DateTimeOffset.UtcNow,
+        BatchId = "batch-1"
+    };
+
+    [TestMethod]
+    public void BuildDegradedReply_IncludesEverySubagentResult_AndCounts()
+    {
+        var results = new[]
+        {
+            MakeResult("a1", isSuccess: true,  output: "alpha findings"),
+            MakeResult("b2", isSuccess: false, output: "(crash)", error: "Status: 503"),
+            MakeResult("c3", isSuccess: true,  output: "gamma findings")
+        };
+
+        var content = SubagentResultHandler.BuildDegradedReplyContent(
+            results, new InvalidOperationException("synthesis 503"));
+
+        StringAssert.Contains(content, "2 succeeded, 1 failed");
+        StringAssert.Contains(content, "synthesis 503");
+        StringAssert.Contains(content, "Subagent a1");
+        StringAssert.Contains(content, "alpha findings");
+        StringAssert.Contains(content, "Subagent b2");
+        StringAssert.Contains(content, "Status: 503");
+        StringAssert.Contains(content, "Subagent c3");
+        StringAssert.Contains(content, "gamma findings");
+    }
+
+    [TestMethod]
+    public void BuildDegradedReply_EmptyOutput_RendersPlaceholder()
+    {
+        var results = new[] { MakeResult("only", isSuccess: false, output: "") };
+
+        var content = SubagentResultHandler.BuildDegradedReplyContent(
+            results, new Exception("boom"));
+
+        StringAssert.Contains(content, "Subagent only");
+        StringAssert.Contains(content, "(no output)");
+    }
+}


### PR DESCRIPTION
## Summary

Three connected fixes after a brief OpenAI 503 burst at ~10:02 silently
killed the morning daily operational brief.

### 1. `FallbackChatClient` doesn't recognize OpenAI SDK exceptions
`ClassifyException` only matched `HttpRequestException`, but the OpenAI
SDK surfaces HTTP failures as `System.ClientModel.ClientResultException`.
Every 503 was classified `Unknown` and re-thrown immediately, bypassing
both in-tier retry and the cross-provider fallback chain. Now both
exception types route through a shared status-code classifier:

| Status | Category |
|---|---|
| 408 / 429 / 500 / 502 / 503 / 504 | Transient (retry, then fall back) |
| 402 | QuotaExhausted (degrade) |
| 401 / 403 / 404 | HardError (degrade) |

### 2. `SubagentResultHandler` had no degraded path
When the consolidation synthesis LLM call threw, the handler logged the
error and returned — the user never received the brief, even though
N-1 subagents had already saved their findings to working memory. Now
publishes a fallback reply stitched from each subagent's raw output and
error so the work that succeeded isn't silently lost.

### 3. `ScheduledTaskHandler` logged misleading `completed` after failure
`logger.LogInformation("...completed")` ran unconditionally after the
error catch, producing `fail` → `completed` log pairs. Now logs the
success/failure path correctly.

## Why this happened today

The 10:02 brief (`patrol/morning-daily-operational-brief`) fanned out
into 3 subagents. Two died mid-tool-loop on 503 (`gpt-5.5`); the
consolidation synthesis also 503'd. With #1 fixed, the same burst would
retry, then fall through to the next Balanced provider — most calls
recover transparently. With #2 fixed, if the synthesizer still failed,
the user would still receive the upstream subagents' content instead of
silence.

## Test plan
- [x] `tests/RockBot.Llm.Tests` — 3 new tests: 503 retries-then-falls-back, all six transient statuses fall back, 401 hard-error degrades the model (124 total green)
- [x] `tests/RockBot.Subagent.Tests` — 2 new tests covering `BuildDegradedReplyContent` (31 total green)
- [x] `tests/RockBot.Agent.Tests` — 145 green, no regressions from the `ScheduledTaskHandler` log change
- [ ] Post-deploy: monitor the next 10:00 patrol log for clean `Scheduled task '...' completed` lines and no orphaned `Failed to handle subagent result consolidation` without a degraded reply

🤖 Generated with [Claude Code](https://claude.com/claude-code)