### PR TITLE
spawn_wisps: stop truncating wisp output at 2KB

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.11.2</Version>
+<Version>0.11.3</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.Wisp/SpawnWispsExecutor.cs
+++ b/src/RockBot.Wisp/SpawnWispsExecutor.cs
@@ -338,9 +338,7 @@ internal sealed class SpawnWispsExecutor(
                         durationMs = (int)r.Duration.TotalMilliseconds,
                         stepsCompleted = r.StepResults.Count(s => s.IsSuccess || s.WasSkipped),
                         stepCount = r.Definition.Steps.Count,
-                        output = lastOutput is not null
-                            ? (lastOutput.Length > 2_000 ? lastOutput[..2_000] + "..." : lastOutput)
-                            : null,
+                        output = lastOutput,
                         error = r.FailedStep is { Error: not null }
                             ? new { category = r.FailedStep.Error.Category.ToString(), message = r.FailedStep.Error.Message }
                             : null
@@ -506,16 +504,9 @@ internal sealed class SpawnWispsExecutor(
 
             if (result.IsSuccess)
             {
-                // Show last step output for successful wisps — this is the primary
-                // way the calling agent consumes wisp results, so don't truncate too aggressively
                 var lastStep = result.StepResults.LastOrDefault(s => s.IsSuccess && s.Content is not null);
                 if (lastStep?.Content is not null)
-                {
-                    var preview = lastStep.Content.Length > 2_000
-                        ? lastStep.Content[..2_000] + $"... ({lastStep.Content.Length:N0} chars total)"
-                        : lastStep.Content;
-                    sb.AppendLine($"  Output: {preview}");
-                }
+                    sb.AppendLine($"  Output: {lastStep.Content}");
             }
         }
 


### PR DESCRIPTION
## Summary
- Removes the 2,000-char cap on per-wisp output in both `FormatBatchResult` (the inline `spawn_wisps` tool response) and the batch summary stashed to working memory at `wisp/batch-<id>/summary`.
- Triggered by a patrol run where a 2,606-char `calendar-mcp/list_accounts` response was clipped at 2KB; the subagent saw the `... (2,606 chars total)` marker and took a defensive detour ("Saving the full account list to a file so no calendar source gets missed") even though only ~600 bytes had been cut.

## Why this is safe now
The wisp-level cap predated #423 (`Stash overflow-trimmed tool results so the model can recover them`). That commit added an agent-loop-level overflow mechanism that:
- Only trims when output actually threatens the context window (not at an arbitrary 2KB).
- Keeps head **and** tail with an elision marker (not just the head).
- Stashes the full original in working memory and surfaces the retrieval key via a system-authored registry message.

So the wisp truncation was a redundant, worse version of behavior the agent loop now handles correctly.

## Test plan
- [x] `dotnet build src/RockBot.Wisp/RockBot.Wisp.csproj` clean
- [x] `dotnet test tests/RockBot.Wisp.Tests/RockBot.Wisp.Tests.csproj` — 129/129 pass
- [ ] Next patrol cycle: confirm subagents no longer report inline truncation for small MCP responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)