### PR TITLE
Worker subagents phase 2: teach directives the wisp/worker/subagent ladder (#431)

### DIFF
--- a/src/RockBot.Agent/agent/common-directives.md
+++ b/src/RockBot.Agent/agent/common-directives.md
@@ -125,36 +125,82 @@ When the user's message is a short follow-up that does not introduce a new fact 
 
 If the short message is genuinely ambiguous, ask one focused clarifying question about the active thread rather than guessing from injected memory.
 
-## Prefer Wisps Over Direct Tool Calls
+## Prefer the Cheapest Rung Over Direct Tool Calls
 
-**For any task requiring two or more tool calls, use `spawn_wisps` instead of calling
-tools directly.** Wisp steps execute without LLM round-trips, making them far cheaper
-than a series of direct tool calls — even for sequential workflows.
+**For any task requiring two or more tool calls, delegate down the three-rung ladder
+(wisp → worker → subagent) instead of calling tools directly.** Each rung trades
+flexibility for cost:
+
+- **Wisps** execute without LLM round-trips at all — far cheaper than a series of
+  direct calls. Use them when the steps are deterministic.
+- **Workers** run a lean LLM loop (no long-term memory, no episodic recall, low-tier
+  model, tight iteration cap). Use them when the steps need interpretation but not
+  persona or history.
+- **Subagents** are the most expensive — full primary-agent context cost. Reserve for
+  open-ended, deliberative work.
+
+Patterns to combine:
 
 - **Sequential workflows**: A single wisp with multiple steps (fetch → transform → store)
   is cheaper than calling each tool yourself with an LLM turn between each step.
 - **Parallel workflows**: Independent tasks (e.g. checking emails from multiple accounts,
-  querying multiple calendars) should be separate wisps in one `spawn_wisps` call so they
-  run concurrently. The batch completes in the time of the slowest wisp, not the sum.
-- **Mixed**: Combine both — spawn multiple wisps, each with its own sequential pipeline.
+  querying multiple calendars) should be separate wisps in one `spawn_wisps` call — or
+  separate workers in one `spawn_workers` call when each slice needs interpretation —
+  so they run concurrently. The batch completes in the time of the slowest item, not
+  the sum.
+- **Mixed**: Combine rungs — a subagent that delegates its gather step to workers, or
+  a worker that delegates its fan-out to a wisp.
 
 Only call tools directly when the task is a single tool call, or when the next step
-genuinely cannot be determined without inspecting the previous result (i.e. the workflow
-requires real-time judgment, not just data flow).
+genuinely cannot be determined without inspecting the previous result inside your own
+context (i.e. the workflow requires real-time judgment from *you*, not just data flow).
 
-Call `get_tool_guide("wisp")` for the full definition format and examples.
+Call `get_tool_guide("wisp")` or `get_tool_guide("worker")` for the full definition
+format and examples.
 
 **Cost comparison**: A 5-step wisp costs 2-3K tokens; the same 5 steps via direct tool
-calls costs 30-50K tokens (one LLM round-trip per step).
+calls in the primary agent costs 30-50K tokens (one LLM round-trip per step). Workers
+sit between the two — cheaper than primary-agent loops, more expensive than wisps.
 
-## Choosing Between Wisps and Subagents
+## Choosing Between Wisps, Workers, and Subagents
 
-- **Wisps** (`spawn_wisps`) — Procedural, known-in-advance workflows. Default choice.
-- **Subagents** (`spawn_subagent`) — Open-ended tasks requiring discovery, judgment, or
-  multi-turn reasoning where you cannot predict the exact tool calls in advance.
+Three rungs, cheapest first. Pick the lowest one that fits.
 
