### PR TITLE
Strip HTML from CLI agent replies (#417)

### DIFF
--- a/RockBot.slnx
+++ b/RockBot.slnx
@@ -57,6 +57,7 @@
     <Project Path="tests/RockBot.A2A.Tests/RockBot.A2A.Tests.csproj" />
     <Project Path="tests/RockBot.Telemetry.Tests/RockBot.Telemetry.Tests.csproj" />
     <Project Path="tests/RockBot.UserProxy.Tests/RockBot.UserProxy.Tests.csproj" />
+    <Project Path="tests/RockBot.Cli.Tests/RockBot.Cli.Tests.csproj" />
     <Project Path="tests/RockBot.Agent.Tests/RockBot.Agent.Tests.csproj" />
     <Project Path="tests/RockBot.Tools.Web.Tests/RockBot.Tools.Web.Tests.csproj" />
     <Project Path="tests/RockBot.Subagent.Tests/RockBot.Subagent.Tests.csproj" />

--- a/src/RockBot.UserProxy.Cli/ChatCommand.cs
+++ b/src/RockBot.UserProxy.Cli/ChatCommand.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using RockBot.UserProxy.Rendering;
 using Spectre.Console;
 using Spectre.Console.Cli;
 
@@ -64,7 +65,7 @@ internal sealed class ChatCommand : AsyncCommand<ChatCommand.Settings>
         // Mirror intermediate progress to stderr so callers piping stdout get
         // only the final reply text.
         var progress = new Progress<AgentReply>(r =>
-            Console.Error.WriteLine($"[{r.AgentName}] {r.Content}"));
+            Console.Error.WriteLine($"[{r.AgentName}] {HtmlPlainTextRenderer.StripHtml(r.Content)}"));
 
         var reply = await proxy.SendAsync(message, progress: progress);
 
@@ -74,7 +75,7 @@ internal sealed class ChatCommand : AsyncCommand<ChatCommand.Settings>
             return 2;
         }
 
-        Console.Out.WriteLine(reply.Content);
+        Console.Out.WriteLine(HtmlPlainTextRenderer.StripHtml(reply.Content));
         return 0;
     }
 

--- a/src/RockBot.UserProxy.Cli/PlainConsoleFrontend.cs
+++ b/src/RockBot.UserProxy.Cli/PlainConsoleFrontend.cs
@@ -1,3 +1,5 @@
+using RockBot.UserProxy.Rendering;
+
 namespace RockBot.UserProxy.Cli;
 
 /// <summary>
