### PR TITLE
Capture subagent failure diagnostics so primary can answer 'why did it fail'

### DIFF
--- a/src/RockBot.Host/AgentLoopRunner.cs
+++ b/src/RockBot.Host/AgentLoopRunner.cs
@@ -315,12 +315,16 @@ public sealed partial class AgentLoopRunner(
         bool enableCompletionEval = true,
         double? complexityScore = null,
         int? maxIterationsOverride = null,
+        LoopDiagnostics? diagnostics = null,
         CancellationToken cancellationToken = default)
     {
         using var _ = ToolCallSessionContext.Set(sessionId);
         // Set the per-async-flow override so RockBotFunctionInvokingChatClient
         // (singleton, native path) picks it up for this request.
         using var __ = MaxIterationsOverrideContext.Set(maxIterationsOverride);
+        // Expose the per-call diagnostics handle to the native FICC so it can
+        // record per-tool-call state from its singleton context.
+        using var ___ = LoopDiagnosticsContext.Set(diagnostics);
 
         // Ensure a current datetime context is always present.
         EnsureDateTimeContext(chatMessages);
@@ -651,7 +655,14 @@ public sealed partial class AgentLoopRunner(
             response.Messages.SelectMany(m => m.Contents.OfType<FunctionCallContent>()).Count(),
             tierTag);
 
-        return new LoopResult(ExtractAssistantText(response), LoopExitReason.ModelStopped);
+        var nativeFinalText = ExtractAssistantText(response);
+        if (LoopDiagnosticsContext.Value is { } diagNative
+            && !string.IsNullOrWhiteSpace(nativeFinalText))
+        {
+            diagNative.LastAssistantText = nativeFinalText;
+        }
+
+        return new LoopResult(nativeFinalText, LoopExitReason.ModelStopped);
     }
 
     /// <summary>
