### PR TITLE
FallbackChatClient: classify transport-level failures as transient

### DIFF
--- a/src/RockBot.Llm/FallbackChatClient.cs
+++ b/src/RockBot.Llm/FallbackChatClient.cs
@@ -1,5 +1,7 @@
 using System.ClientModel;
+using System.IO;
 using System.Net;
+using System.Net.Sockets;
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
@@ -254,9 +256,14 @@ public sealed class FallbackChatClient : IChatClient
         if (ContainsAny(ex.Message, "content_filter"))
             return FallbackErrorCategory.ContentFilter;
 
-        if (ex is HttpRequestException { StatusCode: { } status })
+        if (ex is HttpRequestException hre)
         {
-            return ClassifyStatusCode((int)status);
+            // StatusCode is null when the request failed before any response was received
+            // (DNS failure, TCP reset, socket close). Treat as transient so the next
+            // model gets a chance.
+            return hre.StatusCode is { } status
+                ? ClassifyStatusCode((int)status)
+                : FallbackErrorCategory.Transient;
         }
 
         // OpenAI SDK (and other System.ClientModel-based SDKs) surface HTTP failures
@@ -265,8 +272,28 @@ public sealed class FallbackChatClient : IChatClient
         // gets classified as Unknown, and is re-thrown without retry or fallback.
         if (ex is ClientResultException cre)
         {
-            return ClassifyStatusCode(cre.Status);
+            // Status 0 means no HTTP response was received — the SDK's own retry
+            // policy exhausted its budget on a transport-level failure ("Retry
+            // failed after N tries."). Without this branch we'd classify it as
+            // Unknown and never fall back to OpenRouter.
+            return cre.Status == 0
+                ? FallbackErrorCategory.Transient
+                : ClassifyStatusCode(cre.Status);
         }
+
+        // Socket / IO failures (DNS, TCP reset, "Resource temporarily unavailable")
+        // wrapped inside another exception type. Walk the inner chain.
+        for (var inner = ex.InnerException; inner is not null; inner = inner.InnerException)
+        {
+            if (inner is SocketException or IOException)
+                return FallbackErrorCategory.Transient;
+        }
+
+        // SDK retry-exhaustion wrappers surface as a plain Exception whose message
+        // is "Retry failed after N tries." with the underlying network error in
+        // parentheses. Match the message so we still fall through to the next model.
+        if (ContainsAny(ex.Message, "Retry failed after", "temporarily unavailable"))
+            return FallbackErrorCategory.Transient;
 
         if (ContainsAny(ex.Message, "credit", "quota", "billing", "insufficient_quota", "exceeded"))
             return FallbackErrorCategory.QuotaExhausted;

--- a/tests/RockBot.Llm.Tests/FallbackChatClientTests.cs
+++ b/tests/RockBot.Llm.Tests/FallbackChatClientTests.cs
@@ -390,6 +390,75 @@ public class FallbackChatClientTests
     }
 
     [TestMethod]
