### PR TITLE
Inject mcp/<server> skills on tool-selection and recovery (#410)

### DIFF
--- a/src/RockBot.Tools.Mcp/McpManagementExecutor.cs
+++ b/src/RockBot.Tools.Mcp/McpManagementExecutor.cs
@@ -29,6 +29,7 @@ public sealed class McpManagementExecutor : IToolExecutor, IAsyncDisposable
     private readonly ILogger<McpManagementExecutor> _logger;
     private readonly TimeSpan _timeout;
     private readonly McpRecoveryExecutor? _recovery;
+    private readonly ISkillStore? _skillStore;
 
     private readonly ConcurrentDictionary<string, TaskCompletionSource<MessageEnvelope>> _pending = new();
     private ISubscription? _responseSubscription;
@@ -51,7 +52,8 @@ public sealed class McpManagementExecutor : IToolExecutor, IAsyncDisposable
         AgentIdentity identity,
         ILogger<McpManagementExecutor> logger,
         TimeSpan? timeout = null,
-        McpRecoveryExecutor? recovery = null)
+        McpRecoveryExecutor? recovery = null,
+        ISkillStore? skillStore = null)
     {
         _index = index;
         _proxy = proxy;
@@ -61,6 +63,7 @@ public sealed class McpManagementExecutor : IToolExecutor, IAsyncDisposable
         _logger = logger;
         _timeout = timeout ?? TimeSpan.FromSeconds(30);
         _recovery = recovery;
+        _skillStore = skillStore;
     }
 
     public string ResponseTopic => $"mcp.manage.response.{_identity.Name}";
@@ -135,11 +138,31 @@ public sealed class McpManagementExecutor : IToolExecutor, IAsyncDisposable
             prompts = details.Prompts
         };
 
+        var content = JsonSerializer.Serialize(payload, JsonOptions);
+
+        // Pre-flight skill injection: the LLM has just narrowed in on a single
+        // server, so this is the moment any `mcp/{server}` skills become uniquely
+        // relevant. Append their content to the tool response so the LLM sees
+        // verified parameter shape in the same turn it receives the schema —
+        // before the first mcp_invoke_tool attempt. No-op when no skill exists.
+        try
+        {
+            var skillBlock = await McpServerSkillFormatter.FormatAsync(_skillStore, serverName, ct);
+            if (!string.IsNullOrEmpty(skillBlock))
+                content = content + "\n" + skillBlock;
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to append skill injection block for server '{Server}'", serverName);
+        }
+
         return new ToolInvokeResponse
         {
             ToolCallId = request.ToolCallId,
             ToolName = request.ToolName,
-            Content = JsonSerializer.Serialize(payload, JsonOptions)
+            Content = content
         };
     }
 

