### PR TITLE
Centralize embedding input truncation, add JSON-aware cap (0.10.63)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.10.62</Version>
+<Version>0.10.63</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.Host.Abstractions/EmbeddingOptions.cs
+++ b/src/RockBot.Host.Abstractions/EmbeddingOptions.cs
@@ -23,11 +23,21 @@ public sealed class EmbeddingOptions
     public string? ApiKey { get; set; }
 
     /// <summary>
-    /// Maximum character length of text sent to the embedding model. Text exceeding this
-    /// limit is truncated before embedding. Default 30000 (~7500 tokens) leaves headroom
-    /// below the 8192-token context window of models like <c>nomic-embed-text</c>.
+    /// Maximum character length of prose text sent to the embedding model. Text exceeding
+    /// this limit is truncated before embedding. Default 30000 (~7500 tokens at ~4 chars/token)
+    /// leaves headroom below the 8192-token context window of models like <c>nomic-embed-text</c>.
     /// </summary>
     public int MaxInputChars { get; set; } = 30_000;
+
+    /// <summary>
+    /// Stricter character cap applied when the input looks like a structured payload
+    /// (JSON object/array). JSON tokenizes ~2× denser than prose, so a 19k-char JSON
+    /// blob can push past 9k tokens — over the 8192 window — while the prose cap would
+    /// happily let it through. Default 12000 (~6000 tokens at ~2 chars/token) leaves
+    /// the same headroom for structured input. Selection is centralized in
+    /// <c>EmbeddingTextPreparer</c>; no caller picks the cap directly.
+    /// </summary>
+    public int MaxStructuredInputChars { get; set; } = 12_000;
 
     /// <summary>
     /// Minimum cosine similarity threshold for vector search results. Candidates below

--- a/src/RockBot.Host/AgentMemoryExtensions.cs
+++ b/src/RockBot.Host/AgentMemoryExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 
 namespace RockBot.Host;
@@ -53,6 +54,7 @@ public static class AgentMemoryExtensions
         else
             builder.Services.Configure<MemoryOptions>(_ => { });
 
+        builder.Services.TryAddSingleton<EmbeddingTextPreparer>();
         builder.Services.AddSingleton<ILongTermMemory, FileMemoryStore>();
 
         // Phase 2 self-repair: capability-claim writer and read-side verifier.
@@ -79,6 +81,7 @@ public static class AgentMemoryExtensions
         else
             builder.Services.Configure<WorkingMemoryOptions>(_ => { });
 
+        builder.Services.TryAddSingleton<EmbeddingTextPreparer>();
         builder.Services.AddMemoryCache();
         builder.Services.AddSingleton<HybridCacheWorkingMemory>();
         builder.Services.AddSingleton<FileWorkingMemory>();
@@ -100,6 +103,7 @@ public static class AgentMemoryExtensions
         else
             builder.Services.Configure<SkillOptions>(_ => { });
 
+        builder.Services.TryAddSingleton<EmbeddingTextPreparer>();
         builder.Services.AddSingleton<ISkillStore, FileSkillStore>();
         builder.Services.AddSingleton<ISkillUsageStore, FileSkillUsageStore>();
         builder.Services.AddSingleton<ISkillResourceUsageStore, FileSkillResourceUsageStore>();

--- a/src/RockBot.Host/EmbeddingCache.cs
+++ b/src/RockBot.Host/EmbeddingCache.cs
@@ -16,7 +16,7 @@ internal sealed class EmbeddingCache
     private readonly IEmbeddingGenerator<string, Embedding<float>> _generator;
     private readonly string _embeddingsPath;
     private readonly ILogger _logger;
-    private readonly int _maxInputChars;
+    private readonly EmbeddingTextPreparer _preparer;
     private readonly SemaphoreSlim _semaphore = new(1, 1);
 
     /// <summary>
@@ -29,12 +29,12 @@ internal sealed class EmbeddingCache
         IEmbeddingGenerator<string, Embedding<float>> generator,
         string storePath,
         ILogger logger,
