### PR TITLE
Give council personas their own research agency via working memory

### DIFF
--- a/deploy/k8s/advisor-council-scaledjob.yaml
+++ b/deploy/k8s/advisor-council-scaledjob.yaml
@@ -28,7 +28,7 @@ spec:
         restartPolicy: Never
         containers:
           - name: advisor-council
-            image: rockylhotka/rockbot-advisor-council:0.10.55
+            image: rockylhotka/rockbot-advisor-council:0.10.66
             imagePullPolicy: Always
             env:
               # Ephemeral working memory — lives on the container's local filesystem.

--- a/deploy/k8s/research-agent-scaledjob.yaml
+++ b/deploy/k8s/research-agent-scaledjob.yaml
@@ -28,7 +28,7 @@ spec:
         restartPolicy: Never
         containers:
           - name: research-agent
-            image: rockylhotka/rockbot-research-agent:0.9.15
+            image: rockylhotka/rockbot-research-agent:0.10.66
             imagePullPolicy: Always
             env:
               # Ephemeral working memory path — lives on the container's local filesystem

--- a/src/RockBot.AdvisorCouncil/AdvisorCouncilTaskHandler.cs
+++ b/src/RockBot.AdvisorCouncil/AdvisorCouncilTaskHandler.cs
@@ -74,6 +74,7 @@ internal sealed class AdvisorCouncilTaskHandler(
             }
 
             var json = JsonSerializer.Serialize(response, JsonOpts);
+            var textPart = BuildTextPart(response);
 
             return new AgentTaskResult
             {
@@ -85,7 +86,7 @@ internal sealed class AdvisorCouncilTaskHandler(
                     Role = "agent",
                     Parts =
                     [
-                        new AgentMessagePart { Kind = "text", Text = response.Synthesis },
+                        new AgentMessagePart { Kind = "text", Text = textPart },
                         new AgentMessagePart { Kind = "data", Data = json, MimeType = "application/json" }
                     ]
                 }
@@ -100,5 +101,30 @@ internal sealed class AdvisorCouncilTaskHandler(
         {
             shutdown.NotifyTaskComplete();
         }
+    }
+
+    /// <summary>
+    /// Prepends a coverage banner to the synthesis prose when one or more selected personas
+    /// did not contribute (timed out or failed). The caller would otherwise have no way of
+    /// knowing the recommendation is missing perspectives.
+    /// </summary>
+    private static string BuildTextPart(CouncilResponse response)
+    {
+        var missing = response.Personas
+            .Where(p => p.Status != PersonaStatus.Ok)
+            .ToList();
+
+        if (missing.Count == 0)
+            return response.Synthesis;
+
+        var contributed = response.Personas.Count - missing.Count;
+        var missingDetail = string.Join(", ",
+            missing.Select(p => $"{p.Id} ({p.Status})"));
+
+        var banner =
+            $"> **Council coverage:** {contributed} of {response.Personas.Count} personas contributed. " +
+            $"Missing perspectives: {missingDetail}. The integrated recommendation below does not reflect those viewpoints.";
+
+        return banner + "\n\n---\n\n" + response.Synthesis;
     }
 }

--- a/src/RockBot.AdvisorCouncil/Council/CouncilOptions.cs
+++ b/src/RockBot.AdvisorCouncil/Council/CouncilOptions.cs
@@ -9,10 +9,10 @@ internal sealed class CouncilOptions
     public string PersonasPath { get; set; } = string.Empty;
 
     /// <summary>Hard wall-clock cap on a council run before cancellation.</summary>
-    public int OverallTimeoutSeconds { get; set; } = 180;
+    public int OverallTimeoutSeconds { get; set; } = 300;
 
     /// <summary>Per-persona soft timeout. On expiry the persona view becomes "(timed out)" and synthesis proceeds without it.</summary>
-    public int PerPersonaTimeoutSeconds { get; set; } = 60;
+    public int PerPersonaTimeoutSeconds { get; set; } = 120;
 
     /// <summary>Pre-research stage timeout.</summary>
     public int PreResearchTimeoutSeconds { get; set; } = 90;

--- a/src/RockBot.AdvisorCouncil/Council/CouncilOptions.cs
+++ b/src/RockBot.AdvisorCouncil/Council/CouncilOptions.cs
@@ -19,4 +19,11 @@ internal sealed class CouncilOptions
 
     /// <summary>ResearchAgent invocation timeout (used in Phase 3 by ResearchAgentInvoker).</summary>
     public int ResearchAgentTimeoutSeconds { get; set; } = 90;
+
+    /// <summary>
+    /// Maximum number of research tool calls a single persona may make during its view step.
+    /// Past this cap, the scoped research tool short-circuits with a budget-exhausted sentinel
+    /// so the persona answers from existing context.
+    /// </summary>
+    public int MaxResearchCallsPerPersona { get; set; } = 3;
 }