-Subagents should also prefer wisps internally for their own multi-step work — they are
-wisp orchestrators, not direct tool callers.
+| Tool             | Use when                                                                 |
+|------------------|--------------------------------------------------------------------------|
+| `spawn_wisps`    | Steps are deterministic — no LLM needed to interpret results.            |
+| `spawn_workers`  | LLM needs to interpret tool results and branch, but does NOT need        |
+|                  | persona, history, or long-term memory. Mechanical gather work.           |
+| `spawn_subagent` | Task is deliberative, persona-bearing, or open-ended.                    |
+
+Worked examples:
+
+- "Fetch then transform then save" → **wisp**.
+- "Scan all 6 calendar accounts for next-7-day events and summarise actionables" →
+  **workers** (one worker per account, parallel; primary agent assembles).
+- "Schedule a meeting with Bob, drafting the invite from his last project email" →
+  **subagent** (open-ended, needs judgment).
+
+Subagents may themselves spawn wisps and workers — they are orchestrators, not direct
+tool callers. Workers are leaf nodes and cannot spawn anything further.
+
+## Worker pattern review
+
+When `spawn_workers` returns, the batch receipt includes a `converged_patterns` list
+per worker — tool-call sequences the worker observed converging on success after
+non-trivial discovery. Workers cannot promote skill assets themselves; that is your
+job as the spawning agent.
+
+After consuming each worker's `result_key`:
+
+1. Walk `converged_patterns` for that result.
+2. For each candidate worth keeping (the pattern is genuinely reusable, not a one-off),
+   call `promote_skill_asset` against an existing skill — creating the skill first with
+   `save_skill` if none fits.
+3. Skip patterns that are obviously single-use or already covered by an existing asset.
+
+If you skip the review step, the asset-promotion loop never closes and the same
+discoveries get re-derived next time.
 
 ## Using Your Capabilities
 

--- a/src/RockBot.Agent/agent/common-directives.md
+++ b/src/RockBot.Agent/agent/common-directives.md
@@ -183,9 +183,14 @@ Worked examples:
 
 Who can use which rung:
 
-- **Primary agent** — all three (`spawn_wisps`, `spawn_workers`, `spawn_subagent`).
-- **Subagent** — `spawn_wisps` and `spawn_workers` only. Subagents cannot spawn other
+- **Primary agent** — all three are technically available, but workers and wisps run
+  **synchronously** inside the primary's loop, which locks the user's input box while
+  they finish. For non-trivial work the primary's preferred path is `spawn_subagent`
+  (returns control to the user immediately); let the subagent fan out to wisps and
+  workers from inside its own loop.
+- **Subagent** — `spawn_wisps` and `spawn_workers`. Subagents cannot spawn other
   subagents; if your plan needs that, restructure so wisps/workers cover it.
+  Subagents are the canonical home for `spawn_workers` calls.
 - **Worker** — `spawn_wisps` only. Workers are leaf nodes; they cannot spawn workers,
   subagents, or A2A calls.
 
@@ -193,18 +198,22 @@ Who can use which rung:
 
 When `spawn_workers` returns, the batch receipt includes a `converged_patterns` list
 per worker — tool-call sequences the worker observed converging on success after
-non-trivial discovery. Workers cannot promote skill assets themselves; that is your
-job as the spawning agent.
+non-trivial discovery. Workers cannot promote skill assets themselves; the spawning
+agent must do it.
 
-After consuming each worker's `result_key`:
+This walk lives with **subagents**: `promote_skill_asset` is in the subagent tool
+surface, not the primary's. The canonical flow is therefore:
 
-1. Walk `converged_patterns` for that result.
-2. For each candidate worth keeping (the pattern is genuinely reusable, not a one-off),
-   call `promote_skill_asset` against an existing skill — creating the skill first with
-   `save_skill` if none fits.
-3. Skip patterns that are obviously single-use or already covered by an existing asset.
+1. Primary delegates the gather task to a subagent (`spawn_subagent`).
+2. Subagent spawns its gather slices as workers (`spawn_workers`).
+3. After workers return, the subagent walks each result's `converged_patterns`:
+   - For each candidate worth keeping (genuinely reusable, not a one-off), call
+     `promote_skill_asset` against an existing skill — creating the skill first with
+     `save_skill` if none fits.
+   - Skip patterns that are obviously single-use or already covered by an existing
+     asset.
 
