### PR TITLE
Align shared PVC writers via fsGroup 2000 and umask 002

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.10.59</Version>
+<Version>0.10.61</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/deploy/helm/rockbot/Chart.yaml
+++ b/deploy/helm/rockbot/Chart.yaml
@@ -4,8 +4,8 @@ description: >
   RockBot — an event-driven autonomous agent framework built on .NET.
   Deploys the RockBot agent and the Blazor Server web UI.
 type: application
-version: 0.10.15
-appVersion: "0.10.15"
+version: 0.10.16
+appVersion: "0.10.16"
 home: https://github.com/rockylhotka/rockbot
 keywords:
   - ai

--- a/deploy/helm/rockbot/templates/agent/deployment.yaml
+++ b/deploy/helm/rockbot/templates/agent/deployment.yaml
@@ -25,6 +25,12 @@ spec:
         app.kubernetes.io/component: agent
     spec:
       serviceAccountName: {{ include "rockbot.agentServiceAccountName" . }}
+      # fsGroup applies to the shared-data PVC: kubelet chgrp's the volume to
+      # this GID, sets setgid on dirs, and OR's group rw into the mode. Lets
+      # the agent (UID 999), shared-cleanup (UID 0), and script pods (UID 1000)
+      # all read/write each other's files on /rockbot/shared.
+      securityContext:
+        fsGroup: {{ .Values.shared.fsGroup }}
 
       initContainers:
         - name: init-agent-data

--- a/deploy/helm/rockbot/templates/configmap.yaml
+++ b/deploy/helm/rockbot/templates/configmap.yaml
@@ -22,6 +22,7 @@ data:
   Scripts__Container__MemoryLimit: {{ .Values.scripts.memoryLimit | quote }}
   Scripts__Container__SharedVolumeClaim: {{ include "rockbot.sharedPvcName" . | quote }}
   Scripts__Container__SharedVolumePath: "/rockbot/shared"
+  Scripts__Container__FsGroup: {{ .Values.shared.fsGroup | quote }}
 
   # ── Agent data paths (all under the PVC mount at /data/agent) ─────────────
   AgentProfile__BasePath: "/data/agent"

--- a/deploy/helm/rockbot/templates/shared/cronjob.yaml
+++ b/deploy/helm/rockbot/templates/shared/cronjob.yaml
@@ -14,6 +14,10 @@ spec:
       template:
         spec:
           restartPolicy: OnFailure
+          # Match fsGroup with agent + script pods so any files this cronjob
+          # creates inherit the shared GID and are writable by the others.
+          securityContext:
+            fsGroup: {{ .Values.shared.fsGroup }}
           containers:
             - name: cleanup
               image: busybox:stable

--- a/deploy/helm/rockbot/values.yaml
+++ b/deploy/helm/rockbot/values.yaml
@@ -185,6 +185,13 @@ shared:
   # not touched, so empty structure is preserved. Safety net for ad-hoc paths
   # (e.g. patrol drafts, subagent artifacts) that don't have a dedicated TTL.
   globalTtlDays: 30
+  # Shared POSIX group ID applied via pod-level securityContext.fsGroup on every
+  # pod that mounts the rockbot-shared PVC (agent, shared-cleanup cronjob,
+  # ephemeral script pods). kubelet chgrp's the volume root to this GID, sets
+  # the setgid bit on directories, and OR's group rw into the mode — so the
+  # three writers (agent UID 999, cleanup UID 0, script pods UID 1000) can all
+  # read/write each other's files without coordinating UIDs.
+  fsGroup: 2000
 
 # ── TodoApp MCP server ────────────────────────────────────────────────────────
 # Standalone MCP server that exposes a persistent to-do list to the agent.

