### PR TITLE
mcp_invoke_tool: short-circuit empty-arg calls to parameterized tools

### DIFF
--- a/src/RockBot.Tools.Mcp/McpManagementExecutor.cs
+++ b/src/RockBot.Tools.Mcp/McpManagementExecutor.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using RockBot.Host;
@@ -30,6 +31,7 @@ public sealed class McpManagementExecutor : IToolExecutor, IAsyncDisposable
     private readonly TimeSpan _timeout;
     private readonly McpRecoveryExecutor? _recovery;
     private readonly ISkillStore? _skillStore;
+    private readonly ToolSchemaCache? _schemaCache;
 
     private readonly ConcurrentDictionary<string, TaskCompletionSource<MessageEnvelope>> _pending = new();
     private ISubscription? _responseSubscription;
@@ -53,7 +55,8 @@ public sealed class McpManagementExecutor : IToolExecutor, IAsyncDisposable
         ILogger<McpManagementExecutor> logger,
         TimeSpan? timeout = null,
         McpRecoveryExecutor? recovery = null,
-        ISkillStore? skillStore = null)
+        ISkillStore? skillStore = null,
+        ToolSchemaCache? schemaCache = null)
     {
         _index = index;
         _proxy = proxy;
@@ -64,6 +67,7 @@ public sealed class McpManagementExecutor : IToolExecutor, IAsyncDisposable
         _timeout = timeout ?? TimeSpan.FromSeconds(30);
         _recovery = recovery;
         _skillStore = skillStore;
+        _schemaCache = schemaCache;
     }
 
     public string ResponseTopic => $"mcp.manage.response.{_identity.Name}";
@@ -210,6 +214,21 @@ public sealed class McpManagementExecutor : IToolExecutor, IAsyncDisposable
         if (TryGetNestedArgs(args, out var argsObj))
         {
             toolArgs = argsObj is JsonElement je ? je.GetRawText() : JsonSerializer.Serialize(argsObj, JsonOptions);
+        }
+        else if (!HasNonReservedKeys(args))
+        {
+            // The call carries only server_name + tool_name — no nested arguments wrapper
+            // and no flattened inner-tool fields. Some models hit this when invoking a
+            // parameterized MCP tool: they load the schema, then emit an empty call and
+            // rationalise the dispatch failure as "the wrapper can't pass arguments,"
+            // saving that rationalisation to working memory (see design/self-repair.md).
+            // If we can confirm from the cached schema that the target tool requires
+            // parameters, short-circuit with a remediation error that names the missing
+            // fields and shows the correct wrapper shape. Falls through when the cache
+            // is unavailable or the tool genuinely takes no arguments.
+            var remediation = await TryBuildEmptyArgsRemediationAsync(serverName, toolName, ct);
+            if (remediation is not null)
+                return Error(request, remediation);
         }
 
         var innerRequest = new ToolInvokeRequest
@@ -490,6 +509,11 @@ public sealed class McpManagementExecutor : IToolExecutor, IAsyncDisposable
     // silently dropped when the model deviates from the declared field name.
     private static readonly string[] NestedArgAliases = ["arguments", "params", "args"];
 
+    private static readonly HashSet<string> ReservedTopLevelKeys = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "server_name", "tool_name", "arguments", "params", "args"
+    };
+
     private static bool TryGetNestedArgs(Dictionary<string, object?> args, out object argsObj)
     {
         foreach (var alias in NestedArgAliases)
@@ -502,6 +526,91 @@ public sealed class McpManagementExecutor : IToolExecutor, IAsyncDisposable
         }
         argsObj = null!;
         return false;
