### PR TITLE
Treat dense markdown as structured for embedding input

### DIFF
--- a/src/RockBot.Host.Abstractions/EmbeddingOptions.cs
+++ b/src/RockBot.Host.Abstractions/EmbeddingOptions.cs
@@ -30,12 +30,14 @@ public sealed class EmbeddingOptions
     public int MaxInputChars { get; set; } = 30_000;
 
     /// <summary>
-    /// Stricter character cap applied when the input looks like a structured payload
-    /// (JSON object/array). JSON tokenizes ~2× denser than prose, so a 19k-char JSON
-    /// blob can push past 9k tokens — over the 8192 window — while the prose cap would
-    /// happily let it through. Default 12000 (~6000 tokens at ~2 chars/token) leaves
-    /// the same headroom for structured input. Selection is centralized in
-    /// <c>EmbeddingTextPreparer</c>; no caller picks the cap directly.
+    /// Stricter character cap applied when the input looks like a structured or dense
+    /// payload — JSON object/array, base64 blob, hash listing, or markdown with heavy
+    /// URL / citation / identifier content. Such content tokenizes ~2× denser than
+    /// prose, so a 19k-char structured blob can push past 9k tokens — over the 8192
+    /// window — while the prose cap would happily let it through. Default 12000 (~6000
+    /// tokens at ~2 chars/token) leaves the same headroom for structured input.
+    /// Selection is centralized in <c>EmbeddingTextPreparer</c>; no caller picks the
+    /// cap directly.
     /// </summary>
     public int MaxStructuredInputChars { get; set; } = 12_000;
 

--- a/src/RockBot.Host/EmbeddingTextPreparer.cs
+++ b/src/RockBot.Host/EmbeddingTextPreparer.cs
@@ -49,10 +49,15 @@ internal sealed class EmbeddingTextPreparer(
     }
 
     /// <summary>
-    /// Cheap heuristic: input is treated as structured when the first non-whitespace
-    /// character is <c>{</c> or <c>[</c>. Covers JSON objects, arrays, and JSON-Lines.
-    /// Misses base64/HTML/code blobs, but those don't currently exceed the prose cap
-    /// in practice — promote the heuristic only if real failures show up.
+    /// Cheap heuristic for "should this input get the stricter structured cap." Two signals:
+    /// <list type="number">
+    /// <item>First non-whitespace char is <c>{</c> or <c>[</c> — covers JSON objects, arrays, JSON-Lines.</item>
+    /// <item>Density check on a leading sample — BPE tokenizers split on whitespace and merge
+    /// common subwords, so content with long whitespace-separated runs (URLs, hashes, identifiers,
+    /// base64, dense markdown evidence slices with citations) tokenizes ~2× denser than English
+    /// prose (~5-char average word length) and busts the embedding context window even when the
+    /// char count is under the prose cap.</item>
+    /// </list>
     /// </summary>
     private static bool IsStructured(string text)
     {
@@ -60,8 +65,35 @@ internal sealed class EmbeddingTextPreparer(
         {
             var c = text[i];
             if (char.IsWhiteSpace(c)) continue;
-            return c == '{' || c == '[';
+            if (c == '{' || c == '[') return true;
+            break;
         }
-        return false;
+
+        // Density check only matters for inputs large enough to risk overflow at the
+        // prose cap. Below ~1k chars the cap can't be exceeded anyway.
+        if (text.Length < 1024) return false;
+
+        const int sampleSize = 4096;
+        var sampleLen = Math.Min(text.Length, sampleSize);
+        var whitespaceCount = 0;
+        var nonLetterNonWhitespace = 0;
+        for (var i = 0; i < sampleLen; i++)
+        {
+            var c = text[i];
+            if (char.IsWhiteSpace(c)) whitespaceCount++;
+            else if (!char.IsLetter(c)) nonLetterNonWhitespace++;
+        }
+
+        // Average run length between whitespace boundaries. English prose runs ~5;
+        // URL/hash/identifier-heavy content runs much longer.
+        var avgRunLength = whitespaceCount > 0
+            ? (double)(sampleLen - whitespaceCount) / whitespaceCount
+            : double.MaxValue;
+
+        // Symbol/digit density (excluding whitespace). Prose sits ~5%; dense markdown
+        // with URLs, dates, hashes, and citations climbs past 25%.
+        var nonLetterRatio = (double)nonLetterNonWhitespace / sampleLen;
+
+        return avgRunLength > 15 || nonLetterRatio > 0.25;
     }
 }

