### PR TITLE
Forward MCP server identity to agent and LLM summary

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.10.58</Version>
+<Version>0.10.59</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.Agent/McpBridge/McpBridgeService.cs
+++ b/src/RockBot.Agent/McpBridge/McpBridgeService.cs
@@ -31,6 +31,7 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
     private readonly Dictionary<string, McpBridgeServerConfig> _serverConfigs = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, List<McpClientTool>> _serverTools = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, List<McpClientPrompt>> _serverPrompts = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, McpServerMetadata> _serverMetadata = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, AttachmentGatewayEntry> _attachmentGateways = new(StringComparer.OrdinalIgnoreCase);
     private readonly Lazy<IAttachmentStorage> _attachmentStorage = new(() => new AttachmentStorage());
     private readonly SemaphoreSlim _configPersistLock = new(1, 1);
@@ -414,11 +415,22 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
                 _serverTools[name] = filteredTools;
                 _serverPrompts[name] = prompts;
 
-                _logger.LogInformation("Connected to MCP server {Name} with {ToolCount} tools and {PromptCount} prompts",
-                    name, filteredTools.Count, prompts.Count);
+                var serverInfo = newClient.ServerInfo;
+                var metadata = new McpServerMetadata(
+                    ImplementationName: serverInfo?.Name,
+                    Title: serverInfo?.Title,
+                    Version: serverInfo?.Version,
+                    Description: serverInfo?.Description,
+                    Instructions: newClient.ServerInstructions);
+                _serverMetadata[name] = metadata;
+
+                _logger.LogInformation(
+                    "Connected to MCP server {Name} (impl={ImplName} v{Version}) with {ToolCount} tools and {PromptCount} prompts",
+                    name, metadata.ImplementationName ?? "(unknown)", metadata.Version ?? "(unknown)",
+                    filteredTools.Count, prompts.Count);
 
                 // Build and publish server summary
-                var summary = await GenerateSummaryAsync(name, filteredTools, prompts, ct);
+                var summary = await GenerateSummaryAsync(name, metadata, filteredTools, prompts, ct);
                 await PublishServersIndexedAsync([summary], [], ct);
                 return;
             }
@@ -456,6 +468,7 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
 
         _serverTools.Remove(name);
         _serverPrompts.Remove(name);
+        _serverMetadata.Remove(name);
         _serverConfigs.Remove(name);
         InvalidateAttachmentGateway(name);
 
@@ -503,6 +516,19 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
 
     private sealed record AttachmentGatewayEntry(AttachmentGateway Gateway, HttpClient HttpClient);
 
+    /// <summary>
+    /// Snapshot of a connected MCP server's self-reported identity, captured once at connect
+    /// from <see cref="McpClient.ServerInfo"/> and <see cref="McpClient.ServerInstructions"/>.
+    /// Forwarded to agents via <see cref="McpGetServiceDetailsResponse"/> and used as input
+    /// to the LLM-generated server summary.
+    /// </summary>
+    private sealed record McpServerMetadata(
+        string? ImplementationName,
+        string? Title,
+        string? Version,
+        string? Description,
+        string? Instructions);
+
     private static List<McpClientTool> ApplyToolFilters(List<McpClientTool> tools, McpBridgeServerConfig config)
     {
         if (config.AllowedTools.Count > 0)
@@ -522,6 +548,7 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
 
     private async Task<McpServerSummary> GenerateSummaryAsync(
         string serverName,
+        McpServerMetadata metadata,
         List<McpClientTool> tools,
         List<McpClientPrompt> prompts,
         CancellationToken ct)
@@ -543,6 +570,25 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
                         $"- {p.Name}: {p.Description}"))
                     : string.Empty;
 
