### PR TITLE
Fix FileFeedbackStore DirectoryNotFoundException for patrol sessions

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.11.1</Version>
+<Version>0.11.2</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.Host/FileFeedbackStore.cs
+++ b/src/RockBot.Host/FileFeedbackStore.cs
@@ -42,6 +42,7 @@ internal sealed class FileFeedbackStore : IFeedbackStore
         try
         {
             var path = Path.Combine(_basePath, $"{entry.SessionId}.jsonl");
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
             var line = JsonSerializer.Serialize(entry, JsonOptions);
             await File.AppendAllTextAsync(path, line + Environment.NewLine, cancellationToken);
 
@@ -72,7 +73,7 @@ internal sealed class FileFeedbackStore : IFeedbackStore
 
         var results = new List<FeedbackEntry>();
 
-        foreach (var file in Directory.EnumerateFiles(_basePath, "*.jsonl"))
+        foreach (var file in Directory.EnumerateFiles(_basePath, "*.jsonl", SearchOption.AllDirectories))
         {
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/tests/RockBot.Host.Tests/FileFeedbackStoreTests.cs
+++ b/tests/RockBot.Host.Tests/FileFeedbackStoreTests.cs
@@ -97,6 +97,37 @@ public class FileFeedbackStoreTests
         Assert.IsTrue(files.Any(f => Path.GetFileNameWithoutExtension(f) == "sess-2"));
     }
 
+    // ── Slash-bearing session IDs (patrol/*) ──────────────────────────────────
+
+    [TestMethod]
+    public async Task AppendAsync_SessionIdWithSlash_CreatesSubdirectory()
+    {
+        var store = CreateStore();
+        var entry = MakeEntry("patrol/heartbeat-patrol", FeedbackSignalType.SessionSummary, "patrol summary");
+
+        await store.AppendAsync(entry);
+
+        var results = await store.GetBySessionAsync("patrol/heartbeat-patrol");
+        Assert.AreEqual(1, results.Count);
+        Assert.AreEqual("patrol summary", results[0].Summary);
+    }
+
+    [TestMethod]
+    public async Task QueryRecentAsync_IncludesEntriesFromSubdirectories()
+    {
+        var store = CreateStore();
+        var now = DateTimeOffset.UtcNow;
+
+        await store.AppendAsync(MakeEntry("session-flat", FeedbackSignalType.Correction, "flat", timestamp: now.AddMinutes(-10)));
+        await store.AppendAsync(MakeEntry("patrol/heartbeat-patrol", FeedbackSignalType.SessionSummary, "nested", timestamp: now.AddMinutes(-5)));
+
+        var results = await store.QueryRecentAsync(since: now.AddHours(-1), maxResults: 100);
+
+        Assert.AreEqual(2, results.Count);
+        Assert.IsTrue(results.Any(r => r.Summary == "flat"));
+        Assert.IsTrue(results.Any(r => r.Summary == "nested"));
+    }
+
     // ── QueryRecentAsync ──────────────────────────────────────────────────────
 
     [TestMethod]


### PR DESCRIPTION
## Summary
- `ScheduledTaskHandler` uses `sessionId = "patrol/{taskName}"`, so feedback for the heartbeat patrol lands at `{basePath}/patrol/heartbeat-patrol.jsonl`. The store only created `_basePath`, so the first append from `SessionSummaryService` threw `DirectoryNotFoundException`. Any slash-bearing session ID (`session/abc123`, etc.) has the same risk on a fresh PVC.
- `AppendAsync` now ensures the parent directory exists before writing.
- `QueryRecentAsync` now recurses with `SearchOption.AllDirectories` so nested feedback files are visible to recall (otherwise the fix above would silently hide patrol summaries).
- Added two regression tests using the exact `patrol/heartbeat-patrol` shape that surfaced the bug.

## Test plan
- [x] `dotnet test RockBot.slnx --filter "FullyQualifiedName~FileFeedbackStoreTests"` — 12/12 passing (10 existing + 2 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)