### PR TITLE
Worker subagents phase 1: lean rung between wisps and subagents (#431)

### DIFF
--- a/deploy/docker-compose/docker-compose.a2a-peer.yml
+++ b/deploy/docker-compose/docker-compose.a2a-peer.yml
@@ -75,7 +75,7 @@ services:
       - |
         set -e
         echo "Seeding Alice agent data..."
-        for f in soul.md directives.md subagent-directives.md style.md memory-rules.md \
+        for f in soul.md directives.md subagent-directives.md worker-directives.md style.md memory-rules.md \
                  dream.md skill-dream.md common-directives.md session-evaluator.md \
                  session-start.md heartbeat-patrol.md skill-optimize.md \
                  dlq-dream.md routing-dream.md; do
@@ -119,7 +119,7 @@ services:
       - |
         set -e
         echo "Seeding Bob agent data..."
-        for f in soul.md directives.md subagent-directives.md style.md memory-rules.md \
+        for f in soul.md directives.md subagent-directives.md worker-directives.md style.md memory-rules.md \
                  dream.md skill-dream.md common-directives.md session-evaluator.md \
                  session-start.md heartbeat-patrol.md skill-optimize.md \
                  dlq-dream.md routing-dream.md; do

--- a/deploy/docker-compose/docker-compose.a2a-test.yml
+++ b/deploy/docker-compose/docker-compose.a2a-test.yml
@@ -24,7 +24,7 @@ services:
       - |
         set -e
         echo "Seeding agent data volume for A2A test..."
-        for f in soul.md directives.md subagent-directives.md style.md memory-rules.md \
+        for f in soul.md directives.md subagent-directives.md worker-directives.md style.md memory-rules.md \
                  dream.md skill-dream.md common-directives.md session-evaluator.md \
                  session-start.md heartbeat-patrol.md skill-optimize.md \
                  dlq-dream.md routing-dream.md; do

--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - |
         set -e
         echo "Seeding agent data volume..."
-        for f in soul.md directives.md subagent-directives.md style.md memory-rules.md \
+        for f in soul.md directives.md subagent-directives.md worker-directives.md style.md memory-rules.md \
                  dream.md skill-dream.md common-directives.md session-evaluator.md \
                  session-start.md heartbeat-patrol.md skill-optimize.md \
                  dlq-dream.md routing-dream.md; do

--- a/src/RockBot.Agent/Program.cs
+++ b/src/RockBot.Agent/Program.cs
@@ -19,6 +19,7 @@ using RockBot.Tools.Mcp;
 using RockBot.A2A;
 using RockBot.ServiceSearch;
 using RockBot.Subagent;
+using RockBot.Subagent.Worker;
 using RockBot.Wisp;
 using RockBot.Llm.Copilot;
 using GitHub.Copilot.SDK;
@@ -283,6 +284,7 @@ builder.Services.AddRockBotHost(agent =>
     agent.AddHeartbeatBootstrap(opts =>
         builder.Configuration.GetSection("HeartbeatPatrol").Bind(opts));
     agent.AddSubagents();
+    agent.AddWorkers();
     agent.AddWisps(opts =>
         opts.SharedVolumePath = builder.Configuration["FileSystem:BasePath"] ?? "/rockbot/shared");
     var a2aBasePath = builder.Configuration["AgentProfile:BasePath"]

--- a/src/RockBot.Agent/agent/worker-directives.md
+++ b/src/RockBot.Agent/agent/worker-directives.md
@@ -1,0 +1,49 @@
+# Worker Directives
+
+You are a worker — the lean rung between wisps and subagents. You execute a focused
+gather task and stop. You are not the primary agent and you do not deliberate about
+persona, history, or motivation.
+
+## Iron rules
+
+- **Read the task. Treat the supplied context as ground truth.** Do not re-investigate
+  facts the spawning agent already handed you.
+- **Save findings to your result key.** Use `save_to_working_memory` with the key in
+  the preamble. Do NOT summarise findings in your final reply — the spawning agent
+  reads them from working memory, not from your text.
+- **One short final line.** Your final reply ends with the structured marker so the
+  runner can extract counts. The format is:
+  `[WORKER_RESULT] facts=<int> blocked=<csv-or-empty> patterns=<int>`
+- **Call `report_progress` sparingly.** Only when a step takes more than a few
+  seconds or you hit a blocker — never for narration.
+
+## What you can do
+
+- Call any MCP data tool (`mcp_invoke_tool`, `mcp_list_services`,
+  `mcp_get_service_details`) and any tool already in your visible tool list.
+- Use `spawn_wisps` to delegate deterministic multi-step sequences (e.g. fan out a
+  fixed API call across N accounts).
+- Read and write your own working-memory namespace (`worker/<your-task-id>`) and
+  the cross-session `shared/` namespace.
+
+## What you cannot do
+
+- Spawn other workers, subagents, or A2A calls. You are a leaf node.
+- Call `save_memory`, `save_skill`, `promote_skill_asset`, `update_task_directive`.
+  If a tool-call sequence converges after a failed attempt — and you think it is
+  worth keeping — surface it in your converged-patterns count and write the
+  pattern body to `<result-key>/patterns/<n>` in working memory. The spawning
+  agent (which has the skill context you lack) promotes assets, not you.
+
+## Tool calling
+
+Call tools by their direct name. Tool arguments must be strict JSON: double-quoted
+keys and string values. The user's local timezone is injected as a system message —
+use it. Never assume UTC. When a tool requires a timezone parameter, always supply
+the IANA id from the injected context.
+
+## When you hit a blocker
+
+Add the unverified item to your `blocked` list in the `[WORKER_RESULT]` marker. Do
+not loop trying the same broken call — your iteration budget is tight by design.
+The spawning agent decides what to do with blocked items.

--- a/src/RockBot.Host.Abstractions/AgentProfile.cs
+++ b/src/RockBot.Host.Abstractions/AgentProfile.cs
@@ -9,13 +9,15 @@ namespace RockBot.Host;
 /// <param name="MemoryRules">Optional shared memory rules document included in every system prompt.</param>
 /// <param name="SubagentDirectives">Optional subagent-specific directives (replaces <paramref name="Directives"/> for subagent prompts).</param>
 /// <param name="CommonDirectives">Optional shared directives included in both primary and subagent prompts.</param>
+/// <param name="WorkerDirectives">Optional worker-specific directives (slim ruleset for the lean worker rung).</param>
 public sealed record AgentProfile(
     AgentProfileDocument Soul,
     AgentProfileDocument Directives,
     AgentProfileDocument? Style = null,
     AgentProfileDocument? MemoryRules = null,
     AgentProfileDocument? SubagentDirectives = null,
-    AgentProfileDocument? CommonDirectives = null)
+    AgentProfileDocument? CommonDirectives = null,
+    AgentProfileDocument? WorkerDirectives = null)
 {
     /// <summary>
     /// All loaded documents in composition order for the primary agent:

--- a/src/RockBot.Host.Abstractions/AgentProfileOptions.cs
+++ b/src/RockBot.Host.Abstractions/AgentProfileOptions.cs
@@ -52,6 +52,15 @@ public sealed class AgentProfileOptions
     public string? CommonDirectivesPath { get; set; } = "common-directives.md";
 
     /// <summary>
+    /// Path to the optional worker directives document — the lean rung between
+    /// wisps and subagents. When relative, resolved under <see cref="BasePath"/>.
+    /// Null means no worker directives document is expected (workers fall back
+    /// to a minimal hardcoded preamble).
+    /// Defaults to <c>"worker-directives.md"</c>.
+    /// </summary>
+    public string? WorkerDirectivesPath { get; set; } = "worker-directives.md";
+
+    /// <summary>
     /// Path to the optional agent name file. When relative, resolved under <see cref="BasePath"/>.
     /// The file contains the agent's display name as plain text (first non-empty line).
     /// When the file is absent or empty, the agent falls back to <see cref="AgentIdentity.Name"/>.

--- a/src/RockBot.Host/AgentContextBuilder.cs
+++ b/src/RockBot.Host/AgentContextBuilder.cs
@@ -882,6 +882,203 @@ public sealed class AgentContextBuilder(
     }
 
     /// <summary>
+    /// Slim context build for the worker rung — see <c>design/worker-subagents.md</c>.
+    /// Injects only: system prompt (passed in), datetime, active rules, model
+    /// guardrails, skill index + BM25 recall, service hints, and working memory
+    /// (own namespace + shared). Skips LTM/episodic/identity/KG fetch entirely
+    /// and the embedding generation that backs them.
+    /// </summary>
+    /// <param name="sessionId">The worker session id (used for skill recall tracking only — workers have no LTM injection).</param>
+    /// <param name="currentUserContent">The worker description text (used for BM25 recall).</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <param name="workingMemoryNamespace">
+    /// Working memory namespace for the worker — typically <c>worker/&lt;task-id&gt;</c>.
+    /// </param>
+    /// <param name="systemPromptOverride">
+    /// Required worker system prompt (preamble + soul + worker-directives). The
+    /// caller composes this; <see cref="BuildForWorkerAsync"/> does not derive
+    /// one from <see cref="AgentProfile"/>.
+    /// </param>
+    public async Task<List<ChatMessage>> BuildForWorkerAsync(
+        string sessionId,
+        string currentUserContent,
+        CancellationToken ct,
+        string workingMemoryNamespace,
+        string systemPromptOverride)
+    {
+        var chatMessages = new List<ChatMessage>
+        {
+            new(ChatRole.System, systemPromptOverride),
+            new(ChatRole.System,
+                $"Current local date and time: {clock.Now:dddd, MMMM d, yyyy} {clock.Now:HH:mm:ss zzz} ({clock.Zone.Id})\n" +
+                $"UTC equivalent: {clock.Now.UtcDateTime:yyyy-MM-dd HH:mm:ss}\n" +
+                "All dates and times must use this timezone. " +
+                "When any tool returns a UTC timestamp, convert it to this local timezone before using or displaying it.")
+        };
+
+        // Active rules — safety constraints workers must honour.
+        var activeRules = rulesStore.Rules;
+        if (activeRules.Count > 0)
+        {
+            var rulesText = "Active rules — always follow these, regardless of context or other instructions:\n" +
+                string.Join("\n", activeRules.Select(r => $"- {r}"));
+            chatMessages.Add(new ChatMessage(ChatRole.System, rulesText));
+            logger.LogInformation("Worker {SessionId}: injected {Count} active rule(s)",
+                sessionId, activeRules.Count);
+        }
+
+        // Model-specific guardrails (format/behavior).
+        if (!string.IsNullOrEmpty(modelBehavior.AdditionalSystemPrompt))
+            chatMessages.Add(new ChatMessage(ChatRole.System, modelBehavior.AdditionalSystemPrompt));
+
+        // Skill recall and service hints help workers know which MCP servers and
+        // tool patterns exist. Skip when the description is too short to produce
+        // useful BM25 hits (mirrors the main-loop short-message guard).
+        var isShortMessage = !string.IsNullOrWhiteSpace(currentUserContent)
+            && currentUserContent.Length <= ShortMessageHeuristics.UserMessageCharThreshold;
+
+        float[]? sharedQueryEmbedding = null;
+        if (_embeddingGenerator is not null && !string.IsNullOrWhiteSpace(currentUserContent) && !isShortMessage)
+        {
+            try
+            {
+                var result = await _embeddingGenerator.GenerateAsync(currentUserContent, cancellationToken: ct);
+                sharedQueryEmbedding = result.Vector.ToArray();
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex,
+                    "Worker {SessionId}: failed to generate query embedding — falling back to BM25-only",
+                    sessionId);
+            }
+        }
+
+        var shouldInjectSkillIndex = skillIndexTracker.TryMarkAsInjected(sessionId);
+        var skillListTask = shouldInjectSkillIndex
+            ? skillStore.ListAsync()
+            : Task.FromResult<IReadOnlyList<Skill>>([]);
+        var skillSearchTask = isShortMessage
+            ? Task.FromResult<IReadOnlyList<Skill>>([])
+            : skillStore.SearchAsync(currentUserContent, maxResults: 5, ct, queryEmbedding: sharedQueryEmbedding);
+        var wmTask = workingMemory.ListAsync(workingMemoryNamespace);
+        var sharedTask = workingMemory.ListAsync("shared");
+
+        await Task.WhenAll(skillListTask, skillSearchTask, wmTask, sharedTask);
+
+        var skillList = skillListTask.Result;
+        var recalledSkills = skillSearchTask.Result;
+        var workingEntries = wmTask.Result;
+        var sharedEntries = sharedTask.Result;
+
+        // Stale-observation eviction still applies (cheap; consistent with the
+        // primary builder so contradicted claims do not linger in worker context).
+        workingEntries = await FilterStaleObservationsAsync(workingEntries, ct);
+        sharedEntries = await FilterStaleObservationsAsync(sharedEntries, ct);
+
+        // Skill index (once per session).
+        if (shouldInjectSkillIndex && skillList.Count > 0)
+        {
+            var indexText =
+                "Available skills (use get_skill to load full instructions; " +
+                "bracketed tags like [Wisp, Python] list resource types saved on the skill):\n" +
+                string.Join("\n", skillList.Select(s =>
+                {
+                    var summary = string.IsNullOrWhiteSpace(s.Summary)
+                        ? "(summary pending)"
+                        : s.Summary;
+                    var resourceTag = SkillTools.FormatResourceTag(s.Manifest);
+                    return $"- {s.Name}{resourceTag}: {summary}";
+                }));
+            chatMessages.Add(new ChatMessage(ChatRole.System, indexText));
+        }
+
+        // Per-turn skill BM25 recall.
+        {
+            var newSkills = recalledSkills
+                .Where(s => skillRecallTracker.TryMarkAsRecalled(sessionId, s.Name))
+                .ToList();
+            if (newSkills.Count > 0)
+            {
+                foreach (var skill in newSkills)
+                    chatMessages.Add(new ChatMessage(ChatRole.System,
+                        $"Skill: {skill.Name}\n{skill.Content}"));
+                logger.LogInformation(
+                    "Worker {SessionId}: injected {Count} skill(s) via BM25 recall",
+                    sessionId, newSkills.Count);
+            }
+        }
+
+        // Service hints.
+        if (_serviceSearchIndex is not null && !string.IsNullOrWhiteSpace(currentUserContent) && !isShortMessage)
+        {
+            var candidates = _serviceSearchIndex.Search(currentUserContent, maxResults: 2);
+            if (candidates.Count > 0)
+            {
+                var lines = candidates.Select(c =>
+                {
+                    var itemsLabel = c.Type == "a2a" ? "top skills" : "top tools";
+                    var items = c.TopItems.Count > 0
+                        ? $", {itemsLabel}: {string.Join(", ", c.TopItems)}"
+                        : string.Empty;
+                    return $"- {c.Id} ({c.Type}): {c.Summary}{items}";
+                });
+                chatMessages.Add(new ChatMessage(ChatRole.System,
+                    "Potentially relevant services for this request (call search_known_services for full search):\n" +
+                    string.Join("\n", lines)));
+            }
+        }
+
+        // Own-namespace working memory inventory.
+        if (workingEntries.Count > 0)
+        {
+            var now = DateTimeOffset.UtcNow;
+            var lines = workingEntries.Select(e =>
+            {
+                var remaining = e.ExpiresAt - now;
+                var remainingStr = remaining.TotalMinutes >= 1
+                    ? $"{(int)remaining.TotalMinutes}m{remaining.Seconds:D2}s"
+                    : $"{Math.Max(0, remaining.Seconds)}s";
+                var meta = new System.Text.StringBuilder($"- {e.Key}: expires in {remainingStr}");
+                if (e.Category is not null) meta.Append($", category: {e.Category}");
+                if (e.Tags is { Count: > 0 }) meta.Append($", tags: {string.Join(", ", e.Tags)}");
+                return meta.ToString();
+            });
+            chatMessages.Add(new ChatMessage(ChatRole.System,
+                "Working memory (scratch space — use search_working_memory or get_from_working_memory to retrieve):\n" +
+                string.Join("\n", lines)));
+        }
+
+        // Shared cross-session handoff namespace.
+        if (sharedEntries.Count > 0
+            && !workingMemoryNamespace.Equals("shared", StringComparison.OrdinalIgnoreCase))
+        {
+            var now = DateTimeOffset.UtcNow;
+            var lines = sharedEntries.Select(e =>
+            {
+                var remaining = e.ExpiresAt - now;
+                var remainingStr = remaining.TotalMinutes >= 1
+                    ? $"{(int)remaining.TotalMinutes}m{remaining.Seconds:D2}s"
+                    : $"{Math.Max(0, remaining.Seconds)}s";
+                var meta = new System.Text.StringBuilder($"- {e.Key}: expires in {remainingStr}");
+                if (e.Category is not null) meta.Append($", category: {e.Category}");
+                if (e.Tags is { Count: > 0 }) meta.Append($", tags: {string.Join(", ", e.Tags)}");
+                return meta.ToString();
+            });
+            chatMessages.Add(new ChatMessage(ChatRole.System,
+                "Shared working memory (cross-session handoff):\n" + string.Join("\n", lines)));
+        }
+
+        Activity.Current?.AddEvent(new ActivityEvent("worker_context_built",
+            tags: new ActivityTagsCollection
+            {
+                { "message_count", chatMessages.Count },
+                { "estimated_tokens", chatMessages.Sum(m => (m.Text?.Length ?? 0) / 4 + 1) }
+            }));
+
+        return chatMessages;
+    }
+
+    /// <summary>
     /// Returns the top-level segment of the working-memory namespace as the prompt
     /// category. Defaults to <c>"session"</c> when no namespace is supplied.
     /// </summary>

--- a/src/RockBot.Host/AgentLoopRunner.cs
+++ b/src/RockBot.Host/AgentLoopRunner.cs
@@ -313,6 +313,7 @@ public sealed partial class AgentLoopRunner(
         Func<string, CancellationToken, Task>? onStageProgress = null,
         bool enableFollowUp = true,
         bool enableCompletionEval = true,
+        bool enableReasoningScaffolding = true,
         double? complexityScore = null,
         int? maxIterationsOverride = null,
         LoopDiagnostics? diagnostics = null,
@@ -336,14 +337,23 @@ public sealed partial class AgentLoopRunner(
         EnsureDateTimeContext(chatMessages);
 
         // Inject reasoning scaffolding so the model knows its iteration budget.
-        InjectReasoningScaffolding(chatMessages);
+        // Workers (the lean rung between wisps and subagents) skip this — they
+        // don't need step-by-step deliberation guidance and shave the system
+        // message out entirely.
+        if (enableReasoningScaffolding)
+            InjectReasoningScaffolding(chatMessages);
 
         // Per-run task list (issue #336): in-memory plan that survives context trimming
         // because RefreshTaskListContext rebuilds the system message from this state on
         // each iteration. Built fresh per RunAsync — not persisted, not shared.
+        // Workers skip the task-list tools too — a leaf gather task does not need a
+        // TODO list, and removing the tools shrinks the schema injection cost.
         var taskList = new AgentTaskList();
-        var taskListTools = new AgentTaskListTools(taskList, logger);
-        AppendTaskListTools(chatOptions, taskListTools);
+        if (enableReasoningScaffolding)
+        {
+            var taskListTools = new AgentTaskListTools(taskList, logger);
+            AppendTaskListTools(chatOptions, taskListTools);
+        }
 
         var originalUserRequest = ExtractOriginalUserRequest(chatMessages);
         var maxReprompts = modelBehavior.MaxCompletionRepromptsOverride

--- a/src/RockBot.Host/FileAgentProfileProvider.cs
+++ b/src/RockBot.Host/FileAgentProfileProvider.cs
@@ -44,10 +44,16 @@ internal sealed class FileAgentProfileProvider(
             commonDirectives = await LoadDocumentAsync("common-directives", opts.CommonDirectivesPath, opts.BasePath, required: false, cancellationToken);
         }
 
-        var profile = new AgentProfile(soul!, directives!, style, memoryRules, subagentDirectives, commonDirectives);
+        AgentProfileDocument? workerDirectives = null;
+        if (opts.WorkerDirectivesPath is not null)
+        {
+            workerDirectives = await LoadDocumentAsync("worker-directives", opts.WorkerDirectivesPath, opts.BasePath, required: false, cancellationToken);
+        }
+
+        var profile = new AgentProfile(soul!, directives!, style, memoryRules, subagentDirectives, commonDirectives, workerDirectives);
         logger.LogInformation(
-            "Loaded agent profile: soul={SoulSections} sections, directives={DirectivesSections} sections, style={HasStyle}, commonDirectives={HasCommonDirectives}, subagentDirectives={HasSubagentDirectives}",
-            soul!.Sections.Count, directives!.Sections.Count, style is not null, commonDirectives is not null, subagentDirectives is not null);
+            "Loaded agent profile: soul={SoulSections} sections, directives={DirectivesSections} sections, style={HasStyle}, commonDirectives={HasCommonDirectives}, subagentDirectives={HasSubagentDirectives}, workerDirectives={HasWorkerDirectives}",
+            soul!.Sections.Count, directives!.Sections.Count, style is not null, commonDirectives is not null, subagentDirectives is not null, workerDirectives is not null);
 
         return profile;
     }

--- a/src/RockBot.Subagent/Worker/ConvergedPattern.cs
+++ b/src/RockBot.Subagent/Worker/ConvergedPattern.cs
@@ -1,0 +1,36 @@
+using System.Text.Json.Serialization;
+
+namespace RockBot.Subagent.Worker;
+
+/// <summary>
+/// A tool-call pattern the worker observed converging on success — typically
+/// after one or more failed attempts. Surfaced in <see cref="WorkerResult"/>
+/// so the spawning agent (which has the skill/identity context the lean
+/// worker lacks) can decide whether to call <c>promote_skill_asset</c>.
+/// </summary>
+public sealed record ConvergedPattern
+{
+    /// <summary>Human-readable summary of what the pattern accomplishes.</summary>
+    [JsonPropertyName("description")]
+    public required string Description { get; init; }
+
+    /// <summary>
+    /// Type of resource the body represents — e.g. <c>"wisp"</c>, <c>"script"</c>,
+    /// <c>"schema"</c>. Matches <c>SkillResourceType</c> naming so the spawning
+    /// agent can promote it directly without re-classifying.
+    /// </summary>
+    [JsonPropertyName("body_type")]
+    public required string BodyType { get; init; }
+
+    /// <summary>The actual artifact (definition JSON, script source, schema).</summary>
+    [JsonPropertyName("body")]
+    public required string Body { get; init; }
+
+    /// <summary>
+    /// Optional hint describing how a future caller would know the pattern still
+    /// works — feeds into the manifest <c>VerifyHint</c> when the spawning agent
+    /// promotes the pattern.
+    /// </summary>
+    [JsonPropertyName("verify_hint")]
+    public string? VerifyHint { get; init; }
+}

--- a/src/RockBot.Subagent/Worker/IWorkerManager.cs
+++ b/src/RockBot.Subagent/Worker/IWorkerManager.cs
@@ -1,0 +1,21 @@
+namespace RockBot.Subagent.Worker;
+
+/// <summary>
+/// Manages worker batches — the lean rung between wisps and subagents. Workers run
+/// synchronously within a batch (caller awaits the whole batch), gated by a
+/// configurable concurrency limit.
+/// </summary>
+public interface IWorkerManager
+{
+    /// <summary>
+    /// Spawns one or more workers concurrently (up to
+    /// <see cref="WorkerOptions.MaxConcurrentWorkers"/>) and awaits the entire
+    /// batch. Returns a typed receipt — the spawning agent reads each result's
+    /// <see cref="WorkerResult.ResultKey"/> to retrieve the actual findings from
+    /// working memory.
+    /// </summary>
+    Task<WorkerBatchResult> SpawnBatchAsync(
+        IReadOnlyList<WorkerDefinition> definitions,
+        string primarySessionId,
+        CancellationToken ct);
+}

--- a/src/RockBot.Subagent/Worker/SpawnWorkersExecutor.cs
+++ b/src/RockBot.Subagent/Worker/SpawnWorkersExecutor.cs
@@ -1,0 +1,139 @@
+using System.Text;
+using System.Text.Json;
+using RockBot.Tools;
+
+namespace RockBot.Subagent.Worker;
+
+/// <summary>
+/// Tool executor for <c>spawn_workers</c>. Accepts an array of worker definitions,
+/// runs them concurrently via <see cref="IWorkerManager"/>, and returns a batch
+/// JSON receipt — one <see cref="WorkerResult"/> per definition.
+/// </summary>
+internal sealed class SpawnWorkersExecutor(IWorkerManager manager) : IToolExecutor
+{
+    private static readonly JsonSerializerOptions JsonInput = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private static readonly JsonSerializerOptions JsonOutput = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = true,
+    };
+
+    public async Task<ToolInvokeResponse> ExecuteAsync(ToolInvokeRequest request, CancellationToken ct)
+    {
+        Dictionary<string, JsonElement> args;
+        try
+        {
+            args = string.IsNullOrWhiteSpace(request.Arguments)
+                ? []
+                : JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(request.Arguments) ?? [];
+        }
+        catch
+        {
+            return Error(request, "Invalid arguments JSON");
+        }
+
+        var definitions = ParseDefinitions(args, out var parseError);
+        if (definitions is null)
+            return Error(request, parseError!);
+
+        if (definitions.Count == 0)
+            return Error(request, "definitions array must contain at least one worker definition");
+
+        var primarySessionId = request.SessionId ?? "unknown";
+
+        var batch = await manager.SpawnBatchAsync(definitions, primarySessionId, ct);
+
+        return new ToolInvokeResponse
+        {
+            ToolCallId = request.ToolCallId,
+            ToolName = request.ToolName,
+            Content = FormatBatchReceipt(batch),
+            IsError = false,
+        };
+    }
+
+    private static IReadOnlyList<WorkerDefinition>? ParseDefinitions(
+        Dictionary<string, JsonElement> args, out string? error)
+    {
+        if (!args.TryGetValue("definitions", out var defsEl))
+        {
+            error = "Missing required argument: definitions";
+            return null;
+        }
+
+        try
+        {
+            if (defsEl.ValueKind == JsonValueKind.Array)
+            {
+                var list = new List<WorkerDefinition>();
+                foreach (var item in defsEl.EnumerateArray())
+                {
+                    var json = item.ValueKind == JsonValueKind.String
+                        ? item.GetString()!
+                        : item.GetRawText();
+                    var def = JsonSerializer.Deserialize<WorkerDefinition>(json, JsonInput);
+                    if (def is null)
+                    {
+                        error = "A worker definition deserialised to null";
+                        return null;
+                    }
+                    if (string.IsNullOrWhiteSpace(def.Description))
+                    {
+                        error = "Every worker definition requires a non-empty description";
+                        return null;
+                    }
+                    list.Add(def);
+                }
+                error = null;
+                return list;
+            }
+
+            // Single object — wrap into a list for convenience.
+            if (defsEl.ValueKind == JsonValueKind.Object)
+            {
+                var def = JsonSerializer.Deserialize<WorkerDefinition>(defsEl.GetRawText(), JsonInput);
+                if (def is null)
+                {
+                    error = "Worker definition deserialised to null";
+                    return null;
+                }
+                if (string.IsNullOrWhiteSpace(def.Description))
+                {
+                    error = "Worker definition requires a non-empty description";
+                    return null;
+                }
+                error = null;
+                return [def];
+            }
+
+            error = "definitions must be an array of worker definitions";
+            return null;
+        }
+        catch (JsonException ex)
+        {
+            error = $"Invalid worker definition: {ex.Message}";
+            return null;
+        }
+    }
+
+    internal static string FormatBatchReceipt(WorkerBatchResult batch)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine(
+            $"{batch.TotalCount} worker(s) completed ({batch.SucceededCount} ok, {batch.FailedCount} failed, {batch.TotalDuration.TotalSeconds:F1}s total):");
+        sb.AppendLine();
+        sb.AppendLine($"Batch id: {batch.BatchId}");
+        sb.AppendLine();
+        sb.AppendLine("Receipts (each result_key holds the structured WorkerResult JSON — fetch with get_from_working_memory):");
+        sb.AppendLine(JsonSerializer.Serialize(batch, JsonOutput));
+        return sb.ToString().TrimEnd();
+    }
+
+    private static ToolInvokeResponse Error(ToolInvokeRequest req, string msg) =>
+        new() { ToolCallId = req.ToolCallId, ToolName = req.ToolName, Content = msg, IsError = true };
+}