+                var identityLines = new List<string>();
+                if (!string.IsNullOrWhiteSpace(metadata.ImplementationName))
+                    identityLines.Add($"- Implementation name: {metadata.ImplementationName}");
+                if (!string.IsNullOrWhiteSpace(metadata.Title))
+                    identityLines.Add($"- Title: {metadata.Title}");
+                if (!string.IsNullOrWhiteSpace(metadata.Version))
+                    identityLines.Add($"- Version: {metadata.Version}");
+                if (!string.IsNullOrWhiteSpace(metadata.Description))
+                    identityLines.Add($"- Description: {metadata.Description}");
+
+                var identitySection = identityLines.Count > 0
+                    ? "Server identity (self-reported by the MCP server during initialize):\n"
+                      + string.Join("\n", identityLines) + "\n\n"
+                    : string.Empty;
+
+                var instructionsSection = !string.IsNullOrWhiteSpace(metadata.Instructions)
+                    ? $"Server instructions (the MCP server's own description of its purpose and usage):\n{metadata.Instructions}\n\n"
+                    : string.Empty;
+
                 var prompt = $"""
                     You are summarizing an MCP server's capabilities for an AI agent that must decide
                     which server to query for a given task. The agent sees ONLY this summary when
@@ -554,10 +600,13 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
                        organize emails; create, update, and delete calendar events; look up contacts")
                     3. Mention any notable specifics (e.g. multi-account support, specific platforms)
 
+                    Treat the server's self-reported identity and instructions as authoritative about
+                    its purpose; use the tool list to confirm and enumerate capability categories.
+
                     The summary must give enough detail that an agent can confidently decide "this is the
                     server I need for email/calendar/contact tasks" without seeing tool names.
 
-                    Based on these tools:
+                    {identitySection}{instructionsSection}Based on these tools:
                     {toolList}{promptSection}
                     Respond with only the summary, no preamble or explanation.
                     """;
@@ -971,9 +1020,15 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
 
             var tools = _serverTools.GetValueOrDefault(req.ServerName) ?? [];
             var serverPrompts = _serverPrompts.GetValueOrDefault(req.ServerName) ?? [];