+    public async Task ClientResultException_Status0_TreatsAsTransient_AndFallsBack()
+    {
+        // Regression: when the OpenAI/Azure SDK exhausts its own internal retry policy
+        // on a transport-level failure ("Retry failed after 4 tries. (Resource
+        // temporarily unavailable …)"), it surfaces as ClientResultException with
+        // Status=0 because no HTTP response was ever received. Status-code lookup
+        // mapped 0 to Unknown and re-threw, so OpenRouter never got a chance.
+        var first  = new FixedStub(ex: ClientResultEx(0));
+        var second = new FixedStub(response: OkResponse("from-openrouter"));
+
+        var client = Build([("azure-balanced", first), ("openrouter-balanced", second)], maxRetries: 0);
+
+        var response = await client.GetResponseAsync([]);
+
+        Assert.AreEqual("from-openrouter", response.Messages[^1].Text);
+        Assert.AreEqual(1, first.CallCount);
+        Assert.AreEqual(1, second.CallCount);
+    }
+
+    [TestMethod]
+    public async Task HttpRequestException_NullStatus_TreatsAsTransient_AndFallsBack()
+    {
+        // Regression: HttpRequestException with no StatusCode means the request
+        // failed before any response was received (DNS failure, TCP reset). The
+        // previous classifier required a non-null StatusCode and fell through to
+        // Unknown.
+        var first  = new FixedStub(ex: new HttpRequestException("Connection refused"));
+        var second = new FixedStub(response: OkResponse("from-second"));
+
+        var client = Build([("m1", first), ("m2", second)], maxRetries: 0);
+
+        var response = await client.GetResponseAsync([]);
+
+        Assert.AreEqual("from-second", response.Messages[^1].Text);
+    }
+
+    [TestMethod]
+    public async Task SocketException_WrappedInInnerException_FallsBack()
+    {
+        var socketEx = new System.Net.Sockets.SocketException();
+        var wrapped  = new Exception("Pipeline failure", socketEx);
+        var first    = new FixedStub(ex: wrapped);
+        var second   = new FixedStub(response: OkResponse("from-second"));
+
+        var client = Build([("m1", first), ("m2", second)], maxRetries: 0);
+
+        var response = await client.GetResponseAsync([]);
+
+        Assert.AreEqual("from-second", response.Messages[^1].Text);
+    }
+
+    [TestMethod]
+    public async Task RetryFailedAfterMessage_FallsBack()
+    {
+        // The exact shape the user saw: a plain exception whose message is the
+        // SDK retry-exhaustion wrapper. No HTTP status, no recognizable inner.
+        var first  = new FixedStub(ex: new Exception(
+            "Retry failed after 4 tries. " +
+            "(Resource temporarily unavailable (rocky-ml1nznjr-eastus2.cognitiveservices.azure.com:443))"));
+        var second = new FixedStub(response: OkResponse("from-openrouter"));
+
+        var client = Build([("azure-balanced", first), ("openrouter-balanced", second)], maxRetries: 0);
+
+        var response = await client.GetResponseAsync([]);
+
+        Assert.AreEqual("from-openrouter", response.Messages[^1].Text);
+    }
+
+    [TestMethod]
     public async Task PerAttemptTimeout_UserCancellation_PropagatesImmediately()
     {
         var slow = new SlowStub(delay: TimeSpan.FromSeconds(30));


### PR DESCRIPTION
## Summary
- The OpenAI/Azure SDK's retry policy exhausts on transport-level failures (DNS, TCP reset, "Resource temporarily unavailable") and surfaces `ClientResultException` with `Status == 0` (no HTTP response received). The previous classifier required a known HTTP status, mapped 0/null to `Unknown`, and re-threw immediately — so the Balanced tier never fell back to OpenRouter when Azure's endpoint was unreachable.
- `ClassifyException` now treats four previously-Unknown shapes as `Transient`:
  - `ClientResultException` with `Status == 0`
  - `HttpRequestException` with `StatusCode == null`
  - Any exception whose inner chain contains `SocketException` or `IOException`
  - Message text matching `"Retry failed after"` or `"temporarily unavailable"` (catch-all wrapper)
- Four regression tests added; the message-text test uses the exact shape observed in production (`Retry failed after 4 tries. (Resource temporarily unavailable (rocky-ml1nznjr-eastus2.cognitiveservices.azure.com:443))`).

## Background
A subagent fan-out + synthesis run failed end-to-end against the Balanced-tier Azure endpoint with the message above. OpenRouter is configured as the Balanced fallback but was never tried — both the subagent's own LLM call and the synthesis call gave up after the SDK's internal retries, because `FallbackChatClient` couldn't recognize the resulting exception as transient.

## Test plan
- [x] `dotnet test tests/RockBot.Llm.Tests/RockBot.Llm.Tests.csproj` — 134/134 pass
- [ ] Watch for fallback log lines (`FallbackChatClient: falling back from … to …`) the next time Azure throttles the Balanced endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)