--- a/src/RockBot.AdvisorCouncil/Council/CouncilOrchestrator.cs
+++ b/src/RockBot.AdvisorCouncil/Council/CouncilOrchestrator.cs
@@ -39,34 +39,37 @@ internal sealed class CouncilOrchestrator(
 
         var selectedPersonas = selection.Personas
             .Where(p => personas.ContainsKey(p.Id))
-            .Select(p => (Spec: p, Persona: personas[p.Id]))
+            .Select(p => personas[p.Id])
             .ToList();
 
         if (selectedPersonas.Count == 0)
             return EmptyResponse(question, "No personas selected. The persona registry may be empty or the selector returned no valid ids.", sw.Elapsed, modelCalls);
 
         // ── 2. PreResearch (conditional) ───────────────────────────────────────
-        string? preResearch = null;
+        // Persona-aware research that writes to WM at council/{taskId}/shared; personas
+        // read from there in step 3. The boolean tells us whether to flag preResearchRun
+        // in metadata.
+        var preResearchRun = false;
         if (selection.PreResearch)
         {
-            preResearch = await preResearchStep.RunAsync(question, ct);
-            if (preResearch is not null) modelCalls++;
+            preResearchRun = await preResearchStep.RunAsync(question, selectedPersonas, taskId, ct);
+            if (preResearchRun) modelCalls++;
         }
 
         // ── 3. Fan-out personas in parallel ────────────────────────────────────
         var perPersonaTimeout = TimeSpan.FromSeconds(Math.Max(5, options.Value.PerPersonaTimeoutSeconds));
-        var personaTasks = selectedPersonas.Select(async sp =>
+        var personaTasks = selectedPersonas.Select(async persona =>
         {
             using var personaCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
             personaCts.CancelAfter(perPersonaTimeout);
             try
             {
-                return await personaStep.RunAsync(sp.Persona, question, preResearch, sp.Spec.NeedsResearch, personaCts.Token);
+                return await personaStep.RunAsync(persona, question, taskId, personaCts.Token);
             }
             catch (OperationCanceledException) when (!ct.IsCancellationRequested)
             {
-                logger.LogWarning("Persona {Id} timed out after {Sec}s", sp.Spec.Id, perPersonaTimeout.TotalSeconds);
-                return new PersonaView(sp.Spec.Id, "(timed out)", [], []);
+                logger.LogWarning("Persona {Id} timed out after {Sec}s", persona.Id, perPersonaTimeout.TotalSeconds);
+                return new PersonaView(persona.Id, "(timed out)", [], []);
             }
         }).ToList();
 
@@ -79,13 +82,13 @@ internal sealed class CouncilOrchestrator(
         {
             var critiqueTasks = personaViews.Select(async (own, idx) =>
             {
-                var persona = selectedPersonas[idx].Persona;
+                var persona = selectedPersonas[idx];
                 var siblings = personaViews.Where((_, i) => i != idx).ToList();
                 using var critCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
                 critCts.CancelAfter(perPersonaTimeout);
                 try
                 {
-                    return await critiqueStep.RunAsync(persona, question, own, siblings, critCts.Token);
+                    return await critiqueStep.RunAsync(persona, question, taskId, own, siblings, critCts.Token);
                 }
                 catch (OperationCanceledException) when (!ct.IsCancellationRequested)
                 {
@@ -118,7 +121,7 @@ internal sealed class CouncilOrchestrator(
             Confidence: synthesis.Confidence,
             Metadata: new CouncilMetadata(
                 CritiqueRun: selection.Critique && personaViews.Length > 1,
-                PreResearchRun: preResearch is not null,
+                PreResearchRun: preResearchRun,
                 PersonaCount: personaViews.Length,
                 DurationMs: sw.ElapsedMilliseconds,
                 ModelCalls: modelCalls,

--- a/src/RockBot.AdvisorCouncil/Council/CouncilOrchestrator.cs
+++ b/src/RockBot.AdvisorCouncil/Council/CouncilOrchestrator.cs
@@ -69,7 +69,7 @@ internal sealed class CouncilOrchestrator(
             catch (OperationCanceledException) when (!ct.IsCancellationRequested)
             {
                 logger.LogWarning("Persona {Id} timed out after {Sec}s", persona.Id, perPersonaTimeout.TotalSeconds);
-                return new PersonaView(persona.Id, "(timed out)", [], []);
+                return new PersonaView(persona.Id, "(timed out)", [], [], PersonaStatus.TimedOut);
             }
         }).ToList();
 
@@ -113,6 +113,12 @@ internal sealed class CouncilOrchestrator(
 
         sw.Stop();
 
+        var contributedCount = personaViews.Count(v => v.Status == PersonaStatus.Ok);
+        var missingIds = personaViews
+            .Where(v => v.Status != PersonaStatus.Ok)
+            .Select(v => v.Id)
+            .ToList();
+
         return new CouncilResponse(
             Question: question,
             Personas: personaViews,
@@ -126,7 +132,9 @@ internal sealed class CouncilOrchestrator(
                 DurationMs: sw.ElapsedMilliseconds,
                 ModelCalls: modelCalls,
                 PersonaSetHash: personaRegistry.PersonaSetHash,
-                SelectorRationale: selection.Rationale));
+                SelectorRationale: selection.Rationale,
+                PersonasContributed: contributedCount,
+                PersonasMissing: missingIds));
     }
 
     private CouncilResponse EmptyResponse(string question, string reason, TimeSpan duration, int modelCalls) =>

--- a/src/RockBot.AdvisorCouncil/Council/CritiqueStep.cs
+++ b/src/RockBot.AdvisorCouncil/Council/CritiqueStep.cs
@@ -60,11 +60,18 @@ internal sealed class CritiqueStep(
             var parsed = Parse(raw, persona.Id);
             if (parsed is not null)
             {
+                // Critique can revise the view text but does not change whether the persona
+                // contributed: carry forward the original status (ok/timed_out/failed).
+                var preserved = parsed with
+                {
+                    RevisedView = parsed.RevisedView with { Status = ownView.Status }
+                };
+
                 try
                 {
                     await workingMemory.SetAsync(
                         key: $"council/{taskId}/{persona.Id}/view-revised",
-                        value: parsed.RevisedView.View,
+                        value: preserved.RevisedView.View,
                         ttl: TimeSpan.FromMinutes(30),
                         category: "council/view",
                         tags: [persona.Id, taskId, "revised"]);
@@ -73,7 +80,7 @@ internal sealed class CritiqueStep(
                 {
                     logger.LogWarning(ex, "Failed to write revised view to WM for {Persona}", persona.Id);
                 }
-                return parsed;
+                return preserved;
             }
             logger.LogWarning("CritiqueStep parse failed for persona {Id}; keeping original view", persona.Id);
             return new CritiqueOutput(ownView, []);

--- a/src/RockBot.AdvisorCouncil/Council/CritiqueStep.cs
+++ b/src/RockBot.AdvisorCouncil/Council/CritiqueStep.cs
@@ -4,17 +4,22 @@ using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
 using RockBot.AdvisorCouncil.Personas;
 using RockBot.AdvisorCouncil.Schema;
+using RockBot.Host;
 
 namespace RockBot.AdvisorCouncil.Council;
 
 /// <summary>
 /// For each persona, runs a second IChatClient call that revises the persona's view in
-/// light of sibling views and names explicit tensions. Per-persona parallel.
+/// light of sibling views and names explicit tensions. Reads accumulated research findings
+/// from working memory under <c>council/{taskId}/</c> so the rebuttal round can reference
+/// evidence any persona has surfaced. Per-persona parallel.
 /// </summary>
 internal sealed class CritiqueStep(
     IChatClient chatClient,
+    IWorkingMemory workingMemory,
     ILogger<CritiqueStep> logger)
 {
+    private const int MaxResearchSnippetChars = 300;
     private static readonly JsonSerializerOptions JsonOpts = new() { PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower };
 
     public sealed record CritiqueOutput(PersonaView RevisedView, IReadOnlyList<Tension> Tensions);
@@ -22,6 +27,7 @@ internal sealed class CritiqueStep(
     public async Task<CritiqueOutput> RunAsync(
         Persona persona,
         string question,
+        string taskId,
         PersonaView ownView,
         IReadOnlyList<PersonaView> siblingViews,
         CancellationToken ct)
@@ -37,7 +43,8 @@ internal sealed class CritiqueStep(
             "{ \"revised_view\": \"markdown prose\", \"key_points\": [\"...\"], \"tensions\": " +
             "[{\"with\":\"sibling_id\",\"description\":\"...\",\"stakes\":\"...\"}] }";
 
-        var user = BuildUserPrompt(question, ownView, siblingViews);
+        var researchPool = await BuildResearchPoolAsync(taskId, ct);
+        var user = BuildUserPrompt(question, ownView, siblingViews, researchPool);
 
         var messages = new List<ChatMessage>
         {
@@ -52,7 +59,22 @@ internal sealed class CritiqueStep(
             var raw = response.Text ?? string.Empty;
             var parsed = Parse(raw, persona.Id);
             if (parsed is not null)
+            {
+                try
+                {
+                    await workingMemory.SetAsync(
+                        key: $"council/{taskId}/{persona.Id}/view-revised",
+                        value: parsed.RevisedView.View,
+                        ttl: TimeSpan.FromMinutes(30),
+                        category: "council/view",
+                        tags: [persona.Id, taskId, "revised"]);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(ex, "Failed to write revised view to WM for {Persona}", persona.Id);
+                }
                 return parsed;
+            }
             logger.LogWarning("CritiqueStep parse failed for persona {Id}; keeping original view", persona.Id);
             return new CritiqueOutput(ownView, []);
         }
@@ -67,7 +89,11 @@ internal sealed class CritiqueStep(
         }
     }
 
-    private static string BuildUserPrompt(string question, PersonaView ownView, IReadOnlyList<PersonaView> siblings)
+    private static string BuildUserPrompt(
+        string question,
+        PersonaView ownView,
+        IReadOnlyList<PersonaView> siblings,
+        IReadOnlyList<(string Key, string Snippet)> researchPool)
     {
         var sb = new StringBuilder();
         sb.Append("Question: ").AppendLine(question).AppendLine();
@@ -79,7 +105,54 @@ internal sealed class CritiqueStep(
             sb.Append("### ").AppendLine(s.Id);
             sb.AppendLine(s.View).AppendLine();
         }
+
+        if (researchPool.Count > 0)
+        {
+            sb.AppendLine("Research findings available to the council (use any that sharpen your dissent or concurrence):");
+            foreach (var (key, snippet) in researchPool)
+            {
+                sb.Append("### ").AppendLine(key);
+                sb.AppendLine(snippet).AppendLine();
+            }
+        }
+
         return sb.ToString();
+    }
+
+    /// <summary>
+    /// Lists working-memory entries under the council's task namespace and selects only
+    /// research-type keys (shared baseline + per-persona research calls), truncating each
+    /// snippet to keep the prompt bounded.
+    /// </summary>
+    private async Task<IReadOnlyList<(string Key, string Snippet)>> BuildResearchPoolAsync(string taskId, CancellationToken ct)
+    {
+        try
+        {
+            var entries = await workingMemory.ListAsync($"council/{taskId}/");
+            var pool = new List<(string Key, string Snippet)>();
+            foreach (var entry in entries)
+            {
+                if (ct.IsCancellationRequested) break;
+                if (!IsResearchKey(entry.Key)) continue;
+                var snippet = entry.Value.Length <= MaxResearchSnippetChars
+                    ? entry.Value
+                    : entry.Value[..MaxResearchSnippetChars] + "…";
+                pool.Add((entry.Key, snippet));
+            }
+            return pool;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to enumerate WM research pool for task {TaskId}", taskId);
+            return [];
+        }
+    }
+
+    private static bool IsResearchKey(string key)
+    {
+        if (key.EndsWith("/shared", StringComparison.Ordinal)) return true;
+        var researchIdx = key.IndexOf("/research/", StringComparison.Ordinal);
+        return researchIdx > 0;
     }
 
     private static CritiqueOutput? Parse(string raw, string ownPersonaId)

--- a/src/RockBot.AdvisorCouncil/Council/PersonaStep.cs
+++ b/src/RockBot.AdvisorCouncil/Council/PersonaStep.cs
@@ -1,28 +1,37 @@
+using System.Text.Json;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using RockBot.AdvisorCouncil.Personas;
 using RockBot.AdvisorCouncil.Schema;
+using RockBot.AdvisorCouncil.Tools;
+using RockBot.Host;
 
 namespace RockBot.AdvisorCouncil.Council;
 
 /// <summary>
-/// Runs one persona view. Phase 1: call-only IChatClient call. Phase 3 expands the
-/// agentic-loop branch when <c>needs_research=true</c>.
+/// Runs one persona view. Reads any shared pre-research findings from working memory
+/// at <c>council/{taskId}/shared</c>, exposes a scoped <c>research</c> tool the persona
+/// can invoke autonomously, and writes its final view to <c>council/{taskId}/{personaId}/view</c>.
+/// Per-persona research calls land at <c>council/{taskId}/{personaId}/research/{n}</c>.
 /// </summary>
 internal sealed class PersonaStep(
     IChatClient chatClient,
+    ResearchAgentInvoker invoker,
+    IWorkingMemory workingMemory,
+    IOptions<CouncilOptions> options,
     ILogger<PersonaStep> logger)
 {
     public async Task<PersonaView> RunAsync(
         Persona persona,
         string question,
-        string? preResearchFindings,
-        bool _needsResearch,
+        string taskId,
         CancellationToken ct)
     {
-        var userPrompt = preResearchFindings is null
+        var shared = await workingMemory.GetAsync($"council/{taskId}/shared");
+        var userPrompt = shared is null
             ? question
-            : $"Use the following pre-research findings as context. Do not contradict facts in them.\n\n--- Pre-research findings ---\n{preResearchFindings}\n--- End findings ---\n\nQuestion: {question}";
+            : $"Use the following pre-research findings as context. Do not contradict facts in them.\n\n--- Pre-research findings ---\n{shared}\n--- End findings ---\n\nQuestion: {question}";
 
         var messages = new List<ChatMessage>
         {
@@ -30,10 +39,37 @@ internal sealed class PersonaStep(
             new(ChatRole.User, userPrompt)
         };
 
+        // Lambda (not method group) so the invoker reference is only dereferenced when the
+        // tool is actually invoked. Tests that don't exercise the research path can pass
+        // null! for the invoker without constructing one.
+        var scopedTool = new PersonaScopedResearchTool(
+            research: (q, c) => invoker.InvokeAsync(q, c),
+            wm: workingMemory,
+            taskId: taskId,
+            personaId: persona.Id,
+            maxCalls: options.Value.MaxResearchCallsPerPersona,
+            logger: logger);
+        var chatOptions = new ChatOptions { Tools = [scopedTool] };
+
         try
         {
-            var response = await chatClient.GetResponseAsync(messages, options: null, ct);
+            var response = await chatClient.GetResponseAsync(messages, chatOptions, ct);
             var text = response.Text?.Trim() ?? string.Empty;
+
+            try
+            {
+                await workingMemory.SetAsync(
+                    key: $"council/{taskId}/{persona.Id}/view",
+                    value: text,
+                    ttl: TimeSpan.FromMinutes(30),
+                    category: "council/view",
+                    tags: [persona.Id, taskId]);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Failed to write persona view to WM for {Persona}", persona.Id);
+            }
+
             return new PersonaView(persona.Id, text, [], []);
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
@@ -44,6 +80,95 @@ internal sealed class PersonaStep(
         {
             logger.LogError(ex, "PersonaStep failed for persona {Id}", persona.Id);
             return new PersonaView(persona.Id, "(persona call failed)", [], []);
+        }
+    }
+
+    /// <summary>
+    /// Per-call wrapper around the research invocation delegate. Enforces the per-persona
+    /// research budget and persists successful results to working memory under
+    /// <c>council/{taskId}/{personaId}/research/{n}</c>. Takes a delegate rather than the
+    /// concrete invoker so tests can supply a stub without InProcess messaging setup.
+    /// </summary>
+    internal sealed class PersonaScopedResearchTool : AIFunction
+    {
+        private static readonly JsonElement Schema = JsonDocument.Parse(
+            """{"type":"object","properties":{"question":{"type":"string","description":"The research question."}},"required":["question"]}""")
+            .RootElement;
+
+        private readonly Func<string, CancellationToken, Task<string>> _research;
+        private readonly IWorkingMemory _wm;
+        private readonly string _taskId;
+        private readonly string _personaId;
+        private readonly int _maxCalls;
+        private readonly ILogger _logger;
+        private int _callCount;
+
+        public PersonaScopedResearchTool(
+            Func<string, CancellationToken, Task<string>> research,
+            IWorkingMemory wm,
+            string taskId,
+            string personaId,
+            int maxCalls,
+            ILogger logger)
+        {
+            _research = research;
+            _wm = wm;
+            _taskId = taskId;
+            _personaId = personaId;
+            _maxCalls = maxCalls;
+            _logger = logger;
+        }
+
+        public override string Name => "research";
+
+        public override string Description =>
+            "Search the web and summarise findings on a focused question. Each call is delegated " +
+            "to a research agent and costs latency, so use sparingly and only when current facts " +
+            "would sharpen your view from your persona's lens. Pass one focused question per call.";
+
+        public override JsonElement JsonSchema => Schema;
+
+        protected override async ValueTask<object?> InvokeCoreAsync(
+            AIFunctionArguments arguments, CancellationToken cancellationToken)
+        {
+            string? question = null;
+            if (arguments.TryGetValue("question", out var v))
+                question = v?.ToString();
+            if (string.IsNullOrWhiteSpace(question))
+                return "Error: missing required argument 'question'.";
+
+            var n = Interlocked.Increment(ref _callCount);
+            if (n > _maxCalls)
+            {
+                _logger.LogInformation(
+                    "Persona {Persona} on council {Task} exhausted research budget ({Max} calls); returning sentinel",
+                    _personaId, _taskId, _maxCalls);
+                return $"(research budget exhausted: this persona has already made {_maxCalls} research call(s) — answer from existing context)";
+            }
+
+            var findings = await _research(question!, cancellationToken);
+
+            // Skip writing failure sentinels emitted by ResearchAgentInvoker (e.g. "(research failed: ...)",
+            // "(research timed out)", "(research call failed: ...)") so the WM pool stays signal-rich.
+            if (!string.IsNullOrWhiteSpace(findings) &&
+                !findings.StartsWith("(research", StringComparison.OrdinalIgnoreCase))
+            {
+                try
+                {
+                    await _wm.SetAsync(
+                        key: $"council/{_taskId}/{_personaId}/research/{n}",
+                        value: $"Q: {question}\n\n{findings}",
+                        ttl: TimeSpan.FromMinutes(30),
+                        category: "council/research",
+                        tags: [_personaId, _taskId]);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to write research result to WM for {Persona}", _personaId);
+                }
+            }
+
+            return findings;
         }
     }
 }

--- a/src/RockBot.AdvisorCouncil/Council/PersonaStep.cs
+++ b/src/RockBot.AdvisorCouncil/Council/PersonaStep.cs
@@ -70,7 +70,7 @@ internal sealed class PersonaStep(
                 logger.LogWarning(ex, "Failed to write persona view to WM for {Persona}", persona.Id);
             }
 
-            return new PersonaView(persona.Id, text, [], []);
+            return new PersonaView(persona.Id, text, [], [], PersonaStatus.Ok);
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
@@ -79,7 +79,7 @@ internal sealed class PersonaStep(
         catch (Exception ex)
         {
             logger.LogError(ex, "PersonaStep failed for persona {Id}", persona.Id);
-            return new PersonaView(persona.Id, "(persona call failed)", [], []);
+            return new PersonaView(persona.Id, "(persona call failed)", [], [], PersonaStatus.Failed);
         }
     }
 

--- a/src/RockBot.AdvisorCouncil/Council/PreResearchStep.cs
+++ b/src/RockBot.AdvisorCouncil/Council/PreResearchStep.cs
@@ -1,23 +1,53 @@
+using System.Text;
 using Microsoft.Extensions.Logging;
+using RockBot.AdvisorCouncil.Personas;
 using RockBot.AdvisorCouncil.Tools;
+using RockBot.Host;
 
 namespace RockBot.AdvisorCouncil.Council;
 
 /// <summary>
-/// Conditional stage that runs a single research call up-front and injects the findings
-/// into every persona branch. Skipped unless the selector returns <c>pre_research=true</c>.
+/// Conditional stage that runs a single research call up-front and writes the findings to
+/// working memory at <c>council/{taskId}/shared</c>, where each persona can read them.
+/// Skipped unless the selector returns <c>pre_research=true</c>.
+///
+/// The research question is enriched with the selected council roster so the research
+/// agent gathers facts relevant to each persona's lens, not just the question in isolation.
 /// </summary>
 internal sealed class PreResearchStep(
     ResearchAgentInvoker invoker,
+    IWorkingMemory workingMemory,
     ILogger<PreResearchStep> logger)
 {
-    public async Task<string?> RunAsync(string question, CancellationToken ct)
+    /// <summary>
+    /// Runs persona-aware pre-research and stores the findings in working memory.
+    /// Returns true if findings were written (consumed by orchestrator metadata).
+    /// </summary>
+    public async Task<bool> RunAsync(
+        string question,
+        IReadOnlyList<Persona> selectedPersonas,
+        string taskId,
+        CancellationToken ct)
     {
         try
         {
-            var findings = await invoker.InvokeAsync(question, ct);
-            logger.LogInformation("Pre-research returned {Len} chars", findings.Length);
-            return findings;
+            var enrichedQuestion = BuildPersonaAwareQuestion(question, selectedPersonas);
+            var findings = await invoker.InvokeAsync(enrichedQuestion, ct);
+            if (string.IsNullOrWhiteSpace(findings))
+            {
+                logger.LogInformation("Pre-research returned empty findings; not writing to WM");
+                return false;
+            }
+
+            await workingMemory.SetAsync(
+                key: $"council/{taskId}/shared",
+                value: findings,
+                ttl: TimeSpan.FromMinutes(30),
+                category: "council/research",
+                tags: ["shared", taskId]);
+
+            logger.LogInformation("Pre-research wrote {Len} chars to council/{TaskId}/shared", findings.Length, taskId);
+            return true;
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
@@ -26,7 +56,27 @@ internal sealed class PreResearchStep(
         catch (Exception ex)
         {
             logger.LogError(ex, "Pre-research call failed; continuing without findings");
-            return null;
+            return false;
         }
+    }
+
+    private static string BuildPersonaAwareQuestion(string question, IReadOnlyList<Persona> personas)
+    {
+        if (personas.Count == 0)
+            return question;
+
+        var sb = new StringBuilder();
+        sb.Append("Investigate the following question. The council will examine it through these lenses, ")
+          .AppendLine("so gather facts relevant to each lens, not just the question in isolation:");
+        foreach (var p in personas)
+        {
+            sb.Append("- ").Append(p.Id);
+            if (!string.IsNullOrWhiteSpace(p.Description))
+                sb.Append(" — ").Append(p.Description);
+            sb.AppendLine();
+        }
+        sb.AppendLine();
+        sb.Append("Question: ").Append(question);
+        return sb.ToString();
     }
 }

--- a/src/RockBot.AdvisorCouncil/Council/SelectStep.cs
+++ b/src/RockBot.AdvisorCouncil/Council/SelectStep.cs
@@ -56,7 +56,7 @@ internal sealed class SelectStep(
                 attempt++;
                 messages.Add(new ChatMessage(ChatRole.User,
                     "Your previous response was not valid JSON matching the required schema. " +
-                    "Return ONLY a JSON object with keys: personas (array of {id, needs_research}), " +
+                    "Return ONLY a JSON object with keys: personas (array of {id}), " +
                     "pre_research (boolean), critique (boolean), rationale (string)."));
             }
         }
@@ -84,12 +84,11 @@ internal sealed class SelectStep(
         sb.AppendLine();
         sb.AppendLine("Selection guidance:");
         sb.AppendLine("- Pick 3–5 personas whose framings are most relevant. Do not select all by default.");
-        sb.AppendLine("- pre_research: true only when multiple personas would benefit from a shared factual base (specific technologies, companies, recent events).");
+        sb.AppendLine("- pre_research: true only when multiple personas would benefit from a shared factual base (specific technologies, companies, recent events). Each persona can also invoke research on its own when its lens demands it, so reserve pre_research for genuinely shared factual ground.");
         sb.AppendLine("- critique: true when the question is contested or strategic and personas are likely to disagree. False for mostly factual integration.");
-        sb.AppendLine("- needs_research per persona: true when the persona's framing requires up-to-date facts (e.g. engineer, economist) AND research is relevant to this question.");
         sb.AppendLine();
         sb.AppendLine("Respond with JSON only, in this exact shape:");
-        sb.AppendLine(@"{ ""personas"": [{""id"": ""..."", ""needs_research"": false}], ""pre_research"": false, ""critique"": false, ""rationale"": ""..."" }");
+        sb.AppendLine(@"{ ""personas"": [{""id"": ""...""}], ""pre_research"": false, ""critique"": false, ""rationale"": ""..."" }");
         return sb.ToString();
     }
 
@@ -129,13 +128,13 @@ internal sealed class SelectStep(
         var available = registry.Personas;
         var selected = defaults
             .Where(id => available.ContainsKey(id))
-            .Select(id => new SelectedPersona(id, false))
+            .Select(id => new SelectedPersona(id))
             .ToList();
         if (selected.Count == 0)
         {
             selected = available.Keys
                 .Take(3)
-                .Select(id => new SelectedPersona(id, false))
+                .Select(id => new SelectedPersona(id))
                 .ToList();
         }
         return new SelectorOutput(selected, false, false, "Fallback default selection — selector output failed schema validation.");

--- a/src/RockBot.AdvisorCouncil/Council/SynthesizeStep.cs
+++ b/src/RockBot.AdvisorCouncil/Council/SynthesizeStep.cs
@@ -93,8 +93,20 @@ internal sealed class SynthesizeStep(
     {
         var sb = new StringBuilder();
         sb.Append("Question: ").AppendLine(input.Question).AppendLine();
+
+        var contributing = input.Views.Where(v => v.Status == PersonaStatus.Ok).ToList();
+        var missing = input.Views.Where(v => v.Status != PersonaStatus.Ok).ToList();
+
+        if (missing.Count > 0)
+        {
+            sb.AppendLine("Coverage note: the following personas were selected but did NOT contribute and are absent from the views below. Acknowledge this gap in your synthesis (briefly) and lower the confidence accordingly.");
+            foreach (var v in missing)
+                sb.Append("- ").Append(v.Id).Append(" (").Append(v.Status).AppendLine(")");
+            sb.AppendLine();
+        }
+
         sb.AppendLine("Persona views:");
-        foreach (var v in input.Views)
+        foreach (var v in contributing)
         {
             sb.Append("### ").AppendLine(v.Id);
             sb.AppendLine(v.View).AppendLine();

--- a/src/RockBot.AdvisorCouncil/Program.cs
+++ b/src/RockBot.AdvisorCouncil/Program.cs
@@ -101,7 +101,9 @@ builder.Services.AddRockBotHost(agent =>
 
     // Working memory — persona branches with research write their findings here under
     // council/{taskId}/{personaId}; namespace shared across personas for cross-pollination.
-    agent.WithWorkingMemory();
+    // Bump per-namespace cap above the default 50: a single council run can produce
+    // ~5 personas × (1 view + 3 research + 1 revised) + 1 shared = ~26 entries, with headroom.
+    agent.WithWorkingMemory(opts => opts.MaxEntriesPerNamespace = 200);
 
     agent.AddA2A(opts =>
     {

--- a/src/RockBot.AdvisorCouncil/Schema/CouncilResponse.cs
+++ b/src/RockBot.AdvisorCouncil/Schema/CouncilResponse.cs
@@ -19,7 +19,21 @@ internal sealed record PersonaView(
     [property: JsonPropertyName("id")] string Id,
     [property: JsonPropertyName("view")] string View,
     [property: JsonPropertyName("key_points")] IReadOnlyList<string> KeyPoints,
-    [property: JsonPropertyName("sources")] IReadOnlyList<string> Sources);
+    [property: JsonPropertyName("sources")] IReadOnlyList<string> Sources,
+    [property: JsonPropertyName("status")] string Status = PersonaStatus.Ok);
+
+/// <summary>Standardized values for <see cref="PersonaView.Status"/>.</summary>
+internal static class PersonaStatus
+{
+    /// <summary>The persona produced its view within the per-persona budget.</summary>
+    public const string Ok = "ok";
+
+    /// <summary>The persona was cancelled by the per-persona soft timeout.</summary>
+    public const string TimedOut = "timed_out";
+
+    /// <summary>The persona's chat-client call threw a non-cancellation exception.</summary>
+    public const string Failed = "failed";
+}
 
 internal sealed record Tension(
     [property: JsonPropertyName("between")] IReadOnlyList<string> Between,
@@ -33,4 +47,6 @@ internal sealed record CouncilMetadata(
     [property: JsonPropertyName("duration_ms")] long DurationMs,
     [property: JsonPropertyName("model_calls")] int ModelCalls,
     [property: JsonPropertyName("persona_set_hash")] string PersonaSetHash,
-    [property: JsonPropertyName("selector_rationale")] string SelectorRationale);
+    [property: JsonPropertyName("selector_rationale")] string SelectorRationale,
+    [property: JsonPropertyName("personas_contributed")] int PersonasContributed = 0,
+    [property: JsonPropertyName("personas_missing")] IReadOnlyList<string>? PersonasMissing = null);

--- a/src/RockBot.AdvisorCouncil/Schema/SelectorOutput.cs
+++ b/src/RockBot.AdvisorCouncil/Schema/SelectorOutput.cs
@@ -14,5 +14,4 @@ internal sealed record SelectorOutput(
     [property: JsonPropertyName("rationale")] string Rationale);
 
 internal sealed record SelectedPersona(
-    [property: JsonPropertyName("id")] string Id,
-    [property: JsonPropertyName("needs_research")] bool NeedsResearch);
+    [property: JsonPropertyName("id")] string Id);

--- a/src/RockBot.AdvisorCouncil/appsettings.json
+++ b/src/RockBot.AdvisorCouncil/appsettings.json
@@ -16,8 +16,8 @@
   },
   "Council": {
     "PersonasPath": "",
-    "OverallTimeoutSeconds": 180,
-    "PerPersonaTimeoutSeconds": 60,
+    "OverallTimeoutSeconds": 300,
+    "PerPersonaTimeoutSeconds": 120,
     "PreResearchTimeoutSeconds": 90,
     "ResearchAgentTimeoutSeconds": 90
   }

--- a/src/RockBot.ResearchAgent/NullConversationMemory.cs
+++ b/src/RockBot.ResearchAgent/NullConversationMemory.cs
@@ -1,0 +1,26 @@
+using RockBot.Host;
+
+namespace RockBot.ResearchAgent;
+
+/// <summary>
+/// No-op <see cref="IConversationMemory"/> for the ephemeral research agent.
+/// Each pod handles one task (session = task id) then exits; persisted turns
+/// would have no consumer. <see cref="AgentLoopRunner"/> only touches conversation
+/// memory in the Azure content-filter recovery path, which is non-fatal if these
+/// calls are no-ops.
+/// </summary>
+internal sealed class NullConversationMemory : IConversationMemory
+{
+    public Task AddTurnAsync(string sessionId, ConversationTurn turn,
+        CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+    public Task<IReadOnlyList<ConversationTurn>> GetTurnsAsync(string sessionId,
+        CancellationToken cancellationToken = default) =>
+        Task.FromResult<IReadOnlyList<ConversationTurn>>([]);
+
+    public Task ClearAsync(string sessionId, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+
+    public Task<IReadOnlyList<string>> ListSessionsAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<string>>([]);
+}

--- a/src/RockBot.ResearchAgent/NullSkillStore.cs
+++ b/src/RockBot.ResearchAgent/NullSkillStore.cs
@@ -1,0 +1,26 @@
+using RockBot.Host;
+
+namespace RockBot.ResearchAgent;
+
+/// <summary>
+/// No-op <see cref="ISkillStore"/> for the ephemeral research agent.
+/// The research agent neither persists nor consults skills; this exists solely
+/// to satisfy <see cref="AgentLoopRunner"/>'s constructor.
+/// </summary>
+internal sealed class NullSkillStore : ISkillStore
+{
+    public Task SaveAsync(Skill skill) => Task.CompletedTask;
+
+    public Task<Skill?> GetAsync(string name) => Task.FromResult<Skill?>(null);
+
+    public Task<IReadOnlyList<Skill>> ListAsync() =>
+        Task.FromResult<IReadOnlyList<Skill>>([]);
+
+    public Task DeleteAsync(string name) => Task.CompletedTask;
+
+    public Task<IReadOnlyList<Skill>> SearchAsync(
+        string query, int maxResults,
+        CancellationToken cancellationToken = default,
+        float[]? queryEmbedding = null) =>
+        Task.FromResult<IReadOnlyList<Skill>>([]);
+}

--- a/src/RockBot.ResearchAgent/Program.cs
+++ b/src/RockBot.ResearchAgent/Program.cs
@@ -96,6 +96,12 @@ else
 // AgentLoopRunner requires IFeedbackStore — use no-op since we have no dreaming pipeline
 builder.Services.AddSingleton<IFeedbackStore, NullFeedbackStore>();
 
+// AgentLoopRunner also depends on ISkillStore (used only on completion re-prompt,
+// which we disable via enableFollowUp:false) and IConversationMemory (used only on
+// Azure content-filter recovery). Null stores keep the ephemeral pod stateless.
+builder.Services.AddSingleton<ISkillStore, NullSkillStore>();
+builder.Services.AddSingleton<IConversationMemory, NullConversationMemory>();
+
 builder.Services.AddRockBotHost(agent =>
 {
     agent.WithIdentity("ResearchAgent");

--- a/tests/RockBot.AdvisorCouncil.Tests/CouncilOrchestratorTests.cs
+++ b/tests/RockBot.AdvisorCouncil.Tests/CouncilOrchestratorTests.cs
@@ -34,7 +34,7 @@ public class CouncilOrchestratorTests
         // collide with the plain persona call match.
         var chat = new FakeChatClient()
             .WhenUserContains("selector for an advisor council",
-                """{ "personas": [{"id":"skeptic","needs_research":false},{"id":"engineer","needs_research":false}], "pre_research": false, "critique": false, "rationale": "Engineering decision." }""")
+                """{ "personas": [{"id":"skeptic"},{"id":"engineer"}], "pre_research": false, "critique": false, "rationale": "Engineering decision." }""")
             .WhenUserContains("synthesis step of an advisor council",
                 """{ "synthesis": "## Synthesis\n\nProceed with caution.", "confidence": "medium", "tensions": [] }""")
             .WhenUserContains("Critique addendum",
@@ -62,7 +62,7 @@ public class CouncilOrchestratorTests
         var registry = MakeRegistry();
         var chat = new FakeChatClient()
             .WhenUserContains("selector for an advisor council",
-                """{ "personas": [{"id":"skeptic","needs_research":false},{"id":"engineer","needs_research":false}], "pre_research": false, "critique": true, "rationale": "Contested." }""")
+                """{ "personas": [{"id":"skeptic"},{"id":"engineer"}], "pre_research": false, "critique": true, "rationale": "Contested." }""")
             .WhenUserContains("synthesis step of an advisor council",
                 """{ "synthesis": "Integrated view.", "confidence": "low", "tensions": [{"between":["skeptic","engineer"],"description":"timing","stakes":"ship vs delay"}] }""")
             .WhenUserContains("Critique addendum",
@@ -86,7 +86,7 @@ public class CouncilOrchestratorTests
         // Synthesis always returns invalid; orchestrator falls back to a stub synthesis.
         var chat = new FakeChatClient()
             .WhenUserContains("selector for an advisor council",
-                """{ "personas": [{"id":"skeptic","needs_research":false}], "pre_research": false, "critique": false, "rationale": "Simple." }""")
+                """{ "personas": [{"id":"skeptic"}], "pre_research": false, "critique": false, "rationale": "Simple." }""")
             .WhenUserContains("synthesis step of an advisor council", "not valid json")
             .WhenUserContains("Skeptic body", "Persona view.");
 
@@ -117,12 +117,15 @@ public class CouncilOrchestratorTests
     private static CouncilOrchestrator BuildOrchestrator(PersonaRegistry registry, FakeChatClient chat)
     {
         var opts = Options.Create(new CouncilOptions { PerPersonaTimeoutSeconds = 30, OverallTimeoutSeconds = 60 });
+        var wm = new InMemoryWorkingMemory();
         var select = new SelectStep(chat, registry, NullLogger<SelectStep>.Instance);
-        var persona = new PersonaStep(chat, NullLogger<PersonaStep>.Instance);
-        var critique = new CritiqueStep(chat, NullLogger<CritiqueStep>.Instance);
+        // ResearchAgentInvoker passed as null! — the FakeChatClient never returns a tool-call response,
+        // so PersonaStep's scoped research tool is never invoked. Same applies to PreResearchStep when
+        // pre_research=false (the only case exercised by these orchestrator-shape tests).
+        var persona = new PersonaStep(chat, invoker: null!, wm, opts, NullLogger<PersonaStep>.Instance);
+        var critique = new CritiqueStep(chat, wm, NullLogger<CritiqueStep>.Instance);
         var synth = new SynthesizeStep(chat, NullLogger<SynthesizeStep>.Instance);
-        // PreResearchStep needs a ResearchAgentInvoker — not used in these tests because pre_research=false
-        var preResearch = new PreResearchStep(null!, NullLogger<PreResearchStep>.Instance);
+        var preResearch = new PreResearchStep(invoker: null!, wm, NullLogger<PreResearchStep>.Instance);
         return new CouncilOrchestrator(select, preResearch, persona, critique, synth, registry, opts,
             NullLogger<CouncilOrchestrator>.Instance);
     }

--- a/tests/RockBot.AdvisorCouncil.Tests/CouncilResponseSchemaTests.cs
+++ b/tests/RockBot.AdvisorCouncil.Tests/CouncilResponseSchemaTests.cs
@@ -53,7 +53,7 @@ public class CouncilResponseSchemaTests
     public void SelectorOutput_JsonSchemaShape_IsSnakeCase()
     {
         var sel = new SelectorOutput(
-            [new SelectedPersona("skeptic", true)],
+            [new SelectedPersona("skeptic")],
             PreResearch: true,
             Critique: false,
             Rationale: "r");
@@ -61,8 +61,9 @@ public class CouncilResponseSchemaTests
         var json = JsonSerializer.Serialize(sel);
 
         StringAssert.Contains(json, "\"pre_research\":");
-        StringAssert.Contains(json, "\"needs_research\":");
         StringAssert.Contains(json, "\"critique\":");
         StringAssert.Contains(json, "\"rationale\":");
+        Assert.IsFalse(json.Contains("needs_research", StringComparison.Ordinal),
+            "needs_research was removed; SelectedPersona should serialize with only id");
     }
 }

--- a/tests/RockBot.AdvisorCouncil.Tests/InMemoryWorkingMemory.cs
+++ b/tests/RockBot.AdvisorCouncil.Tests/InMemoryWorkingMemory.cs
@@ -1,0 +1,54 @@
+using RockBot.Host;
+
+namespace RockBot.AdvisorCouncil.Tests;
+
+/// <summary>
+/// Minimal <see cref="IWorkingMemory"/> for council tests. Backed by a dictionary, ignores
+/// TTL (test runs are short), supports prefix-based listing — enough for the WM-mediated
+/// council pipeline.
+/// </summary>
+internal sealed class InMemoryWorkingMemory : IWorkingMemory
+{
+    private readonly Dictionary<string, WorkingMemoryEntry> _entries = new(StringComparer.Ordinal);
+
+    public IReadOnlyDictionary<string, WorkingMemoryEntry> Entries => _entries;
+
+    public Task SetAsync(string key, string value, TimeSpan? ttl = null,
+        string? category = null, IReadOnlyList<string>? tags = null)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var expires = now.Add(ttl ?? TimeSpan.FromHours(1));
+        _entries[key] = new WorkingMemoryEntry(key, value, now, expires, category, tags);
+        return Task.CompletedTask;
+    }
+
+    public Task<string?> GetAsync(string key) =>
+        Task.FromResult(_entries.TryGetValue(key, out var e) ? e.Value : null);
+
+    public Task<IReadOnlyList<WorkingMemoryEntry>> ListAsync(string? prefix = null)
+    {
+        IReadOnlyList<WorkingMemoryEntry> list = _entries.Values
+            .Where(e => string.IsNullOrEmpty(prefix) || e.Key.StartsWith(prefix, StringComparison.Ordinal))
+            .ToList();
+        return Task.FromResult(list);
+    }
+
+    public Task DeleteAsync(string key)
+    {
+        _entries.Remove(key);
+        return Task.CompletedTask;
+    }
+
+    public Task ClearAsync(string? prefix = null)
+    {
+        var toRemove = _entries.Keys
+            .Where(k => string.IsNullOrEmpty(prefix) || k.StartsWith(prefix, StringComparison.Ordinal))
+            .ToList();
+        foreach (var k in toRemove)
+            _entries.Remove(k);
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<WorkingMemoryEntry>> SearchAsync(MemorySearchCriteria criteria, string? prefix = null) =>
+        ListAsync(prefix);
+}

--- a/tests/RockBot.AdvisorCouncil.Tests/PersonaStepWorkingMemoryTests.cs
+++ b/tests/RockBot.AdvisorCouncil.Tests/PersonaStepWorkingMemoryTests.cs
@@ -1,0 +1,194 @@
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using RockBot.AdvisorCouncil.Council;
+using RockBot.AdvisorCouncil.Personas;
+
+namespace RockBot.AdvisorCouncil.Tests;
+
+/// <summary>
+/// Behaviour tests for the WM-mediated parts of the council pipeline:
+/// shared pre-research read-through, per-persona view write, scoped research tool
+/// (WM write + budget enforcement), and CritiqueStep's WM pool inclusion.
+/// </summary>
+[TestClass]
+public class PersonaStepWorkingMemoryTests
+{
+    private static Persona MakePersona(string id = "skeptic") => new(
+        Id: id,
+        Name: id,
+        Description: $"{id} description",
+        SystemPrompt: $"{id} system prompt",
+        DefaultResearch: false);
+
+    [TestMethod]
+    public async Task PersonaStep_PrependsSharedPreResearchToPrompt_WhenWmHasShared()
+    {
+        var wm = new InMemoryWorkingMemory();
+        await wm.SetAsync("council/task-99/shared", "Pre-existing baseline findings about X.");
+
+        var chat = new FakeChatClient().EnqueueResponse("persona response text");
+        var opts = Options.Create(new CouncilOptions());
+        var step = new PersonaStep(chat, invoker: null!, wm, opts, NullLogger<PersonaStep>.Instance);
+
+        var view = await step.RunAsync(MakePersona(), "Original question?", "task-99", CancellationToken.None);
+
+        Assert.AreEqual("persona response text", view.View);
+        var lastCall = chat.Calls[^1];
+        var userMessage = lastCall.Messages.Last(m => m.Role == ChatRole.User).Text ?? string.Empty;
+        StringAssert.Contains(userMessage, "Pre-existing baseline findings about X.");
+        StringAssert.Contains(userMessage, "Original question?");
+        StringAssert.Contains(userMessage, "Pre-research findings");
+    }
+
+    [TestMethod]
+    public async Task PersonaStep_WritesViewToWm_AtPersonaViewKey()
+    {
+        var wm = new InMemoryWorkingMemory();
+        var chat = new FakeChatClient().EnqueueResponse("My view as the skeptic.");
+        var opts = Options.Create(new CouncilOptions());
+        var step = new PersonaStep(chat, invoker: null!, wm, opts, NullLogger<PersonaStep>.Instance);
+
+        await step.RunAsync(MakePersona("skeptic"), "Q?", "task-7", CancellationToken.None);
+
+        var stored = await wm.GetAsync("council/task-7/skeptic/view");
+        Assert.AreEqual("My view as the skeptic.", stored);
+    }
+
+    [TestMethod]
+    public async Task PersonaStep_NoSharedInWm_UsesRawQuestionAsPrompt()
+    {
+        var wm = new InMemoryWorkingMemory();
+        var chat = new FakeChatClient().EnqueueResponse("view");
+        var opts = Options.Create(new CouncilOptions());
+        var step = new PersonaStep(chat, invoker: null!, wm, opts, NullLogger<PersonaStep>.Instance);
+
+        await step.RunAsync(MakePersona(), "Just the question.", "task-x", CancellationToken.None);
+
+        var userMessage = chat.Calls[^1].Messages.Last(m => m.Role == ChatRole.User).Text ?? string.Empty;
+        Assert.AreEqual("Just the question.", userMessage);
+    }
+
+    [TestMethod]
+    public async Task ScopedResearchTool_OnSuccess_WritesFindingsToWm_WithIncrementingIndex()
+    {
+        var wm = new InMemoryWorkingMemory();
+        var tool = new PersonaStep.PersonaScopedResearchTool(
+            research: (q, _) => Task.FromResult($"answer for: {q}"),
+            wm: wm,
+            taskId: "task-a",
+            personaId: "engineer",
+            maxCalls: 3,
+            logger: NullLogger.Instance);
+
+        await InvokeToolAsync(tool, "first question");
+        await InvokeToolAsync(tool, "second question");
+
+        var first = await wm.GetAsync("council/task-a/engineer/research/1");
+        var second = await wm.GetAsync("council/task-a/engineer/research/2");
+        Assert.IsNotNull(first);
+        Assert.IsNotNull(second);
+        StringAssert.Contains(first!, "first question");
+        StringAssert.Contains(first!, "answer for: first question");
+        StringAssert.Contains(second!, "second question");
+    }
+
+    [TestMethod]
+    public async Task ScopedResearchTool_PastBudget_ReturnsSentinel_AndDoesNotWriteToWm()
+    {
+        var wm = new InMemoryWorkingMemory();
+        var underlyingCalls = 0;
+        var tool = new PersonaStep.PersonaScopedResearchTool(
+            research: (q, _) =>
+            {
+                Interlocked.Increment(ref underlyingCalls);
+                return Task.FromResult($"answer-{q}");
+            },
+            wm: wm,
+            taskId: "task-b",
+            personaId: "engineer",
+            maxCalls: 3,
+            logger: NullLogger.Instance);
+
+        var r1 = (string?)await InvokeToolAsync(tool, "q1");
+        var r2 = (string?)await InvokeToolAsync(tool, "q2");
+        var r3 = (string?)await InvokeToolAsync(tool, "q3");
+        var r4 = (string?)await InvokeToolAsync(tool, "q4");
+
+        StringAssert.Contains(r1!, "answer-q1");
+        StringAssert.Contains(r3!, "answer-q3");
+        StringAssert.Contains(r4!, "research budget exhausted");
+        Assert.AreEqual(3, underlyingCalls, "Underlying research delegate should not be invoked past the cap");
+        Assert.IsNull(await wm.GetAsync("council/task-b/engineer/research/4"));
+    }
+
+    [TestMethod]
+    public async Task ScopedResearchTool_DoesNotWriteFailureSentinelsToWm()
+    {
+        var wm = new InMemoryWorkingMemory();
+        var tool = new PersonaStep.PersonaScopedResearchTool(
+            research: (_, _) => Task.FromResult("(research failed: simulated)"),
+            wm: wm,
+            taskId: "task-c",
+            personaId: "skeptic",
+            maxCalls: 3,
+            logger: NullLogger.Instance);
+
+        await InvokeToolAsync(tool, "any");
+
+        Assert.IsNull(await wm.GetAsync("council/task-c/skeptic/research/1"));
+    }
+
+    [TestMethod]
+    public async Task CritiqueStep_IncludesResearchPoolFromWm_AndExcludesViewKeys()
+    {
+        var wm = new InMemoryWorkingMemory();
+        const string taskId = "task-crit";
+
+        // Populate WM as the orchestrator would after pre-research + persona views ran.
+        await wm.SetAsync($"council/{taskId}/shared", "Shared baseline content.");
+        await wm.SetAsync($"council/{taskId}/engineer/research/1", "Q: feasibility?\n\nFeasibility looks tight.");
+        await wm.SetAsync($"council/{taskId}/skeptic/view", "Skeptic view text.");
+        await wm.SetAsync($"council/{taskId}/skeptic/view-revised", "Skeptic revised text.");
+
+        var chat = new FakeChatClient().EnqueueResponse(
+            """{ "revised_view": "revised", "key_points": [], "tensions": [] }""");
+        var step = new CritiqueStep(chat, wm, NullLogger<CritiqueStep>.Instance);
+
+        var own = new RockBot.AdvisorCouncil.Schema.PersonaView("skeptic", "Skeptic view text.", [], []);
+        var siblings = new[] { new RockBot.AdvisorCouncil.Schema.PersonaView("engineer", "Engineer view.", [], []) };
+
+        await step.RunAsync(MakePersona("skeptic"), "Question?", taskId, own, siblings, CancellationToken.None);
+
+        var userMessage = chat.Calls[^1].Messages.Last(m => m.Role == ChatRole.User).Text ?? string.Empty;
+        StringAssert.Contains(userMessage, "Research findings available to the council");
+        StringAssert.Contains(userMessage, "Shared baseline content.");
+        StringAssert.Contains(userMessage, "Feasibility looks tight.");
+        Assert.IsFalse(userMessage.Contains("Skeptic revised text.", StringComparison.Ordinal),
+            "view-revised entries must not be included in the research pool section");
+    }
+
+    [TestMethod]
+    public async Task CritiqueStep_WritesRevisedViewToWm()
+    {
+        var wm = new InMemoryWorkingMemory();
+        const string taskId = "task-revised";
+        var chat = new FakeChatClient().EnqueueResponse(
+            """{ "revised_view": "post-rebuttal text", "key_points": [], "tensions": [] }""");
+        var step = new CritiqueStep(chat, wm, NullLogger<CritiqueStep>.Instance);
+
+        var own = new RockBot.AdvisorCouncil.Schema.PersonaView("skeptic", "before", [], []);
+        var siblings = new[] { new RockBot.AdvisorCouncil.Schema.PersonaView("engineer", "engineer view", [], []) };
+
+        await step.RunAsync(MakePersona("skeptic"), "Q?", taskId, own, siblings, CancellationToken.None);
+
+        var stored = await wm.GetAsync($"council/{taskId}/skeptic/view-revised");
+        Assert.AreEqual("post-rebuttal text", stored);
+    }
+
+    private static async Task<object?> InvokeToolAsync(AIFunction tool, string question)
+    {
+        var args = new AIFunctionArguments { ["question"] = question };
+        return await tool.InvokeAsync(args, CancellationToken.None);
+    }
+}

--- a/tests/RockBot.AdvisorCouncil.Tests/SelectStepTests.cs
+++ b/tests/RockBot.AdvisorCouncil.Tests/SelectStepTests.cs
@@ -27,7 +27,7 @@ public class SelectStepTests
         var registry = MakeRegistry(("skeptic", false), ("engineer", true), ("economist", true));
         var chat = new FakeChatClient().EnqueueResponse(
             """
-            { "personas": [{"id":"skeptic","needs_research":false},{"id":"engineer","needs_research":true}],
+            { "personas": [{"id":"skeptic"},{"id":"engineer"}],
               "pre_research": false, "critique": true, "rationale": "Design question with engineering tradeoffs." }
             """);
         var step = new SelectStep(chat, registry, NullLogger<SelectStep>.Instance);
@@ -38,7 +38,7 @@ public class SelectStepTests
         Assert.IsTrue(result.Critique);
         Assert.IsFalse(result.PreResearch);
         Assert.AreEqual("skeptic", result.Personas[0].Id);
-        Assert.IsTrue(result.Personas[1].NeedsResearch);
+        Assert.AreEqual("engineer", result.Personas[1].Id);
     }
 
     [TestMethod]
@@ -48,7 +48,7 @@ public class SelectStepTests
         var chat = new FakeChatClient()
             .EnqueueResponse("not json")
             .EnqueueResponse(
-                """{ "personas": [{"id":"skeptic","needs_research":false}], "pre_research": false, "critique": false, "rationale": "x" }""");
+                """{ "personas": [{"id":"skeptic"}], "pre_research": false, "critique": false, "rationale": "x" }""");
         var step = new SelectStep(chat, registry, NullLogger<SelectStep>.Instance);
 
         var result = await step.RunAsync("Trivial", CancellationToken.None);
@@ -80,7 +80,7 @@ public class SelectStepTests
     {
         var registry = MakeRegistry(("skeptic", false), ("engineer", false));
         var chat = new FakeChatClient().EnqueueResponse(
-            """{ "personas": [{"id":"unknown","needs_research":false},{"id":"skeptic","needs_research":false}], "pre_research": false, "critique": false, "rationale": "x" }""");
+            """{ "personas": [{"id":"unknown"},{"id":"skeptic"}], "pre_research": false, "critique": false, "rationale": "x" }""");
         var step = new SelectStep(chat, registry, NullLogger<SelectStep>.Instance);
 
         var result = await step.RunAsync("q", CancellationToken.None);


### PR DESCRIPTION
## Summary
- Selector previously decided per-persona research needs before any persona saw the question, and `PersonaStep` ignored the flag anyway. Shared pre-research was also persona-agnostic — the ethicist could receive research that ignored ethics entirely.
- Personas now read shared pre-research and write their own findings through working memory at `council/{taskId}/...`:
  - `PreResearchStep` takes the selected roster and writes a persona-aware baseline to `council/{taskId}/shared`.
  - `PersonaStep` wires a scoped `research` `AIFunction` into `ChatOptions.Tools` so each persona invokes research autonomously (capped at 3 calls per persona via `CouncilOptions.MaxResearchCallsPerPersona`), writing findings to `council/{taskId}/{personaId}/research/{n}`.
  - `CritiqueStep` enumerates the WM pool so the rebuttal round sees every persona's accumulated evidence, not just sibling views.
  - `SelectorOutput` drops `needs_research`; the selector keeps only orchestration-level decisions (roster, `pre_research`, `critique`).
- Per-namespace WM cap bumped to 200 to accommodate ~5 personas × multiple research + view + revised-view entries.

## Test plan
- [x] `dotnet build RockBot.slnx` clean
- [x] `dotnet test RockBot.slnx --filter "FullyQualifiedName~AdvisorCouncil"` — 30/30 pass (22 existing + 8 new WM-behaviour tests)
- [ ] Deployed test image `rockylhotka/rockbot-advisor-council:0.10.65-council-wm` to the cluster via `kubectl patch scaledjob`; smoke-test a contested A2A council question and verify:
  - `council/{taskId}/shared` is populated when `pre_research=true`
  - At least one persona's `council/{taskId}/{personaId}/research/*` keys exist when the model elects to research
  - Critique prompt logs reference cross-persona research

🤖 Generated with [Claude Code](https://claude.com/claude-code)