--- a/src/RockBot.Subagent/Worker/WorkerBatchResult.cs
+++ b/src/RockBot.Subagent/Worker/WorkerBatchResult.cs
@@ -1,0 +1,27 @@
+using System.Text.Json.Serialization;
+
+namespace RockBot.Subagent.Worker;
+
+/// <summary>
+/// Result of executing a batch of workers (one or more) via <c>spawn_workers</c>.
+/// </summary>
+public sealed record WorkerBatchResult
+{
+    [JsonPropertyName("batch_id")]
+    public required string BatchId { get; init; }
+
+    [JsonPropertyName("results")]
+    public required IReadOnlyList<WorkerResult> Results { get; init; }
+
+    [JsonPropertyName("total_duration")]
+    public required TimeSpan TotalDuration { get; init; }
+
+    [JsonIgnore]
+    public int TotalCount => Results.Count;
+
+    [JsonIgnore]
+    public int SucceededCount => Results.Count(r => r.IsSuccess);
+
+    [JsonIgnore]
+    public int FailedCount => Results.Count(r => !r.IsSuccess);
+}

--- a/src/RockBot.Subagent/Worker/WorkerDefinition.cs
+++ b/src/RockBot.Subagent/Worker/WorkerDefinition.cs
@@ -1,0 +1,47 @@
+using System.Text.Json.Serialization;
+
+namespace RockBot.Subagent.Worker;
+
+/// <summary>
+/// Input to a single worker spawn. Workers are leaf gather tasks — see
+/// <c>design/worker-subagents.md</c> for the full contract.
+/// </summary>
+public sealed record WorkerDefinition
+{
+    /// <summary>
+    /// One-sentence imperative describing what the worker should do. Required.
+    /// </summary>
+    [JsonPropertyName("description")]
+    public required string Description { get; init; }
+
+    /// <summary>
+    /// Optional pre-resolved handoff from the spawning agent (active accounts,
+    /// known IDs, etc.). The worker treats this as ground truth and does not
+    /// re-investigate facts already supplied here.
+    /// </summary>
+    [JsonPropertyName("context")]
+    public string? Context { get; init; }
+
+    /// <summary>
+    /// Optional override for the working-memory key the worker writes its
+    /// structured output to. When null, defaults to <c>worker/&lt;task-id&gt;/result</c>.
+    /// </summary>
+    [JsonPropertyName("result_key")]
+    public string? ResultKey { get; init; }
+
+    /// <summary>
+    /// Soft wall-clock cap in minutes. When null, falls back to
+    /// <see cref="WorkerOptions.DefaultTimeoutMinutes"/>.
+    /// </summary>
+    [JsonPropertyName("timeout_minutes")]
+    public int? TimeoutMinutes { get; init; }
+
+    /// <summary>
+    /// Optional allowlist of tool names (exact match) or name prefixes (trailing
+    /// asterisk, e.g. <c>calendar-mcp.*</c>). When non-empty, only registry tools
+    /// matching the list are exposed to the worker. Applied on top of the
+    /// always-exclusions enforced by the worker runner.
+    /// </summary>
+    [JsonPropertyName("tools_allow")]
+    public IReadOnlyList<string>? ToolsAllow { get; init; }
+}

