### PR TITLE
Fix subagent publishing before A2A response arrives (0.10.62)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.10.61</Version>
+<Version>0.10.62</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.A2A/A2ACallerServiceCollectionExtensions.cs
+++ b/src/RockBot.A2A/A2ACallerServiceCollectionExtensions.cs
@@ -63,6 +63,12 @@ public static class A2ACallerServiceCollectionExtensions
         // when the LLM retries the wisp.
         builder.Services.AddSingleton<ISessionA2ACanceller, A2ATaskCanceller>();
 
+        // Session-scoped A2A wait seam. Subagent code (which doesn't reference
+        // RockBot.A2A) uses this to block before publishing its final result so a
+        // late A2A response isn't dropped against a subagent session that has
+        // already exited.
+        builder.Services.AddSingleton<ISessionA2AAwaiter, A2ATaskAwaiter>();
+
         // InputRequired handler for multi-turn follow-up (trust-gated LLM response generation)
         builder.Services.AddSingleton<InputRequiredHandler>();
 

--- a/src/RockBot.A2A/A2ATaskAwaiter.cs
+++ b/src/RockBot.A2A/A2ATaskAwaiter.cs
@@ -1,0 +1,69 @@
+using Microsoft.Extensions.Logging;
+using RockBot.Host;
+
+namespace RockBot.A2A;
+
+/// <summary>
+/// Waits for in-flight A2A tasks by <c>PrimarySessionId</c>. Invoked by the
+/// subagent runner (via the <see cref="ISessionA2AAwaiter"/> seam) so a
+/// subagent that dispatched an A2A call doesn't publish its result while the
+/// target agent is still working — otherwise the response, when it arrives,
+/// is dropped by <c>A2ATaskResultHandler</c> because its subagent originator
+/// has already exited and is treated as a non-user session with nobody left
+/// to consume the working-memory result.
+///
+/// Termination signal: a task disappears from <see cref="A2ATaskTracker"/>
+/// when <c>A2ATaskResultHandler</c> or <c>A2ATaskErrorHandler</c> calls
+/// <c>TryRemove</c> on it (both terminal paths). Polling the tracker is
+/// sufficient — no extra synchronization is needed.
+/// </summary>
+internal sealed class A2ATaskAwaiter(
+    A2ATaskTracker tracker,
+    ILogger<A2ATaskAwaiter> logger) : ISessionA2AAwaiter
+{
+    private static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(250);
+
+    public async Task<int> WaitForSessionAsync(string sessionId, CancellationToken ct)
+    {
+        if (string.IsNullOrEmpty(sessionId))
+            return 0;
+
+        var initial = tracker.ListBySession(sessionId);
+        if (initial.Count == 0)
+            return 0;
+
+        logger.LogInformation(
+            "Awaiting {Count} in-flight A2A task(s) for session {SessionId}: {TaskIds}",
+            initial.Count, sessionId,
+            string.Join(", ", initial.Select(t => $"{t.TargetAgent}:{t.TaskId}")));
+
+        while (!ct.IsCancellationRequested)
+        {
+            if (tracker.ListBySession(sessionId).Count == 0)
+            {
+                logger.LogInformation(
+                    "All A2A task(s) for session {SessionId} reached terminal state",
+                    sessionId);
+                return initial.Count;
+            }
+
+            try
+            {
+                await Task.Delay(PollInterval, ct);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+        }
+
+        var remaining = tracker.ListBySession(sessionId).Count;
+        if (remaining > 0)
+        {
+            logger.LogWarning(
+                "Stopped awaiting A2A task(s) for session {SessionId} with {Remaining} still pending (cancelled or timed out)",
+                sessionId, remaining);
+        }
+        return initial.Count;
+    }
+}

--- a/src/RockBot.Host.Abstractions/ISessionA2AAwaiter.cs
+++ b/src/RockBot.Host.Abstractions/ISessionA2AAwaiter.cs
@@ -1,0 +1,19 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Waits for any in-flight A2A tasks that were dispatched with the given
+/// <c>PrimarySessionId</c> (e.g. a subagent's working-memory namespace) to reach
+/// a terminal state. Cross-assembly seam: subagent code (which doesn't reference
+/// RockBot.A2A) needs to block before publishing its final result so that an
+/// A2A response that arrives a few seconds after the LLM loop concludes still
+/// reaches the primary agent — instead of being dropped because the originating
+/// subagent session no longer exists by the time A2ATaskResultHandler runs.
+///
+/// Implementations poll the pending-task registry and return when no tasks
+/// remain for the session or when the cancellation token fires. Returns the
+/// number of tasks observed pending at the start of the wait.
+/// </summary>
+public interface ISessionA2AAwaiter
+{
+    Task<int> WaitForSessionAsync(string sessionId, CancellationToken ct);
+}

--- a/src/RockBot.Subagent/SubagentRunner.cs
+++ b/src/RockBot.Subagent/SubagentRunner.cs
@@ -31,7 +31,8 @@ internal sealed class SubagentRunner(
     TierRoutingLogger tierRoutingLogger,
     AgentProfile agentProfile,
     ILogger<SubagentRunner> logger,
-    ISkillResourceUsageStore? skillResourceUsageStore = null)
+    ISkillResourceUsageStore? skillResourceUsageStore = null,
+    ISessionA2AAwaiter? a2aAwaiter = null)
 {
     public async Task RunAsync(
         string taskId,
@@ -208,6 +209,36 @@ internal sealed class SubagentRunner(
             isSuccess = false;
             error = ex.Message;
             subagentActivity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+        }
+
+        // Wait for any in-flight A2A tasks the subagent dispatched (via wisps) to
+        // reach a terminal state before publishing the subagent result. Without this,
+        // the wisp's "dispatched, result arrives async" semantics let the subagent's
+        // LLM declare success while the target agent is still working — and the late
+        // A2A response is then dropped by A2ATaskResultHandler because its originating
+        // subagent session has exited and is not a user session. The wait uses the
+        // subagent's overall CancellationToken so a subagent timeout/cancel doesn't
+        // get stretched waiting on remote agents. Once the wait completes, A2A result
+        // working-memory keys (subagent/{taskId}/a2a/.../result) are populated and
+        // SubagentResultHandler's existing whiteboard listing surfaces them to the
+        // primary agent's synthesis turn automatically.
+        if (a2aAwaiter is not null)
+        {
+            try
+            {
+                var awaited = await a2aAwaiter.WaitForSessionAsync(subagentNamespace, ct);
+                if (awaited > 0)
+                {
+                    logger.LogInformation(
+                        "Subagent {TaskId} awaited {Count} A2A task(s) before publishing result",
+                        taskId, awaited);
+                }
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                logger.LogWarning(ex,
+                    "Subagent {TaskId} A2A await threw — continuing to publish anyway", taskId);
+            }
         }
 
         subagentSw.Stop();

--- a/tests/RockBot.A2A.Tests/A2ATaskAwaiterTests.cs
+++ b/tests/RockBot.A2A.Tests/A2ATaskAwaiterTests.cs
@@ -1,0 +1,119 @@
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace RockBot.A2A.Tests;
+
+[TestClass]
+public class A2ATaskAwaiterTests
+{
+    private static A2ATaskAwaiter Build(A2ATaskTracker tracker) =>
+        new(tracker, NullLogger<A2ATaskAwaiter>.Instance);
+
+    private static PendingA2ATask MakeTask(string taskId, string targetAgent, string sessionId) =>
+        new()
+        {
+            TaskId = taskId,
+            TargetAgent = targetAgent,
+            Skill = "skill",
+            PrimarySessionId = sessionId,
+            StartedAt = DateTimeOffset.UtcNow,
+            Cts = new CancellationTokenSource()
+        };
+
+    [TestMethod]
+    public async Task WaitForSessionAsync_NoPendingTasks_ReturnsZeroImmediately()
+    {
+        var tracker = new A2ATaskTracker();
+        var awaiter = Build(tracker);
+
+        var count = await awaiter.WaitForSessionAsync("subagent/none", CancellationToken.None);
+
+        Assert.AreEqual(0, count);
+    }
+
+    [TestMethod]
+    public async Task WaitForSessionAsync_EmptySessionId_ReturnsZero()
+    {
+        var tracker = new A2ATaskTracker();
+        tracker.Track(MakeTask("t1", "agent", "subagent/s1"));
+        var awaiter = Build(tracker);
+
+        var count = await awaiter.WaitForSessionAsync("", CancellationToken.None);
+
+        Assert.AreEqual(0, count);
+    }
+
+    [TestMethod]
+    public async Task WaitForSessionAsync_OnlyOtherSessionsPending_ReturnsZero()
+    {
+        var tracker = new A2ATaskTracker();
+        tracker.Track(MakeTask("t1", "agent", "subagent/other"));
+        var awaiter = Build(tracker);
+
+        var count = await awaiter.WaitForSessionAsync("subagent/mine", CancellationToken.None);
+
+        Assert.AreEqual(0, count);
+    }
+
+    [TestMethod]
+    public async Task WaitForSessionAsync_ReturnsWhenTrackerEmpties()
+    {
+        var tracker = new A2ATaskTracker();
+        tracker.Track(MakeTask("t1", "agent", "subagent/s1"));
+        var awaiter = Build(tracker);
+
+        // Remove the task shortly after the wait begins, simulating an A2A result arriving.
+        _ = Task.Run(async () =>
+        {
+            await Task.Delay(100);
+            tracker.TryRemove("t1", out _);
+        });
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        var count = await awaiter.WaitForSessionAsync("subagent/s1", CancellationToken.None);
+        sw.Stop();
+
+        Assert.AreEqual(1, count);
+        // Polling interval is 250ms; allow generous slack for CI scheduling jitter.
+        Assert.IsTrue(sw.Elapsed < TimeSpan.FromSeconds(5),
+            $"awaiter took {sw.Elapsed} — should return shortly after tracker empties");
+    }
+
+    [TestMethod]
+    public async Task WaitForSessionAsync_OnlyAwaitsMatchingSession()
+    {
+        var tracker = new A2ATaskTracker();
+        tracker.Track(MakeTask("t1", "agent", "subagent/mine"));
+        tracker.Track(MakeTask("t2", "agent", "subagent/sibling")); // unrelated, stays pending
+        var awaiter = Build(tracker);
+
+        _ = Task.Run(async () =>
+        {
+            await Task.Delay(100);
+            tracker.TryRemove("t1", out _);
+        });
+
+        var count = await awaiter.WaitForSessionAsync("subagent/mine", CancellationToken.None);
+
+        Assert.AreEqual(1, count);
+        // Sibling-session task should still be tracked — the awaiter must not touch it.
+        Assert.AreEqual(1, tracker.ListBySession("subagent/sibling").Count);
+    }
+
+    [TestMethod]
+    public async Task WaitForSessionAsync_CancelledToken_StopsWaitingButReturnsInitialCount()
+    {
+        var tracker = new A2ATaskTracker();
+        tracker.Track(MakeTask("t1", "agent", "subagent/s1"));
+        tracker.Track(MakeTask("t2", "agent", "subagent/s1"));
+        var awaiter = Build(tracker);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
+
+        var count = await awaiter.WaitForSessionAsync("subagent/s1", cts.Token);
+
+        // Returns initial count even when cancelled — callers see what they signed up to wait for.
+        Assert.AreEqual(2, count);
+        // Tasks remain in the tracker; nothing happened to them.
+        Assert.AreEqual(2, tracker.ListBySession("subagent/s1").Count);
+    }
+}


### PR DESCRIPTION
## Summary
- Subagents that dispatched an A2A task via `spawn_wisps` were treating the "dispatched, result async" ack as a final answer and publishing success immediately. When the target agent's actual response landed seconds later, the originating subagent session had exited; `A2ATaskResultHandler` then skipped synthesis and bubble publish for the non-user session and the user never saw the result.
- Add `ISessionA2AAwaiter` (Host.Abstractions) implemented by `A2ATaskAwaiter` (RockBot.A2A), wired into `SubagentRunner`. After the LLM loop completes, the subagent polls `A2ATaskTracker` for any pending tasks on its session and waits for them to reach a terminal state (bounded by the subagent's CT, so cancels/timeouts still resolve promptly).
- Side effect: A2A result keys (`subagent/{taskId}/a2a/{TargetAgent}/{a2aTaskId}/result` and `.../result.data`) are populated in working memory before the subagent publishes, so the existing `SubagentResultHandler` whiteboard hint surfaces them to the consolidation LLM automatically — no handler changes needed.

## Test plan
- [x] `dotnet build RockBot.slnx` — clean
- [x] `dotnet test tests/RockBot.A2A.Tests/RockBot.A2A.Tests.csproj` — 158 pass (6 new awaiter tests)
- [x] `dotnet test tests/RockBot.Subagent.Tests/RockBot.Subagent.Tests.csproj` — 31 pass
- [x] `dotnet test tests/RockBot.Wisp.Tests/RockBot.Wisp.Tests.csproj` — 117 pass
- [ ] Smoke test in live cluster: ask agent to consult the AdvisorCouncil and confirm the deliberation reaches the chat reply

🤖 Generated with [Claude Code](https://claude.com/claude-code)