--- a/tests/RockBot.Host.Tests/EmbeddingTextPreparerTests.cs
+++ b/tests/RockBot.Host.Tests/EmbeddingTextPreparerTests.cs
@@ -105,4 +105,59 @@ public class EmbeddingTextPreparerTests
 
         Assert.AreEqual(json, preparer.Prepare(json));
     }
+
+    [TestMethod]
+    public void Prepare_LongProse_UsesProseCap()
+    {
+        var preparer = Build(new EmbeddingOptions { MaxInputChars = 5000, MaxStructuredInputChars = 1000 });
+        // ~2k chars of realistic English prose (lots of whitespace, mostly letters).
+        var paragraph = string.Concat(Enumerable.Repeat(
+            "The quick brown fox jumps over the lazy dog near the riverbank at dawn. ", 30));
+
+        var result = preparer.Prepare(paragraph);
+
+        Assert.AreEqual(paragraph, result, "ordinary prose should never trip the density heuristic");
+    }
+
+    [TestMethod]
+    public void Prepare_LongBase64Blob_TreatedAsStructured()
+    {
+        var preparer = Build(new EmbeddingOptions { MaxInputChars = 5000, MaxStructuredInputChars = 500 });
+        // 2k-char base64-style blob — no whitespace, all letters/digits.
+        var blob = string.Concat(Enumerable.Repeat(
+            "AbCdEfGhIjKlMnOpQrStUvWxYz0123456789AbCdEfGhIjKlMnOpQrStUvWxYz0123456789", 30));
+
+        var result = preparer.Prepare(blob);
+
+        Assert.AreEqual(500, result.Length, "no-whitespace blob should hit the structured cap");
+    }
+
+    [TestMethod]
+    public void Prepare_LongUrlAndCitationMarkdown_TreatedAsStructured()
+    {
+        var preparer = Build(new EmbeddingOptions { MaxInputChars = 5000, MaxStructuredInputChars = 500 });
+        // Markdown evidence slice — short prose lines mixed with URLs, hashes, and dates.
+        // This is the shape that was busting nomic-embed-text's 8192-token context
+        // despite being under the prose cap.
+        var slice = string.Concat(Enumerable.Repeat(
+            "- 2026-05-15 https://example.com/posts/abc-def-ghi-jkl-mno/permalink#section-2 (sha:9f8e7d6c5b4a3) " +
+            "reference 04d7ed9cf308b1a2c3d4e5f6 entry-id\n", 20));
+
+        var result = preparer.Prepare(slice);
+
+        Assert.AreEqual(500, result.Length, "URL/hash-heavy markdown should hit the structured cap");
+    }
+
+    [TestMethod]
+    public void Prepare_DensityCheckSkipped_ForSmallInputs()
+    {
+        // Below ~1k chars the prose cap can't be exceeded, so density-shaped input
+        // smaller than that should still take the prose path. This protects callers
+        // from cap thrash on short identifier-heavy keys.
+        var preparer = Build(new EmbeddingOptions { MaxInputChars = 2000, MaxStructuredInputChars = 100 });
+        var smallDense = string.Concat(Enumerable.Repeat("https://example.com/abc-def ", 20));
+
+        Assert.IsTrue(smallDense.Length < 1024);
+        Assert.AreEqual(smallDense, preparer.Prepare(smallDense));
+    }
 }


### PR DESCRIPTION
## Summary
- `EmbeddingTextPreparer.IsStructured` only flagged JSON-shaped input, so URL/hash/citation-heavy markdown (e.g. A2A evidence-slice payloads stored in working memory) took the 30k-char prose cap and busted nomic-embed-text's 8192-token window despite being under the cap.
- Add a density heuristic on inputs >= 1024 chars (sample-based, O(4k)): treat as structured when average whitespace-separated run length > 15 chars or non-letter ratio > 25%. Catches base64 blobs, hash listings, and dense markdown with URLs/dates/IDs.
- Existing JSON-shape behavior and small-input behavior are unchanged.

## Test plan
- [x] `dotnet test --filter ClassName~EmbeddingTextPreparerTests` — 13/13 pass (4 new tests for prose / base64 / dense markdown / sub-1k bypass)
- [x] `dotnet test --filter ClassName~HybridCacheWorkingMemoryTests` — 45/45 pass (no regression on the embedding call site)
- [ ] Watch pod logs after deploy — `"Failed to generate working memory embedding"` should drop to zero for evidence-slice keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)