-If you skip the review step, the asset-promotion loop never closes and the same
+If the subagent skips this step, the asset-promotion loop never closes and the same
 discoveries get re-derived next time.
 
 ## Using Your Capabilities

--- a/src/RockBot.Agent/agent/common-directives.md
+++ b/src/RockBot.Agent/agent/common-directives.md
@@ -181,8 +181,13 @@ Worked examples:
 - "Schedule a meeting with Bob, drafting the invite from his last project email" →
   **subagent** (open-ended, needs judgment).
 
-Subagents may themselves spawn wisps and workers — they are orchestrators, not direct
-tool callers. Workers are leaf nodes and cannot spawn anything further.
+Who can use which rung:
+
+- **Primary agent** — all three (`spawn_wisps`, `spawn_workers`, `spawn_subagent`).
+- **Subagent** — `spawn_wisps` and `spawn_workers` only. Subagents cannot spawn other
+  subagents; if your plan needs that, restructure so wisps/workers cover it.
+- **Worker** — `spawn_wisps` only. Workers are leaf nodes; they cannot spawn workers,
+  subagents, or A2A calls.
 
 ## Worker pattern review
 

--- a/src/RockBot.Agent/agent/heartbeat-patrol.md
+++ b/src/RockBot.Agent/agent/heartbeat-patrol.md
@@ -31,6 +31,31 @@ You are an autonomous agent. Act like one.
 
 ---
 
+## Prefer workers for gather steps
+
+Patrol checklists typically contain gather slices — calendar scan, email scan, active
+plans review, deadlines sweep. Default to `spawn_workers` for each slice rather than
+running the tools inline. A single `spawn_workers` call with several definitions
+executes the slices in parallel and keeps each one mechanical: no persona, no
+long-term-memory injection, lean model, tight iteration cap.
+
+You — the patrol agent, running as a subagent yourself — then read each worker's
+`result_key` from working memory and assemble the patrol summary and any
+`shared/patrol/*-latest` overwrites from those findings. Walk each worker's
+`converged_patterns` and call `promote_skill_asset` for any worth keeping (workers
+cannot promote themselves).
+
+When you want a worker to overwrite a shared key directly, pass that key as
+`result_key` on the definition (e.g. `result_key: "shared/patrol/calendar-latest"`).
+Otherwise the worker writes to its auto-assigned key and you copy the consolidated
+result over.
+
+`update_task_directive` updates the live checklist; the static markdown here is only
+the seed for fresh deployments. A future phase will rewrite the live directive on the
+cluster to match.
+
+---
+
 ## Working Memory Key Rules
 
 When you save findings via `save_to_working_memory`, use a **stable key per topic**

--- a/src/RockBot.Agent/agent/heartbeat-patrol.md
+++ b/src/RockBot.Agent/agent/heartbeat-patrol.md
@@ -33,22 +33,17 @@ You are an autonomous agent. Act like one.
 
 ## Prefer workers for gather steps
 
-Patrol checklists typically contain gather slices — calendar scan, email scan, active
-plans review, deadlines sweep. Default to `spawn_workers` for each slice rather than
-running the tools inline. A single `spawn_workers` call with several definitions
-executes the slices in parallel and keeps each one mechanical: no persona, no
-long-term-memory injection, lean model, tight iteration cap.
+Patrol checklists are gather-heavy — calendar scan, email scan, active-plans review,
+deadlines sweep. Default to one `spawn_workers` call with one definition per slice so
+they execute in parallel; assemble the patrol summary from the returned
+`result_key` values.
 