-        int maxInputChars = 30_000)
+        EmbeddingTextPreparer preparer)
     {
         _generator = generator;
         _embeddingsPath = Path.Combine(storePath, ".embeddings");
         _logger = logger;
-        _maxInputChars = maxInputChars;
+        _preparer = preparer;
 
         Directory.CreateDirectory(_embeddingsPath);
     }
@@ -121,8 +121,9 @@ internal sealed class EmbeddingCache
             {
                 HostDiagnostics.EmbeddingCalls.Add(1);
 
-                var texts = stillMissing.Select(m =>
-                    m.Text.Length > _maxInputChars ? m.Text[.._maxInputChars] : m.Text).ToList();
+                var texts = stillMissing
+                    .Select(m => _preparer.Prepare(m.Text, diagnosticKey: m.Id))
+                    .ToList();
                 var generated = await _generator.GenerateAsync(texts, cancellationToken: ct);
 
                 sw.Stop();
@@ -240,13 +241,7 @@ internal sealed class EmbeddingCache
         {
             HostDiagnostics.EmbeddingCalls.Add(1);
 
-            // Truncate to avoid exceeding the embedding model's context window.
-            if (text.Length > _maxInputChars)
-            {
-                _logger.LogInformation("Truncating embedding input from {Original} to {Max} chars",
-                    text.Length, _maxInputChars);
-                text = text[.._maxInputChars];
-            }
+            text = _preparer.Prepare(text);
 
             var result = await _generator.GenerateAsync(text, cancellationToken: ct);
             sw.Stop();

--- a/src/RockBot.Host/EmbeddingTextPreparer.cs
+++ b/src/RockBot.Host/EmbeddingTextPreparer.cs
@@ -1,0 +1,67 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace RockBot.Host;
+
+/// <summary>
+/// Single source of truth for "what string does the embedding model actually see".
+/// Centralizes input truncation so prose and structured payloads (JSON, JSON-Lines)
+/// get appropriately different char caps — JSON tokenizes ~2× denser than prose, so
+/// the prose cap can blow past an 8k-token context window on otherwise-modest inputs.
+/// All embedding call sites (long-term memory, skills, working memory) route through
+/// this preparer instead of slicing locally.
+/// </summary>
+internal sealed class EmbeddingTextPreparer(
+    IOptions<EmbeddingOptions> options,
+    ILogger<EmbeddingTextPreparer> logger)
+{
+    private readonly EmbeddingOptions _opts = options.Value;
+
+    /// <summary>
+    /// Test-only convenience factory. Tests that exercise the embedding path don't care
+    /// about preparer behaviour and don't want every fixture to construct an options
+    /// shell — returns a preparer with default <see cref="EmbeddingOptions"/>.
+    /// </summary>
+    internal static EmbeddingTextPreparer ForTests() =>
+        new(Microsoft.Extensions.Options.Options.Create(new EmbeddingOptions()),
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<EmbeddingTextPreparer>.Instance);
+
+    /// <summary>
+    /// Returns the text the embedder should receive — truncated to the appropriate
+    /// per-shape cap when needed, otherwise unchanged. <paramref name="diagnosticKey"/>
+    /// is purely for log correlation; it does not affect the output.
+    /// </summary>
+    public string Prepare(string text, string? diagnosticKey = null)
+    {
+        if (string.IsNullOrEmpty(text))
+            return text;
+
+        var structured = IsStructured(text);
+        var cap = structured ? _opts.MaxStructuredInputChars : _opts.MaxInputChars;
+        if (text.Length <= cap)
+            return text;
+
+        logger.LogInformation(
+            "Truncating embedding input{KeyTag} from {Original} to {Cap} chars (structured={Structured})",
+            diagnosticKey is null ? "" : $" for '{diagnosticKey}'",
+            text.Length, cap, structured);
+        return text[..cap];
+    }
+
+    /// <summary>
+    /// Cheap heuristic: input is treated as structured when the first non-whitespace
+    /// character is <c>{</c> or <c>[</c>. Covers JSON objects, arrays, and JSON-Lines.
+    /// Misses base64/HTML/code blobs, but those don't currently exceed the prose cap
+    /// in practice — promote the heuristic only if real failures show up.
+    /// </summary>
+    private static bool IsStructured(string text)
+    {
+        for (var i = 0; i < text.Length; i++)
+        {
+            var c = text[i];
+            if (char.IsWhiteSpace(c)) continue;
+            return c == '{' || c == '[';
+        }
+        return false;
+    }
+}

--- a/src/RockBot.Host/FileMemoryStore.cs
+++ b/src/RockBot.Host/FileMemoryStore.cs
@@ -34,12 +34,13 @@ internal sealed partial class FileMemoryStore : ILongTermMemory
         IOptions<AgentProfileOptions> profileOptions,
         IOptions<EmbeddingOptions> embeddingOptions,
         ILogger<FileMemoryStore> logger,
+        EmbeddingTextPreparer embeddingTextPreparer,
         IEmbeddingGenerator<string, Embedding<float>>? embeddingGenerator = null)
     {
         _basePath = ResolvePath(memoryOptions.Value.BasePath, profileOptions.Value.BasePath);
         _logger = logger;
         _embeddingCache = embeddingGenerator is not null
-            ? new EmbeddingCache(embeddingGenerator, _basePath, logger, embeddingOptions.Value.MaxInputChars)
+            ? new EmbeddingCache(embeddingGenerator, _basePath, logger, embeddingTextPreparer)
             : null;
         _minSimilarity = embeddingOptions.Value.MinSimilarityThreshold;
 

--- a/src/RockBot.Host/FileSkillStore.cs
+++ b/src/RockBot.Host/FileSkillStore.cs
@@ -41,12 +41,13 @@ internal sealed partial class FileSkillStore : ISkillStore
         IOptions<AgentProfileOptions> profileOptions,
         IOptions<EmbeddingOptions> embeddingOptions,
         ILogger<FileSkillStore> logger,
+        EmbeddingTextPreparer embeddingTextPreparer,
         IEmbeddingGenerator<string, Embedding<float>>? embeddingGenerator = null)
     {
         _basePath = ResolvePath(skillOptions.Value.BasePath, profileOptions.Value.BasePath);
         _logger = logger;
         _embeddingCache = embeddingGenerator is not null
-            ? new EmbeddingCache(embeddingGenerator, _basePath, logger, embeddingOptions.Value.MaxInputChars)
+            ? new EmbeddingCache(embeddingGenerator, _basePath, logger, embeddingTextPreparer)
             : null;
         _minSimilarity = embeddingOptions.Value.MinSimilarityThreshold;
 

--- a/src/RockBot.Host/HybridCacheWorkingMemory.cs
+++ b/src/RockBot.Host/HybridCacheWorkingMemory.cs
@@ -17,7 +17,7 @@ internal sealed class HybridCacheWorkingMemory : IWorkingMemory
     private readonly WorkingMemoryOptions _options;
     private readonly ILogger<HybridCacheWorkingMemory> _logger;
     private readonly IEmbeddingGenerator<string, Embedding<float>>? _embeddingGenerator;
-    private readonly int _maxEmbeddingInputChars;
+    private readonly EmbeddingTextPreparer _preparer;
     private readonly float _minSimilarity;
 
     // fullKey -> EntryMeta
@@ -36,6 +36,7 @@ internal sealed class HybridCacheWorkingMemory : IWorkingMemory
         IMemoryCache cache,
         IOptions<WorkingMemoryOptions> options,
         IOptions<EmbeddingOptions> embeddingOptions,
+        EmbeddingTextPreparer preparer,
         ILogger<HybridCacheWorkingMemory> logger,
         IEmbeddingGenerator<string, Embedding<float>>? embeddingGenerator = null)
     {
@@ -43,7 +44,7 @@ internal sealed class HybridCacheWorkingMemory : IWorkingMemory
         _options = options.Value;
         _logger = logger;
         _embeddingGenerator = embeddingGenerator;
-        _maxEmbeddingInputChars = embeddingOptions.Value.MaxInputChars;
+        _preparer = preparer;
         _minSimilarity = embeddingOptions.Value.MinSimilarityThreshold;
     }
 
@@ -105,9 +106,7 @@ internal sealed class HybridCacheWorkingMemory : IWorkingMemory
     {
         try
         {
-            var docText = BuildDocumentText(key, value, category, tags);
-            if (docText.Length > _maxEmbeddingInputChars)
-                docText = docText[.._maxEmbeddingInputChars];
+            var docText = _preparer.Prepare(BuildDocumentText(key, value, category, tags), diagnosticKey: key);
             var result = await _embeddingGenerator!.GenerateAsync(docText);
 
             // Only store if the entry still exists — prevents orphaned embeddings
@@ -222,9 +221,7 @@ internal sealed class HybridCacheWorkingMemory : IWorkingMemory
         {
             try
             {
-                var queryText = criteria.Query.Length > _maxEmbeddingInputChars
-                    ? criteria.Query[.._maxEmbeddingInputChars]
-                    : criteria.Query;
+                var queryText = _preparer.Prepare(criteria.Query);
                 var queryResult = await _embeddingGenerator.GenerateAsync(queryText);
                 var queryEmbedding = queryResult.Vector.ToArray();
 

--- a/tests/RockBot.Host.Tests/CapabilityClaimEndToEndTests.cs
+++ b/tests/RockBot.Host.Tests/CapabilityClaimEndToEndTests.cs
@@ -48,7 +48,8 @@ public class CapabilityClaimEndToEndTests
 
         var ltm = new FileMemoryStore(
             memoryOpts, profileOpts, embedOpts,
-            NullLogger<FileMemoryStore>.Instance);
+            NullLogger<FileMemoryStore>.Instance,
+            EmbeddingTextPreparer.ForTests());
 
         // 2. Save a claim through the real writer.
         var writer = new CapabilityClaimWriter(ltm);
@@ -106,7 +107,8 @@ public class CapabilityClaimEndToEndTests
 
         var ltm = new FileMemoryStore(
             memoryOpts, profileOpts, embedOpts,
-            NullLogger<FileMemoryStore>.Instance);
+            NullLogger<FileMemoryStore>.Instance,
+            EmbeddingTextPreparer.ForTests());
 
         var writer = new CapabilityClaimWriter(ltm);
         await writer.SaveCapabilityClaimAsync(new CapabilityClaim(

--- a/tests/RockBot.Host.Tests/DreamServiceContradictionSweepTests.cs
+++ b/tests/RockBot.Host.Tests/DreamServiceContradictionSweepTests.cs
@@ -153,6 +153,6 @@ public class DreamServiceContradictionSweepTests
         var memOpts = Options.Create(new MemoryOptions { BasePath = Path.Combine(_tempDir, "ltm") });
         var profOpts = Options.Create(new AgentProfileOptions { BasePath = _tempDir });
         var embedOpts = Options.Create(new EmbeddingOptions());
-        return new FileMemoryStore(memOpts, profOpts, embedOpts, NullLogger<FileMemoryStore>.Instance);
+        return new FileMemoryStore(memOpts, profOpts, embedOpts, NullLogger<FileMemoryStore>.Instance, EmbeddingTextPreparer.ForTests());
     }
 }

--- a/tests/RockBot.Host.Tests/EmbeddingTextPreparerTests.cs
+++ b/tests/RockBot.Host.Tests/EmbeddingTextPreparerTests.cs
@@ -1,0 +1,108 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using RockBot.Host;
+
+namespace RockBot.Host.Tests;
+
+[TestClass]
+public class EmbeddingTextPreparerTests
+{
+    private static EmbeddingTextPreparer Build(EmbeddingOptions opts) =>
+        new(Options.Create(opts), NullLogger<EmbeddingTextPreparer>.Instance);
+
+    [TestMethod]
+    public void Prepare_EmptyString_ReturnsUnchanged()
+    {
+        var preparer = Build(new EmbeddingOptions());
+
+        Assert.AreEqual("", preparer.Prepare(""));
+    }
+
+    [TestMethod]
+    public void Prepare_ProseUnderProseCap_ReturnsUnchanged()
+    {
+        var preparer = Build(new EmbeddingOptions { MaxInputChars = 100, MaxStructuredInputChars = 50 });
+        var prose = new string('a', 90);
+
+        Assert.AreEqual(prose, preparer.Prepare(prose));
+    }
+
+    [TestMethod]
+    public void Prepare_ProseOverProseCap_TruncatesToProseCap()
+    {
+        var preparer = Build(new EmbeddingOptions { MaxInputChars = 50, MaxStructuredInputChars = 20 });
+        var prose = "Once upon a time " + new string('a', 200);
+
+        var result = preparer.Prepare(prose);
+
+        Assert.AreEqual(50, result.Length);
+        Assert.IsTrue(result.StartsWith("Once upon a time"));
+    }
+
+    [TestMethod]
+    public void Prepare_JsonObjectOverStructuredCap_TruncatesToStructuredCap()
+    {
+        var preparer = Build(new EmbeddingOptions { MaxInputChars = 1000, MaxStructuredInputChars = 30 });
+        // 100-char JSON object — under the prose cap, over the structured cap.
+        var json = "{\"x\":\"" + new string('y', 90) + "\"}";
+
+        var result = preparer.Prepare(json);
+
+        Assert.AreEqual(30, result.Length, "structured cap should win for JSON-shaped input");
+        Assert.IsTrue(result.StartsWith("{"));
+    }
+
+    [TestMethod]
+    public void Prepare_JsonObjectWithLeadingWhitespace_StillStructured()
+    {
+        var preparer = Build(new EmbeddingOptions { MaxInputChars = 1000, MaxStructuredInputChars = 20 });
+        var json = "  \n\t {\"x\":\"" + new string('y', 90) + "\"}";
+
+        var result = preparer.Prepare(json);
+
+        Assert.AreEqual(20, result.Length);
+    }
+
+    [TestMethod]
+    public void Prepare_JsonArray_IsStructured()
+    {
+        var preparer = Build(new EmbeddingOptions { MaxInputChars = 1000, MaxStructuredInputChars = 25 });
+        var json = "[" + string.Join(",", Enumerable.Range(0, 50).Select(i => $"\"{i}\"")) + "]";
+
+        var result = preparer.Prepare(json);
+
+        Assert.AreEqual(25, result.Length);
+        Assert.IsTrue(result.StartsWith("["));
+    }
+
+    [TestMethod]
+    public void Prepare_ProseStartingWithCurlyMidSentence_NotStructured()
+    {
+        // The heuristic only checks the *first* non-whitespace char. A prose paragraph
+        // that mentions { somewhere isn't structured.
+        var preparer = Build(new EmbeddingOptions { MaxInputChars = 200, MaxStructuredInputChars = 30 });
+        var prose = "C# initializer syntax uses { and } around object literals. " + new string('.', 200);
+
+        var result = preparer.Prepare(prose);
+
+        Assert.AreEqual(200, result.Length, "prose with embedded braces should still use the prose cap");
+    }
+
+    [TestMethod]
+    public void Prepare_WhitespaceOnly_NotStructured_ReturnsUnchanged()
+    {
+        var preparer = Build(new EmbeddingOptions { MaxInputChars = 1000, MaxStructuredInputChars = 5 });
+        var ws = "     ";
+
+        Assert.AreEqual(ws, preparer.Prepare(ws));
+    }
+
+    [TestMethod]
+    public void Prepare_StructuredCapNotApplied_WhenInputFitsStructuredCap()
+    {
+        var preparer = Build(new EmbeddingOptions { MaxInputChars = 1000, MaxStructuredInputChars = 100 });
+        var json = "{\"x\":1}";
+
+        Assert.AreEqual(json, preparer.Prepare(json));
+    }
+}

--- a/tests/RockBot.Host.Tests/FileMemoryStoreSupersededByTests.cs
+++ b/tests/RockBot.Host.Tests/FileMemoryStoreSupersededByTests.cs
@@ -103,7 +103,7 @@ public class FileMemoryStoreSupersededByTests
         var memOpts = Options.Create(new MemoryOptions { BasePath = ltmPath });
         var profOpts = Options.Create(new AgentProfileOptions { BasePath = _tempDir });
         var embedOpts = Options.Create(new EmbeddingOptions());
-        return new FileMemoryStore(memOpts, profOpts, embedOpts, NullLogger<FileMemoryStore>.Instance);
+        return new FileMemoryStore(memOpts, profOpts, embedOpts, NullLogger<FileMemoryStore>.Instance, EmbeddingTextPreparer.ForTests());
     }
 
     private static MemoryEntry NewEntry(string id, string content, string category) =>

--- a/tests/RockBot.Host.Tests/FileMemoryStoreTests.cs
+++ b/tests/RockBot.Host.Tests/FileMemoryStoreTests.cs
@@ -763,7 +763,8 @@ public class FileMemoryStoreTests
             Options.Create(new MemoryOptions { BasePath = _tempDir }),
             Options.Create(new AgentProfileOptions()),
             Options.Create(new EmbeddingOptions()),
-            NullLogger<FileMemoryStore>.Instance);
+            NullLogger<FileMemoryStore>.Instance,
+            EmbeddingTextPreparer.ForTests());
     }
 
     // ── Importance boost ─────────────────────────────────────────────────────