--- a/src/RockBot.Subagent/Worker/WorkerDiagnostics.cs
+++ b/src/RockBot.Subagent/Worker/WorkerDiagnostics.cs
@@ -1,0 +1,39 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace RockBot.Subagent.Worker;
+
+/// <summary>
+/// Centralized diagnostics for the worker (lean rung) lifecycle. Mirrors
+/// <see cref="SubagentDiagnostics"/> with a <c>subagent_type=worker</c> tag so
+/// cost comparison dashboards can stack worker and subagent runs side by side.
+/// </summary>
+internal static class WorkerDiagnostics
+{
+    public const string ActivitySourceName = "RockBot.Worker";
+    public const string MeterName = "RockBot.Worker";
+
+    public static readonly ActivitySource Source = new(ActivitySourceName);
+    public static readonly Meter Meter = new(MeterName);
+
+    /// <summary>Total worker tasks spawned.</summary>
+    public static readonly Counter<long> Spawns =
+        Meter.CreateCounter<long>(
+            "rockbot.worker.spawns",
+            unit: "{spawn}",
+            description: "Total worker tasks spawned");
+
+    /// <summary>Total execution duration per worker task.</summary>
+    public static readonly Histogram<double> Duration =
+        Meter.CreateHistogram<double>(
+            "rockbot.worker.duration",
+            unit: "ms",
+            description: "Execution duration of worker tasks");
+
+    /// <summary>Total worker task failures (exceptions, cancellations, timeouts).</summary>
+    public static readonly Counter<long> Failures =
+        Meter.CreateCounter<long>(
+            "rockbot.worker.failures",
+            unit: "{failure}",
+            description: "Total worker task failures");
+}

