### PR TITLE
Ship Introspection MCP with agent; mark Llm.Copilot packable

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,8 +263,10 @@ The Helm chart at `deploy/helm/rockbot` deploys the full stack into two namespac
 
 | Namespace | Contents |
 |---|---|
-| `rockbot` | Agent, Blazor UI, Scripts Manager, OpenRouter MCP *(optional)*, ConfigMap, Secret |
+| `rockbot` | Agent, Blazor UI, Scripts Manager, Introspection MCP, TodoApp MCP, OpenRouter MCP *(optional)*, ConfigMap, Secret |
 | `rockbot-scripts` | Ephemeral Python execution pods (created on demand) |
+
+The Introspection MCP server is enabled by default and ships as part of the standard agent install — it provides the tools the agent uses to rename itself, look up LLM pricing, and read Copilot quota. To disable it, set `introspectionMcp.enabled: false` in your values file.
 
 #### 1. Create your values file
 

--- a/deploy/helm/rockbot/templates/introspection-mcp/deployment.yaml
+++ b/deploy/helm/rockbot/templates/introspection-mcp/deployment.yaml
@@ -1,0 +1,59 @@
+{{- if .Values.introspectionMcp.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mcp-introspection
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "rockbot.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mcp-introspection
+spec:
+  replicas: {{ .Values.introspectionMcp.replicaCount }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: mcp-introspection
+  template:
+    metadata:
+      labels:
+        app: mcp-introspection
+        {{- include "rockbot.labels" . | nindent 8 }}
+        app.kubernetes.io/component: mcp-introspection
+    spec:
+      securityContext:
+        fsGroup: {{ .Values.shared.fsGroup }}
+      containers:
+        - name: mcp-introspection
+          image: {{ .Values.introspectionMcp.image.repository }}:{{ .Values.introspectionMcp.image.tag }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: AgentName__Path
+              value: /data/agent/agent-name.md
+          volumeMounts:
+            - name: agent-data
+              mountPath: /data/agent
+              readOnly: false
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            {{- toYaml .Values.introspectionMcp.resources | nindent 12 }}
+      volumes:
+        - name: agent-data
+          persistentVolumeClaim:
+            claimName: {{ include "rockbot.agentPvcName" . }}
+{{- end }}

--- a/deploy/helm/rockbot/templates/introspection-mcp/service.yaml
+++ b/deploy/helm/rockbot/templates/introspection-mcp/service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.introspectionMcp.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: mcp-introspection
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "rockbot.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mcp-introspection
+spec:
+  type: ClusterIP
+  selector:
+    app: mcp-introspection
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+{{- end }}

--- a/deploy/helm/rockbot/values.yaml
+++ b/deploy/helm/rockbot/values.yaml
@@ -193,6 +193,27 @@ shared:
   # read/write each other's files without coordinating UIDs.
   fsGroup: 2000
 
+# ── Introspection MCP server ──────────────────────────────────────────────────
+# Standalone MCP server that exposes core agent introspection tools:
+#   - get/set agent name (drives Blazor UI title and `agent-name.md` on the PVC)
+#   - GitHub Copilot quota/usage (only meaningful when LLM provider is Copilot)
+#   - LLM pricing table lookup (cost-estimation tools the agent calls)
+# Shipped as part of the standard agent install — enable by default.
+# Cluster URL exposed as http://mcp-introspection (port 80 → containerPort 8080).
+introspectionMcp:
+  enabled: true
+  image:
+    repository: rockylhotka/rockbot-introspection-mcp
+    tag: latest
+  replicaCount: 1
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
+
 # ── TodoApp MCP server ────────────────────────────────────────────────────────
 # Standalone MCP server that exposes a persistent to-do list to the agent.
 # Data is stored in a Longhorn PVC mounted at /data inside the container.

--- a/docs/getting-started-docker-desktop.md
+++ b/docs/getting-started-docker-desktop.md
@@ -185,6 +185,10 @@ The agent logs will confirm: `Embedding model configured: nomic-embed-text @ htt
 
 The agent's MCP bridge and A2A client make standard HTTP calls — they work the same in Docker as in Kubernetes. Any SSE-based MCP server or A2A agent reachable over HTTP can be registered.
 
+### Built-in introspection MCP
+
+The compose stack ships an `introspection-mcp` service alongside the agent, and the agent's default `mcp.json` already points at it (`http://introspection-mcp:8080/`). It exposes the tools the agent uses to rename itself (`get_agent_name` / `set_agent_name`), look up LLM pricing, and read GitHub Copilot quota. You don't have to register anything — it's running by the time the agent starts.
+
 ### MCP servers
 
 Edit `/data/agent/mcp.json` on the volume to add SSE-based MCP servers:

--- a/src/RockBot.Agent/mcp.json
+++ b/src/RockBot.Agent/mcp.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
-    "aggregator": {
+    "introspection": {
       "type": "sse",
-      "url": "https://mcp-aggregator.<your-tailnet>.ts.net/"
+      "url": "http://mcp-introspection/"
     },
     "routing-stats": {
       "type": "sse",

--- a/src/RockBot.Llm.Copilot/RockBot.Llm.Copilot.csproj
+++ b/src/RockBot.Llm.Copilot/RockBot.Llm.Copilot.csproj
@@ -5,6 +5,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>RockBot.Llm.Copilot</RootNamespace>
+    <IsPackable>true</IsPackable>
+    <Description>GitHub Copilot LLM provider for RockBot, exposing Copilot models via Microsoft.Extensions.AI.</Description>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Two release-prep changes for 0.10.63:

- **Introspection MCP server is now part of the standard agent install.** It's already in `docker-compose.yml`, so this PR just adds the helm chart (`templates/introspection-mcp/{deployment,service}.yaml`), enables it by default in `values.yaml`, points the default `mcp.json` at the in-cluster service (`http://mcp-introspection/`), and notes it in the docs.
- **`RockBot.Llm.Copilot` is marked `IsPackable=true`** so it ships to NuGet alongside the rest of the Llm libraries. It already references the GitHub Copilot SDK and follows the same pattern as `RockBot.Llm`.

## Test plan

- [x] `dotnet build src/RockBot.Llm.Copilot/RockBot.Llm.Copilot.csproj -c Release` succeeds
- [x] `helm lint deploy/helm/rockbot` passes
- [ ] After merge, cut `release/v0.10.63` to publish NuGet packages including `RockBot.Llm.Copilot`
- [ ] After merge, deploy with `helm upgrade` and confirm `mcp-introspection` pod comes up

🤖 Generated with [Claude Code](https://claude.com/claude-code)