--- a/src/RockBot.Tools.Mcp/McpServerSkillFormatter.cs
+++ b/src/RockBot.Tools.Mcp/McpServerSkillFormatter.cs
@@ -1,0 +1,91 @@
+using System.Text;
+using RockBot.Host;
+
+namespace RockBot.Tools.Mcp;
+
+/// <summary>
+/// Looks up <c>mcp/{server}</c> (and any <c>mcp/{server}/*</c> sub-skills) from
+/// <see cref="ISkillStore"/> and renders them into a compact markdown block.
+/// Both the <c>mcp_get_service_details</c> pre-flight path and the recovery-time
+/// <see cref="Recovery.SchemaErrorEnricher"/> append the same block to their output
+/// so the LLM sees verified parameter shape and usage notes in the same turn it
+/// receives the tool response.
+/// </summary>
+internal static class McpServerSkillFormatter
+{
+    /// <summary>
+    /// Per-skill content cap when rendering. Skill bodies above this are
+    /// truncated with a tail marker — the goal is to keep the injected block
+    /// from dominating the LLM context when a single skill body is unusually
+    /// large.
+    /// </summary>
+    internal const int PerSkillContentCap = 4_000;
+
+    /// <summary>
+    /// Returns the formatted skill block for <paramref name="serverName"/>, or
+    /// <c>null</c> when no matching skills exist or the store is unavailable.
+    /// Lookup is case-insensitive on <c>mcp/{server}</c>.
+    /// </summary>
+    public static async Task<string?> FormatAsync(
+        ISkillStore? skillStore,
+        string serverName,
+        CancellationToken ct)
+    {
+        if (skillStore is null || string.IsNullOrWhiteSpace(serverName))
+            return null;
+
+        // ListAsync is the only prefix-aware API on ISkillStore. Skill counts on
+        // production agents are in the low hundreds, so a single list+filter is
+        // cheaper than two separate Get calls plus a second filtered scan, and
+        // avoids the case where a sub-skill exists without the canonical parent.
+        IReadOnlyList<Skill> all;
+        try
+        {
+            all = await skillStore.ListAsync();
+        }
+        catch (OperationCanceledException) { throw; }
+        catch
+        {
+            return null;
+        }
+
+        var canonicalName = $"mcp/{serverName.ToLowerInvariant()}";
+        var subPrefix = canonicalName + "/";
+
+        var matches = all
+            .Where(s => string.Equals(s.Name, canonicalName, StringComparison.OrdinalIgnoreCase)
+                        || s.Name.StartsWith(subPrefix, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(s => s.Name, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        if (matches.Count == 0)
+            return null;
+
+        var sb = new StringBuilder();
+        sb.AppendLine();
+        sb.AppendLine("---");
+        sb.Append("[mcp-skill-injection] Skills already document `").Append(serverName)
+          .AppendLine("`. Read them before authoring the next call — these capture verified parameter shapes, required fields, and quirks from prior sessions.");
+        foreach (var skill in matches)
+        {
+            sb.AppendLine();
+            sb.Append("### Skill: `").Append(skill.Name).AppendLine("`");
+            if (!string.IsNullOrWhiteSpace(skill.Summary))
+                sb.Append("_").Append(skill.Summary.Trim()).AppendLine("_");
+            sb.AppendLine();
+
+            var body = skill.Content ?? string.Empty;
+            if (body.Length > PerSkillContentCap)
+            {
+                sb.Append(body.AsSpan(0, PerSkillContentCap));
+                sb.Append("\n…[truncated — full skill body is ").Append(body.Length)
+                  .Append(" chars; load with get_skill(\"").Append(skill.Name).AppendLine("\") for the rest]");
+            }
+            else
+            {
+                sb.AppendLine(body);
+            }
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+}

--- a/src/RockBot.Tools.Mcp/Recovery/SchemaErrorEnricher.cs
+++ b/src/RockBot.Tools.Mcp/Recovery/SchemaErrorEnricher.cs
@@ -16,7 +16,8 @@ namespace RockBot.Tools.Mcp.Recovery;
 /// </summary>
 public sealed class SchemaErrorEnricher(
     ToolSchemaCache schemas,
-    IToolCallLog toolCallLog)
+    IToolCallLog toolCallLog,
+    ISkillStore? skillStore = null)
 {
     /// <summary>Maximum number of recent calls listed in the enriched output.</summary>
     internal const int MaxRecentCallsListed = 5;
@@ -83,6 +84,22 @@ public sealed class SchemaErrorEnricher(
                 sb.Append("Use the value of '").Append(fieldName)
                   .AppendLine("' from those results in your conversation history.");
             }
+        }
+
+        // Recovery-time skill injection: the LLM just hit a parameter-required
+        // error and is about to retry. If a `mcp/{server}` skill exists, append
+        // its content so the next attempt can use verified parameter shape
+        // instead of re-guessing from training priors.
+        try
+        {
+            var skillBlock = await McpServerSkillFormatter.FormatAsync(skillStore, serverName, ct);
+            if (!string.IsNullOrEmpty(skillBlock))
+                sb.AppendLine().Append(skillBlock);
+        }
+        catch (OperationCanceledException) { throw; }
+        catch
+        {
+            // Best-effort — never let skill injection break enrichment.
         }
 
         return sb.ToString().TrimEnd();

--- a/tests/RockBot.Tools.Tests/McpSkillInjectionTests.cs
+++ b/tests/RockBot.Tools.Tests/McpSkillInjectionTests.cs
@@ -1,0 +1,304 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using RockBot.Host;
+using RockBot.Messaging;
+using RockBot.Tools.Mcp;
+using RockBot.Tools.Mcp.Recovery;
+
+namespace RockBot.Tools.Tests;
+
+/// <summary>
+/// Coverage for the two MCP skill-injection paths:
+/// pre-flight on <c>mcp_get_service_details</c> and recovery-time inside
+/// <see cref="SchemaErrorEnricher"/>. The shared helper
+/// <see cref="McpServerSkillFormatter"/> is exercised through the public surface
+/// of both call sites so the assertions reflect what the LLM actually sees.
+/// </summary>
+[TestClass]
+public class McpSkillInjectionTests
+{
+    private static readonly AgentIdentity Identity = new("test-agent");
+
+    // ── Pre-flight: mcp_get_service_details ──────────────────────────────────
+
+    [TestMethod]
+    public async Task GetServiceDetails_AppendsMatchingSkill()
+    {
+        var skills = new SkillSeed()
+            .With("mcp/filesystem", "FS server skill", "# Use FS\nCall read_file with `path` (required).")
+            .Build();
+        var (executor, publisher, subscriber) = NewExecutor(skills);
+
+        var result = await RunGetServiceDetailsAsync(executor, publisher, subscriber, "filesystem");
+
+        StringAssert.Contains(result.Content!, "[mcp-skill-injection]");
+        StringAssert.Contains(result.Content!, "mcp/filesystem");
+        StringAssert.Contains(result.Content!, "Call read_file with `path` (required).");
+    }
+
+    [TestMethod]
+    public async Task GetServiceDetails_AppendsMatchingSubSkills()
+    {
+        var skills = new SkillSeed()
+            .With("mcp/calendar-mcp", "Calendar server", "# Calendar")
+            .With("mcp/calendar-mcp/calendar-operations", "Calendar ops", "## get_calendar_events\nRequires accountId.")
+            .With("mcp/unrelated", "Other", "should not appear")
+            .Build();
+        var (executor, publisher, subscriber) = NewExecutor(skills);
+
+        var result = await RunGetServiceDetailsAsync(executor, publisher, subscriber, "calendar-mcp");
+
+        StringAssert.Contains(result.Content!, "mcp/calendar-mcp");
+        StringAssert.Contains(result.Content!, "mcp/calendar-mcp/calendar-operations");
+        StringAssert.Contains(result.Content!, "Requires accountId.");
+        Assert.IsFalse(result.Content!.Contains("mcp/unrelated"),
+            "Skills for other servers must not be injected");
+    }
+
+    [TestMethod]
+    public async Task GetServiceDetails_NoMatchingSkill_LeavesResponseIntact()
+    {
+        var skills = new SkillSeed()
+            .With("mcp/something-else", "x", "x")
+            .Build();
+        var (executor, publisher, subscriber) = NewExecutor(skills);
+
+        var result = await RunGetServiceDetailsAsync(executor, publisher, subscriber, "filesystem");
+
+        Assert.IsFalse(result.Content!.Contains("[mcp-skill-injection]"));
+        // Should still parse cleanly as the original JSON payload (the appended
+        // block only lands when there is a skill to append).
+        var doc = JsonDocument.Parse(result.Content!);
+        Assert.AreEqual("filesystem", doc.RootElement.GetProperty("server").GetProperty("name").GetString());
+    }
+
+    [TestMethod]
+    public async Task GetServiceDetails_NoSkillStore_LeavesResponseIntact()
+    {
+        var (executor, publisher, subscriber) = NewExecutor(skillStore: null);
+
+        var result = await RunGetServiceDetailsAsync(executor, publisher, subscriber, "filesystem");
+
+        Assert.IsFalse(result.Content!.Contains("[mcp-skill-injection]"));
+    }
+
+    [TestMethod]
+    public async Task ListServices_DoesNotTriggerInjection()
+    {
+        // The whole point of skipping list_services is that it returns many
+        // servers; injecting every matching skill would crowd the context.
+        var skills = new SkillSeed()
+            .With("mcp/filesystem", "FS", "# FS body")
+            .Build();
+        var (executor, _, _) = NewExecutor(skills);
+
+        var result = await executor.ExecuteAsync(new ToolInvokeRequest
+        {
+            ToolCallId = "list-1",
+            ToolName = "mcp_list_services"
+        }, CancellationToken.None);
+
+        Assert.IsFalse(result.IsError);
+        Assert.IsFalse(result.Content!.Contains("[mcp-skill-injection]"),
+            "mcp_list_services must not append skill blocks");
+        Assert.IsFalse(result.Content!.Contains("# FS body"));
+    }
+
+    [TestMethod]
+    public async Task GetServiceDetails_LargeSkillIsTruncated()
+    {
+        var bigBody = new string('x', McpServerSkillFormatter.PerSkillContentCap + 500);
+        var skills = new SkillSeed()
+            .With("mcp/filesystem", "big", bigBody)
+            .Build();
+        var (executor, publisher, subscriber) = NewExecutor(skills);
+
+        var result = await RunGetServiceDetailsAsync(executor, publisher, subscriber, "filesystem");
+
+        StringAssert.Contains(result.Content!, "[mcp-skill-injection]");
+        StringAssert.Contains(result.Content!, "truncated");
+        StringAssert.Contains(result.Content!, "get_skill(\"mcp/filesystem\")");
+    }
+
+    // ── Recovery-time: SchemaErrorEnricher ───────────────────────────────────
+
+    [TestMethod]
+    public async Task SchemaErrorEnricher_AppendsServerSkill()
+    {
+        var skills = new SkillSeed()
+            .With("mcp/calendar-mcp", "Calendar", "## get_calendar_events\nRequires accountId.")
+            .Build();
+        var enricher = new SchemaErrorEnricher(
+            new ToolSchemaCache((_, _) => Task.FromResult<IReadOnlyList<McpToolDefinition>?>(null)),
+            new EmptyToolCallLog(),
+            skills);
+
+        var result = await enricher.EnrichAsync(
+            serverName: "calendar-mcp",
+            toolName: "get_calendar_events",
+            fieldName: "accountId",
+            sessionId: null,
+            originalError: "Required parameter 'accountId' was not provided",
+            CancellationToken.None);
+
+        StringAssert.StartsWith(result, "Required parameter 'accountId'");
+        StringAssert.Contains(result, "[mcp-recovery]");
+        StringAssert.Contains(result, "[mcp-skill-injection]");
+        StringAssert.Contains(result, "Requires accountId.");
+    }
+
+    [TestMethod]
+    public async Task SchemaErrorEnricher_NoMatchingSkill_StillEnrichesNormally()
+    {
+        var skills = new SkillSeed()
+            .With("mcp/something-else", "x", "x")
+            .Build();
+        var enricher = new SchemaErrorEnricher(
+            new ToolSchemaCache((_, _) => Task.FromResult<IReadOnlyList<McpToolDefinition>?>(null)),
+            new EmptyToolCallLog(),
+            skills);
+
+        var result = await enricher.EnrichAsync(
+            "calendar-mcp", "get_calendar_events", "accountId",
+            sessionId: null,
+            originalError: "Required parameter 'accountId' was not provided",
+            CancellationToken.None);
+
+        StringAssert.Contains(result, "[mcp-recovery]");
+        Assert.IsFalse(result.Contains("[mcp-skill-injection]"),
+            "Recovery output should be unchanged when no matching skill exists");
+    }
+
+    [TestMethod]
+    public async Task SchemaErrorEnricher_NoSkillStore_PreservesExistingBehavior()
+    {
+        // Verifies the new ctor parameter is genuinely optional — null skillStore
+        // means recovery output looks exactly like it did before this change.
+        var enricher = new SchemaErrorEnricher(
+            new ToolSchemaCache((_, _) => Task.FromResult<IReadOnlyList<McpToolDefinition>?>(null)),
+            new EmptyToolCallLog());
+
+        var result = await enricher.EnrichAsync(
+            "calendar-mcp", "get_calendar_events", "accountId",
+            sessionId: null,
+            originalError: "Required parameter 'accountId' was not provided",
+            CancellationToken.None);
+
+        StringAssert.Contains(result, "[mcp-recovery]");
+        Assert.IsFalse(result.Contains("[mcp-skill-injection]"));
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static (McpManagementExecutor Executor, TrackingPublisher Publisher, StubSubscriber Subscriber)
+        NewExecutor(InMemorySkillStore? skillStore = null)
+    {
+        var publisher = new TrackingPublisher();
+        var subscriber = new StubSubscriber();
+        var proxy = new McpToolProxy(publisher, subscriber, Identity, NullLogger<McpToolProxy>.Instance);
+
+        var index = new McpServerIndex();
+        index.Apply(new McpServersIndexed
+        {
+            Servers =
+            [
+                new McpServerSummary
+                {
+                    ServerName = "filesystem",
+                    Summary = "FS tools",
+                    ToolCount = 1,
+                    ToolNames = ["read_file"]
+                },
+                new McpServerSummary
+                {
+                    ServerName = "calendar-mcp",
+                    Summary = "Calendar tools",
+                    ToolCount = 1,
+                    ToolNames = ["get_calendar_events"]
+                }
+            ]
+        });
+
+        var executor = new McpManagementExecutor(
+            index, proxy, publisher, subscriber, Identity,
+            NullLogger<McpManagementExecutor>.Instance,
+            timeout: null, recovery: null, skillStore: skillStore);
+        return (executor, publisher, subscriber);
+    }
+
+    private static async Task<ToolInvokeResponse> RunGetServiceDetailsAsync(
+        McpManagementExecutor executor, TrackingPublisher publisher, StubSubscriber subscriber,
+        string serverName)
+    {
+        var request = new ToolInvokeRequest
+        {
+            ToolCallId = "call-1",
+            ToolName = "mcp_get_service_details",
+            Arguments = $$$"""{"server_name":"{{{serverName}}}"}"""
+        };
+
+        var executeTask = executor.ExecuteAsync(request, CancellationToken.None);
+        await Task.Delay(50);
+
+        Assert.AreEqual(1, publisher.Published.Count, "expected one management request");
+        var published = publisher.Published[0].Envelope;
+        var response = new McpGetServiceDetailsResponse
+        {
+            ServerName = serverName,
+            Tools = [new McpToolDefinition { Name = "stub_tool", Description = "stub" }]
+        };
+        var envelope = response.ToEnvelope("bridge", correlationId: published.CorrelationId);
+        await subscriber.DeliverAsync(executor.ResponseTopic, envelope);
+
+        return await executeTask;
+    }
+}
+
+internal sealed class SkillSeed
+{
+    private readonly Dictionary<string, Skill> _skills = new(StringComparer.OrdinalIgnoreCase);
+
+    public SkillSeed With(string name, string summary, string content)
+    {
+        _skills[name] = new Skill(name, summary, content, DateTimeOffset.UtcNow);
+        return this;
+    }
+
+    public InMemorySkillStore Build() => new(_skills);
+}
+
+internal sealed class InMemorySkillStore(Dictionary<string, Skill>? seed = null) : ISkillStore
+{
+    private readonly Dictionary<string, Skill> _skills = seed ?? new(StringComparer.OrdinalIgnoreCase);
+
+    public Task SaveAsync(Skill skill)
+    {
+        _skills[skill.Name] = skill;
+        return Task.CompletedTask;
+    }
+
+    public Task<Skill?> GetAsync(string name) => Task.FromResult(_skills.GetValueOrDefault(name));
+
+    public Task<IReadOnlyList<Skill>> ListAsync() =>
+        Task.FromResult<IReadOnlyList<Skill>>(_skills.Values.OrderBy(s => s.Name).ToList());
+
+    public Task DeleteAsync(string name)
+    {
+        _skills.Remove(name);
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<Skill>> SearchAsync(
+        string query, int maxResults, CancellationToken cancellationToken = default,
+        float[]? queryEmbedding = null) =>
+        Task.FromResult<IReadOnlyList<Skill>>([]);
+}
+
+internal sealed class EmptyToolCallLog : IToolCallLog
+{
+    public Task AppendAsync(ToolCallEvent evt, CancellationToken ct = default) => Task.CompletedTask;
+    public Task<IReadOnlyList<ToolCallEvent>> GetBySessionAsync(string sessionId, CancellationToken ct = default) =>
+        Task.FromResult<IReadOnlyList<ToolCallEvent>>([]);
+    public Task<IReadOnlyList<ToolCallEvent>> QueryRecentAsync(DateTimeOffset since, int maxResults, CancellationToken ct = default) =>
+        Task.FromResult<IReadOnlyList<ToolCallEvent>>([]);
+}


### PR DESCRIPTION
Closes #410.

## Summary

Two complementary skill-injection points, both keyed on the agent's tool selection rather than on user-message tokens (users rarely name MCP servers explicitly):

- **Pre-flight on `mcp_get_service_details`** — when the LLM has narrowed in on a single server, append matching `mcp/{server}` and `mcp/{server}/*` skill content to the tool response so the LLM sees verified parameter shapes BEFORE the first `mcp_invoke_tool` attempt. Does NOT fire on `mcp_list_services` — that would crowd context with every registered server's skill.
- **Recovery-time inside `SchemaErrorEnricher`** — when `mcp_invoke_tool` fails with a parameter-required error and the enricher builds its structured recovery message, append the matching `mcp/{server}` skill alongside the schema, hint, and recent-call sections so the retry uses verified shape instead of re-guessing.

Both call sites share `McpServerSkillFormatter`, a small helper that queries `ISkillStore` for `mcp/{server}` and any `mcp/{server}/*` sub-skills, renders them as a markdown block, and caps per-skill body at 4 KiB with a `get_skill()` hint for the rest. Both injection sites take `ISkillStore` as an optional constructor dependency, so existing call sites and tests that don't wire a store are unaffected.

## Why

Diagnosed from live telemetry: `calendar-mcp/get_calendar_events` with `accountId is required` had **88 occurrences in 8 days** even though `mcp/calendar-mcp/calendar-operations-itinerary-event-and-invoke-shape` documents the requirement — because that skill wasn't in context when the LLM authored the call. Same pattern for `search_emails query is required` (24x), `search_contacts query is required` (8x), `complete_task` empty-args (5x), etc. Each one has a documenting skill that simply wasn't recalled. Both injections close that gap.

## Files

- `src/RockBot.Tools.Mcp/McpServerSkillFormatter.cs` — shared formatter (new)
- `src/RockBot.Tools.Mcp/McpManagementExecutor.cs` — pre-flight injection after `mcp_get_service_details`
- `src/RockBot.Tools.Mcp/Recovery/SchemaErrorEnricher.cs` — recovery-time injection
- `tests/RockBot.Tools.Tests/McpSkillInjectionTests.cs` — 9 new tests (pre-flight + recovery + negative: `mcp_list_services` doesn't trigger)

## Test plan

- [x] `dotnet build RockBot.slnx` — clean, 0 errors
- [x] `dotnet test RockBot.slnx` — full suite green. RockBot.Tools.Tests went 163 → 172 (+9); everything else unchanged.
- [x] Verified `mcp_list_services` explicitly does NOT trigger injection
- [x] Verified absent skill leaves response intact (no `[mcp-skill-injection]` block)
- [x] Verified absent `ISkillStore` preserves prior behavior (constructor remains backward-compatible)
- [ ] Deploy to live cluster; check next-week failure-clusters snapshot — expect `accountId is required` and `query is required` counts to plateau

🤖 Generated with [Claude Code](https://claude.com/claude-code)