### PR TITLE
Promote recurring wisps via shape hash and eager scheduled-task path

### DIFF
--- a/src/RockBot.Host.Abstractions/WispExecutionRecord.cs
+++ b/src/RockBot.Host.Abstractions/WispExecutionRecord.cs
@@ -15,6 +15,18 @@ public sealed record WispExecutionRecord
     /// <summary>SHA-256 hash of the serialized step definitions for matching retries.</summary>
     public required string DefinitionHash { get; init; }
 
+    /// <summary>
+    /// Normalized "shape" hash of the wisp — descriptions, prompts, and per-run
+    /// parameter values are stripped, leaving only structural identity (mode,
+    /// gateway, server, tool, language, agent, skill, on_failure, and the SORTED
+    /// SET of parameter keys per step). Two runs of the same pipeline that differ
+    /// only by description text, dates, account ids, or other literal values will
+    /// share the same shape hash.
+    /// Null on records written before this field existed; consumers should fall
+    /// back to <see cref="DefinitionHash"/> grouping in that case.
+    /// </summary>
+    public string? ShapeHash { get; init; }
+
     /// <summary>Whether all steps completed successfully.</summary>
     public required bool Succeeded { get; init; }
 

--- a/src/RockBot.Host/DreamService.cs
+++ b/src/RockBot.Host/DreamService.cs
@@ -2789,12 +2789,15 @@ internal sealed class DreamService : IHostedService, IDisposable
                 return;
             }
 
-            // Group by definitionHash. Keep groups where every recorded run succeeded
-            // and the cumulative count meets the threshold. Tighter than the failure
-            // pass intentionally — we want zero false positives.
+            // Group by ShapeHash when present (collapses runs that differ only by
+            // description text or per-run literal values such as dates and account
+            // ids), falling back to DefinitionHash for legacy records written before
+            // the shape hash existed. Keep groups where every recorded run
+            // succeeded and the cumulative count meets the threshold. Tighter than
+            // the failure pass intentionally — we want zero false positives.
             var groups = records
-                .Where(r => !string.IsNullOrEmpty(r.DefinitionHash))
-                .GroupBy(r => r.DefinitionHash)
+                .Where(r => !string.IsNullOrEmpty(r.ShapeHash) || !string.IsNullOrEmpty(r.DefinitionHash))
+                .GroupBy(r => !string.IsNullOrEmpty(r.ShapeHash) ? r.ShapeHash! : r.DefinitionHash)
                 .Where(g => g.Count() >= threshold && g.All(r => r.Succeeded))
                 .ToList();
 
@@ -2835,8 +2838,17 @@ internal sealed class DreamService : IHostedService, IDisposable
                 if (invokingSkill is null)
                     continue;  // no target skill — cannot promote
 
-                // Recover canonical body — required for the SaveSkill call below.
-                var body = await _wispExecutionLog.GetCanonicalBodyAsync(hash, ct);
+                // Recover canonical body from any record in the group that retained
+                // one — prefer the oldest successful body so the saved asset matches
+                // the earliest verified shape. Falls back to the log lookup (keyed
+                // on DefinitionHash) when the in-memory records don't carry a body.
+                var body = group
+                    .Where(r => r.Succeeded && !string.IsNullOrEmpty(r.DefinitionBody))
+                    .OrderBy(r => r.Timestamp)
+                    .Select(r => r.DefinitionBody)
+                    .FirstOrDefault();
+                if (string.IsNullOrEmpty(body))
+                    body = await _wispExecutionLog.GetCanonicalBodyAsync(representative.DefinitionHash, ct);
                 if (string.IsNullOrEmpty(body))
                     continue;  // body unavailable (oversize / pre-Phase-1 record)
 
@@ -3061,8 +3073,12 @@ internal sealed class DreamService : IHostedService, IDisposable
                 IReadOnlyList<WispExecutionRecord> wispRecords = [];
                 if (!string.IsNullOrEmpty(resource.DefinitionHash))
                 {
+                    // Match new shape-hashed resources against either ShapeHash (preferred)
+                    // or DefinitionHash (legacy resources written with a body hash).
                     var allRecords = await _wispExecutionLog.QueryRecentAsync(since, maxResults: 1000, ct);
-                    wispRecords = allRecords.Where(r => r.DefinitionHash == resource.DefinitionHash).ToList();
+                    wispRecords = allRecords.Where(r =>
+                        r.ShapeHash == resource.DefinitionHash
+                        || r.DefinitionHash == resource.DefinitionHash).ToList();
                 }
 
                 IReadOnlyList<SkillResourceCheckoutEvent> checkouts = [];