--- a/src/RockBot.Scripts.Container/ContainerScriptHandler.cs
+++ b/src/RockBot.Scripts.Container/ContainerScriptHandler.cs
@@ -113,7 +113,13 @@ internal sealed class ContainerScriptHandler(
     {
         var command = new List<string> { "sh", "-c" };
 
-        var scriptCommand = "";
+        // umask 002 so new files/dirs are group-writable. The shared PVC uses
+        // fsGroup, so anything the script creates inherits the shared GID via
+        // setgid on the parent dir — but only the agent and cleanup cronjob can
+        // later modify it if group write is set. Without this, scripts leave
+        // behind dirs (mode 755) and files (mode 644) that nothing else can
+        // clean up.
+        var scriptCommand = "umask 002 && ";
         if (request.PipPackages is { Count: > 0 })
         {
             scriptCommand += $"pip install --quiet --target /tmp/pypackages {string.Join(' ', request.PipPackages)} 2>&1 && ";
@@ -141,6 +147,9 @@ internal sealed class ContainerScriptHandler(
                 ActiveDeadlineSeconds = request.TimeoutSeconds,
                 AutomountServiceAccountToken = false,
                 EnableServiceLinks = false,
+                SecurityContext = options.FsGroup is { } gid && gid > 0
+                    ? new V1PodSecurityContext { FsGroup = gid }
+                    : null,
                 Containers =
                 [
                     new V1Container

--- a/src/RockBot.Scripts.Container/ContainerScriptOptions.cs
+++ b/src/RockBot.Scripts.Container/ContainerScriptOptions.cs
@@ -41,4 +41,13 @@ public sealed class ContainerScriptOptions
     /// Exposed to scripts via the <c>ROCKBOT_SHARED_PATH</c> environment variable.
     /// </summary>
     public string SharedVolumePath { get; set; } = "/rockbot/shared";
+
+    /// <summary>
+    /// Optional POSIX group ID applied as the pod-level <c>fsGroup</c>. When set
+    /// (non-null and &gt; 0), kubelet chgrp's the shared volume to this GID and
+    /// adds group-rw to the mode, so script pods (which run as UID 1000) can
+    /// share files with the agent (UID 999) and the shared-cleanup cronjob
+    /// (UID 0). Must match the fsGroup configured on those other pods.
+    /// </summary>
+    public long? FsGroup { get; set; }
 }


### PR DESCRIPTION
## Summary

- Aligns the three writers of `/rockbot/shared` — agent (UID 999), shared-cleanup cronjob (UID 0), ephemeral script pods (UID 1000) — under a common `fsGroup` (2000), so each can read/write/delete the others' files
- Prefixes the script-pod sh command with `umask 002` so new dirs/files are group-writable (combined with setgid from fsGroup, the agent can later clean up script-pod artifacts)
- Bumps agent to 0.10.61 and chart to 0.10.16

## Why

Morning brief on 2026-05-12 failed when a subagent's `execute_python_script` tried `os.makedirs('/rockbot/shared/attachments/teams-bridge-triage-2026-05-12')` and got `PermissionError: [Errno 13]`. Root cause: `/rockbot/shared/attachments` was `drwxr-xr-x 999:999` and the script pod runs as UID 1000 — three writers, three UIDs, no shared group bit. Already verified live in the cluster; this PR commits what was deployed.

## Test plan

- [x] `helm template` renders `fsGroup: 2000` on agent deployment, cleanup cronjob, and configmap (`Scripts__Container__FsGroup`)
- [x] `dotnet test tests/RockBot.Scripts.Tests` — 46 pass, 0 fail (existing `Contains` assertions unaffected by the `umask 002 &&` prefix)
- [x] Deployed to live cluster (`rockbot/default`); agent pod's `spec.securityContext.fsGroup = 2000`, supplementary groups include 2000
- [x] Smoke pod (`runAsUser:1000, fsGroup:2000`) successfully created `/rockbot/shared/attachments/teams-bridge-triage-smoke-test/hello.txt` — the exact failing path from this morning
- [x] After umask change: smoke pod creates dirs `drwxrwsr-x 1000:2000` (mode 2775), and agent pod (UID 999, group 2000) can `rm -rf` them

🤖 Generated with [Claude Code](https://claude.com/claude-code)