@@ -886,6 +897,16 @@ public sealed partial class AgentLoopRunner(
 
             LogResponseMessages(response, iterationLabel: (iteration + 2).ToString());
 
+            // Update diagnostics with the iteration count and the latest assistant text
+            // so callers can see how far the loop got even if it later throws.
+            if (LoopDiagnosticsContext.Value is { } diagText)
+            {
+                diagText.Iterations = iteration + 1;
+                var preFunctionText = ExtractAssistantText(response);
+                if (!string.IsNullOrWhiteSpace(preFunctionText))
+                    diagText.LastAssistantText = preFunctionText;
+            }
+
             var functionCalls = response.Messages
                 .SelectMany(m => m.Contents.OfType<FunctionCallContent>())
                 .ToList();
@@ -993,6 +1014,22 @@ public sealed partial class AgentLoopRunner(
                     textToolActivity?.SetTag("rockbot.tool.name", toolName);
                     var toolSw = Stopwatch.StartNew();
                     var textToolStatus = "ok";
+
+                    // Record this tool as in-flight in diagnostics so even an
+                    // OperationCanceledException mid-call leaves a usable trail.
+                    if (LoopDiagnosticsContext.Value is { } diagTextPre)
+                    {
+                        diagTextPre.ToolCalls++;
+                        diagTextPre.LastToolName = toolName;
+                        diagTextPre.LastToolArguments = argsJson is { Length: > 500 }
+                            ? argsJson[..500] + "…"
+                            : argsJson;
+                        diagTextPre.LastToolStartedAt = DateTimeOffset.UtcNow;
+                        diagTextPre.LastToolCompletedAt = null;
+                        diagTextPre.LastToolResult = null;
+                        diagTextPre.LastToolStatus = "in-flight";
+                    }
+
                     object? result;
                     try
                     {
@@ -1029,6 +1066,15 @@ public sealed partial class AgentLoopRunner(
                     ToolDiagnostics.Invocations.Add(1,
                         new KeyValuePair<string, object?>("rockbot.tool.name", toolName),
                         new KeyValuePair<string, object?>("rockbot.tool.status", textToolStatus));
+
+                    if (LoopDiagnosticsContext.Value is { } diagTextPost)
+                    {
+                        diagTextPost.LastToolCompletedAt = DateTimeOffset.UtcNow;
+                        diagTextPost.LastToolStatus = textToolStatus;
+                        diagTextPost.LastToolResult = textResultStr is { Length: > 500 }
+                            ? textResultStr[..500] + "…"
+                            : textResultStr;
+                    }
 
                     // Chunking is handled by ChunkingAIFunction wrapper on the tool itself.
                     chatMessages.Add(new ChatMessage(ChatRole.User,

--- a/src/RockBot.Host/LoopDiagnostics.cs
+++ b/src/RockBot.Host/LoopDiagnostics.cs
@@ -1,0 +1,39 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Mutable diagnostic state populated by <see cref="AgentLoopRunner.RunAsync"/> and
+/// <see cref="RockBotFunctionInvokingChatClient"/> as the LLM tool loop progresses.
+/// Callers create an instance and pass it in; even when the loop throws or is
+/// cancelled, the partially-populated snapshot is available in the caller's
+/// catch block so failure-detail handlers (notably <c>SubagentRunner</c>) can
+/// report what the agent was doing at the moment of failure.
+/// </summary>
+public sealed class LoopDiagnostics
+{
+    /// <summary>Number of LLM iterations the loop completed (text-based path) or invoked (native path).</summary>
+    public int Iterations { get; set; }
+
+    /// <summary>Total tool calls observed across all iterations.</summary>
+    public int ToolCalls { get; set; }
+
+    /// <summary>The last non-empty assistant text the loop produced, if any.</summary>
+    public string? LastAssistantText { get; set; }
+
+    /// <summary>Name of the most recently invoked tool (whether it succeeded, failed, or was in flight).</summary>
+    public string? LastToolName { get; set; }
+
+    /// <summary>Argument summary of the most recently invoked tool (compact, may be truncated).</summary>
+    public string? LastToolArguments { get; set; }
+
+    /// <summary>Result preview of the most recently invoked tool, or null if the tool was still running when the loop exited.</summary>
+    public string? LastToolResult { get; set; }
+
+    /// <summary>Status of the most recently invoked tool ("ok", "error", "timeout", or "in-flight").</summary>
+    public string? LastToolStatus { get; set; }
+
+    /// <summary>When the most recently invoked tool started.</summary>
+    public DateTimeOffset? LastToolStartedAt { get; set; }
+
+    /// <summary>When the most recently invoked tool completed; null if it never returned.</summary>
+    public DateTimeOffset? LastToolCompletedAt { get; set; }
+}

--- a/src/RockBot.Host/LoopDiagnosticsContext.cs
+++ b/src/RockBot.Host/LoopDiagnosticsContext.cs
@@ -1,0 +1,32 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Ambient per-async-flow handle to a <see cref="LoopDiagnostics"/> instance the
+/// caller of <see cref="AgentLoopRunner.RunAsync"/> wants the loop infrastructure
+/// to populate. Set by the runner; read by <see cref="RockBotFunctionInvokingChatClient"/>
+/// so the native tool path can record per-tool-call state from inside a singleton
+/// without plumbing the diagnostics object through the M.E.AI middleware chain.
+/// </summary>
+public static class LoopDiagnosticsContext
+{
+    private static readonly AsyncLocal<LoopDiagnostics?> Current = new();
+
+    /// <summary>Gets the active diagnostics instance, or null when no caller is collecting.</summary>
+    public static LoopDiagnostics? Value => Current.Value;
+
+    /// <summary>
+    /// Binds <paramref name="diagnostics"/> to the current async flow. Returns a
+    /// disposable that restores the previous value on dispose.
+    /// </summary>
+    public static IDisposable Set(LoopDiagnostics? diagnostics)
+    {
+        var previous = Current.Value;
+        Current.Value = diagnostics;
+        return new Scope(previous);
+    }
+
+    private sealed class Scope(LoopDiagnostics? previous) : IDisposable
+    {
+        public void Dispose() => Current.Value = previous;
+    }
+}

--- a/src/RockBot.Host/RockBotFunctionInvokingChatClient.cs
+++ b/src/RockBot.Host/RockBotFunctionInvokingChatClient.cs
@@ -73,6 +73,21 @@ public class RockBotFunctionInvokingChatClient : FunctionInvokingChatClient
             await _progressNotifier.OnToolInvokingAsync(callContent.Name, desc, cancellationToken);
         }
 
+        // Record the in-flight tool in LoopDiagnostics so a mid-call cancel still
+        // leaves a usable "last tool" trail for the caller's failure handler.
+        if (LoopDiagnosticsContext.Value is { } diagPre)
+        {
+            diagPre.ToolCalls++;
+            diagPre.LastToolName = callContent.Name;
+            diagPre.LastToolArguments = argsSummary is { Length: > 500 }
+                ? argsSummary[..500] + "…"
+                : argsSummary;
+            diagPre.LastToolStartedAt = DateTimeOffset.UtcNow;
+            diagPre.LastToolCompletedAt = null;
+            diagPre.LastToolResult = null;
+            diagPre.LastToolStatus = "in-flight";
+        }
+
         var sw = System.Diagnostics.Stopwatch.StartNew();
         var status = "ok";
         object? result;
@@ -82,6 +97,12 @@ public class RockBotFunctionInvokingChatClient : FunctionInvokingChatClient
         }
         catch (OperationCanceledException)
         {
+            // Record cancel before unwinding so the failure handler sees this tool as the last one.
+            if (LoopDiagnosticsContext.Value is { } diagCancel)
+            {
+                diagCancel.LastToolCompletedAt = DateTimeOffset.UtcNow;
+                diagCancel.LastToolStatus = "cancelled";
+            }
             throw; // host shutting down — don't record metrics
         }
         catch (Exception ex)
@@ -101,6 +122,13 @@ public class RockBotFunctionInvokingChatClient : FunctionInvokingChatClient
             ToolDiagnostics.Invocations.Add(1,
                 new KeyValuePair<string, object?>("rockbot.tool.name", callContent.Name),
                 new KeyValuePair<string, object?>("rockbot.tool.status", status));
+
+            if (LoopDiagnosticsContext.Value is { } diagEx)
+            {
+                diagEx.LastToolCompletedAt = DateTimeOffset.UtcNow;
+                diagEx.LastToolStatus = status;
+                diagEx.LastToolResult = $"Error: {ex.Message}";
+            }
             throw;
         }
         sw.Stop();
@@ -159,6 +187,15 @@ public class RockBotFunctionInvokingChatClient : FunctionInvokingChatClient
         ToolDiagnostics.Invocations.Add(1,
             new KeyValuePair<string, object?>("rockbot.tool.name", callContent.Name),
             new KeyValuePair<string, object?>("rockbot.tool.status", status));
+
+        if (LoopDiagnosticsContext.Value is { } diagPost)
+        {
+            diagPost.LastToolCompletedAt = DateTimeOffset.UtcNow;
+            diagPost.LastToolStatus = status;
+            diagPost.LastToolResult = resultStr is { Length: > 500 }
+                ? resultStr[..500] + "…"
+                : resultStr;
+        }
 
         // Log tool-call event for sequence analysis (fire-and-forget)
         if (_toolCallLog is not null && ToolCallSessionContext.SessionId is { } sid)

--- a/src/RockBot.Subagent/ReportProgressFunction.cs
+++ b/src/RockBot.Subagent/ReportProgressFunction.cs
@@ -19,6 +19,7 @@ internal sealed class ReportProgressFunctions
     private readonly IMessagePublisher _publisher;
     private readonly string _subagentId;
     private readonly ILogger _logger;
+    private readonly Action<string>? _onReport;
 
     private readonly string _agentName;
 
@@ -28,7 +29,8 @@ internal sealed class ReportProgressFunctions
         IMessagePublisher publisher,
         string subagentId,
         string agentName,
-        ILogger logger)
+        ILogger logger,
+        Action<string>? onReport = null)
     {
         _taskId = taskId;
         _primarySessionId = primarySessionId;
@@ -36,6 +38,7 @@ internal sealed class ReportProgressFunctions
         _subagentId = subagentId;
         _agentName = agentName;
         _logger = logger;
+        _onReport = onReport;
 
         Tools =
         [
@@ -61,6 +64,12 @@ internal sealed class ReportProgressFunctions
         await _publisher.PublishAsync($"{SubagentTopics.Progress}.{_agentName}", envelope, CancellationToken.None);
 
         _logger.LogInformation("Subagent {TaskId} reported progress: {Message}", _taskId, message);
+
+        // Notify in-process listeners (e.g. SubagentRunner's rolling buffer used for
+        // failure-detail reports). Errors here must not break progress reporting.
+        try { _onReport?.Invoke(message); }
+        catch (Exception ex) { _logger.LogDebug(ex, "Progress callback for {TaskId} threw — ignoring", _taskId); }
+
         return "Progress reported.";
     }
 }

--- a/src/RockBot.Subagent/SubagentManager.cs
+++ b/src/RockBot.Subagent/SubagentManager.cs
@@ -46,15 +46,16 @@ public sealed class SubagentManager(
 
         var taskId = Guid.NewGuid().ToString("N")[..12];
         var subagentSessionId = $"subagent-{taskId}";
-        var timeout = timeoutMinutes ?? opts.DefaultTimeoutMinutes;
+        var timeoutMin = timeoutMinutes ?? opts.DefaultTimeoutMinutes;
+        var timeoutSpan = TimeSpan.FromMinutes(timeoutMin);
         // Do NOT link to the caller's ct — that token is the session token which gets
         // canceled when the next user message arrives. Subagents are independent background
         // work that must survive new user messages. They cancel only on their own timeout
         // or via explicit CancelAsync.
         var cts = new CancellationTokenSource();
-        cts.CancelAfter(TimeSpan.FromMinutes(timeout));
+        cts.CancelAfter(timeoutSpan);
 
-        var task = RunSubagentAsync(taskId, subagentSessionId, description, context, primarySessionId, batchId, consolidate, maxIterations, cts.Token);
+        var task = RunSubagentAsync(taskId, subagentSessionId, description, context, primarySessionId, batchId, consolidate, maxIterations, timeoutSpan, cts.Token);
 
         var newEntry = new SubagentEntry
         {
@@ -113,6 +114,7 @@ public sealed class SubagentManager(
         string? batchId,
         bool consolidate,
         int? maxIterations,
+        TimeSpan timeout,
         CancellationToken ct)
     {
         // SubagentRunner.RunAsync handles all its own exit paths (success, failure,
@@ -123,7 +125,7 @@ public sealed class SubagentManager(
         {
             await using var scope = scopeFactory.CreateAsyncScope();
             var runner = scope.ServiceProvider.GetRequiredService<SubagentRunner>();
-            await runner.RunAsync(taskId, subagentSessionId, description, context, primarySessionId, batchId, consolidate, maxIterations, ct);
+            await runner.RunAsync(taskId, subagentSessionId, description, context, primarySessionId, batchId, consolidate, maxIterations, timeout, ct);
         }
         catch (Exception ex)
         {

--- a/src/RockBot.Subagent/SubagentResultHandler.cs
+++ b/src/RockBot.Subagent/SubagentResultHandler.cs
@@ -95,10 +95,31 @@ internal sealed class SubagentResultHandler(
               "Retrieve and present them to the user using get_from_working_memory with the full key."
             : string.Empty;
 
-        // Add synthetic user turn to conversation memory
-        var syntheticUserTurn = message.IsSuccess
-            ? $"[Subagent task {message.TaskId} completed]: {safeOutput}{whiteboardHint}"
-            : $"[Subagent task {message.TaskId} completed with error: {message.Error}]: {message.Output}";
+        // Add synthetic user turn to conversation memory.
+        // On the failure path, explicitly point the primary at the structured
+        // failure-details working-memory entry SubagentRunner writes — otherwise
+        // the primary only has the terse Error/Output strings and cannot answer
+        // "why did it fail?" without spawning another investigation subagent.
+        string syntheticUserTurn;
+        if (message.IsSuccess)
+        {
+            syntheticUserTurn = $"[Subagent task {message.TaskId} completed]: {safeOutput}{whiteboardHint}";
+        }
+        else
+        {
+            var failureKey = $"subagent/{message.TaskId}/failure-details";
+            var hasFailureDetails = whiteboardEntries.Any(e =>
+                string.Equals(e.Key, failureKey, StringComparison.OrdinalIgnoreCase));
+            var failurePointer = hasFailureDetails
+                ? $" Structured failure diagnostics are in working memory at '{failureKey}' " +
+                  $"(reason, last tool call, last assistant message, recent progress notes, " +
+                  $"elapsed time). Retrieve with get_from_working_memory('{failureKey}') " +
+                  $"before answering any question about why the subagent failed."
+                : string.Empty;
+            syntheticUserTurn =
+                $"[Subagent task {message.TaskId} failed with error: {message.Error}]: " +
+                $"{message.Output}{failurePointer}{whiteboardHint}";
+        }
 
         await conversationMemory.AddTurnAsync(
             rawSessionId,

--- a/src/RockBot.Subagent/SubagentRunner.cs
+++ b/src/RockBot.Subagent/SubagentRunner.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Text.Json;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
 using RockBot.Host;
@@ -43,6 +44,7 @@ internal sealed class SubagentRunner(
         string? batchId,
         bool consolidate,
         int? maxIterations,
+        TimeSpan timeout,
         CancellationToken ct)
     {
         var classification = tierSelector.Classify(description, new TierRoutingContext(Origin: "subagent"));
@@ -141,10 +143,23 @@ internal sealed class SubagentRunner(
                 r, toolRegistry.GetExecutor(r.Name)!, subagentNamespace))
             .ToArray();
 
-        // report_progress tool — baked with taskId and primarySessionId
+        // report_progress tool — baked with taskId and primarySessionId.
+        // The onReport callback feeds a rolling buffer used to populate the
+        // failure-details working-memory entry when the subagent fails or is cancelled.
         var subagentId = $"subagent-{taskId}";
+        var recentProgress = new System.Collections.Generic.Queue<(DateTimeOffset At, string Message)>();
+        const int RecentProgressCapacity = 5;
         var reportProgressFunctions = new ReportProgressFunctions(
-            taskId, primarySessionId, publisher, subagentId, agent.Name, logger);
+            taskId, primarySessionId, publisher, subagentId, agent.Name, logger,
+            onReport: msg =>
+            {
+                lock (recentProgress)
+                {
+                    recentProgress.Enqueue((DateTimeOffset.UtcNow, msg));
+                    while (recentProgress.Count > RecentProgressCapacity)
+                        recentProgress.Dequeue();
+                }
+            });
 
         var chatOptions = new ChatOptions
         {
@@ -164,7 +179,10 @@ internal sealed class SubagentRunner(
         string finalOutput;
         bool isSuccess;
         string? error = null;
+        string? failureReason = null;
+        var diagnostics = new LoopDiagnostics();
         var subagentSw = System.Diagnostics.Stopwatch.StartNew();
+        var startedAt = DateTimeOffset.UtcNow;
 
         using var subagentActivity = SubagentDiagnostics.Source.StartActivity("rockbot.subagent.task");
         subagentActivity?.SetTag("rockbot.subagent.task_id", taskId);
@@ -186,29 +204,58 @@ internal sealed class SubagentRunner(
                 chatMessages, chatOptions, subagentSessionId,
                 tier: tier, enableFollowUp: false, enableCompletionEval: false,
                 maxIterationsOverride: maxIterations,
+                diagnostics: diagnostics,
                 cancellationToken: ct);
             finalOutput = ResponseSanitizer.StripTrailingOffers(finalOutput);
             isSuccess = true;
             subagentActivity?.SetStatus(ActivityStatusCode.Ok);
         }
-        catch (OperationCanceledException oce)
+        catch (OperationCanceledException)
         {
-            // Timeout or explicit cancellation — always notify the primary agent
-            // so it isn't left waiting indefinitely.
-            var reason = ct.IsCancellationRequested ? "cancelled" : "timed out";
-            logger.LogWarning("Subagent {TaskId} {Reason}", taskId, reason);
-            finalOutput = $"Subagent task was {reason} before completing.";
+            // Distinguish timeout (CTS fired at deadline) from explicit cancel
+            // (manager called CancelAsync before the deadline). We compare elapsed
+            // time against the configured timeout — if we're at or past the
+            // deadline the trigger was the timer, otherwise it was an external call.
+            var elapsedAtCancel = DateTimeOffset.UtcNow - startedAt;
+            failureReason = timeout > TimeSpan.Zero && elapsedAtCancel >= timeout - TimeSpan.FromSeconds(2)
+                ? "timeout"
+                : "cancelled";
+            logger.LogWarning(
+                "Subagent {TaskId} {Reason} after {ElapsedSec:F1}s (timeout={TimeoutSec:F0}s)",
+                taskId, failureReason, elapsedAtCancel.TotalSeconds, timeout.TotalSeconds);
+            finalOutput = failureReason == "timeout"
+                ? $"Subagent timed out after {timeout.TotalMinutes:0.#} minutes. " +
+                  $"Failure diagnostics in working memory at 'subagent/{taskId}/failure-details'."
+                : $"Subagent was cancelled before completing. " +
+                  $"Failure diagnostics in working memory at 'subagent/{taskId}/failure-details'.";
             isSuccess = false;
-            error = oce.Message;
-            subagentActivity?.SetStatus(ActivityStatusCode.Error, reason);
+            error = failureReason == "timeout"
+                ? $"Timed out after {timeout.TotalMinutes:0.#} minutes"
+                : "Cancelled by request";
+            subagentActivity?.SetStatus(ActivityStatusCode.Error, failureReason);
         }
         catch (Exception ex)
         {
             logger.LogError(ex, "Subagent {TaskId} tool loop failed", taskId);
-            finalOutput = $"Task failed: {ex.Message}";
+            failureReason = "exception";
+            finalOutput = $"Subagent failed: {ex.Message}. " +
+                          $"Failure diagnostics in working memory at 'subagent/{taskId}/failure-details'.";
             isSuccess = false;
             error = ex.Message;
             subagentActivity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+        }
+
+        // On any non-success path, write a structured failure-details entry to working
+        // memory so the primary agent can answer "why did it fail" without having to
+        // re-investigate from logs. Lives under the same subagent/{taskId}/ namespace
+        // as the rest of the subagent's outputs so the SubagentResultHandler's existing
+        // whiteboard-hint flow surfaces it automatically.
+        if (!isSuccess)
+        {
+            await SaveFailureDetailsAsync(
+                taskId, description, failureReason ?? "unknown",
+                error, startedAt, subagentSw.Elapsed, timeout,
+                diagnostics, recentProgress, ct);
         }
 
         // Wait for any in-flight A2A tasks the subagent dispatched (via wisps) to
@@ -279,5 +326,106 @@ internal sealed class SubagentRunner(
         await publisher.PublishAsync($"{SubagentTopics.Result}.{agent.Name}", envelope, CancellationToken.None);
 
         logger.LogInformation("Subagent {TaskId} published result (success={Success})", taskId, isSuccess);
+    }
+
+    /// <summary>
+    /// Persists a structured failure-details payload to working memory under
+    /// <c>subagent/{taskId}/failure-details</c>. The primary agent reads this entry
+    /// (surfaced automatically by SubagentResultHandler's whiteboard hint) to answer
+    /// "why did the subagent fail" without having to dig through pod logs.
+    /// </summary>
+    private async Task SaveFailureDetailsAsync(
+        string taskId,
+        string description,
+        string reason,
+        string? errorMessage,
+        DateTimeOffset startedAt,
+        TimeSpan elapsed,
+        TimeSpan timeout,
+        LoopDiagnostics diagnostics,
+        Queue<(DateTimeOffset At, string Message)> recentProgress,
+        CancellationToken ct)
+    {
+        try
+        {
+            (DateTimeOffset At, string Message)[] progressSnapshot;
+            lock (recentProgress)
+                progressSnapshot = recentProgress.ToArray();
+
+            var json = BuildFailureDetailsPayload(
+                taskId, description, reason, errorMessage,
+                startedAt, elapsed, timeout, diagnostics, progressSnapshot);
+
+            // TTL 240 minutes matches the convention subagents use for their other
+            // long-lived outputs so the primary can refer back across follow-ups.
+            await workingMemory.SetAsync(
+                $"subagent/{taskId}/failure-details",
+                json,
+                TimeSpan.FromMinutes(240),
+                category: "subagent-failure",
+                tags: ["subagent-failure", reason]);
+
+            logger.LogInformation(
+                "Subagent {TaskId} failure details saved to working memory (reason={Reason}, lastTool={Tool})",
+                taskId, reason, diagnostics.LastToolName ?? "(none)");
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // Failure-detail persistence is best-effort — never block the result publish.
+            logger.LogWarning(ex,
+                "Failed to persist failure details for subagent {TaskId}; primary agent will see only the inline reason",
+                taskId);
+        }
+    }
+
+    /// <summary>
+    /// Builds the JSON payload that <see cref="SaveFailureDetailsAsync"/> writes to
+    /// working memory. Exposed as <c>internal static</c> so unit tests can exercise
+    /// the payload shape without instantiating the full SubagentRunner DI graph.
+    /// </summary>
+    internal static string BuildFailureDetailsPayload(
+        string taskId,
+        string description,
+        string reason,
+        string? errorMessage,
+        DateTimeOffset startedAt,
+        TimeSpan elapsed,
+        TimeSpan timeout,
+        LoopDiagnostics diagnostics,
+        IReadOnlyList<(DateTimeOffset At, string Message)> recentProgress)
+    {
+        var payload = new
+        {
+            taskId,
+            reason,
+            description = description.Length > 500 ? description[..500] + "…" : description,
+            error = errorMessage,
+            startedAt = startedAt.ToString("O"),
+            elapsedSeconds = Math.Round(elapsed.TotalSeconds, 1),
+            timeoutMinutes = timeout.TotalMinutes > 0 ? Math.Round(timeout.TotalMinutes, 1) : (double?)null,
+            iterations = diagnostics.Iterations,
+            toolCalls = diagnostics.ToolCalls,
+            lastAssistantText = diagnostics.LastAssistantText,
+            lastTool = diagnostics.LastToolName is null ? null : new
+            {
+                name = diagnostics.LastToolName,
+                arguments = diagnostics.LastToolArguments,
+                status = diagnostics.LastToolStatus,
+                result = diagnostics.LastToolResult,
+                startedAt = diagnostics.LastToolStartedAt?.ToString("O"),
+                completedAt = diagnostics.LastToolCompletedAt?.ToString("O"),
+            },
+            recentProgress = recentProgress.Select(p => new
+            {
+                at = p.At.ToString("O"),
+                message = p.Message
+            }).ToArray(),
+        };
+
+        return JsonSerializer.Serialize(payload, new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        });
     }
 }

--- a/tests/RockBot.Host.Tests/LoopDiagnosticsContextTests.cs
+++ b/tests/RockBot.Host.Tests/LoopDiagnosticsContextTests.cs
@@ -1,0 +1,69 @@
+namespace RockBot.Host.Tests;
+
+[TestClass]
+public class LoopDiagnosticsContextTests
+{
+    [TestMethod]
+    public void Value_DefaultsToNull()
+    {
+        Assert.IsNull(LoopDiagnosticsContext.Value);
+    }
+
+    [TestMethod]
+    public void Set_BindsInstanceForCurrentAsyncFlow()
+    {
+        var diag = new LoopDiagnostics();
+        using var _ = LoopDiagnosticsContext.Set(diag);
+
+        Assert.AreSame(diag, LoopDiagnosticsContext.Value);
+    }
+
+    [TestMethod]
+    public void Dispose_RestoresPreviousBinding()
+    {
+        var outer = new LoopDiagnostics { Iterations = 1 };
+        using (LoopDiagnosticsContext.Set(outer))
+        {
+            Assert.AreSame(outer, LoopDiagnosticsContext.Value);
+
+            var inner = new LoopDiagnostics { Iterations = 2 };
+            using (LoopDiagnosticsContext.Set(inner))
+            {
+                Assert.AreSame(inner, LoopDiagnosticsContext.Value);
+            }
+
+            Assert.AreSame(outer, LoopDiagnosticsContext.Value);
+        }
+
+        Assert.IsNull(LoopDiagnosticsContext.Value);
+    }
+
+    [TestMethod]
+    public async Task ConcurrentAsyncFlows_DoNotShareDiagnostics()
+    {
+        // Two concurrent tasks each bind their own diagnostics. AsyncLocal must
+        // give each task its own view, otherwise subagent A's failure handler
+        // would see subagent B's last tool call.
+        async Task<int> RunFlow(int marker)
+        {
+            var diag = new LoopDiagnostics();
+            using var _ = LoopDiagnosticsContext.Set(diag);
+            await Task.Yield();
+
+            // The handle inside this async flow must be the one we just set.
+            Assert.AreSame(diag, LoopDiagnosticsContext.Value);
+
+            LoopDiagnosticsContext.Value!.Iterations = marker;
+            await Task.Delay(10);
+            return LoopDiagnosticsContext.Value.Iterations;
+        }
+
+        var a = RunFlow(101);
+        var b = RunFlow(202);
+
+        var results = await Task.WhenAll(a, b);
+        Assert.AreEqual(101, results[0]);
+        Assert.AreEqual(202, results[1]);
+        Assert.IsNull(LoopDiagnosticsContext.Value);
+    }
+}

--- a/tests/RockBot.Subagent.Tests/SubagentFailureDetailsTests.cs
+++ b/tests/RockBot.Subagent.Tests/SubagentFailureDetailsTests.cs
@@ -1,0 +1,122 @@
+using System.Text.Json;
+using RockBot.Host;
+
+namespace RockBot.Subagent.Tests;
+
+[TestClass]
+public class SubagentFailureDetailsTests
+{
+    [TestMethod]
+    public void BuildFailureDetailsPayload_TimeoutWithFullDiagnostics_IncludesEverythingPrimaryNeeds()
+    {
+        var startedAt = DateTimeOffset.Parse("2026-05-18T15:17:49Z");
+        var elapsed = TimeSpan.FromMinutes(14).Add(TimeSpan.FromSeconds(58.453));
+        var timeout = TimeSpan.FromMinutes(15);
+
+        var diag = new LoopDiagnostics
+        {
+            Iterations = 22,
+            ToolCalls = 47,
+            LastAssistantText = "Switching to OneDrive default save location and then inspecting returned paths.",
+            LastToolName = "spawn_wisps",
+            LastToolArguments = "definitions=[{\"description\":\"Download Teams bridge May 18…\"}]",
+            LastToolStatus = "in-flight",
+            LastToolResult = null,
+            LastToolStartedAt = startedAt + TimeSpan.FromMinutes(14),
+            LastToolCompletedAt = null,
+        };
+
+        var progress = new (DateTimeOffset At, string Message)[]
+        {
+            (startedAt + TimeSpan.FromMinutes(1), "Services confirmed: calendar-mcp and onedrive-personal."),
+            (startedAt + TimeSpan.FromMinutes(8), "Initial email sweep completed."),
+            (startedAt + TimeSpan.FromMinutes(13), "Teams archive search found two Xebia Teams JSON files."),
+        };
+
+        var json = SubagentRunner.BuildFailureDetailsPayload(
+            taskId: "f57cb6b15c6b",
+            description: "Daily Operational Brief email/Teams communications evidence slice.",
+            reason: "timeout",
+            errorMessage: "Timed out after 15 minutes",
+            startedAt: startedAt,
+            elapsed: elapsed,
+            timeout: timeout,
+            diagnostics: diag,
+            recentProgress: progress);
+
+        // Parse it back so the assertions check semantic shape, not exact formatting.
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.AreEqual("f57cb6b15c6b", root.GetProperty("taskId").GetString());
+        Assert.AreEqual("timeout", root.GetProperty("reason").GetString());
+        Assert.AreEqual("Timed out after 15 minutes", root.GetProperty("error").GetString());
+        Assert.AreEqual(22, root.GetProperty("iterations").GetInt32());
+        Assert.AreEqual(47, root.GetProperty("toolCalls").GetInt32());
+        Assert.AreEqual(15.0, root.GetProperty("timeoutMinutes").GetDouble());
+
+        var lastTool = root.GetProperty("lastTool");
+        Assert.AreEqual("spawn_wisps", lastTool.GetProperty("name").GetString());
+        Assert.AreEqual("in-flight", lastTool.GetProperty("status").GetString());
+        Assert.AreEqual(JsonValueKind.Null, lastTool.GetProperty("completedAt").ValueKind);
+
+        StringAssert.Contains(
+            root.GetProperty("lastAssistantText").GetString() ?? string.Empty,
+            "OneDrive default save location");
+
+        var progressArr = root.GetProperty("recentProgress");
+        Assert.AreEqual(3, progressArr.GetArrayLength());
+        StringAssert.Contains(
+            progressArr[2].GetProperty("message").GetString() ?? string.Empty,
+            "Teams archive search");
+    }
+
+    [TestMethod]
+    public void BuildFailureDetailsPayload_WhenNoToolEverRan_LastToolIsNull()
+    {
+        var diag = new LoopDiagnostics
+        {
+            Iterations = 1,
+            ToolCalls = 0,
+            LastAssistantText = "Starting work.",
+        };
+
+        var json = SubagentRunner.BuildFailureDetailsPayload(
+            taskId: "abc123",
+            description: "test",
+            reason: "exception",
+            errorMessage: "Boom",
+            startedAt: DateTimeOffset.UtcNow,
+            elapsed: TimeSpan.FromSeconds(2),
+            timeout: TimeSpan.FromMinutes(10),
+            diagnostics: diag,
+            recentProgress: Array.Empty<(DateTimeOffset, string)>());
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.AreEqual(JsonValueKind.Null, doc.RootElement.GetProperty("lastTool").ValueKind);
+        Assert.AreEqual(0, doc.RootElement.GetProperty("recentProgress").GetArrayLength());
+    }
+
+    [TestMethod]
+    public void BuildFailureDetailsPayload_TruncatesLongDescription()
+    {
+        var longDescription = new string('x', 1500);
+
+        var json = SubagentRunner.BuildFailureDetailsPayload(
+            taskId: "t1",
+            description: longDescription,
+            reason: "cancelled",
+            errorMessage: null,
+            startedAt: DateTimeOffset.UtcNow,
+            elapsed: TimeSpan.FromSeconds(1),
+            timeout: TimeSpan.FromMinutes(5),
+            diagnostics: new LoopDiagnostics(),
+            recentProgress: Array.Empty<(DateTimeOffset, string)>());
+
+        using var doc = JsonDocument.Parse(json);
+        var stored = doc.RootElement.GetProperty("description").GetString() ?? string.Empty;
+        Assert.IsTrue(stored.Length < longDescription.Length,
+            $"Expected truncation, got {stored.Length} chars");
+        StringAssert.EndsWith(stored, "…");
+    }
+}


### PR DESCRIPTION
## Summary

- When a subagent timed out or failed, the primary agent received only a 46-char generic "Subagent task was cancelled before completing." plus the bare `OperationCanceledException` message — not enough to diagnose anything, so the primary had to spawn a second 15-minute investigation subagent just to *guess* at what went wrong.
- `SubagentRunner` now captures the loop's last state (iterations, tool calls, last assistant text, last tool name/args/status/result, recent `ReportProgress` notes) into a new `LoopDiagnostics` handle threaded through `AgentLoopRunner` and the native `RockBotFunctionInvokingChatClient` via an AsyncLocal context.
- On any failure path, the runner persists a structured JSON failure-details entry to working memory at `subagent/{taskId}/failure-details`, distinguishing **timeout** from **explicit cancel** via the configured deadline. `SubagentResultHandler` points the primary at that key in the synthetic conversation turn so the LLM retrieves it before answering follow-up questions.
- The inline `Output`/`Error` strings stay short and act as pointers to the WM key.

## Files

- `src/RockBot.Host/LoopDiagnostics.cs` (new) — captures iterations, tool calls, last assistant message, last tool name/args/status/result/timing
- `src/RockBot.Host/LoopDiagnosticsContext.cs` (new) — `AsyncLocal` so the singleton FICC can populate per-call diagnostics
- `src/RockBot.Host/AgentLoopRunner.cs` — accepts an optional `LoopDiagnostics`; text-based loop records iterations + last assistant text + per-tool start/end; native loop records final assistant text
- `src/RockBot.Host/RockBotFunctionInvokingChatClient.cs` — records per-tool name/args/status/result, **including** the cancelled/threw paths so a mid-call cancel leaves a usable trail
- `src/RockBot.Subagent/SubagentRunner.cs` — wraps `ReportProgress` with a rolling 5-message buffer; receives the configured timeout from the manager; on failure writes the JSON failure-details entry; extracts `BuildFailureDetailsPayload` as `internal static` for testing
- `src/RockBot.Subagent/SubagentManager.cs` — passes timeout into the runner so cancel/timeout can be distinguished
- `src/RockBot.Subagent/ReportProgressFunction.cs` — adds `onReport` callback for the rolling buffer
- `src/RockBot.Subagent/SubagentResultHandler.cs` — failure branch names the `failure-details` key in the synthetic conversation turn
- `tests/RockBot.Host.Tests/LoopDiagnosticsContextTests.cs` (new) — 4 tests covering default, scope, dispose, async-flow isolation
- `tests/RockBot.Subagent.Tests/SubagentFailureDetailsTests.cs` (new) — 3 tests for full payload shape, no-tool-ever-ran, description truncation

## Test plan

- [x] All 7 new tests pass
- [x] Full solution test suite (2,000+ tests across 17 projects) passes with no regressions
- [ ] On next live subagent failure, verify the primary can answer "why did it fail?" by reading `subagent/{taskId}/failure-details` instead of spawning an investigation subagent

🤖 Generated with [Claude Code](https://claude.com/claude-code)