-You — the patrol agent, running as a subagent yourself — then read each worker's
-`result_key` from working memory and assemble the patrol summary and any
-`shared/patrol/*-latest` overwrites from those findings. Walk each worker's
-`converged_patterns` and call `promote_skill_asset` for any worth keeping (workers
-cannot promote themselves).
+**Patrol trick:** pass `result_key: "shared/patrol/<slice>-latest"` on a worker
+definition when you want the worker to overwrite the shared key directly. Otherwise
+the worker writes to its auto-assigned key and you copy the consolidated result over.
 
-When you want a worker to overwrite a shared key directly, pass that key as
-`result_key` on the definition (e.g. `result_key: "shared/patrol/calendar-latest"`).
-Otherwise the worker writes to its auto-assigned key and you copy the consolidated
-result over.
+(The three-rung selection ladder and the post-batch `converged_patterns` /
+`promote_skill_asset` review live in `common-directives` — they apply here too.)
 
 `update_task_directive` updates the live checklist; the static markdown here is only
 the seed for fresh deployments. A future phase will rewrite the live directive on the

--- a/src/RockBot.Agent/agent/subagent-directives.md
+++ b/src/RockBot.Agent/agent/subagent-directives.md
@@ -18,26 +18,21 @@ A working-memory key like `subagent-whiteboards/{task_id}/tasks-brief` is a bug:
 it conflates the long-term-memory category convention with a working-memory key
 and uses an unsubstituted placeholder.
 
-## Spawn workers for mechanical sub-tasks
+## Spawn scope for subagents
 
-You may spawn workers with `spawn_workers`. Workers are leaf nodes — they cannot spawn
-back into subagents, workers, or A2A calls — so there is no fan-out risk in using them.
+You can spawn `spawn_wisps` and `spawn_workers`. You **cannot** spawn other subagents
+or A2A calls — if your plan needs that, restructure so wisps/workers cover it.
+Workers are leaf nodes, so spawning them carries no fan-out risk.
 
-When your plan includes a focused gather slice (list these accounts, scan this folder,
-fetch events for this range, summarise these threads), prefer `spawn_workers` over
-running the calls inline. You stay open-ended and persona-bearing; the gather slice
-runs lean — no long-term-memory injection, low-tier model, tight iteration cap.
+The three-rung selection ladder and the post-batch `converged_patterns` /
+`promote_skill_asset` walk live in `common-directives` and apply to you the same way
+they apply to the primary agent. The takeaway specific to you: when your plan
+contains a focused gather slice (list these accounts, scan this folder, fetch events
+for this range), default to `spawn_workers` instead of inlining the calls so the
+slice runs on a lean loop while you stay open-ended.
 
-A single `spawn_workers` call with multiple definitions executes the slices in
-parallel. The batch completes in the time of the slowest worker, not the sum.
-
-After workers return, walk each result's `converged_patterns` the same way the primary
-agent does: for patterns worth keeping, call `promote_skill_asset` against a relevant
-skill (creating one with `save_skill` first if none exists). Workers cannot promote —
-you have the skill context they lack.
-
-Call `get_tool_guide("worker")` for parameter details, the result-key convention, and
-the `[WORKER_RESULT]` marker format.
+Call `get_tool_guide("worker")` for parameter details and the `[WORKER_RESULT]`
+marker format.
 
 ## Tool Calling
 

--- a/src/RockBot.Agent/agent/subagent-directives.md
+++ b/src/RockBot.Agent/agent/subagent-directives.md
@@ -25,8 +25,9 @@ or A2A calls — if your plan needs that, restructure so wisps/workers cover it.
 Workers are leaf nodes, so spawning them carries no fan-out risk.
 
 The three-rung selection ladder and the post-batch `converged_patterns` /
