### PR TITLE
Allow omitting params on MCP wisp steps for no-arg tools

### DIFF
--- a/src/RockBot.Wisp/GatewayRouter.cs
+++ b/src/RockBot.Wisp/GatewayRouter.cs
@@ -54,23 +54,17 @@ internal static partial class GatewayRouter
             return ToolRouteResult.Failure("MCP gateway requires 'server' field", FailureCategory.Structural);
         if (string.IsNullOrEmpty(step.Tool))
             return ToolRouteResult.Failure("MCP gateway requires 'tool' field", FailureCategory.Structural);
-        if (step.ResolvedParams is null)
-            return ToolRouteResult.Failure(
-                $"MCP step '{step.Id}' has no 'params' field. Put the tool arguments " +
-                $"for {step.Server}/{step.Tool} in \"params\": {{...}}. Example: " +
-                $"\"params\": {{\"timeZone\": \"America/Chicago\", \"startDate\": \"2025-04-01\"}}",
-                FailureCategory.Structural);
 
+        // Missing params is treated as an empty arguments object. The MCP server validates
+        // its own tool schema and returns a specific error if required arguments are absent.
         var resolvedParams = ResolveTemplates(step.ResolvedParams, priorResults);
 
         var args = new Dictionary<string, object?>
         {
             ["server_name"] = step.Server,
-            ["tool_name"] = step.Tool
+            ["tool_name"] = step.Tool,
+            ["arguments"] = resolvedParams ?? JsonDocument.Parse("{}").RootElement
         };
-
-        if (resolvedParams is not null)
-            args["arguments"] = resolvedParams;
 
         return ToolRouteResult.Success("mcp_invoke_tool", JsonSerializer.Serialize(args, JsonOptions));
     }

--- a/src/RockBot.Wisp/WispToolSkillProvider.cs
+++ b/src/RockBot.Wisp/WispToolSkillProvider.cs
@@ -190,7 +190,8 @@ public sealed class WispToolSkillProvider : IToolSkillProvider
 
         **IMPORTANT:** Tool arguments go in the `"params"` field (not `"input"` or
         `"arguments"`). Include ALL required parameters — the harness passes them
-        directly to the tool with no defaulting or inference.
+        directly to the tool with no defaulting or inference. For MCP tools that take
+        no arguments, you may omit `params` entirely (or set it to `{}`).
 
         **MCP** — Call any MCP server tool:
         ```json
@@ -202,6 +203,17 @@ public sealed class WispToolSkillProvider : IToolSkillProvider
           "tool": "search_emails",
           "params": { "query": "from:sales subject:report", "max_results": 5 },
           "output_to": "wisp-data/emails.json"
+        }
+        ```
+
+        For a no-argument MCP tool, `params` can be omitted:
+        ```json
+        {
+          "id": "list_calendars",
+          "mode": "Direct",
+          "gateway": "Mcp",
+          "server": "ms365",
+          "tool": "list_calendars"
         }
         ```
 

--- a/tests/RockBot.Wisp.Tests/GatewayRouterTests.cs
+++ b/tests/RockBot.Wisp.Tests/GatewayRouterTests.cs
@@ -87,6 +87,34 @@ public class GatewayRouterTests
     }
 
     [TestMethod]
+    public void Route_Mcp_MissingParams_DefaultsToEmptyArguments()
+    {
+        // No-argument MCP tools (e.g. list_calendars) should route successfully
+        // with an empty arguments object — the MCP server validates required args
+        // against its own schema and returns a tool-specific error if needed.
+        var step = new WispStep
+        {
+            Id = "list",
+            Mode = StepMode.Direct,
+            Gateway = GatewayType.Mcp,
+            Server = "ms365",
+            Tool = "list_calendars"
+        };
+
+        var result = GatewayRouter.Route(step, "wisp-123", EmptyResults);
+
+        Assert.IsTrue(result.IsSuccess, result.ErrorMessage);
+        Assert.AreEqual("mcp_invoke_tool", result.ToolName);
+
+        var args = JsonDocument.Parse(result.Arguments!).RootElement;
+        Assert.AreEqual("ms365", args.GetProperty("server_name").GetString());
+        Assert.AreEqual("list_calendars", args.GetProperty("tool_name").GetString());
+        Assert.IsTrue(args.TryGetProperty("arguments", out var argsObj));
+        Assert.AreEqual(JsonValueKind.Object, argsObj.ValueKind);
+        Assert.AreEqual(0, argsObj.EnumerateObject().Count());
+    }
+
+    [TestMethod]
     public void Route_Mcp_MissingServer_ReturnsStructuralError()
     {
         var step = new WispStep


### PR DESCRIPTION
## Summary
- `GatewayRouter.RouteMcp` no longer fails MCP wisp steps that omit the `params` field — missing params now routes with `arguments: {}`. The downstream `mcp_invoke_tool` schema already marks `arguments` as optional, so the pre-flight structural check served no purpose and produced recurring failures the dream loop could not patch from skill annotations alone.
- If the target tool actually requires arguments, the MCP server returns its own schema-specific error, which is more accurate than the generic router message.
- Updated `WispToolSkillProvider` author guidance to state that `params` may be omitted for no-arg tools, with a concrete example.

## Test plan
- [x] `dotnet test tests/RockBot.Wisp.Tests` — 129/129 pass, including new `Route_Mcp_MissingParams_DefaultsToEmptyArguments`.
- [ ] Smoke a no-arg MCP wisp step in the deployed agent (e.g. `calendar-mcp/list_accounts` via spawn_wisps) to confirm the relaxation flows through end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)