### PR TITLE
Bump version to 0.10.65

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.10.64</Version>
+<Version>0.10.65</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->


### PR DESCRIPTION
## Summary

- Bumps `Directory.Build.props` to 0.10.65, releasing the subagent failure-diagnostics work from #406.

## Test plan

- [ ] CI builds the solution
- [ ] After merge, build/push `rockylhotka/rockbot-agent:0.10.65` and helm upgrade for live testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)