-`promote_skill_asset` walk live in `common-directives` and apply to you the same way
-they apply to the primary agent. The takeaway specific to you: when your plan
+`promote_skill_asset` walk live in `common-directives`. The pattern-review walk is
+specifically *your* responsibility — you have `promote_skill_asset` in your tool
+surface and the primary does not. The takeaway specific to you: when your plan
 contains a focused gather slice (list these accounts, scan this folder, fetch events
 for this range), default to `spawn_workers` instead of inlining the calls so the
 slice runs on a lean loop while you stay open-ended.

--- a/src/RockBot.Agent/agent/subagent-directives.md
+++ b/src/RockBot.Agent/agent/subagent-directives.md
@@ -18,6 +18,27 @@ A working-memory key like `subagent-whiteboards/{task_id}/tasks-brief` is a bug:
 it conflates the long-term-memory category convention with a working-memory key
 and uses an unsubstituted placeholder.
 
+## Spawn workers for mechanical sub-tasks
+
+You may spawn workers with `spawn_workers`. Workers are leaf nodes — they cannot spawn
+back into subagents, workers, or A2A calls — so there is no fan-out risk in using them.
+
+When your plan includes a focused gather slice (list these accounts, scan this folder,
+fetch events for this range, summarise these threads), prefer `spawn_workers` over
+running the calls inline. You stay open-ended and persona-bearing; the gather slice
+runs lean — no long-term-memory injection, low-tier model, tight iteration cap.
+
+A single `spawn_workers` call with multiple definitions executes the slices in
+parallel. The batch completes in the time of the slowest worker, not the sum.
+
+After workers return, walk each result's `converged_patterns` the same way the primary
+agent does: for patterns worth keeping, call `promote_skill_asset` against a relevant
+skill (creating one with `save_skill` first if none exists). Workers cannot promote —
+you have the skill context they lack.
+
+Call `get_tool_guide("worker")` for parameter details, the result-key convention, and
+the `[WORKER_RESULT]` marker format.
+
 ## Tool Calling
 
 Call tools by their direct name (e.g. `get_calendar_events`, `search_emails`) — these are already in your tool list. Use `mcp_invoke_tool` only if a tool is not in your list and you have confirmed its existence via `mcp_get_service_details`.


### PR DESCRIPTION
## Summary
- Replace `common-directives.md` "Choosing Between Wisps and Subagents" with a three-rung selection table (wisp / worker / subagent) plus a new "Worker pattern review" section covering the post-batch `promote_skill_asset` walk; rewrite "Prefer Wisps Over Direct Tool Calls" as a three-rung cost ladder.
- Add a "Spawn workers for mechanical sub-tasks" section near the top of `subagent-directives.md` (leaf nodes, no fan-out risk, subagent owns the pattern-review step).
- Add a "Prefer workers for gather steps" section to `heartbeat-patrol.md` between Mindset and Working Memory Key Rules — parallel `spawn_workers` for patrol slices, with a note that the live cluster directive gets rewritten in phase 3.

Worker mechanics already live in the on-demand `WorkerToolSkillProvider` tool guide; phase 2 lifts the selection / review guidance into the always-injected directives so the primary path actually picks workers.

Builds on phase 1 PR #432. Base is the umbrella branch `feature/worker-subagents`, not main.

## Test plan
- [x] `dotnet build RockBot.slnx` — succeeds; markdown copied to `bin/Debug/net10.0/agent/` confirmed (the `Content Include="agent\**\*.md"` glob is unchanged).
- [ ] Manual cross-check that the three-way selection table reads consistently across `common-directives.md`, `WorkerToolSkillProvider`, and `worker-directives.md` once phase 1 lands.
- [ ] No code/runtime tests — markdown changes have no compile or runtime surface.

## What's next
- **Phase 3** — rewrite the live patrol task directive on the cluster via `update_task_directive` so existing deployments get the worker guidance without an image bump.
- **Phase 4** — once we have post-deploy traces, tighten defaults (selection wording, escalation thresholds, telemetry on skipped `promote_skill_asset` follow-ups) if measurements show the primary agent still defaults to subagents or ignores pattern review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)