### PR TITLE
Bump version to 0.10.66

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.10.65</Version>
+<Version>0.10.66</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->


### PR DESCRIPTION
Releases two structural recall improvements that landed back-to-back:

- **#411** — wisp shape hash + eager scheduled-task promotion. Successful recurring scheduled-task wisps now turn into reusable provisional resources on their parent skill after only two same-shape successes, instead of waiting for the nightly dream pass that the byte-identical hash requirement was silently blocking.
- **#412** — `mcp/<server>` skill injection on tool selection (`mcp_get_service_details`) and on parameter-error recovery. The LLM sees verified parameter shapes from existing skills BEFORE the first `mcp_invoke_tool` attempt, and again as part of the enriched recovery response when a parameter-required error fires.

Both verified end-to-end on the live cluster against a pre-release test image before this bump; the agent followed up the recovery test by saving its own learning back onto the `mcp/calendar-mcp/...` sub-skill.

## Test plan

- [x] `dotnet build` clean
- [x] Full test suite green on the combined branch
- [x] Live cluster smoke: pre-flight injection fires on `mcp_get_service_details`
- [x] Live cluster smoke: recovery injection fires on `accountId is required` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)