+    }
+
+    private static bool HasNonReservedKeys(Dictionary<string, object?> args)
+    {
+        foreach (var key in args.Keys)
+        {
+            if (!ReservedTopLevelKeys.Contains(key))
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Returns a remediation message if the cached schema for the given tool declares
+    /// any required parameters. Returns null when the schema cache is unavailable, the
+    /// schema can't be fetched, the tool isn't found, or the tool takes no required
+    /// parameters — in any of those cases the caller should fall through to the normal
+    /// MCP dispatch and let the server respond authoritatively.
+    /// </summary>
+    private async Task<string?> TryBuildEmptyArgsRemediationAsync(
+        string serverName, string toolName, CancellationToken ct)
+    {
+        if (_schemaCache is null) return null;
+
+        McpToolDefinition? schema;
+        try
+        {
+            schema = await _schemaCache.GetAsync(serverName, toolName, ct);
+        }
+        catch (OperationCanceledException) { throw; }
+        catch
+        {
+            return null;
+        }
+
+        if (schema is null) return null;
+
+        var required = ExtractRequiredFieldNames(schema.ParametersSchema);
+        if (required.Count == 0) return null;
+
+        var sample = BuildExampleArgs(required);
+        var requiredList = string.Join(", ", required);
+        return
+            $"Call to '{serverName}/{toolName}' carried no inner arguments. " +
+            $"This tool requires: {requiredList}. " +
+            $"Pass the inner-tool parameters nested inside the 'arguments' field of mcp_invoke_tool. " +
+            $"Retry with shape: {{\"server_name\":\"{serverName}\",\"tool_name\":\"{toolName}\",\"arguments\":{sample}}}";
+    }
+
+    internal static IReadOnlyList<string> ExtractRequiredFieldNames(string? parametersSchema)
+    {
+        if (string.IsNullOrWhiteSpace(parametersSchema)) return [];
+        try
+        {
+            using var doc = JsonDocument.Parse(parametersSchema);
+            if (doc.RootElement.ValueKind != JsonValueKind.Object) return [];
+            if (!doc.RootElement.TryGetProperty("required", out var req)) return [];
+            if (req.ValueKind != JsonValueKind.Array) return [];
+            var names = new List<string>(req.GetArrayLength());
+            foreach (var item in req.EnumerateArray())
+            {
+                if (item.ValueKind == JsonValueKind.String)
+                {
+                    var name = item.GetString();
+                    if (!string.IsNullOrEmpty(name)) names.Add(name);
+                }
+            }
+            return names;
+        }
+        catch (JsonException)
+        {
+            return [];
+        }
+    }
+
+    private static string BuildExampleArgs(IReadOnlyList<string> requiredFieldNames)
+    {
+        var sb = new StringBuilder("{");
+        for (var i = 0; i < requiredFieldNames.Count; i++)
+        {
+            if (i > 0) sb.Append(',');
+            sb.Append('"').Append(requiredFieldNames[i]).Append("\":\"…\"");
+        }
+        sb.Append('}');
+        return sb.ToString();
     }
 
     private static ToolInvokeResponse Error(ToolInvokeRequest request, string message) => new()

--- a/tests/RockBot.Tools.Tests/McpManagementExecutorTests.cs
+++ b/tests/RockBot.Tools.Tests/McpManagementExecutorTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using RockBot.Host;
 using RockBot.Messaging;
 using RockBot.Tools.Mcp;
+using RockBot.Tools.Mcp.Recovery;
 
 namespace RockBot.Tools.Tests;
 
@@ -313,6 +314,160 @@ public class McpManagementExecutorTests
 
         Assert.IsTrue(result.IsError);
         Assert.IsTrue(result.Content!.Contains("server_name"));
+    }
+
+    // ── mcp_invoke_tool: empty-args pre-flight remediation ───────────────────
+
+    private (McpManagementExecutor Executor, TrackingPublisher Publisher, StubSubscriber Subscriber)
+        CreateExecutorWithSchemas(IReadOnlyList<McpToolDefinition> tools)
+    {
+        var publisher = new TrackingPublisher();
+        var subscriber = new StubSubscriber();
+
+        var proxy = new McpToolProxy(
+            publisher,
+            subscriber,
+            _identity,
+            NullLogger<McpToolProxy>.Instance);
+
+        var index = new McpServerIndex();
+        index.Apply(new McpServersIndexed
+        {
+            Servers =
+            [
+                new McpServerSummary
+                {
+                    ServerName = "filesystem",
+                    Summary = "File system tools.",
+                    ToolCount = tools.Count,
+                    ToolNames = tools.Select(t => t.Name).ToList()
+                }
+            ]
+        });
+
+        var schemaCache = new ToolSchemaCache((server, ct) =>
+            Task.FromResult<IReadOnlyList<McpToolDefinition>?>(
+                string.Equals(server, "filesystem", StringComparison.OrdinalIgnoreCase) ? tools : null));
+
+        var executor = new McpManagementExecutor(
+            index,
+            proxy,
+            publisher,
+            subscriber,
+            _identity,
+            NullLogger<McpManagementExecutor>.Instance,
+            timeout: null,
+            recovery: null,
+            skillStore: null,
+            schemaCache: schemaCache);
+
+        return (executor, publisher, subscriber);
+    }
+
+    [TestMethod]
+    public async Task InvokeTool_EmptyArgs_RequiredParamsTool_ReturnsRemediationBeforeDispatch()
+    {
+        // Repro of the patrol-trace failure: LLM emits a mcp_invoke_tool call with
+        // only server_name + tool_name for a parameterized tool. The framework should
+        // short-circuit with a remediation that names the required fields and shows
+        // the wrapper shape, instead of dispatching and letting the MCP server return
+        // a tool-server error that the model misinterprets as "the wrapper is broken."
+        var schema = """
+            {"type":"object","properties":{"to":{"type":"string"},"subject":{"type":"string"},"body":{"type":"string"}},"required":["to","subject","body"]}
+            """;
+        var (executor, publisher, _) = CreateExecutorWithSchemas(
+        [
+            new McpToolDefinition { Name = "send_email", Description = "Send email.", ParametersSchema = schema }
+        ]);
+
+        var request = new ToolInvokeRequest
+        {
+            ToolCallId = "call-empty",
+            ToolName = "mcp_invoke_tool",
+            Arguments = """{"server_name":"filesystem","tool_name":"send_email"}"""
+        };
+
+        var result = await executor.ExecuteAsync(request, CancellationToken.None);
+
+        Assert.IsTrue(result.IsError, "Empty-args call to a parameterized tool must short-circuit.");
+        Assert.AreEqual(0, publisher.Published.Count,
+            "Pre-flight remediation must not dispatch to the bridge.");
+        StringAssert.Contains(result.Content!, "to");
+        StringAssert.Contains(result.Content!, "subject");
+        StringAssert.Contains(result.Content!, "body");
+        StringAssert.Contains(result.Content!, "arguments",
+            "Remediation must point the model at the 'arguments' wrapper field.");
+    }
+
+    [TestMethod]
+    public async Task InvokeTool_EmptyArgs_NoRequiredParams_DispatchesNormally()
+    {
+        // No-arg MCP tools (e.g. list_accounts) must still dispatch when the wrapper
+        // carries only server_name + tool_name — the remediation is gated on the
+        // schema declaring required fields.
+        var schema = """{"type":"object","properties":{}}""";
+        var (executor, publisher, subscriber) = CreateExecutorWithSchemas(
+        [
+            new McpToolDefinition { Name = "list_accounts", Description = "List accounts.", ParametersSchema = schema }
+        ]);
+
+        var request = new ToolInvokeRequest
+        {
+            ToolCallId = "call-noargs",
+            ToolName = "mcp_invoke_tool",
+            Arguments = """{"server_name":"filesystem","tool_name":"list_accounts"}"""
+        };
+
+        var executeTask = executor.ExecuteAsync(request, CancellationToken.None);
+        await Task.Delay(100);
+
+        Assert.AreEqual(1, publisher.Published.Count,
+            "No-required-params tool should reach the bridge.");
+
+        var response = new ToolInvokeResponse
+        {
+            ToolCallId = "call-noargs",
+            ToolName = "list_accounts",
+            Content = "[]"
+        };
+        await subscriber.DeliverAsync($"tool.result.{_identity.Name}",
+            response.ToEnvelope("bridge", correlationId: publisher.Published[0].Envelope.CorrelationId));
+
+        var result = await executeTask;
+        Assert.IsFalse(result.IsError);
+    }
+
+    [TestMethod]
+    public async Task InvokeTool_EmptyArgs_SchemaCacheUnavailable_DispatchesNormally()
+    {
+        // When the schema cache can't supply a schema (cold cache miss against an
+        // unreachable bridge, unknown tool, etc.) the executor must fall through to
+        // the existing dispatch path — the MCP server's own error is still useful.
+        var (executor, publisher, subscriber) = CreateExecutor();   // no schema cache wired
+
+        var request = new ToolInvokeRequest
+        {
+            ToolCallId = "call-noschema",
+            ToolName = "mcp_invoke_tool",
+            Arguments = """{"server_name":"filesystem","tool_name":"send_email"}"""
+        };
+
+        var executeTask = executor.ExecuteAsync(request, CancellationToken.None);
+        await Task.Delay(100);
+
+        Assert.AreEqual(1, publisher.Published.Count,
+            "Without a schema cache the executor must still dispatch.");
+
+        var response = new ToolInvokeResponse
+        {
+            ToolCallId = "call-noschema",
+            ToolName = "send_email",
+            Content = "ok"
+        };
+        await subscriber.DeliverAsync($"tool.result.{_identity.Name}",
+            response.ToEnvelope("bridge", correlationId: publisher.Published[0].Envelope.CorrelationId));
+
+        await executeTask;
     }
 
     // ── mcp_register_server ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- When `mcp_invoke_tool` is called with only `server_name` + `tool_name` (no nested wrapper, no flat-shape inner fields) **and** the target tool's cached schema declares required parameters, `McpManagementExecutor.InvokeToolAsync` now short-circuits with a remediation error that names the required fields and shows the correct nested wrapper shape.
- Falls through to normal dispatch when the schema cache is unavailable, the tool isn't found, or no required parameters are declared — no-arg tools like `list_accounts` still reach the bridge.
- Targets the self-deceptive failure loop documented in `design/self-repair.md`: model emits empty call → MCP server returns \"'to' not provided\" → model rationalises \"the wrapper can't carry parameters\" → saves the lie to working memory → future runs pre-emptively detour through wisps.

## Trace that motivated this

In the 2026-05-19 patrol run (subagent `7c8187976c60`), the model loaded `calendar-mcp/send_email`'s schema via `mcp_get_service_details`, then emitted:

```
mcp_invoke_tool(args=server_name=calendar-mcp, tool_name=send_email)
→ MCP calendar-mcp/send_email args=(none)
← ERROR: Required parameter 'to' was not provided
```

The dict literally contained only those two keys — no nested `arguments`, no flat `to`/`subject`/`body`. With this change the framework's error becomes:

> Call to 'calendar-mcp/send_email' carried no inner arguments. This tool requires: to, subject, body. Pass the inner-tool parameters nested inside the 'arguments' field of mcp_invoke_tool. Retry with shape: `{\"server_name\":\"calendar-mcp\",\"tool_name\":\"send_email\",\"arguments\":{\"to\":\"…\",\"subject\":\"…\",\"body\":\"…\"}}`

…which is framed at the call site instead of looking like a tool-server fault.

## Scope

This is the targeted stopgap for #420 (typed bridge tools per MCP tool). It does not address the broader \"LLMs author the generic wrapper unreliably\" question — that's the durable fix.

## Test plan
- [x] `dotnet test tests/RockBot.Tools.Tests` — 175/175 pass, including 3 new tests:
  - `InvokeTool_EmptyArgs_RequiredParamsTool_ReturnsRemediationBeforeDispatch`
  - `InvokeTool_EmptyArgs_NoRequiredParams_DispatchesNormally`
  - `InvokeTool_EmptyArgs_SchemaCacheUnavailable_DispatchesNormally`
- [ ] Smoke-test in the deployed agent: trigger a parameterized MCP call that would have failed empty (e.g. `calendar-mcp/send_email` without arguments) and confirm the new remediation message appears in the trace, and that the model recovers without pivoting to a wisp.
- [ ] After deployment, evict the stale \"wrapper can't carry arguments\" rationalisation from working memory so the agent stops pre-emptively detouring.

Related: #420 (durable per-server typed bridge tools).

🤖 Generated with [Claude Code](https://claude.com/claude-code)