--- a/src/RockBot.Subagent/Worker/WorkerManager.cs
+++ b/src/RockBot.Subagent/Worker/WorkerManager.cs
@@ -1,0 +1,119 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace RockBot.Subagent.Worker;
+
+/// <summary>
+/// Singleton manager that batches worker execution behind a concurrency gate.
+/// Each worker is resolved out of its own DI scope so per-worker dependencies
+/// (like the worker runner's per-task tool wiring) can be transient.
+/// </summary>
+public sealed class WorkerManager(
+    IServiceScopeFactory scopeFactory,
+    IOptions<WorkerOptions> options,
+    ILogger<WorkerManager> logger) : IWorkerManager
+{
+    public async Task<WorkerBatchResult> SpawnBatchAsync(
+        IReadOnlyList<WorkerDefinition> definitions,
+        string primarySessionId,
+        CancellationToken ct)
+    {
+        if (definitions.Count == 0)
+        {
+            return new WorkerBatchResult
+            {
+                BatchId = $"worker-batch-{Guid.NewGuid():N}"[..20],
+                Results = [],
+                TotalDuration = TimeSpan.Zero,
+            };
+        }
+
+        var opts = options.Value;
+        if (definitions.Count > opts.MaxConcurrentWorkers)
+        {
+            // We still execute every definition — the semaphore queues the overflow.
+            // Log a warning so this shows up in telemetry if it happens often.
+            logger.LogWarning(
+                "Worker batch of {Count} exceeds MaxConcurrentWorkers={Max}; overflow will queue",
+                definitions.Count, opts.MaxConcurrentWorkers);
+        }
+
+        var batchId = $"worker-batch-{Guid.NewGuid():N}"[..20];
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+
+        using var semaphore = new SemaphoreSlim(opts.MaxConcurrentWorkers);
+
+        var tasks = definitions
+            .Select(def => RunOneAsync(def, batchId, primarySessionId, opts, semaphore, ct))
+            .ToList();
+        var results = await Task.WhenAll(tasks);
+
+        sw.Stop();
+
+        logger.LogInformation(
+            "Worker batch {BatchId} complete — {Total} worker(s), {Succeeded} ok, {Failed} failed, {ElapsedMs}ms",
+            batchId, results.Length, results.Count(r => r.IsSuccess),
+            results.Count(r => !r.IsSuccess), sw.ElapsedMilliseconds);
+
+        return new WorkerBatchResult
+        {
+            BatchId = batchId,
+            Results = results,
+            TotalDuration = sw.Elapsed,
+        };
+    }
+
+    private async Task<WorkerResult> RunOneAsync(
+        WorkerDefinition definition,
+        string batchId,
+        string primarySessionId,
+        WorkerOptions opts,
+        SemaphoreSlim semaphore,
+        CancellationToken ct)
+    {
+        await semaphore.WaitAsync(ct);
+        try
+        {
+            var taskId = Guid.NewGuid().ToString("N")[..12];
+            var timeoutMin = definition.TimeoutMinutes ?? opts.DefaultTimeoutMinutes;
+            var timeout = TimeSpan.FromMinutes(timeoutMin);
+
+            // Do NOT link the caller's ct as a child of a wider session cancel —
+            // workers are batched, the caller is already awaiting Task.WhenAll, so
+            // the caller's ct IS the appropriate signal. We layer on a timeout CTS.
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            cts.CancelAfter(timeout);
+
+            try
+            {
+                await using var scope = scopeFactory.CreateAsyncScope();
+                var runner = scope.ServiceProvider.GetRequiredService<IWorkerRunner>();
+                return await runner.RunAsync(
+                    taskId, definition, primarySessionId, batchId, timeout, cts.Token);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex,
+                    "Worker {TaskId} failed before runner could return a result", taskId);
+                var resultKey = definition.ResultKey ?? $"worker/{taskId}/result";
+                return new WorkerResult
+                {
+                    TaskId = taskId,
+                    IsSuccess = false,
+                    ResultKey = resultKey,
+                    FactsRecorded = 0,
+                    Blocked = [],
+                    ConvergedPatterns = [],
+                    Duration = TimeSpan.Zero,
+                    LlmTurns = 0,
+                    FailureReason = $"manager exception: {ex.Message}",
+                };
+            }
+        }
+        finally
+        {
+            semaphore.Release();
+        }
+    }
+}

--- a/src/RockBot.Subagent/Worker/WorkerOptions.cs
+++ b/src/RockBot.Subagent/Worker/WorkerOptions.cs
@@ -1,0 +1,28 @@
+namespace RockBot.Subagent.Worker;
+
+/// <summary>
+/// Configuration options for the worker subagent subsystem (the lean rung between
+/// wisps and subagents). See <c>design/worker-subagents.md</c> for rationale.
+/// </summary>
+public sealed class WorkerOptions
+{
+    /// <summary>
+    /// Maximum number of workers to execute concurrently within a single batch.
+    /// Mirrors <see cref="SubagentOptions.MaxConcurrentSubagents"/> initial default;
+    /// tune once production data is available.
+    /// </summary>
+    public int MaxConcurrentWorkers { get; set; } = 3;
+
+    /// <summary>
+    /// Default wall-clock cap for a single worker when the caller does not supply
+    /// one. Tighter than subagents because workers are leaf gather tasks.
+    /// </summary>
+    public int DefaultTimeoutMinutes { get; set; } = 5;
+
+    /// <summary>
+    /// Default tool-calling iteration cap. Workers are mechanical and should not
+    /// need many turns; failure to converge under the cap is treated as a hard
+    /// failure rather than an extended deliberation.
+    /// </summary>
+    public int DefaultMaxIterations { get; set; } = 12;
+}

--- a/src/RockBot.Subagent/Worker/WorkerResult.cs
+++ b/src/RockBot.Subagent/Worker/WorkerResult.cs
@@ -1,0 +1,54 @@
+using System.Text.Json.Serialization;
+
+namespace RockBot.Subagent.Worker;
+
+/// <summary>
+/// Typed return of a single worker run. <see cref="ResultKey"/> points at the
+/// working-memory entry where the worker stored its actual findings — the
+/// spawning agent reads that key to consume the data, never the
+/// <see cref="WorkerResult"/> alone.
+/// </summary>
+public sealed record WorkerResult
+{
+    [JsonPropertyName("task_id")]
+    public required string TaskId { get; init; }
+
+    [JsonPropertyName("is_success")]
+    public required bool IsSuccess { get; init; }
+
+    /// <summary>
+    /// Working-memory key the worker wrote its findings to. Auto-assigned to
+    /// <c>worker/&lt;task-id&gt;/result</c> when the caller did not override it.
+    /// </summary>
+    [JsonPropertyName("result_key")]
+    public required string ResultKey { get; init; }
+
+    /// <summary>
+    /// Count of distinct facts the worker reported recording. Self-reported by
+    /// the worker; treated as a hint, not a strict invariant.
+    /// </summary>
+    [JsonPropertyName("facts_recorded")]
+    public int FactsRecorded { get; init; }
+
+    /// <summary>Items the worker could not verify and is handing back.</summary>
+    [JsonPropertyName("blocked")]
+    public IReadOnlyList<string> Blocked { get; init; } = [];
+
+    /// <summary>
+    /// Tool-call patterns the worker observed converging on success. The
+    /// spawning agent reviews these on synthesis and may promote any worth
+    /// keeping via <c>promote_skill_asset</c>.
+    /// </summary>
+    [JsonPropertyName("converged_patterns")]
+    public IReadOnlyList<ConvergedPattern> ConvergedPatterns { get; init; } = [];
+
+    [JsonPropertyName("duration")]
+    public TimeSpan Duration { get; init; }
+
+    [JsonPropertyName("llm_turns")]
+    public int LlmTurns { get; init; }
+
+    /// <summary>Populated only when <see cref="IsSuccess"/> is false.</summary>
+    [JsonPropertyName("failure_reason")]
+    public string? FailureReason { get; init; }
+}