--- a/tests/RockBot.Host.Tests/FileSkillStoreTests.cs
+++ b/tests/RockBot.Host.Tests/FileSkillStoreTests.cs
@@ -838,7 +838,8 @@ public class FileSkillStoreTests
         new(Options.Create(new SkillOptions { BasePath = _tempDir }),
             Options.Create(new AgentProfileOptions()),
             Options.Create(new EmbeddingOptions()),
-            NullLogger<FileSkillStore>.Instance);
+            NullLogger<FileSkillStore>.Instance,
+            EmbeddingTextPreparer.ForTests());
 
     private static Skill MakeSkill(string name, string summary, string content) =>
         new(name, summary, content, DateTimeOffset.UtcNow);

--- a/tests/RockBot.Host.Tests/HybridCacheWorkingMemoryTests.cs
+++ b/tests/RockBot.Host.Tests/HybridCacheWorkingMemoryTests.cs
@@ -582,6 +582,7 @@ public class HybridCacheWorkingMemoryTests
             _cache,
             Options.Create(opts),
             Options.Create(new EmbeddingOptions()),
+            EmbeddingTextPreparer.ForTests(),
             NullLogger<HybridCacheWorkingMemory>.Instance,
             embeddingGenerator);
     }

--- a/tests/RockBot.Host.Tests/Phase3ContradictionEndToEndTests.cs
+++ b/tests/RockBot.Host.Tests/Phase3ContradictionEndToEndTests.cs
@@ -153,7 +153,7 @@ public class Phase3ContradictionEndToEndTests
         var memOpts = Options.Create(new MemoryOptions { BasePath = Path.Combine(_tempDir, "ltm") });
         var profOpts = Options.Create(new AgentProfileOptions { BasePath = _tempDir });
         var embedOpts = Options.Create(new EmbeddingOptions());