--- a/src/RockBot.Wisp/SpawnWispsExecutor.cs
+++ b/src/RockBot.Wisp/SpawnWispsExecutor.cs
@@ -19,7 +19,9 @@ internal sealed class SpawnWispsExecutor(
     IFeedbackStore? feedbackStore,
     IWorkingMemory workingMemory,
     WispOptions options,
-    ILogger<SpawnWispsExecutor> logger) : IToolExecutor
+    ILogger<SpawnWispsExecutor> logger,
+    ISkillStore? skillStore = null,
+    ISkillUsageStore? skillUsageStore = null) : IToolExecutor
 {
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -95,11 +97,12 @@ internal sealed class SpawnWispsExecutor(
             var wispId = $"wisp-{Guid.NewGuid():N}"[..16];
             var defJson = JsonSerializer.Serialize(definition, JsonOptions);
             var defHash = ComputeDefinitionHash(defJson);
+            var shapeHash = ComputeShapeHash(definition);
 
             var result = await wispExecutor.ExecuteAsync(definition, wispId, parentSessionId: sessionId, ct);
 
             // Log execution (fire-and-forget, don't block the batch)
-            _ = LogExecutionAsync(result, defHash, defJson, batchId, sessionId, ct);
+            _ = LogExecutionAsync(result, defHash, shapeHash, defJson, batchId, sessionId, ct);
 
             return result;
         }
@@ -117,7 +120,7 @@ internal sealed class SpawnWispsExecutor(
     internal const int DefinitionBodyMaxBytes = 8 * 1024;
 
     private async Task LogExecutionAsync(
-        WispExecutionResult result, string defHash, string defJson,
+        WispExecutionResult result, string defHash, string shapeHash, string defJson,
         string batchId, string? sessionId, CancellationToken ct)
     {
         if (executionLog is null)
@@ -181,6 +184,7 @@ internal sealed class SpawnWispsExecutor(
                 WispId = result.WispId,
                 Description = result.Definition.Description,
                 DefinitionHash = defHash,
+                ShapeHash = shapeHash,
                 Succeeded = result.IsSuccess,
                 StepCount = result.Definition.Steps.Count,
                 StepsCompleted = result.StepResults.Count(s => s.IsSuccess || s.WasSkipped),
@@ -199,11 +203,114 @@ internal sealed class SpawnWispsExecutor(
             };
 
             await executionLog.AppendAsync(record, ct);
+
+            if (result.IsSuccess)
+                await TryEagerPromoteAsync(record, ct);
         }
         catch (Exception ex)
         {
             logger.LogWarning(ex, "Failed to log wisp execution record for {WispId}", result.WispId);
         }
+    }
+
+    /// <summary>
+    /// When a scheduled-task wisp succeeds and the same shape has already
+    /// succeeded enough times, attach its body to the originating skill as a
+    /// provisional <c>Wisp</c> resource. Bypasses the slower dream-pass promotion
+    /// path so daily/weekly scheduled work captures a reusable asset after only
+    /// a couple of fires.
+    ///
+    /// Best-effort: any failure logs and returns without disturbing the wisp run.
+    /// </summary>
+    private async Task TryEagerPromoteAsync(WispExecutionRecord record, CancellationToken ct)
+    {
+        if (!options.EagerScheduledTaskPromotionEnabled
+            || skillStore is null
+            || executionLog is null
+            || string.IsNullOrEmpty(record.SessionId)
+            || string.IsNullOrEmpty(record.ShapeHash)
+            || string.IsNullOrEmpty(record.DefinitionBody))
+            return;
+
+        if (!record.SessionId.StartsWith(options.ScheduledTaskSessionPrefix, StringComparison.OrdinalIgnoreCase))
+            return;
+
+        try
+        {
+            // Count prior successful runs of this shape (including the one just
+            // appended). The 30-day window matches the dream-pass horizon.
+            var recent = await executionLog.QueryRecentAsync(
+                DateTimeOffset.UtcNow.AddDays(-30), maxResults: 1000, ct);
+            var sameShape = recent
+                .Where(r => r.Succeeded && string.Equals(r.ShapeHash, record.ShapeHash, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            var threshold = Math.Max(1, options.EagerScheduledTaskPromotionThreshold);
+            if (sameShape.Count < threshold)
+                return;
+
+            // Resolve invoking skill the same way the dream pass does — most recent
+            // skill invocation in the session that precedes the wisp run.
+            var invokingSkill = await ResolveInvokingSkillAsync(record, ct);
+            if (string.IsNullOrEmpty(invokingSkill))
+                return;
+
+            // Don't re-attach if the same shape is already on the skill.
+            var skill = await skillStore.GetAsync(invokingSkill);
+            if (skill is null)
+                return;
+            if (skill.Manifest?.Any(r =>
+                    string.Equals(r.DefinitionHash, record.ShapeHash, StringComparison.OrdinalIgnoreCase)) == true)
+                return;
+
+            var filename = $"eager-{record.ShapeHash[..Math.Min(8, record.ShapeHash.Length)]}.json";
+            var description = $"Scheduled-task pattern: {record.Description}";
+            var entry = new SkillResource(
+                Filename: filename,
+                Type: SkillResourceType.Wisp,
+                Description: description,
+                Provisional: true,
+                CreatedAt: DateTimeOffset.UtcNow,
+                VerifyHint: $"Repeats shape {record.ShapeHash} from scheduled-task session {record.SessionId}",
+                DefinitionHash: record.ShapeHash);
+            var input = new SkillResourceInput(
+                filename, SkillResourceType.Wisp, description, record.DefinitionBody!,
+                Provisional: true);
+
+            var attached = await skillStore.AttachResourceAsync(invokingSkill, input, entry);
+            if (attached)
+            {
+                logger.LogInformation(
+                    "Eager promotion attached '{Filename}' to skill '{Skill}' (shape={Shape}, successes={Count}, session={Session})",
+                    filename, invokingSkill, record.ShapeHash, sameShape.Count, record.SessionId);
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "Eager promotion failed for wisp {WispId} (session={Session})",
+                record.WispId, record.SessionId);
+        }
+    }
+
+    private async Task<string?> ResolveInvokingSkillAsync(WispExecutionRecord record, CancellationToken ct)
+    {
+        if (skillUsageStore is null || skillStore is null || string.IsNullOrEmpty(record.SessionId))
+            return null;
+
+        var events = await skillUsageStore.GetBySessionAsync(record.SessionId!, ct);
+        if (events.Count == 0)
+            return null;
+
+        var existingNames = (await skillStore.ListAsync())
+            .Select(s => s.Name)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        return events
+            .Where(e => e.Timestamp <= record.Timestamp && existingNames.Contains(e.SkillName))
+            .OrderByDescending(e => e.Timestamp)
+            .Select(e => e.SkillName)
+            .FirstOrDefault();
     }
 
     private async Task WriteBatchSummaryAsync(WispBatchResult batch, CancellationToken ct)
@@ -326,6 +433,56 @@ internal sealed class SpawnWispsExecutor(
     {
         var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(definitionJson));
         return Convert.ToHexStringLower(bytes)[..16];
+    }
+
+    /// <summary>
+    /// Hash the structural shape of a wisp — gateway/server/tool/mode plus the
+    /// sorted set of parameter keys per step — while stripping description,
+    /// prompt text, and literal parameter values. Two wisps that differ only by
+    /// description or by date/accountId values share the same shape hash, so
+    /// the success-promotion pass can group repeated patterns that the LLM
+    /// authored as cosmetically distinct invocations.
+    /// </summary>
+    internal static string ComputeShapeHash(WispDefinition definition)
+    {
+        var canonical = new
+        {
+            steps = definition.Steps.Select(s => new
+            {
+                id = s.Id,
+                mode = s.Mode.ToString(),
+                gateway = s.Gateway?.ToString(),
+                server = s.Server,
+                tool = s.Tool,
+                language = s.Language,
+                agent = s.Agent,
+                skill = s.Skill,
+                hasPrompt = !string.IsNullOrEmpty(s.Prompt),
+                hasMessage = !string.IsNullOrEmpty(s.Message),
+                paramKeys = ExtractParamKeys(s.ResolvedParams),
+                metadataKeys = ExtractParamKeys(s.Metadata),
+                hasInputFrom = !string.IsNullOrEmpty(s.InputFrom),
+                hasOutputTo = !string.IsNullOrEmpty(s.OutputTo),
+                onFailure = s.OnFailure?.Action.ToString()
+            }).ToList()
+        };
+
+        var json = JsonSerializer.Serialize(canonical, JsonOptions);
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(json));
+        return Convert.ToHexStringLower(bytes)[..16];
+    }
+
+    private static IReadOnlyList<string> ExtractParamKeys(JsonElement? element)
+    {
+        if (element is null || element.Value.ValueKind != JsonValueKind.Object)
+            return [];
+
+        var keys = new List<string>();
+        foreach (var prop in element.Value.EnumerateObject())
+            keys.Add(prop.Name);
+
+        keys.Sort(StringComparer.Ordinal);
+        return keys;
     }
 
     internal static string FormatBatchResult(WispBatchResult batch)

--- a/src/RockBot.Wisp/WispOptions.cs
+++ b/src/RockBot.Wisp/WispOptions.cs
@@ -18,4 +18,29 @@ public sealed class WispOptions
     /// to this limit using a semaphore.
     /// </summary>
     public int MaxConcurrentWisps { get; set; } = 10;
+
+    /// <summary>
+    /// When true, wisp runs originating from a scheduled-task session
+    /// (sessionId prefixed with <c>patrol/</c>) eagerly attach their body as a
+    /// provisional resource on the originating skill once the shape has succeeded
+    /// at least <see cref="EagerScheduledTaskPromotionThreshold"/> times. Bypasses
+    /// the slower dream-pass promotion path so recurring scheduled work captures
+    /// reusable assets after the first couple of fires instead of waiting for a
+    /// nightly dream cycle.
+    /// </summary>
+    public bool EagerScheduledTaskPromotionEnabled { get; set; } = true;
+
+    /// <summary>
+    /// Minimum same-shape successful runs required before a scheduled-task wisp is
+    /// eagerly attached as a provisional skill resource. Defaults to 2 (record on
+    /// the first success, promote on the second).
+    /// </summary>
+    public int EagerScheduledTaskPromotionThreshold { get; set; } = 2;
+
+    /// <summary>
+    /// Session-id prefix that marks a scheduled-task execution. The
+    /// <see cref="RockBot.Agent.ScheduledTaskHandler"/> uses
+    /// <c>patrol/{taskName}</c>; if that convention changes, update this default.
+    /// </summary>
+    public string ScheduledTaskSessionPrefix { get; set; } = "patrol/";
 }

--- a/src/RockBot.Wisp/WispToolRegistrar.cs
+++ b/src/RockBot.Wisp/WispToolRegistrar.cs
@@ -16,7 +16,9 @@ internal sealed class WispToolRegistrar(
     ILoggerFactory loggerFactory,
     ILogger<WispToolRegistrar> logger,
     IWispExecutionLog? executionLog = null,
-    IFeedbackStore? feedbackStore = null) : IHostedService
+    IFeedbackStore? feedbackStore = null,
+    ISkillStore? skillStore = null,
+    ISkillUsageStore? skillUsageStore = null) : IHostedService
 {
     private const string SpawnWispsSchema = """
         {
@@ -116,7 +118,7 @@ internal sealed class WispToolRegistrar(
             ParametersSchema = SpawnWispsSchema,
             Source = "wisp"
         }, new SpawnWispsExecutor(wispExecutor, executionLog, feedbackStore, workingMemory, options,
-            loggerFactory.CreateLogger<SpawnWispsExecutor>()));
+            loggerFactory.CreateLogger<SpawnWispsExecutor>(), skillStore, skillUsageStore));
         logger.LogInformation("Registered tool: spawn_wisps");
 
         return Task.CompletedTask;

--- a/tests/RockBot.Wisp.Tests/ShapeHashAndEagerPromotionTests.cs
+++ b/tests/RockBot.Wisp.Tests/ShapeHashAndEagerPromotionTests.cs
@@ -1,0 +1,459 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using RockBot.Host;
+using RockBot.Tools;
+using RockBot.Wisp;
+
+namespace RockBot.Wisp.Tests;
+
+[TestClass]
+public class ShapeHashTests
+{
+    [TestMethod]
+    public void ShapeHash_IgnoresDescriptionDifferences()
+    {
+        var a = MakeDef(description: "Calendar events for marimer-work today and tomorrow",
+            paramsJson: """{"accountId":"marimer-work","startDate":"2026-05-19"}""");
+        var b = MakeDef(description: "Calendar events for lhotka.net tomorrow and day-after",
+            paramsJson: """{"accountId":"lhotka.net","startDate":"2026-05-20"}""");
+
+        Assert.AreEqual(
+            SpawnWispsExecutor.ComputeShapeHash(a),
+            SpawnWispsExecutor.ComputeShapeHash(b),
+            "Same step shape with different descriptions/values should share a shape hash");
+    }
+
+    [TestMethod]
+    public void ShapeHash_DiffersWhenParamKeysDiffer()
+    {
+        var a = MakeDef("x", """{"accountId":"a","startDate":"d"}""");
+        var b = MakeDef("x", """{"accountId":"a","endDate":"d"}""");
+
+        Assert.AreNotEqual(
+            SpawnWispsExecutor.ComputeShapeHash(a),
+            SpawnWispsExecutor.ComputeShapeHash(b),
+            "Different param key sets should produce different shape hashes");
+    }
+
+    [TestMethod]
+    public void ShapeHash_DiffersWhenToolDiffers()
+    {
+        var a = MakeDef("x", """{"q":"v"}""", tool: "get_calendar_events");
+        var b = MakeDef("x", """{"q":"v"}""", tool: "search_emails");
+
+        Assert.AreNotEqual(
+            SpawnWispsExecutor.ComputeShapeHash(a),
+            SpawnWispsExecutor.ComputeShapeHash(b));
+    }
+
+    [TestMethod]
+    public void ShapeHash_StableAcrossParamKeyOrder()
+    {
+        var a = MakeDef("x", """{"accountId":"a","startDate":"d","timeZone":"z"}""");
+        var b = MakeDef("x", """{"timeZone":"z","accountId":"a","startDate":"d"}""");
+
+        Assert.AreEqual(
+            SpawnWispsExecutor.ComputeShapeHash(a),
+            SpawnWispsExecutor.ComputeShapeHash(b),
+            "Param key order must not affect the shape hash");
+    }
+
+    [TestMethod]
+    public void ShapeHash_DiffersFromDefinitionHashSemantics()
+    {
+        var a = MakeDef(description: "alpha", paramsJson: """{"k":"v1"}""");
+        var b = MakeDef(description: "beta",  paramsJson: """{"k":"v2"}""");
+
+        var defJsonA = JsonSerializer.Serialize(a, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+        var defJsonB = JsonSerializer.Serialize(b, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+
+        Assert.AreNotEqual(
+            SpawnWispsExecutor.ComputeDefinitionHash(defJsonA),
+            SpawnWispsExecutor.ComputeDefinitionHash(defJsonB),
+            "Definition hashes should differ across cosmetic/value drift");
+        Assert.AreEqual(
+            SpawnWispsExecutor.ComputeShapeHash(a),
+            SpawnWispsExecutor.ComputeShapeHash(b),
+            "Shape hash must collapse cosmetic/value drift");
+    }
+
+    private static WispDefinition MakeDef(string description, string paramsJson, string tool = "get_calendar_events")
+    {
+        var paramsEl = JsonDocument.Parse(paramsJson).RootElement;
+        return new WispDefinition
+        {
+            Description = description,
+            Steps =
+            [
+                new WispStep
+                {
+                    Id = "s1",
+                    Mode = StepMode.Direct,
+                    Gateway = GatewayType.Mcp,
+                    Server = "calendar-mcp",
+                    Tool = tool,
+                    Params = paramsEl.Clone()
+                }
+            ]
+        };
+    }
+}
+
+[TestClass]
+public class EagerPromotionTests
+{
+    [TestMethod]
+    public async Task PatrolSession_SecondSuccess_AttachesProvisionalResource()
+    {
+        var (executor, registry, log, skills, usage) = Build();
+
+        registry.Register(
+            new ToolRegistration { Name = "web_search", Description = "x", Source = "web" },
+            new FakeToolExecutor("ok"));
+
+        // Skill exists and was the most recently invoked skill in this session.
+        await skills.SaveAsync(new Skill("calendar/scan", "scan", "# scan", DateTimeOffset.UtcNow));
+        usage.Append("patrol/heartbeat-patrol", "calendar/scan", DateTimeOffset.UtcNow.AddMinutes(-1));
+
+        // First run records the shape; second run should trip eager promotion.
+        await Spawn(executor, "patrol/heartbeat-patrol", paramsJson: """{"q":"v"}""");
+        await Spawn(executor, "patrol/heartbeat-patrol", paramsJson: """{"q":"v"}""");
+        await WaitForBackground();
+
+        var saved = await skills.GetAsync("calendar/scan");
+        var entry = saved!.Manifest!.SingleOrDefault();
+        Assert.IsNotNull(entry, "Eager promotion should have attached a single resource on the second success");
+        Assert.IsTrue(entry.Provisional, "Eager-attached resources land as provisional");
+        Assert.AreEqual(SkillResourceType.Wisp, entry.Type);
+        StringAssert.StartsWith(entry.Filename, "eager-");
+        Assert.IsNotNull(entry.DefinitionHash);
+    }
+
+    [TestMethod]
+    public async Task PatrolSession_FirstSuccess_DoesNotAttach()
+    {
+        var (executor, registry, _, skills, usage) = Build();
+
+        registry.Register(
+            new ToolRegistration { Name = "web_search", Description = "x", Source = "web" },
+            new FakeToolExecutor("ok"));
+
+        await skills.SaveAsync(new Skill("calendar/scan", "scan", "# scan", DateTimeOffset.UtcNow));
+        usage.Append("patrol/heartbeat-patrol", "calendar/scan", DateTimeOffset.UtcNow.AddMinutes(-1));
+
+        await Spawn(executor, "patrol/heartbeat-patrol", paramsJson: """{"q":"v"}""");
+        await WaitForBackground();
+
+        var saved = await skills.GetAsync("calendar/scan");
+        Assert.IsTrue(saved!.Manifest is null or { Count: 0 },
+            "Single success is below the eager threshold");
+    }
+
+    [TestMethod]
+    public async Task NonPatrolSession_TwoSuccesses_DoesNotAttach()
+    {
+        var (executor, registry, _, skills, usage) = Build();
+
+        registry.Register(
+            new ToolRegistration { Name = "web_search", Description = "x", Source = "web" },
+            new FakeToolExecutor("ok"));
+
+        await skills.SaveAsync(new Skill("calendar/scan", "scan", "# scan", DateTimeOffset.UtcNow));
+        usage.Append("session/blazor-session", "calendar/scan", DateTimeOffset.UtcNow.AddMinutes(-1));
+
+        await Spawn(executor, "session/blazor-session", paramsJson: """{"q":"v"}""");
+        await Spawn(executor, "session/blazor-session", paramsJson: """{"q":"v"}""");
+        await WaitForBackground();
+
+        var saved = await skills.GetAsync("calendar/scan");
+        Assert.IsTrue(saved!.Manifest is null or { Count: 0 },
+            "Non-patrol sessions should NOT trigger eager promotion");
+    }
+
+    [TestMethod]
+    public async Task PatrolSession_NoInvokingSkill_DoesNotAttach()
+    {
+        var (executor, registry, _, skills, _) = Build();
+
+        registry.Register(
+            new ToolRegistration { Name = "web_search", Description = "x", Source = "web" },
+            new FakeToolExecutor("ok"));
+
+        // No usage events recorded — no invoking skill to attach to.
+        await skills.SaveAsync(new Skill("calendar/scan", "scan", "# scan", DateTimeOffset.UtcNow));
+
+        await Spawn(executor, "patrol/heartbeat-patrol", paramsJson: """{"q":"v"}""");
+        await Spawn(executor, "patrol/heartbeat-patrol", paramsJson: """{"q":"v"}""");
+        await WaitForBackground();
+
+        var saved = await skills.GetAsync("calendar/scan");
+        Assert.IsTrue(saved!.Manifest is null or { Count: 0 });
+    }
+
+    [TestMethod]
+    public async Task PatrolSession_AlreadyAttached_DoesNotReAttach()
+    {
+        var (executor, registry, _, skills, usage) = Build();
+
+        registry.Register(
+            new ToolRegistration { Name = "web_search", Description = "x", Source = "web" },
+            new FakeToolExecutor("ok"));
+
+        await skills.SaveAsync(new Skill("calendar/scan", "scan", "# scan", DateTimeOffset.UtcNow));
+        usage.Append("patrol/heartbeat-patrol", "calendar/scan", DateTimeOffset.UtcNow.AddMinutes(-1));
+
+        // Two runs → first eager attach. Then two more runs of the same shape → no extra entries.
+        await Spawn(executor, "patrol/heartbeat-patrol", paramsJson: """{"q":"v"}""");
+        await Spawn(executor, "patrol/heartbeat-patrol", paramsJson: """{"q":"v"}""");
+        await WaitForBackground();
+        await Spawn(executor, "patrol/heartbeat-patrol", paramsJson: """{"q":"v"}""");
+        await Spawn(executor, "patrol/heartbeat-patrol", paramsJson: """{"q":"v"}""");
+        await WaitForBackground();
+
+        var saved = await skills.GetAsync("calendar/scan");
+        Assert.AreEqual(1, saved!.Manifest!.Count,
+            "A second pair of runs with the same shape should not produce another attachment");
+    }
+
+    [TestMethod]
+    public async Task PatrolSession_DifferentDescriptions_StillAttachOnceBySharedShape()
+    {
+        var (executor, registry, _, skills, usage) = Build();
+
+        registry.Register(
+            new ToolRegistration { Name = "web_search", Description = "x", Source = "web" },
+            new FakeToolExecutor("ok"));
+
+        await skills.SaveAsync(new Skill("calendar/scan", "scan", "# scan", DateTimeOffset.UtcNow));
+        usage.Append("patrol/heartbeat-patrol", "calendar/scan", DateTimeOffset.UtcNow.AddMinutes(-1));
+
+        // Two runs whose descriptions and param values differ but whose shape is identical.
+        await Spawn(executor, "patrol/heartbeat-patrol",
+            description: "Today's events for marimer-work", paramsJson: """{"q":"a"}""");
+        await Spawn(executor, "patrol/heartbeat-patrol",
+            description: "Tomorrow's events for lhotka.net", paramsJson: """{"q":"b"}""");
+        await WaitForBackground();
+
+        var saved = await skills.GetAsync("calendar/scan");
+        Assert.AreEqual(1, saved!.Manifest!.Count,
+            "Shape-hash grouping should collapse cosmetically distinct runs into one promotion");
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static (SpawnWispsExecutor executor, FakeToolRegistry registry,
+                    TrackingWispExecutionLog log, InMemorySkillStore skills, InMemorySkillUsageStore usage)
+        Build()
+    {
+        var registry = new FakeToolRegistry();
+        var memory = new FakeWorkingMemory();
+        var options = new WispOptions(); // eager promotion default-on, threshold 2
+        var wispExecutor = new WispExecutor(registry, memory, agentLoopRunner: null!, options,
+            NullLogger<WispExecutor>.Instance);
+        var log = new TrackingWispExecutionLog();
+        var skills = new InMemorySkillStore();
+        var usage = new InMemorySkillUsageStore();
+        var executor = new SpawnWispsExecutor(
+            wispExecutor, log, feedbackStore: null, memory, options,
+            NullLogger<SpawnWispsExecutor>.Instance,
+            skillStore: skills, skillUsageStore: usage);
+        return (executor, registry, log, skills, usage);
+    }
+
+    private static async Task Spawn(
+        SpawnWispsExecutor executor, string sessionId,
+        string paramsJson = """{"q":"v"}""",
+        string description = "Shape test")
+    {
+        var request = new ToolInvokeRequest
+        {
+            ToolCallId = Guid.NewGuid().ToString("N")[..8],
+            ToolName = "spawn_wisps",
+            SessionId = sessionId,
+            Arguments = $$"""
+            {
+              "definitions": [
+                {
+                  "description": "{{description}}",
+                  "steps": [
+                    { "id": "s1", "mode": "Direct", "gateway": "Web", "tool": "web_search", "params": {{paramsJson}} }
+                  ]
+                }
+              ]
+            }
+            """
+        };
+        var response = await executor.ExecuteAsync(request, CancellationToken.None);
+        Assert.IsFalse(response.IsError, response.Content);
+    }
+
+    private static Task WaitForBackground() => Task.Delay(150);
+}
+
+/// <summary>
+/// Wisp execution log fake that actually returns appended records from
+/// <see cref="QueryRecentAsync"/>, so eager-promotion code can count prior
+/// successes. The <see cref="FakeWispExecutionLog"/> in the sibling test file
+/// returns empty unconditionally — fine for batch-id tests, useless for these.
+/// </summary>
+internal sealed class TrackingWispExecutionLog : IWispExecutionLog
+{
+    public List<WispExecutionRecord> Records { get; } = [];
+
+    public Task AppendAsync(WispExecutionRecord record, CancellationToken ct)
+    {
+        lock (Records) { Records.Add(record); }
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<WispExecutionRecord>> QueryRecentAsync(
+        DateTimeOffset since, int maxResults, CancellationToken ct)
+    {
+        lock (Records)
+        {
+            return Task.FromResult<IReadOnlyList<WispExecutionRecord>>(
+                Records.Where(r => r.Timestamp >= since)
+                       .OrderBy(r => r.Timestamp)
+                       .Take(maxResults)
+                       .ToList());
+        }
+    }
+
+    public Task<WispExecutionRecord?> FindRecentFailureAsync(
+        string definitionHash, string? sessionId, CancellationToken ct)
+    {
+        lock (Records)
+        {
+            return Task.FromResult(Records
+                .Where(r => !r.Succeeded && r.DefinitionHash == definitionHash)
+                .OrderByDescending(r => r.Timestamp)
+                .FirstOrDefault());
+        }
+    }
+}
+
+internal sealed class InMemorySkillStore : ISkillStore
+{
+    private readonly Dictionary<string, Skill> _skills = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, Dictionary<string, string>> _resources = new(StringComparer.OrdinalIgnoreCase);
+
+    public Task SaveAsync(Skill skill)
+    {
+        lock (_skills) { _skills[skill.Name] = skill; }
+        return Task.CompletedTask;
+    }
+
+    public Task SaveAsync(Skill skill, IReadOnlyList<SkillResourceInput>? resources) => SaveAsync(skill);
+
+    public Task<Skill?> GetAsync(string name)
+    {
+        lock (_skills) { return Task.FromResult(_skills.GetValueOrDefault(name)); }
+    }
+
+    public Task<IReadOnlyList<Skill>> ListAsync()
+    {
+        lock (_skills)
+        {
+            return Task.FromResult<IReadOnlyList<Skill>>(_skills.Values.OrderBy(s => s.Name).ToList());
+        }
+    }
+
+    public Task DeleteAsync(string name)
+    {
+        lock (_skills) { _skills.Remove(name); }
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<Skill>> SearchAsync(
+        string query, int maxResults, CancellationToken cancellationToken = default, float[]? queryEmbedding = null) =>
+        Task.FromResult<IReadOnlyList<Skill>>([]);
+
+    public Task<string?> GetResourceAsync(string skillName, string filename)
+    {
+        lock (_skills)
+        {
+            if (_resources.TryGetValue(skillName, out var files) && files.TryGetValue(filename, out var content))
+                return Task.FromResult<string?>(content);
+            return Task.FromResult<string?>(null);
+        }
+    }
+
+    public Task<bool> AttachResourceAsync(
+        string skillName, SkillResourceInput resource, SkillResource? manifestEntry = null)
+    {
+        lock (_skills)
+        {
+            if (!_skills.TryGetValue(skillName, out var existing))
+                return Task.FromResult(false);
+
+            if (!_resources.TryGetValue(skillName, out var files))
+                _resources[skillName] = files = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            files[resource.Filename] = resource.Content;
+
+            var entry = manifestEntry ?? new SkillResource(
+                resource.Filename, resource.Type, resource.Description,
+                Provisional: resource.Provisional,
+                CreatedAt: DateTimeOffset.UtcNow,
+                VerifyHint: resource.VerifyHint);
+
+            var oldManifest = existing.Manifest ?? [];
+            var newManifest = new List<SkillResource>(oldManifest.Count + 1);
+            var replaced = false;
+            foreach (var old in oldManifest)
+            {
+                if (string.Equals(old.Filename, resource.Filename, StringComparison.OrdinalIgnoreCase))
+                {
+                    newManifest.Add(entry);
+                    replaced = true;
+                }
+                else
+                {
+                    newManifest.Add(old);
+                }
+            }
+            if (!replaced)
+                newManifest.Add(entry);
+
+            _skills[skillName] = existing with { Manifest = newManifest };
+            return Task.FromResult(true);
+        }
+    }
+}
+
+internal sealed class InMemorySkillUsageStore : ISkillUsageStore
+{
+    private readonly List<SkillInvocationEvent> _events = [];
+
+    public void Append(string sessionId, string skillName, DateTimeOffset ts)
+    {
+        lock (_events)
+        {
+            _events.Add(new SkillInvocationEvent(
+                Guid.NewGuid().ToString("N")[..8], skillName, sessionId, ts));
+        }
+    }
+
+    public Task AppendAsync(SkillInvocationEvent evt, CancellationToken ct = default)
+    {
+        lock (_events) { _events.Add(evt); }
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<SkillInvocationEvent>> GetBySessionAsync(string sessionId, CancellationToken ct = default)
+    {
+        lock (_events)
+        {
+            return Task.FromResult<IReadOnlyList<SkillInvocationEvent>>(
+                _events.Where(e => e.SessionId == sessionId).ToList());
+        }
+    }
+
+    public Task<IReadOnlyList<SkillInvocationEvent>> QueryRecentAsync(DateTimeOffset since, int maxResults, CancellationToken ct = default)
+    {
+        lock (_events)
+        {
+            return Task.FromResult<IReadOnlyList<SkillInvocationEvent>>(
+                _events.Where(e => e.Timestamp >= since).OrderBy(e => e.Timestamp).Take(maxResults).ToList());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Live telemetry showed `calendar-mcp/get_calendar_events accountId is required` hitting 88 times in 8 days — and the corresponding lesson was being re-derived by the dream pass over and over without ever turning into a reusable wisp resource. Root cause: every patrol run produces a different `DefinitionHash` (descriptions and accountIds are baked into the hashed body), so the success-promotion pass never finds a group of repeats to promote. Even when it would, the dream cycle only fires nightly.

This PR fixes both:

- **Shape hash.** New `WispExecutionRecord.ShapeHash` companion to `DefinitionHash`. `ComputeShapeHash` keeps step structure (mode/gateway/server/tool/language/agent/skill/on_failure + sorted parameter and metadata KEY sets) and drops description text, prompt bodies, and literal param values. The success-dream pass now groups by `ShapeHash ?? DefinitionHash`. Provisional-validation matches resources against either field for backward compat.
- **Eager promotion for scheduled-task wisps.** When a wisp succeeds in a `patrol/*` session and the same shape has succeeded `EagerScheduledTaskPromotionThreshold` times (default 2), `SpawnWispsExecutor` immediately attaches the body as a `Provisional` wisp resource on the originating skill — without waiting for the nightly dream cycle. Skips if the skill already carries an entry with that shape. Fire-and-forget, never blocks the wisp run.

Related: #410 (skill recall hard-pinning) tracks the third gap from the same diagnosis.

## Files

- `WispExecutionRecord.cs` — added nullable `ShapeHash`.
- `SpawnWispsExecutor.cs` — `ComputeShapeHash`, `TryEagerPromoteAsync`, optional `ISkillStore`/`ISkillUsageStore` deps.
- `WispOptions.cs` — `EagerScheduledTaskPromotion{Enabled,Threshold}` + configurable session prefix.
- `WispToolRegistrar.cs` — forwards the new deps so DI can fill them.
- `DreamService.cs` — success-pass group key + provisional-validation hash match.
- `ShapeHashAndEagerPromotionTests.cs` — 11 new tests (5 shape-hash, 6 eager-promotion).

## Test plan

- [x] `dotnet build RockBot.slnx` — clean, 0 errors
- [x] `dotnet test RockBot.slnx` — full suite green (128 Wisp, 915 Host, all others pass; pre-existing Docker-gated tests skipped)
- [ ] Deploy to the live cluster and observe at next heartbeat-patrol fire: expect an `eager-{shape8}.json` to land on the invoking skill within two patrol cycles
- [ ] Check `failure-clusters.snapshot.json` after a week: `accountId is required` count for `get_calendar_events` should plateau as the reusable wisp gets reused

🤖 Generated with [Claude Code](https://claude.com/claude-code)