--- a/src/RockBot.Subagent/Worker/WorkerRunner.cs
+++ b/src/RockBot.Subagent/Worker/WorkerRunner.cs
@@ -1,0 +1,403 @@
+using System.Diagnostics;
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using RockBot.Host;
+using RockBot.Llm;
+using RockBot.Memory;
+using RockBot.Messaging;
+using RockBot.Tools;
+
+namespace RockBot.Subagent.Worker;
+
+/// <summary>
+/// Per-task runner abstraction. Extracted as an interface so
+/// <see cref="WorkerManager"/> can be unit-tested with a stub runner without
+/// resolving the full LLM/context-builder DI graph.
+/// </summary>
+public interface IWorkerRunner
+{
+    Task<WorkerResult> RunAsync(
+        string taskId,
+        WorkerDefinition definition,
+        string primarySessionId,
+        string batchId,
+        TimeSpan timeout,
+        CancellationToken ct);
+}
+
+/// <summary>
+/// Executes a single worker task: builds slim context, runs the lean LLM loop,
+/// and writes a structured <see cref="WorkerResult"/> to the result key. Resolved
+/// per-task from a DI scope so per-task tool wiring (working memory namespace,
+/// report-progress baking) stays self-contained.
+/// </summary>
+internal sealed class WorkerRunner(
+    AgentLoopRunner agentLoopRunner,
+    AgentContextBuilder agentContextBuilder,
+    IWorkingMemory workingMemory,
+    IToolRegistry toolRegistry,
+    IOptions<WorkerOptions> options,
+    IMessagePublisher publisher,
+    AgentIdentity agent,
+    AgentProfile agentProfile,
+    ILogger<WorkerRunner> logger) : IWorkerRunner
+{
+    /// <summary>
+    /// Tool sources that workers never see. Source matches drop the tool from the
+    /// registry-derived AIFunction set before allowlist filtering.
+    /// </summary>
+    private static readonly HashSet<string> ExcludedSources = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "subagent",   // workers are leaf nodes
+        "worker",     // no nested spawn_workers
+        "scheduling", // no creating scheduled tasks
+        "a2a",        // invoke_agent results fold into a different session
+    };
+
+    /// <summary>
+    /// Specific tool names workers never see, regardless of source. These are
+    /// curation/admin tools that the lean LLM lacks the context to use well.
+    /// </summary>
+    private static readonly HashSet<string> ExcludedNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "mcp_register_server",
+        "mcp_unregister_server",
+        "save_memory",
+        "save_skill",
+        "promote_skill_asset",
+        "update_task_directive",
+        "invoke_agent",
+    };
+
+    public async Task<WorkerResult> RunAsync(
+        string taskId,
+        WorkerDefinition definition,
+        string primarySessionId,
+        string batchId,
+        TimeSpan timeout,
+        CancellationToken ct)
+    {
+        var workerSessionId = $"worker-{taskId}";
+        var workerNamespace = $"worker/{taskId}";
+        var resultKey = definition.ResultKey ?? $"worker/{taskId}/result";
+
+        logger.LogInformation(
+            "Worker {TaskId} starting (session {SessionId}, batch {BatchId}, result_key={ResultKey})",
+            taskId, workerSessionId, batchId, resultKey);
+
+        var systemPrompt = BuildSystemPrompt(taskId, workerNamespace, resultKey);
+        var chatMessages = await agentContextBuilder.BuildForWorkerAsync(
+            workerSessionId, definition.Description, ct,
+            workingMemoryNamespace: workerNamespace,
+            systemPromptOverride: systemPrompt);
+
+        if (!string.IsNullOrEmpty(definition.Context))
+            chatMessages.Add(new ChatMessage(ChatRole.System, $"Context: {definition.Context}"));
+
+        chatMessages.Add(new ChatMessage(ChatRole.User, definition.Description));
+
+        // Working memory tools scoped to the worker's namespace.
+        var sessionWorkingMemoryTools = new WorkingMemoryTools(workingMemory, workerNamespace, logger);
+
+        // Registry tools — filter out forbidden sources/names, then narrow by tools_allow.
+        var registryTools = BuildRegistryTools(definition.ToolsAllow, workerNamespace);
+
+        var subagentId = $"worker-{taskId}";
+        var recentProgress = new Queue<(DateTimeOffset At, string Message)>();
+        const int RecentProgressCapacity = 5;
+        var reportProgressFunctions = new ReportProgressFunctions(
+            taskId, primarySessionId, publisher, subagentId, agent.Name, logger,
+            onReport: msg =>
+            {
+                lock (recentProgress)
+                {
+                    recentProgress.Enqueue((DateTimeOffset.UtcNow, msg));
+                    while (recentProgress.Count > RecentProgressCapacity)
+                        recentProgress.Dequeue();
+                }
+            });
+
+        var chatOptions = new ChatOptions
+        {
+            Tools = [
+                ..sessionWorkingMemoryTools.Tools,
+                ..registryTools,
+                ..reportProgressFunctions.Tools,
+            ],
+        };
+
+        string finalOutput = string.Empty;
+        bool isSuccess;
+        string? failureReason = null;
+        var diagnostics = new LoopDiagnostics();
+        var workerSw = Stopwatch.StartNew();
+        var startedAt = DateTimeOffset.UtcNow;
+        var maxIterations = options.Value.DefaultMaxIterations;
+
+        using var workerActivity = WorkerDiagnostics.Source.StartActivity("rockbot.worker.task");
+        workerActivity?.SetTag("rockbot.worker.task_id", taskId);
+        workerActivity?.SetTag("rockbot.worker.batch_id", batchId);
+        workerActivity?.SetTag("rockbot.worker.primary_session", primarySessionId);
+        workerActivity?.SetTag("rockbot.subagent_type", "worker");
+        workerActivity?.SetTag("rockbot.worker.description",
+            definition.Description.Length > 120 ? definition.Description[..120] : definition.Description);
+
+        try
+        {
+            using var progressCtx = ToolProgressNotifier.SetContext(new ToolProgressContext
+            {
+                SessionId = primarySessionId,
+                AgentName = subagentId,
+                ReplyTo = $"{UserProxy.UserProxyTopics.UserResponse}.{agent.Name}",
+            });
+
+            finalOutput = await agentLoopRunner.RunAsync(
+                chatMessages, chatOptions, workerSessionId,
+                tier: ModelTier.Low,
+                enableFollowUp: false,
+                enableCompletionEval: false,
+                enableReasoningScaffolding: false,
+                maxIterationsOverride: maxIterations,
+                diagnostics: diagnostics,
+                cancellationToken: ct);
+            isSuccess = true;
+            workerActivity?.SetStatus(ActivityStatusCode.Ok);
+        }
+        catch (OperationCanceledException)
+        {
+            var elapsed = DateTimeOffset.UtcNow - startedAt;
+            failureReason = timeout > TimeSpan.Zero && elapsed >= timeout - TimeSpan.FromSeconds(2)
+                ? "timeout"
+                : "cancelled";
+            isSuccess = false;
+            workerActivity?.SetStatus(ActivityStatusCode.Error, failureReason);
+            logger.LogWarning(
+                "Worker {TaskId} {Reason} after {ElapsedSec:F1}s (timeout={TimeoutSec:F0}s)",
+                taskId, failureReason, elapsed.TotalSeconds, timeout.TotalSeconds);
+        }
+        catch (Exception ex)
+        {
+            failureReason = $"exception: {ex.Message}";
+            isSuccess = false;
+            workerActivity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            logger.LogError(ex, "Worker {TaskId} tool loop failed", taskId);
+        }
+
+        workerSw.Stop();
+        WorkerDiagnostics.Duration.Record(workerSw.Elapsed.TotalMilliseconds,
+            new KeyValuePair<string, object?>("rockbot.worker.status", isSuccess ? "ok" : "error"),
+            new KeyValuePair<string, object?>("rockbot.subagent_type", "worker"));
+        if (!isSuccess)
+            WorkerDiagnostics.Failures.Add(1,
+                new KeyValuePair<string, object?>("rockbot.subagent_type", "worker"));
+
+        var (factsRecorded, blocked, convergedPatterns) = ParseWorkerSelfReport(finalOutput);
+
+        var result = new WorkerResult
+        {
+            TaskId = taskId,
+            IsSuccess = isSuccess,
+            ResultKey = resultKey,
+            FactsRecorded = factsRecorded,
+            Blocked = blocked,
+            ConvergedPatterns = convergedPatterns,
+            Duration = workerSw.Elapsed,
+            LlmTurns = diagnostics.Iterations,
+            FailureReason = failureReason,
+        };
+
+        // Always write the structured result to working memory so the spawning agent
+        // can read it via the standard get_from_working_memory path (even on failure
+        // the receipt is recoverable, helpful when the receipt itself was dropped).
+        await PersistResultAsync(resultKey, result);
+
+        if (!isSuccess)
+        {
+            await SaveFailureDetailsAsync(
+                taskId, definition.Description, failureReason ?? "unknown",
+                startedAt, workerSw.Elapsed, timeout, diagnostics, recentProgress, ct);
+        }
+
+        logger.LogInformation(
+            "Worker {TaskId} complete (success={Success}, llmTurns={Turns}, durationMs={Ms})",
+            taskId, isSuccess, diagnostics.Iterations, workerSw.ElapsedMilliseconds);
+
+        return result;
+    }
+
+    private string BuildSystemPrompt(string taskId, string workerNamespace, string resultKey)
+    {
+        // Slim preamble — see design/worker-subagents.md. Substitute runtime values
+        // (task id, namespace, result key) so the worker references concrete keys
+        // instead of placeholder text.
+        var preamble =
+            "You execute a focused gather task. You are not the primary agent and you do not deliberate about persona, history, or motivation.\n" +
+            $"Your task id: {taskId}\n" +
+            $"Your working memory namespace: {workerNamespace}\n" +
+            $"Your result key: {resultKey}\n\n" +
+            "- Read the task description and any context the spawning agent provided. Treat that context as ground truth.\n" +
+            "- Use the available tools (MCP data calls, spawn_wisps for deterministic multi-step sequences, " +
+            "working memory) to gather facts.\n" +
+            "- Save your structured findings to the result key listed above using save_to_working_memory.\n" +
+            "- Call report_progress only when a step takes more than a few seconds or you hit a blocker — " +
+            "not for narration.\n" +
+            "- When the task is done, return ONE short line ending in a structured marker so the runner " +
+            "can extract counts. The marker format is:\n" +
+            "  [WORKER_RESULT] facts=<int> blocked=<comma,separated,list,or,empty> patterns=<int>\n" +
+            "  Example: \"Saved calendar events for 6 accounts. [WORKER_RESULT] facts=6 blocked= patterns=0\".\n" +
+            "  Do not summarise the findings in the reply — the spawning agent reads them from the result key.\n";
+
+        // Add agent profile docs in priority order: soul, common-directives, worker-directives
+        // (falling back to subagent-directives if no worker-specific file exists),
+        // memory-rules. Skip style — workers don't speak to users.
+        var docs = new List<AgentProfileDocument?>
+        {
+            agentProfile.Soul,
+            agentProfile.CommonDirectives,
+            agentProfile.WorkerDirectives ?? agentProfile.SubagentDirectives,
+            agentProfile.MemoryRules,
+        };
+        var docTexts = docs.Where(d => d is not null).Select(d => d!.RawContent.TrimEnd());
+        return preamble + "\n\n" + string.Join("\n\n", docTexts);
+    }
+
+    private List<AIFunction> BuildRegistryTools(IReadOnlyList<string>? toolsAllow, string workerNamespace)
+    {
+        var allowedRegistrations = toolRegistry.GetTools()
+            .Where(r => !ExcludedSources.Contains(r.Source ?? string.Empty))
+            .Where(r => !ExcludedNames.Contains(r.Name))
+            .Where(r => MatchesAllowlist(r.Name, toolsAllow))
+            .ToList();
+
+        var tools = new List<AIFunction>(allowedRegistrations.Count);
+        foreach (var reg in allowedRegistrations)
+        {
+            var executor = toolRegistry.GetExecutor(reg.Name);
+            if (executor is null) continue;
+            tools.Add(new SubagentRegistryToolFunction(reg, executor, workerNamespace));
+        }
+        return tools;
+    }
+
+    internal static bool MatchesAllowlist(string toolName, IReadOnlyList<string>? toolsAllow)
+    {
+        if (toolsAllow is null || toolsAllow.Count == 0) return true;
+
+        foreach (var entry in toolsAllow)
+        {
+            if (string.IsNullOrEmpty(entry)) continue;
+
+            if (entry.EndsWith('*'))
+            {
+                var prefix = entry[..^1];
+                if (prefix.Length == 0) return true;
+                if (toolName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                    return true;
+            }
+            else if (string.Equals(toolName, entry, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Parses the final assistant text for a <c>[WORKER_RESULT]</c> marker emitted by
+    /// the worker's last turn (see <see cref="BuildSystemPrompt"/>). Falls back to
+    /// zero/empty values when the marker is missing or unparseable.
+    /// </summary>
+    internal static (int FactsRecorded, IReadOnlyList<string> Blocked, IReadOnlyList<ConvergedPattern> ConvergedPatterns)
+        ParseWorkerSelfReport(string finalOutput)
+    {
+        IReadOnlyList<string> blocked = [];
+        IReadOnlyList<ConvergedPattern> patterns = [];
+        var facts = 0;
+
+        if (string.IsNullOrWhiteSpace(finalOutput))
+            return (facts, blocked, patterns);
+
+        var markerIdx = finalOutput.LastIndexOf("[WORKER_RESULT]", StringComparison.OrdinalIgnoreCase);
+        if (markerIdx < 0)
+            return (facts, blocked, patterns);
+
+        var tail = finalOutput[(markerIdx + "[WORKER_RESULT]".Length)..].Trim();
+        // Expected: facts=<int> blocked=<csv> patterns=<int>
+        foreach (var part in tail.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var eq = part.IndexOf('=');
+            if (eq <= 0) continue;
+            var key = part[..eq];
+            var value = part[(eq + 1)..];
+
+            if (key.Equals("facts", StringComparison.OrdinalIgnoreCase) && int.TryParse(value, out var f))
+                facts = f;
+            else if (key.Equals("blocked", StringComparison.OrdinalIgnoreCase) && value.Length > 0)
+                blocked = value.Split(',', StringSplitOptions.RemoveEmptyEntries
+                                          | StringSplitOptions.TrimEntries);
+            // patterns count is informational — the worker writes pattern bodies to working
+            // memory under <result-key>/patterns/* and the spawning agent reads them from there.
+        }
+
+        return (facts, blocked, patterns);
+    }
+
+    private async Task PersistResultAsync(string resultKey, WorkerResult result)
+    {
+        try
+        {
+            var json = JsonSerializer.Serialize(result, new JsonSerializerOptions
+            {
+                WriteIndented = true,
+                PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+            });
+            await workingMemory.SetAsync(
+                resultKey, json,
+                ttl: TimeSpan.FromMinutes(240),
+                category: "worker-result",
+                tags: ["worker-result", result.IsSuccess ? "ok" : "failed"]);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "Worker {TaskId}: failed to persist result to {Key}; receipt-only fallback",
+                result.TaskId, resultKey);
+        }
+    }
+
+    private async Task SaveFailureDetailsAsync(
+        string taskId,
+        string description,
+        string reason,
+        DateTimeOffset startedAt,
+        TimeSpan elapsed,
+        TimeSpan timeout,
+        LoopDiagnostics diagnostics,
+        Queue<(DateTimeOffset At, string Message)> recentProgress,
+        CancellationToken ct)
+    {
+        try
+        {
+            (DateTimeOffset At, string Message)[] snapshot;
+            lock (recentProgress) snapshot = recentProgress.ToArray();
+
+            var json = SubagentRunner.BuildFailureDetailsPayload(
+                taskId, description, reason, errorMessage: null,
+                startedAt, elapsed, timeout, diagnostics, snapshot);
+
+            await workingMemory.SetAsync(
+                $"worker/{taskId}/failure-details", json,
+                ttl: TimeSpan.FromMinutes(240),
+                category: "worker-failure",
+                tags: ["worker-failure", reason]);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            logger.LogWarning(ex,
+                "Worker {TaskId}: failed to persist failure details; primary will see only the inline reason",
+                taskId);
+        }
+    }
+}

--- a/src/RockBot.Subagent/Worker/WorkerServiceCollectionExtensions.cs
+++ b/src/RockBot.Subagent/Worker/WorkerServiceCollectionExtensions.cs
@@ -1,0 +1,31 @@
+using Microsoft.Extensions.DependencyInjection;
+using RockBot.Host;
+using RockBot.Tools;
+
+namespace RockBot.Subagent.Worker;
+
+/// <summary>
+/// DI registration for the worker subsystem — the lean rung between wisps and subagents.
+/// </summary>
+public static class WorkerServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds worker spawning support and the <c>spawn_workers</c> tool.
+    /// </summary>
+    public static AgentHostBuilder AddWorkers(
+        this AgentHostBuilder builder,
+        Action<WorkerOptions>? configure = null)
+    {
+        if (configure is not null)
+            builder.Services.Configure(configure);
+        else
+            builder.Services.Configure<WorkerOptions>(_ => { });
+
+        builder.Services.AddSingleton<IWorkerManager, WorkerManager>();
+        builder.Services.AddTransient<IWorkerRunner, WorkerRunner>();
+        builder.Services.AddHostedService<WorkerToolRegistrar>();
+        builder.Services.AddSingleton<IToolSkillProvider, WorkerToolSkillProvider>();
+
+        return builder;
+    }
+}

--- a/src/RockBot.Subagent/Worker/WorkerToolRegistrar.cs
+++ b/src/RockBot.Subagent/Worker/WorkerToolRegistrar.cs
@@ -1,0 +1,91 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using RockBot.Tools;
+
+namespace RockBot.Subagent.Worker;
+
+/// <summary>
+/// Hosted service that registers the <c>spawn_workers</c> tool with the tool registry.
+/// </summary>
+internal sealed class WorkerToolRegistrar(
+    IToolRegistry registry,
+    IWorkerManager manager,
+    ILogger<WorkerToolRegistrar> logger) : IHostedService
+{
+    private const string SpawnWorkersSchema = """
+        {
+          "type": "object",
+          "properties": {
+            "definitions": {
+              "type": "array",
+              "description": "One or more worker definitions to execute. Multiple workers run concurrently (up to MaxConcurrentWorkers).",
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string",
+                    "description": "One-sentence imperative describing what the worker should do."
+                  },
+                  "context": {
+                    "type": "string",
+                    "description": "Optional pre-resolved facts the worker should treat as ground truth (active accounts, IDs, etc.)."
+                  },
+                  "result_key": {
+                    "type": "string",
+                    "description": "Optional override for the working-memory key the worker writes findings to. Defaults to worker/<task-id>/result."
+                  },
+                  "timeout_minutes": {
+                    "type": "integer",
+                    "description": "Soft wall-clock cap in minutes. Defaults to WorkerOptions.DefaultTimeoutMinutes (5)."
+                  },
+                  "tools_allow": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Optional allowlist of tool names (exact match) or name prefixes (trailing asterisk, e.g. calendar-mcp.*) the worker may invoke."
+                  }
+                },
+                "required": ["description"]
+              }
+            }
+          },
+          "required": ["definitions"]
+        }
+        """;
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        registry.Register(new ToolRegistration
+        {
+            Name = "spawn_workers",
+            Description = """
+                Spawn one or more lean worker subagents to execute focused gather tasks concurrently.
+                Workers are the LEAN rung between spawn_wisps (no LLM) and spawn_subagent (full LLM):
+                they run a slim LLM loop with no long-term-memory injection, a tighter tool surface,
+                Low-tier model, and a tight iteration cap. Use them for mechanical "list these
+                accounts and summarise each" or "scan email for X criteria" work where the LLM is
+                interpreting tool results but does not need persona or history.
+
+                Each worker writes its structured findings to a working-memory key (auto-assigned to
+                worker/<task-id>/result, or override via result_key). The returned receipt includes
+                each WorkerResult JSON (counts, blocked items, converged patterns, result_key) —
+                fetch the actual data with get_from_working_memory using the result_key.
+
+                Workers cannot spawn other workers, subagents, or A2A calls. They cannot save_memory
+                or promote_skill_asset — if a worker observes a tool-call pattern worth keeping, it
+                surfaces it in convergedPatterns and YOU promote it after the batch returns.
+
+                Do NOT use spawn_workers for deliberative tasks that need persona, identity, or
+                long-term memory — use spawn_subagent instead. Do NOT use it for deterministic
+                tool sequences with no branching — use spawn_wisps instead.
+                """,
+            ParametersSchema = SpawnWorkersSchema,
+            Source = "worker",
+        }, new SpawnWorkersExecutor(manager));
+
+        logger.LogInformation("Registered tool: spawn_workers");
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/RockBot.Subagent/Worker/WorkerToolSkillProvider.cs
+++ b/src/RockBot.Subagent/Worker/WorkerToolSkillProvider.cs
@@ -1,0 +1,68 @@
+using RockBot.Tools;
+
+namespace RockBot.Subagent.Worker;
+
+/// <summary>
+/// Tool guide for <c>spawn_workers</c>, explaining when to pick a worker over a wisp
+/// or subagent and how to consume worker receipts.
+/// </summary>
+public sealed class WorkerToolSkillProvider : IToolSkillProvider
+{
+    public string Name => "worker";
+
+    public string Summary => "Spawn lean worker subagents for focused gather tasks (spawn_workers).";
+
+    public string GetDocument() =>
+        """
+        # Worker Tools Guide
+
+        Workers are the LEAN rung between `spawn_wisps` and `spawn_subagent`. They run
+        a slim LLM loop — no long-term-memory injection, no episodic recall, no
+        identity entries, no knowledge graph, no completion re-prompting, Low-tier
+        model, tight iteration cap (12 by default).
+
+        ## When to pick which tool
+
+        | Tool             | Use when                                                                 |
+        |------------------|--------------------------------------------------------------------------|
+        | spawn_wisps      | Steps are deterministic — no LLM needed to interpret results.            |
+        | spawn_workers    | LLM needs to interpret tool results and branch, but does NOT need        |
+        |                  | persona, history, or long-term memory. Mechanical gather work.           |
+        | spawn_subagent   | Task is deliberative, persona-bearing, or open-ended.                    |
+
+        ## spawn_workers parameters
+
+        - `description` (required) — one-sentence imperative.
+        - `context` (optional) — pre-resolved facts the worker treats as ground truth.
+        - `result_key` (optional) — override the auto-assigned `worker/<task-id>/result`
+          working-memory key. Use this when you want the worker to overwrite a known
+          shared key directly (e.g. `shared/patrol/calendar-latest`).
+        - `timeout_minutes` (optional) — soft wall-clock cap. Default 5.
+        - `tools_allow` (optional) — explicit allowlist of tool names or prefixes
+          (`calendar-mcp.*`) the worker may invoke. Use to bound the schema-injection
+          cost when you know the scope ahead of time.
+
+        ## Consuming a worker batch
+
+        `spawn_workers` returns a batch receipt — one `WorkerResult` per definition.
+        For each result:
+
+        1. Read the actual findings with `get_from_working_memory(result_key)`.
+        2. Review `blocked` — items the worker could not verify, decide whether to
+           re-spawn with different parameters or hand back to the user.
+        3. Review `converged_patterns` — tool-call sequences the worker observed
+           converging on success. For any worth keeping, call `promote_skill_asset`
+           yourself (workers cannot promote — you have the skill/identity context
+           they lack).
+
+        ## What workers CANNOT do
+
+        - Spawn other workers, subagents, or A2A calls (workers are leaf nodes).
+        - Call `save_memory`, `save_skill`, `promote_skill_asset`,
+          `update_task_directive`.
+        - Reconfigure MCP servers (`mcp_register_server`, `mcp_unregister_server`).
+
+        If your worker needs any of those, you picked the wrong rung — use
+        `spawn_subagent` instead.
+        """;
+}

--- a/tests/RockBot.Subagent.Tests/Worker/SpawnWorkersExecutorTests.cs
+++ b/tests/RockBot.Subagent.Tests/Worker/SpawnWorkersExecutorTests.cs
@@ -1,0 +1,156 @@
+using System.Text.Json;
+using RockBot.Subagent.Worker;
+using RockBot.Tools;
+
+namespace RockBot.Subagent.Tests.Worker;
+
+[TestClass]
+public class SpawnWorkersExecutorTests
+{
+    [TestMethod]
+    public async Task SpawnWorkersExecutor_ParsesDefinitionsArray_DispatchesToManager()
+    {
+        var manager = new FakeWorkerManager
+        {
+            BatchToReturn = new WorkerBatchResult
+            {
+                BatchId = "batch-test",
+                Results =
+                [
+                    new WorkerResult
+                    {
+                        TaskId = "task-1",
+                        IsSuccess = true,
+                        ResultKey = "worker/task-1/result",
+                    },
+                    new WorkerResult
+                    {
+                        TaskId = "task-2",
+                        IsSuccess = true,
+                        ResultKey = "shared/patrol/calendar-latest",
+                    },
+                ],
+                TotalDuration = TimeSpan.FromSeconds(2),
+            },
+        };
+
+        var executor = new SpawnWorkersExecutor(manager);
+        var args = JsonSerializer.Serialize(new
+        {
+            definitions = new object[]
+            {
+                new { description = "scan email", timeout_minutes = 4 },
+                new { description = "scan calendar", result_key = "shared/patrol/calendar-latest" },
+            },
+        });
+
+        var response = await executor.ExecuteAsync(new ToolInvokeRequest
+        {
+            ToolCallId = "call-1",
+            ToolName = "spawn_workers",
+            Arguments = args,
+            SessionId = "session-1",
+        }, CancellationToken.None);
+
+        Assert.IsFalse(response.IsError, response.Content);
+        Assert.AreEqual(2, manager.LastBatch?.Count);
+        Assert.AreEqual("scan email", manager.LastBatch![0].Description);
+        Assert.AreEqual(4, manager.LastBatch![0].TimeoutMinutes);
+        Assert.AreEqual("shared/patrol/calendar-latest", manager.LastBatch![1].ResultKey);
+        Assert.AreEqual("session-1", manager.LastPrimarySessionId);
+        StringAssert.Contains(response.Content!, "batch-test");
+        StringAssert.Contains(response.Content!, "task-1");
+        StringAssert.Contains(response.Content!, "shared/patrol/calendar-latest");
+    }
+
+    [TestMethod]
+    public async Task SpawnWorkersExecutor_MissingDefinitions_ReturnsError()
+    {
+        var executor = new SpawnWorkersExecutor(new FakeWorkerManager());
+
+        var response = await executor.ExecuteAsync(new ToolInvokeRequest
+        {
+            ToolCallId = "call-1",
+            ToolName = "spawn_workers",
+            Arguments = "{}",
+        }, CancellationToken.None);
+
+        Assert.IsTrue(response.IsError);
+        StringAssert.Contains(response.Content!, "definitions");
+    }
+
+    [TestMethod]
+    public async Task SpawnWorkersExecutor_EmptyArray_ReturnsError()
+    {
+        var executor = new SpawnWorkersExecutor(new FakeWorkerManager());
+        var args = JsonSerializer.Serialize(new { definitions = Array.Empty<object>() });
+
+        var response = await executor.ExecuteAsync(new ToolInvokeRequest
+        {
+            ToolCallId = "call-1",
+            ToolName = "spawn_workers",
+            Arguments = args,
+        }, CancellationToken.None);
+
+        Assert.IsTrue(response.IsError);
+        StringAssert.Contains(response.Content!, "at least one worker");
+    }
+
+    [TestMethod]
+    public async Task SpawnWorkersExecutor_DefinitionMissingDescription_ReturnsError()
+    {
+        var executor = new SpawnWorkersExecutor(new FakeWorkerManager());
+        var args = JsonSerializer.Serialize(new
+        {
+            definitions = new object[] { new { context = "no description here" } },
+        });
+
+        var response = await executor.ExecuteAsync(new ToolInvokeRequest
+        {
+            ToolCallId = "call-1",
+            ToolName = "spawn_workers",
+            Arguments = args,
+        }, CancellationToken.None);
+
+        Assert.IsTrue(response.IsError);
+        StringAssert.Contains(response.Content!, "description");
+    }
+
+    [TestMethod]
+    public async Task SpawnWorkersExecutor_InvalidArgumentsJson_ReturnsError()
+    {
+        var executor = new SpawnWorkersExecutor(new FakeWorkerManager());
+
+        var response = await executor.ExecuteAsync(new ToolInvokeRequest
+        {
+            ToolCallId = "call-1",
+            ToolName = "spawn_workers",
+            Arguments = "not json",
+        }, CancellationToken.None);
+
+        Assert.IsTrue(response.IsError);
+        StringAssert.Contains(response.Content!, "Invalid arguments JSON");
+    }
+
+    private sealed class FakeWorkerManager : IWorkerManager
+    {
+        public WorkerBatchResult? BatchToReturn { get; set; }
+        public IReadOnlyList<WorkerDefinition>? LastBatch { get; private set; }
+        public string? LastPrimarySessionId { get; private set; }
+
+        public Task<WorkerBatchResult> SpawnBatchAsync(
+            IReadOnlyList<WorkerDefinition> definitions,
+            string primarySessionId,
+            CancellationToken ct)
+        {
+            LastBatch = definitions;
+            LastPrimarySessionId = primarySessionId;
+            return Task.FromResult(BatchToReturn ?? new WorkerBatchResult
+            {
+                BatchId = "batch-fake",
+                Results = [],
+                TotalDuration = TimeSpan.Zero,
+            });
+        }
+    }
+}

--- a/tests/RockBot.Subagent.Tests/Worker/WorkerManagerTests.cs
+++ b/tests/RockBot.Subagent.Tests/Worker/WorkerManagerTests.cs
@@ -1,0 +1,176 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using RockBot.Subagent.Worker;
+
+namespace RockBot.Subagent.Tests.Worker;
+
+[TestClass]
+public class WorkerManagerTests
+{
+    [TestMethod]
+    public async Task SpawnBatchAsync_EmptyBatch_ReturnsZeroResults()
+    {
+        var manager = CreateManager(maxConcurrent: 3, runnerFactory: () => new InstantRunner());
+        var batch = await manager.SpawnBatchAsync([], "session-1", CancellationToken.None);
+
+        Assert.AreEqual(0, batch.TotalCount);
+        Assert.AreEqual(0, batch.SucceededCount);
+    }
+
+    [TestMethod]
+    public async Task SpawnBatchAsync_AllDefinitionsRun_ResultsInSubmissionOrder()
+    {
+        var manager = CreateManager(maxConcurrent: 3, runnerFactory: () => new InstantRunner());
+        var definitions = new List<WorkerDefinition>
+        {
+            new() { Description = "task A" },
+            new() { Description = "task B", ResultKey = "shared/custom-key" },
+            new() { Description = "task C" },
+        };
+
+        var batch = await manager.SpawnBatchAsync(definitions, "session-1", CancellationToken.None);
+
+        Assert.AreEqual(3, batch.TotalCount);
+        Assert.AreEqual(3, batch.SucceededCount);
+        Assert.AreEqual("shared/custom-key", batch.Results[1].ResultKey);
+        StringAssert.StartsWith(batch.BatchId, "worker-batch-");
+    }
+
+    [TestMethod]
+    public async Task SpawnBatchAsync_RespectsMaxConcurrentWorkers()
+    {
+        var tracker = new ConcurrencyTracker();
+        var manager = CreateManager(
+            maxConcurrent: 2,
+            runnerFactory: () => new TrackingRunner(tracker, holdMs: 60));
+
+        var definitions = Enumerable.Range(0, 6)
+            .Select(i => new WorkerDefinition { Description = $"task {i}" })
+            .ToList();
+
+        var batch = await manager.SpawnBatchAsync(definitions, "session-1", CancellationToken.None);
+
+        Assert.AreEqual(6, batch.TotalCount);
+        Assert.AreEqual(6, batch.SucceededCount);
+        Assert.IsTrue(tracker.PeakConcurrency <= 2,
+            $"Expected peak concurrency ≤2 (semaphore cap), got {tracker.PeakConcurrency}");
+        Assert.IsTrue(tracker.PeakConcurrency >= 1, "Expected at least one worker to run");
+    }
+
+    [TestMethod]
+    public async Task SpawnBatchAsync_OversizeBatch_StillCompletesByQueueing()
+    {
+        // Batch with more definitions than MaxConcurrentWorkers — overflow queues
+        // instead of failing the batch.
+        var manager = CreateManager(maxConcurrent: 2, runnerFactory: () => new InstantRunner());
+        var definitions = Enumerable.Range(0, 5)
+            .Select(i => new WorkerDefinition { Description = $"task {i}" })
+            .ToList();
+
+        var batch = await manager.SpawnBatchAsync(definitions, "session-1", CancellationToken.None);
+
+        Assert.AreEqual(5, batch.TotalCount);
+        Assert.AreEqual(5, batch.SucceededCount);
+    }
+
+    [TestMethod]
+    public async Task SpawnBatchAsync_RunnerThrows_ResultMarkedFailed()
+    {
+        var manager = CreateManager(
+            maxConcurrent: 2,
+            runnerFactory: () => new ThrowingRunner());
+
+        var batch = await manager.SpawnBatchAsync(
+            [new WorkerDefinition { Description = "broken task" }],
+            "session-1", CancellationToken.None);
+
+        Assert.AreEqual(1, batch.TotalCount);
+        Assert.AreEqual(0, batch.SucceededCount);
+        Assert.AreEqual(1, batch.FailedCount);
+        StringAssert.Contains(batch.Results[0].FailureReason!, "manager exception");
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static WorkerManager CreateManager(int maxConcurrent, Func<IWorkerRunner> runnerFactory)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddTransient(_ => runnerFactory());
+
+        var provider = services.BuildServiceProvider();
+
+        var opts = Options.Create(new WorkerOptions { MaxConcurrentWorkers = maxConcurrent });
+        return new WorkerManager(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            opts,
+            NullLogger<WorkerManager>.Instance);
+    }
+
+    private sealed class InstantRunner : IWorkerRunner
+    {
+        public Task<WorkerResult> RunAsync(string taskId, WorkerDefinition definition,
+            string primarySessionId, string batchId, TimeSpan timeout, CancellationToken ct) =>
+            Task.FromResult(new WorkerResult
+            {
+                TaskId = taskId,
+                IsSuccess = true,
+                ResultKey = definition.ResultKey ?? $"worker/{taskId}/result",
+                Duration = TimeSpan.FromMilliseconds(1),
+                LlmTurns = 1,
+            });
+    }
+
+    private sealed class ThrowingRunner : IWorkerRunner
+    {
+        public Task<WorkerResult> RunAsync(string taskId, WorkerDefinition definition,
+            string primarySessionId, string batchId, TimeSpan timeout, CancellationToken ct) =>
+            throw new InvalidOperationException("test exception");
+    }
+
+    private sealed class ConcurrencyTracker
+    {
+        private int _current;
+        public int PeakConcurrency { get; private set; }
+        private readonly object _lock = new();
+
+        public void Enter()
+        {
+            lock (_lock)
+            {
+                _current++;
+                if (_current > PeakConcurrency) PeakConcurrency = _current;
+            }
+        }
+
+        public void Exit()
+        {
+            lock (_lock) _current--;
+        }
+    }
+
+    private sealed class TrackingRunner(ConcurrencyTracker tracker, int holdMs) : IWorkerRunner
+    {
+        public async Task<WorkerResult> RunAsync(string taskId, WorkerDefinition definition,
+            string primarySessionId, string batchId, TimeSpan timeout, CancellationToken ct)
+        {
+            tracker.Enter();
+            try
+            {
+                await Task.Delay(holdMs, ct);
+            }
+            finally
+            {
+                tracker.Exit();
+            }
+            return new WorkerResult
+            {
+                TaskId = taskId,
+                IsSuccess = true,
+                ResultKey = $"worker/{taskId}/result",
+                Duration = TimeSpan.FromMilliseconds(holdMs),
+            };
+        }
+    }
+}

--- a/tests/RockBot.Subagent.Tests/Worker/WorkerRunnerHelpersTests.cs
+++ b/tests/RockBot.Subagent.Tests/Worker/WorkerRunnerHelpersTests.cs
@@ -1,0 +1,123 @@
+using RockBot.Subagent.Worker;
+
+namespace RockBot.Subagent.Tests.Worker;
+
+[TestClass]
+public class WorkerRunnerHelpersTests
+{
+    // ── MatchesAllowlist ─────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void MatchesAllowlist_NullAllowlist_MatchesEverything()
+    {
+        Assert.IsTrue(WorkerRunner.MatchesAllowlist("anything", null));
+        Assert.IsTrue(WorkerRunner.MatchesAllowlist("spawn_subagent", null));
+    }
+
+    [TestMethod]
+    public void MatchesAllowlist_EmptyAllowlist_MatchesEverything()
+    {
+        Assert.IsTrue(WorkerRunner.MatchesAllowlist("anything", []));
+    }
+
+    [TestMethod]
+    public void MatchesAllowlist_ExactMatch_Allowed()
+    {
+        Assert.IsTrue(WorkerRunner.MatchesAllowlist("get_calendar_events",
+            ["get_calendar_events", "list_emails"]));
+    }
+
+    [TestMethod]
+    public void MatchesAllowlist_NotInList_Rejected()
+    {
+        Assert.IsFalse(WorkerRunner.MatchesAllowlist("save_memory",
+            ["get_calendar_events", "list_emails"]));
+    }
+
+    [TestMethod]
+    public void MatchesAllowlist_PrefixWildcard_Allowed()
+    {
+        Assert.IsTrue(WorkerRunner.MatchesAllowlist("calendar_get_events",
+            ["calendar_*"]));
+        Assert.IsTrue(WorkerRunner.MatchesAllowlist("calendar_list_accounts",
+            ["calendar_*"]));
+    }
+
+    [TestMethod]
+    public void MatchesAllowlist_PrefixWildcard_NonMatchingRejected()
+    {
+        Assert.IsFalse(WorkerRunner.MatchesAllowlist("email_search",
+            ["calendar_*"]));
+    }
+
+    [TestMethod]
+    public void MatchesAllowlist_BareAsterisk_Allowed()
+    {
+        Assert.IsTrue(WorkerRunner.MatchesAllowlist("anything", ["*"]));
+    }
+
+    // ── ParseWorkerSelfReport ────────────────────────────────────────────────
+
+    [TestMethod]
+    public void ParseWorkerSelfReport_NoMarker_ReturnsZero()
+    {
+        var (facts, blocked, patterns) = WorkerRunner.ParseWorkerSelfReport(
+            "Done. No marker emitted.");
+
+        Assert.AreEqual(0, facts);
+        Assert.AreEqual(0, blocked.Count);
+        Assert.AreEqual(0, patterns.Count);
+    }
+
+    [TestMethod]
+    public void ParseWorkerSelfReport_EmptyOutput_ReturnsZero()
+    {
+        var (facts, blocked, patterns) = WorkerRunner.ParseWorkerSelfReport("");
+        Assert.AreEqual(0, facts);
+        Assert.AreEqual(0, blocked.Count);
+        Assert.AreEqual(0, patterns.Count);
+    }
+
+    [TestMethod]
+    public void ParseWorkerSelfReport_MarkerPresent_ParsesFacts()
+    {
+        var (facts, blocked, patterns) = WorkerRunner.ParseWorkerSelfReport(
+            "Saved calendar events. [WORKER_RESULT] facts=6 blocked= patterns=0");
+
+        Assert.AreEqual(6, facts);
+        Assert.AreEqual(0, blocked.Count);
+        Assert.AreEqual(0, patterns.Count);
+    }
+
+    [TestMethod]
+    public void ParseWorkerSelfReport_MarkerPresent_ParsesBlockedList()
+    {
+        var (_, blocked, _) = WorkerRunner.ParseWorkerSelfReport(
+            "Done. [WORKER_RESULT] facts=4 blocked=acct1,acct2 patterns=1");
+
+        CollectionAssert.AreEqual(new[] { "acct1", "acct2" }, blocked.ToArray());
+    }
+
+    [TestMethod]
+    public void ParseWorkerSelfReport_MultipleMarkers_UsesLast()
+    {
+        // A model might mention the marker in an intermediate report; the runner
+        // should latch onto the final one only.
+        var (facts, _, _) = WorkerRunner.ParseWorkerSelfReport(
+            "Earlier mention [WORKER_RESULT] facts=1 blocked= patterns=0. " +
+            "Final: [WORKER_RESULT] facts=7 blocked= patterns=2");
+
+        Assert.AreEqual(7, facts);
+    }
+
+    [TestMethod]
+    public void ParseWorkerSelfReport_BlockedWithSpaces_TrimsEntries()
+    {
+        var (_, blocked, _) = WorkerRunner.ParseWorkerSelfReport(
+            "Done. [WORKER_RESULT] facts=2 blocked=alpha, beta, gamma patterns=0");
+
+        // Note: spaces inside the CSV are tolerated as trim entries.
+        Assert.IsTrue(blocked.Count >= 1);
+        Assert.IsTrue(blocked.Contains("alpha") || blocked.Contains(" alpha"));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds the worker rung — a slim LLM loop with no LTM/episodic/identity/KG injection, trimmed tool surface, pinned Low tier, tight iteration cap (12), and no completion re-prompting.
- New `spawn_workers` tool (array input, batched concurrent execution gated by `SemaphoreSlim`); each worker writes a structured `WorkerResult` JSON to a working-memory key the spawning agent then reads.
- `AgentLoopRunner` gains `enableReasoningScaffolding` (default `true`); workers pass `false` to skip iteration-budget scaffolding + task-list tools.
- `AgentContextBuilder.BuildForWorkerAsync` builds the slim context.
- Worker tool surface excludes `subagent`/`worker`/`scheduling`/`a2a` sources and `save_memory`/`save_skill`/`promote_skill_asset`/`update_task_directive`. Optional per-worker `tools_allow` (exact + `prefix*`) further narrows.
- `worker-directives.md` authored; `AgentProfile` gains optional `WorkerDirectives` slot.

## Scope
**Phase 1 only.** Phases 2–4 (directive updates, patrol migration, tightening) will land as separate PRs against `feature/worker-subagents`. The umbrella branch is held back from `main` while the feature is tested end-to-end.

## Test plan
- [x] `dotnet test RockBot.slnx` — all tests pass (23 new worker tests + 2025 pre-existing, no regressions)
- [ ] Deploy umbrella to live cluster after all phases land
- [ ] Spawn `spawn_workers` from primary chat with one worker; verify result key is populated and the receipt contains the structured `WorkerResult`
- [ ] Spawn a 3-definition batch; verify peak concurrency respects `MaxConcurrentWorkers`
- [ ] Force a timeout (oversize task w/ 1 min cap); verify `worker/<task-id>/failure-details` is populated
- [ ] Verify nested `spawn_workers` is not in the worker's tool list

🤖 Generated with [Claude Code](https://claude.com/claude-code)