@@ -10,13 +12,13 @@ internal sealed class PlainConsoleFrontend : IUserFrontend
 {
     public Task DisplayReplyAsync(AgentReply reply, CancellationToken cancellationToken = default)
     {
-        Console.Out.WriteLine(reply.Content);
+        Console.Out.WriteLine(HtmlPlainTextRenderer.StripHtml(reply.Content));
         return Task.CompletedTask;
     }
 
     public Task DisplayStatusAsync(AgentReply reply, CancellationToken cancellationToken = default)
     {
-        Console.Error.WriteLine($"[{reply.AgentName}] {reply.Content}");
+        Console.Error.WriteLine($"[{reply.AgentName}] {HtmlPlainTextRenderer.StripHtml(reply.Content)}");
         return Task.CompletedTask;
     }
 

--- a/src/RockBot.UserProxy.Cli/RockBot.UserProxy.Cli.csproj
+++ b/src/RockBot.UserProxy.Cli/RockBot.UserProxy.Cli.csproj
@@ -9,6 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="RockBot.Cli.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Spectre.Console" Version="0.49.*" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.49.*" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.*" />

--- a/src/RockBot.UserProxy.Cli/SpectreConsoleFrontend.cs
+++ b/src/RockBot.UserProxy.Cli/SpectreConsoleFrontend.cs
@@ -10,7 +10,7 @@ internal sealed class SpectreConsoleFrontend : IUserFrontend
 {
     public Task DisplayReplyAsync(AgentReply reply, CancellationToken cancellationToken = default)
     {
-        var panel = new Panel(Markup.Escape(reply.Content))
+        var panel = new Panel(SpectreMarkupConverter.ToSpectreMarkup(reply.Content))
         {
             Header = new PanelHeader(Markup.Escape(reply.AgentName)),
             Border = BoxBorder.Rounded,
@@ -26,7 +26,7 @@ internal sealed class SpectreConsoleFrontend : IUserFrontend
         // Render ephemeral progress as a single dim line rather than a panel,
         // so unsolicited subagent / A2A progress doesn't stack as bubbles.
         AnsiConsole.MarkupLine(
-            $"[dim italic]{Markup.Escape(reply.AgentName)}: {Markup.Escape(reply.Content)}[/]");
+            $"[dim italic]{Markup.Escape(reply.AgentName)}: {SpectreMarkupConverter.ToSpectreMarkup(reply.Content)}[/]");
         return Task.CompletedTask;
     }
 

--- a/src/RockBot.UserProxy.Cli/SpectreMarkupConverter.cs
+++ b/src/RockBot.UserProxy.Cli/SpectreMarkupConverter.cs
@@ -1,0 +1,91 @@
+using System.Text.RegularExpressions;
+using Spectre.Console;
+
+namespace RockBot.UserProxy.Cli;
+
+/// <summary>
+/// Translates a small subset of agent-emitted HTML (color spans, bold,
+/// SVG placeholders) into Spectre markup, strips anything else, and escapes
+/// the surrounding text so user-supplied <c>[</c> / <c>]</c> can't break the
+/// Spectre parser.
+/// </summary>
+internal static class SpectreMarkupConverter
+{
+    private const char PlaceholderOpen = '￰';
+    private const char PlaceholderClose = '￱';
+
+    private static readonly Regex SvgRegex = new(
+        @"<svg\b[^>]*>.*?</svg\s*>",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+    private static readonly Regex SpanColorRegex = new(
+        @"<span\b[^>]*\bstyle\s*=\s*[""']\s*color\s*:\s*([^""';]+?)\s*;?\s*[""'][^>]*>(.*?)</span\s*>",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+    private static readonly Regex BoldRegex = new(
+        @"<(strong|b)\b[^>]*>(.*?)</\1\s*>",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+    private static readonly Regex TagRegex = new(@"<[^>]+>", RegexOptions.Compiled);
+
+    private static readonly Regex PlaceholderRegex = new(
+        $"{PlaceholderOpen}(\\d+){PlaceholderClose}",
+        RegexOptions.Compiled);
+
+    private static readonly Regex HexColorRegex = new(
+        @"^#[0-9a-fA-F]{6}$",
+        RegexOptions.Compiled);
+
+    private static readonly HashSet<string> NamedColors = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "red", "green", "blue", "yellow", "cyan", "magenta", "grey", "gray", "white"
+    };
+
+    public static string ToSpectreMarkup(string? input)
+    {
+        if (string.IsNullOrEmpty(input))
+            return input ?? string.Empty;
+
+        var placeholders = new List<string>();
+
+        string Stash(string token)
+        {
+            var index = placeholders.Count;
+            placeholders.Add(token);
+            return $"{PlaceholderOpen}{index}{PlaceholderClose}";
+        }
+
+        var stage = SvgRegex.Replace(input, _ => Stash(Markup.Escape("[chart — view in Blazor]")));
+
+        stage = SpanColorRegex.Replace(stage, m =>
+        {
+            var color = m.Groups[1].Value.Trim();
+            var innerText = TagRegex.Replace(m.Groups[2].Value, string.Empty);
+            var escapedInner = Markup.Escape(innerText);
+
+            if (NamedColors.Contains(color))
+                return Stash($"[{color.ToLowerInvariant()}]{escapedInner}[/]");
+
+            if (HexColorRegex.IsMatch(color))
+                return Stash($"[{color.ToLowerInvariant()}]{escapedInner}[/]");
+
+            return innerText;
+        });
+
+        stage = BoldRegex.Replace(stage, m =>
+        {
+            var innerText = TagRegex.Replace(m.Groups[2].Value, string.Empty);
+            return Stash($"[bold]{Markup.Escape(innerText)}[/]");
+        });
+
+        stage = TagRegex.Replace(stage, string.Empty);
+
+        var escaped = Markup.Escape(stage);
+
+        return PlaceholderRegex.Replace(escaped, m =>
+        {
+            var idx = int.Parse(m.Groups[1].Value);
+            return placeholders[idx];
+        });
+    }
+}

--- a/src/RockBot.UserProxy/Rendering/HtmlPlainTextRenderer.cs
+++ b/src/RockBot.UserProxy/Rendering/HtmlPlainTextRenderer.cs
@@ -1,0 +1,35 @@
+using System.Text.RegularExpressions;
+
+namespace RockBot.UserProxy.Rendering;
+
+/// <summary>
+/// Strips HTML / SVG markup from agent replies so text-only frontends (CLI,
+/// future WhatsApp / Discord proxies) never render literal tags. Acts as a
+/// safety net for the honour-system <c>ClientCapabilities</c> gate: even if a
+/// scheduled task fires with <c>outputFormat: "rich"</c> while a plain-text
+/// client is connected, the user sees readable text instead of raw markup.
+/// </summary>
+public static class HtmlPlainTextRenderer
+{
+    private static readonly Regex SvgRegex = new(
+        @"<svg\b[^>]*>.*?</svg\s*>",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+    private static readonly Regex TagRegex = new(
+        @"<[^>]+>",
+        RegexOptions.Compiled);
+
+    /// <summary>
+    /// Replaces <c>&lt;svg&gt;...&lt;/svg&gt;</c> blocks with a chart placeholder
+    /// and removes any other HTML tags. Newlines and whitespace are preserved;
+    /// null / empty input passes through unchanged.
+    /// </summary>
+    public static string StripHtml(string? input)
+    {
+        if (string.IsNullOrEmpty(input))
+            return input ?? string.Empty;
+
+        var withoutSvg = SvgRegex.Replace(input, "[chart — view in Blazor]");
+        return TagRegex.Replace(withoutSvg, string.Empty);
+    }
+}

--- a/tests/RockBot.Cli.Tests/RockBot.Cli.Tests.csproj
+++ b/tests/RockBot.Cli.Tests/RockBot.Cli.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <RootNamespace>RockBot.Cli.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.*" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\RockBot.UserProxy.Cli\RockBot.UserProxy.Cli.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/RockBot.Cli.Tests/SpectreMarkupConverterTests.cs
+++ b/tests/RockBot.Cli.Tests/SpectreMarkupConverterTests.cs
@@ -1,0 +1,110 @@
+using RockBot.UserProxy.Cli;
+
+namespace RockBot.Cli.Tests;
+
+[TestClass]
+public sealed class SpectreMarkupConverterTests
+{
+    [TestMethod]
+    public void PlainText_PassesThroughUnchanged()
+    {
+        Assert.AreEqual("hello world", SpectreMarkupConverter.ToSpectreMarkup("hello world"));
+    }
+
+    [TestMethod]
+    public void NamedColorSpan_TranslatedToSpectreMarkup()
+    {
+        Assert.AreEqual(
+            "[red]x[/]",
+            SpectreMarkupConverter.ToSpectreMarkup("<span style=\"color:red\">x</span>"));
+    }
+
+    [TestMethod]
+    public void GreyAlias_PreservedAsLowercaseNamedColor()
+    {
+        Assert.AreEqual(
+            "[grey]x[/]",
+            SpectreMarkupConverter.ToSpectreMarkup("<span style=\"color:GREY\">x</span>"));
+    }
+
+    [TestMethod]
+    public void HexColorSpan_PassesThroughAsSpectreColor()
+    {
+        Assert.AreEqual(
+            "[#ff0000]x[/]",
+            SpectreMarkupConverter.ToSpectreMarkup("<span style=\"color:#ff0000\">x</span>"));
+    }
+
+    [TestMethod]
+    public void UnknownColor_FallsBackToInnerTextWithoutMarkup()
+    {
+        Assert.AreEqual(
+            "danger",
+            SpectreMarkupConverter.ToSpectreMarkup("<span style=\"color:rebeccapurple\">danger</span>"));
+    }
+
+    [TestMethod]
+    public void StrongTag_TranslatedToBold()
+    {
+        Assert.AreEqual("[bold]x[/]", SpectreMarkupConverter.ToSpectreMarkup("<strong>x</strong>"));
+    }
+
+    [TestMethod]
+    public void BTag_TranslatedToBold()
+    {
+        Assert.AreEqual("[bold]x[/]", SpectreMarkupConverter.ToSpectreMarkup("<b>x</b>"));
+    }
+
+    [TestMethod]
+    public void Svg_ReplacedWithEscapedChartPlaceholder()
+    {
+        var input = "<svg width=\"10\"><rect/></svg>";
+        // The placeholder text uses square brackets, which must be Spectre-escaped
+        // so the user sees the literal text rather than a Spectre parse error.
+        Assert.AreEqual(
+            "[[chart — view in Blazor]]",
+            SpectreMarkupConverter.ToSpectreMarkup(input));
+    }
+
+    [TestMethod]
+    public void SquareBrackets_InPlainText_AreEscaped()
+    {
+        Assert.AreEqual("[[foo]]", SpectreMarkupConverter.ToSpectreMarkup("[foo]"));
+    }
+
+    [TestMethod]
+    public void SquareBrackets_InsideTranslatedTagContent_AreEscaped()
+    {
+        Assert.AreEqual(
+            "[red][[foo]][/]",
+            SpectreMarkupConverter.ToSpectreMarkup("<span style=\"color:red\">[foo]</span>"));
+    }
+
+    [TestMethod]
+    public void SquareBrackets_InsideBoldTagContent_AreEscaped()
+    {
+        Assert.AreEqual(
+            "[bold][[bar]][/]",
+            SpectreMarkupConverter.ToSpectreMarkup("<strong>[bar]</strong>"));
+    }
+
+    [TestMethod]
+    public void UnknownTag_Stripped_InnerTextRetained()
+    {
+        Assert.AreEqual(
+            "rows",
+            SpectreMarkupConverter.ToSpectreMarkup("<table>rows</table>"));
+    }
+
+    [TestMethod]
+    public void NullInput_ReturnsEmptyString()
+    {
+        Assert.AreEqual(string.Empty, SpectreMarkupConverter.ToSpectreMarkup(null));
+    }
+
+    [TestMethod]
+    public void EmptyInput_ReturnsEmptyString()
+    {
+        Assert.AreEqual(string.Empty, SpectreMarkupConverter.ToSpectreMarkup(string.Empty));
+    }
+}

--- a/tests/RockBot.UserProxy.Tests/HtmlPlainTextRendererTests.cs
+++ b/tests/RockBot.UserProxy.Tests/HtmlPlainTextRendererTests.cs
@@ -1,0 +1,69 @@
+using RockBot.UserProxy.Rendering;
+
+namespace RockBot.UserProxy.Tests;
+
+[TestClass]
+public sealed class HtmlPlainTextRendererTests
+{
+    [TestMethod]
+    public void PlainText_PassesThroughUnchanged()
+    {
+        Assert.AreEqual("hello world", HtmlPlainTextRenderer.StripHtml("hello world"));
+    }
+
+    [TestMethod]
+    public void ColorSpan_InnerTextRetained()
+    {
+        Assert.AreEqual(
+            "danger",
+            HtmlPlainTextRenderer.StripHtml("<span style=\"color:red\">danger</span>"));
+    }
+
+    [TestMethod]
+    public void StrongTag_InnerTextRetained()
+    {
+        Assert.AreEqual("x", HtmlPlainTextRenderer.StripHtml("<strong>x</strong>"));
+    }
+
+    [TestMethod]
+    public void Svg_ReplacedWithPlaceholder()
+    {
+        var input = "before <svg width=\"10\" height=\"10\"><rect x=\"0\"/></svg> after";
+        Assert.AreEqual(
+            "before [chart — view in Blazor] after",
+            HtmlPlainTextRenderer.StripHtml(input));
+    }
+
+    [TestMethod]
+    public void Svg_MultilineInner_ReplacedWithPlaceholder()
+    {
+        var input = "<svg>\n  <rect />\n  <circle />\n</svg>";
+        Assert.AreEqual("[chart — view in Blazor]", HtmlPlainTextRenderer.StripHtml(input));
+    }
+
+    [TestMethod]
+    public void MultilineContent_PreservesNewlines()
+    {
+        var input = "line1\n<strong>line2</strong>\nline3";
+        Assert.AreEqual("line1\nline2\nline3", HtmlPlainTextRenderer.StripHtml(input));
+    }
+
+    [TestMethod]
+    public void MultipleTags_AllStripped()
+    {
+        var input = "<p>hello <b>bold</b> and <em>italic</em></p>";
+        Assert.AreEqual("hello bold and italic", HtmlPlainTextRenderer.StripHtml(input));
+    }
+
+    [TestMethod]
+    public void NullInput_ReturnsEmptyString()
+    {
+        Assert.AreEqual(string.Empty, HtmlPlainTextRenderer.StripHtml(null));
+    }
+
+    [TestMethod]
+    public void EmptyInput_ReturnsEmptyString()
+    {
+        Assert.AreEqual(string.Empty, HtmlPlainTextRenderer.StripHtml(string.Empty));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `HtmlPlainTextRenderer.StripHtml` in `RockBot.UserProxy` — replaces `<svg>...</svg>` with `[chart — view in Blazor]` and strips remaining tags. Used by `PlainConsoleFrontend` and `ChatCommand`'s one-shot path so piped/scripted output stays clean.
- Adds `SpectreMarkupConverter.ToSpectreMarkup` in `RockBot.UserProxy.Cli` — translates a small subset (named/hex color spans, `<strong>`/`<b>`, SVG placeholder) into Spectre markup and strips the rest. Uses a placeholder-then-escape strategy so user-supplied `[`/`]` can't break the Spectre parser. `SpectreConsoleFrontend` now runs reply content through it.
- New `RockBot.Cli.Tests` MSTest project (14 tests) plus `HtmlPlainTextRendererTests` in the existing UserProxy.Tests (9 tests).

Acts as a safety net for the honour-system `ClientCapabilities` gate introduced in #415 — a rich scheduled task fired while a CLI client is connected no longer renders literal markup in the terminal.

Closes #417.

## Test plan
- [x] `dotnet build RockBot.slnx` — 0 errors
- [x] `dotnet test tests/RockBot.UserProxy.Tests` — 57/57 pass (9 new)
- [x] `dotnet test tests/RockBot.Cli.Tests` — 14/14 pass (new project)

🤖 Generated with [Claude Code](https://claude.com/claude-code)