-        return new FileMemoryStore(memOpts, profOpts, embedOpts, NullLogger<FileMemoryStore>.Instance);
+        return new FileMemoryStore(memOpts, profOpts, embedOpts, NullLogger<FileMemoryStore>.Instance, EmbeddingTextPreparer.ForTests());
     }
 
     private static VerifyShape NewVerify() => new(


### PR DESCRIPTION
## Summary
- Working memory IS vector-encoded for non-wisp keys (`HybridCacheWorkingMemory.SetAsync` fires a background embed). The existing prose-sized 30k-char cap let a 19k-char `application/json` payload reach nomic-embed-text and blow past its 8192-token window — `input length exceeds context length`.
- Replace three near-identical truncation slices (in `EmbeddingCache.GenerateAsync`, `EmbeddingCache.GetOrCreateBatchAsync`, `HybridCacheWorkingMemory.GenerateEmbeddingAsync` — plus a fourth at query time) with a single `EmbeddingTextPreparer`. New `MaxStructuredInputChars` option (default 12 000, ~6k tokens) applies when input's first non-whitespace char is `{` or `[`.
- All store ctors take the preparer; DI registers it once via `TryAddSingleton` across the three `With*` memory extensions.

## Test plan
- [x] `dotnet build RockBot.slnx` clean
- [x] `dotnet test tests/RockBot.Host.Tests` — 911 pass (9 new `EmbeddingTextPreparerTests`)
- [ ] Live cluster: trigger an A2A return whose JSON data part exceeds 12k chars; confirm no `HybridCacheWorkingMemory: Failed to generate working memory embedding ... input length exceeds the context length` warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)