+            var metadata = _serverMetadata.GetValueOrDefault(req.ServerName);
             var response = new McpGetServiceDetailsResponse
             {
                 ServerName = req.ServerName,
+                ImplementationName = metadata?.ImplementationName,
+                Title = metadata?.Title,
+                Version = metadata?.Version,
+                Description = metadata?.Description,
+                Instructions = metadata?.Instructions,
                 Tools = tools.Select(t => new McpToolDefinition
                 {
                     Name = t.Name,
@@ -1466,6 +1521,7 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
         _clients.Clear();
         _serverTools.Clear();
         _serverPrompts.Clear();
+        _serverMetadata.Clear();
         _serverConfigs.Clear();
 
         foreach (var (_, entry) in _attachmentGateways)

--- a/src/RockBot.Tools.Mcp/McpManagementExecutor.cs
+++ b/src/RockBot.Tools.Mcp/McpManagementExecutor.cs
@@ -98,10 +98,13 @@ public sealed class McpManagementExecutor : IToolExecutor, IAsyncDisposable
         if (!TryGetServerName(args, out var serverName))
             return Error(request, "Missing required parameter: server_name");
 
-        var tools = await GetSchemasAsync(serverName, ct);
-        if (tools is null)
+        var details = await GetServiceDetailsAsync(serverName, ct);
+        if (details is null)
             return Error(request, $"Timed out waiting for service details for '{serverName}'");
+        if (details.Error is not null)
+            return Error(request, details.Error);
 
+        var tools = (IReadOnlyList<McpToolDefinition>)details.Tools;
         if (TryGetString(args, "tool_name", out var toolName))
         {
             tools = tools
@@ -111,11 +114,32 @@ public sealed class McpManagementExecutor : IToolExecutor, IAsyncDisposable
                 return Error(request, $"No tool named '{toolName}' found on server '{serverName}'");
         }
 
+        // Surface the server's self-reported identity alongside tool schemas so the
+        // agent can reason about what the server actually is — not just what tools
+        // happen to be exposed. The MCP `initialize` handshake provides name/version
+        // and a free-text instructions string; both shape how the LLM picks and uses
+        // a server. Always include the "server" object even when fields are null so
+        // the contract is stable for the agent's tool-result parser.
+        var payload = new
+        {
+            server = new
+            {
+                name = serverName,
+                implementationName = details.ImplementationName,
+                title = details.Title,
+                version = details.Version,
+                description = details.Description,
+                instructions = details.Instructions
+            },
+            tools,
+            prompts = details.Prompts
+        };
+
         return new ToolInvokeResponse
         {
             ToolCallId = request.ToolCallId,
             ToolName = request.ToolName,
-            Content = JsonSerializer.Serialize(tools, JsonOptions)
+            Content = JsonSerializer.Serialize(payload, JsonOptions)
         };
     }
 
@@ -128,14 +152,24 @@ public sealed class McpManagementExecutor : IToolExecutor, IAsyncDisposable
     public async Task<IReadOnlyList<McpToolDefinition>?> GetSchemasAsync(
         string serverName, CancellationToken ct)
     {
+        var response = await GetServiceDetailsAsync(serverName, ct);
+        if (response is null || response.Error is not null) return null;
+        return response.Tools;
+    }
+
+    /// <summary>
+    /// Fetches the full <see cref="McpGetServiceDetailsResponse"/> for one MCP server,
+    /// including server-level identity (name/version/instructions), tool schemas, and prompts.
+    /// Returns null on timeout or transport failure.
+    /// </summary>
+    private async Task<McpGetServiceDetailsResponse?> GetServiceDetailsAsync(
+        string serverName, CancellationToken ct)
+    {
         var mgmtRequest = new McpGetServiceDetailsRequest { ServerName = serverName };
         var responseEnvelope = await SendRequestAsync(mgmtRequest, ct);
         if (responseEnvelope is null) return null;
 
-        var response = responseEnvelope.GetPayload<McpGetServiceDetailsResponse>();
-        if (response is null || response.Error is not null) return null;
-
-        return response.Tools;
+        return responseEnvelope.GetPayload<McpGetServiceDetailsResponse>();
     }
 
     // ── mcp_invoke_tool ──────────────────────────────────────────────────────

--- a/src/RockBot.Tools.Mcp/McpManagementMessages.cs
+++ b/src/RockBot.Tools.Mcp/McpManagementMessages.cs
@@ -12,11 +12,28 @@ public sealed record McpGetServiceDetailsRequest
 }
 
 /// <summary>
-/// Bridge response carrying all tool and prompt definitions for the requested server.
+/// Bridge response carrying all tool and prompt definitions for the requested server,
+/// plus the server's self-reported identity from the MCP <c>initialize</c> handshake.
 /// </summary>
 public sealed record McpGetServiceDetailsResponse
 {
     public required string ServerName { get; init; }
+
+    /// <summary>Server's self-reported implementation name (from <c>initialize.result.serverInfo.name</c>).</summary>
+    public string? ImplementationName { get; init; }
+
+    /// <summary>Server's self-reported display title.</summary>
+    public string? Title { get; init; }
+
+    /// <summary>Server's self-reported version string.</summary>
+    public string? Version { get; init; }
+
+    /// <summary>Server's self-reported implementation description.</summary>
+    public string? Description { get; init; }
+
+    /// <summary>Free-text usage instructions supplied by the server during initialize.</summary>
+    public string? Instructions { get; init; }
+
     public List<McpToolDefinition> Tools { get; init; } = [];
     public List<McpPromptDefinition> Prompts { get; init; } = [];
     public string? Error { get; init; }

--- a/tests/RockBot.Tools.Tests/McpManagementExecutorTests.cs
+++ b/tests/RockBot.Tools.Tests/McpManagementExecutorTests.cs
@@ -135,6 +135,50 @@ public class McpManagementExecutorTests
     }
 
     [TestMethod]
+    public async Task GetServiceDetails_SurfacesServerIdentityToAgent()
+    {
+        var (executor, publisher, subscriber) = CreateExecutor();
+
+        var request = new ToolInvokeRequest
+        {
+            ToolCallId = "call-1",
+            ToolName = "mcp_get_service_details",
+            Arguments = """{"server_name":"uber"}"""
+        };
+
+        var executeTask = executor.ExecuteAsync(request, CancellationToken.None);
+        await Task.Delay(100);
+
+        var published = publisher.Published[0].Envelope;
+        var response = new McpGetServiceDetailsResponse
+        {
+            ServerName = "uber",
+            ImplementationName = "rides-3p-demand-mcp",
+            Title = "Uber",
+            Version = "1.2.3",
+            Instructions = "MCP server for rides-3p-demand-mcp service",
+            Tools =
+            [
+                new McpToolDefinition { Name = "get_estimates_between_two_locations", Description = "..." }
+            ]
+        };
+        var responseEnvelope = response.ToEnvelope("bridge", correlationId: published.CorrelationId);
+        await subscriber.DeliverAsync(executor.ResponseTopic, responseEnvelope);
+
+        var result = await executeTask;
+
+        Assert.IsFalse(result.IsError);
+        var doc = JsonDocument.Parse(result.Content!);
+        var server = doc.RootElement.GetProperty("server");
+        Assert.AreEqual("uber", server.GetProperty("name").GetString());
+        Assert.AreEqual("rides-3p-demand-mcp", server.GetProperty("implementationName").GetString());
+        Assert.AreEqual("1.2.3", server.GetProperty("version").GetString());
+        Assert.AreEqual("MCP server for rides-3p-demand-mcp service",
+            server.GetProperty("instructions").GetString());
+        Assert.AreEqual(1, doc.RootElement.GetProperty("tools").GetArrayLength());
+    }
+
+    [TestMethod]
     public async Task GetServiceDetails_MissingServerName_ReturnsError()
     {
         var (executor, _, _) = CreateExecutor();

--- a/tests/RockBot.Tools.Tests/McpManagementMessageSerializationTests.cs
+++ b/tests/RockBot.Tools.Tests/McpManagementMessageSerializationTests.cs
@@ -107,6 +107,40 @@ public class McpManagementMessageSerializationTests
     }
 
     [TestMethod]
+    public void McpGetServiceDetailsResponse_WithServerMetadata_RoundTrips()
+    {
+        var original = new McpGetServiceDetailsResponse
+        {
+            ServerName = "uber",
+            ImplementationName = "rides-3p-demand-mcp",
+            Title = "Uber",
+            Version = "1.2.3",
+            Description = "Rides 3P demand surface",
+            Instructions = "MCP server for rides-3p-demand-mcp service",
+            Tools =
+            [
+                new McpToolDefinition
+                {
+                    Name = "get_estimates_between_two_locations",
+                    Description = "Returns ride estimates"
+                }
+            ]
+        };
+
+        var envelope = original.ToEnvelope("test");
+        var deserialized = envelope.GetPayload<McpGetServiceDetailsResponse>();
+
+        Assert.IsNotNull(deserialized);
+        Assert.AreEqual("uber", deserialized.ServerName);
+        Assert.AreEqual("rides-3p-demand-mcp", deserialized.ImplementationName);
+        Assert.AreEqual("Uber", deserialized.Title);
+        Assert.AreEqual("1.2.3", deserialized.Version);
+        Assert.AreEqual("Rides 3P demand surface", deserialized.Description);
+        Assert.AreEqual("MCP server for rides-3p-demand-mcp service", deserialized.Instructions);
+        Assert.AreEqual(1, deserialized.Tools.Count);
+    }
+
+    [TestMethod]
     public void McpGetServiceDetailsResponse_WithError_RoundTrips()
     {
         var original = new McpGetServiceDetailsResponse


### PR DESCRIPTION
## Summary

The MCP bridge currently captures nothing from the MCP `initialize` handshake about the server itself — no implementation name, no version, no `instructions` text. The LLM summary prompt is built from tool name + description only, and `mcp_get_service_details` returns just the tool array (also silently dropping prompts).

This PR captures and forwards that metadata on three layers:

- **Capture** — `McpBridgeService` snapshots `McpClient.ServerInfo` (Implementation.Name/Title/Version/Description) and `ServerInstructions` after every successful connect; clears on disconnect.
- **LLM summary prompt** — `GenerateSummaryAsync` now prepends a "Server identity" block and the verbatim "Server instructions" string before the tool list, and tells the LLM to treat them as authoritative about the server's purpose.
- **Agent surface** — `McpGetServiceDetailsResponse` gained `ImplementationName`, `Title`, `Version`, `Description`, `Instructions`. The `mcp_get_service_details` tool output now returns `{ server: {...}, tools, prompts }` so the agent sees the server's self-description, not just whatever tools happen to be exposed. (Also fixes a pre-existing gap where prompts were dropped from the tool's output entirely.)

`mcp_list_services` is intentionally unchanged — the index stays lean. Server identity is absorbed into the short `Summary` string at generation time and only expanded when the agent drills in via `mcp_get_service_details`.

Version bumped to `0.10.59` for the test deploy.

## Test plan

- [x] `dotnet build RockBot.slnx` — clean
- [x] `dotnet test tests/RockBot.Tools.Tests --filter "FullyQualifiedName~McpManagement"` — 31/31 pass
- [x] `dotnet test tests/RockBot.Agent.Tests --filter "FullyQualifiedName~McpBridge"` — 13/13 pass
- [ ] Deploy `rockbot-agent:0.10.59` and verify `mcp_get_service_details` returns the new `server.*` block for a registered server (e.g. Uber, Gmail)
- [ ] Verify the regenerated LLM summary for at least one server reflects the server's self-reported purpose

🤖 Generated with [Claude Code](https://claude.com/claude-code)