### PR TITLE
Seed ResearchAgent and AdvisorCouncil in well-known-agents.json

### DIFF
--- a/src/RockBot.Agent/agent/well-known-agents.json
+++ b/src/RockBot.Agent/agent/well-known-agents.json
@@ -2,5 +2,29 @@
   {
     "agentName": "SampleAgent-Http",
     "url": "http://rockbot-sample-agent-http.rockbot.svc.cluster.local"
+  },
+  {
+    "agentName": "ResearchAgent",
+    "description": "On-demand research agent. Searches the web, fetches pages, and synthesises answers using an LLM.",
+    "version": "1.0",
+    "skills": [
+      {
+        "id": "research",
+        "name": "Research",
+        "description": "Research a topic using web search and page fetching, then synthesise a concise answer."
+      }
+    ]
+  },
+  {
+    "agentName": "AdvisorCouncil",
+    "description": "Multi-perspective advisor council. Analyzes questions from a curated set of personas and returns integrated guidance.",
+    "version": "1.0",
+    "skills": [
+      {
+        "id": "advise",
+        "name": "Advise",
+        "description": "Take a question or idea and return multi-perspective analysis with synthesis."
+      }
+    ]
   }
 ]


### PR DESCRIPTION
## Summary

- Both `ResearchAgent` and `AdvisorCouncil` are deployed as KEDA scale-to-zero ScaledJobs (`deploy/k8s/research-agent-scaledjob.yaml`, `deploy/k8s/advisor-council-scaledjob.yaml`). While idle they never broadcast their `AgentCard` on the discovery topic, so the primary agent's `IAgentDirectory` doesn't learn about them.
- Without a directory entry, `list_known_agents` and `search_known_services` don't surface them, and `directives.md` tells the LLM to invoke `AdvisorCouncil` / `ResearchAgent` by name without giving it any skill metadata to build a valid `invoke_agent` call.
- Add queue-only seed entries to `well-known-agents.json`. With no `url`, `InvokeAgentExecutor.cs:181-209` falls through to RabbitMQ queue dispatch (`{TaskTopic}.{agentName}`) and `AgentDirectory.RefreshAllWellKnownAsync` (line 119-120) skips the `/.well-known/agent-card.json` fetch. Skills are embedded so the seed is self-sufficient.

## Test plan

- [x] Pushed equivalent file to live cluster PVC and restarted `rockbot-agent` — startup logs show `Seeded well-known agent 'ResearchAgent'` and `Seeded well-known agent 'AdvisorCouncil'`
- [ ] After merge: confirm a fresh-PVC deploy seeds correctly (the init container does not copy `well-known-agents.json` so this only matters on first install / when the file is absent — operators with existing PVC entries will need to merge manually)

🤖 Generated with [Claude Code](https://claude.com/claude-code)