### PR TITLE
TierRoutingEntry: capture ModelId for routing cost analysis

### DIFF
--- a/src/McpServer.RoutingStats/Tools/RoutingStatsTools.cs
+++ b/src/McpServer.RoutingStats/Tools/RoutingStatsTools.cs
@@ -153,6 +153,7 @@ internal sealed record RoutingEntry
     public List<string> MatchedHighKeywords { get; init; } = [];
     public List<string> MatchedLowKeywords { get; init; } = [];
     public int? PostInjectionTokenEstimate { get; init; }
+    public string? ModelId { get; init; }
     public long? InputTokens { get; init; }
     public long? OutputTokens { get; init; }
     public long? LatencyMs { get; init; }

--- a/src/RockBot.Agent/UserMessageHandler.cs
+++ b/src/RockBot.Agent/UserMessageHandler.cs
@@ -255,6 +255,7 @@ internal sealed class UserMessageHandler(
                     MatchedHighKeywords = classification.MatchedHighKeywords,
                     MatchedLowKeywords = classification.MatchedLowKeywords,
                     PostInjectionTokenEstimate = postInjectionTokenEstimate,
+                    ModelId = firstResponse.ModelId ?? registry.GetModelId(tier),
                     InputTokens = firstResponse.Usage?.InputTokenCount,
                     OutputTokens = firstResponse.Usage?.OutputTokenCount,
                     LatencyMs = routingSw.ElapsedMilliseconds,
@@ -469,6 +470,7 @@ internal sealed class UserMessageHandler(
                 MatchedHighKeywords = classification.MatchedHighKeywords,
                 MatchedLowKeywords = classification.MatchedLowKeywords,
                 PostInjectionTokenEstimate = postInjectionTokenEstimate,
+                ModelId = registry.GetModelId(classification.Tier),
             });
 
             text = ResponseSanitizer.StripTrailingOffers(text);

--- a/src/RockBot.Host.Abstractions/TierRoutingEntry.cs
+++ b/src/RockBot.Host.Abstractions/TierRoutingEntry.cs
@@ -44,6 +44,14 @@ public sealed record TierRoutingEntry
 
     // ── LLM response telemetry ─────────────────────────────────────────────────
 
+    /// <summary>
+    /// The model that handled this routing decision. Populated from the chat response's
+    /// <c>ModelId</c> when available, falling back to the tier's configured default model.
+    /// Used by the routing analyzer to compute per-entry USD cost by joining with the
+    /// pricing table. Null on entries written before this field existed.
+    /// </summary>
+    public string? ModelId { get; init; }
+
     public long? InputTokens { get; init; }
     public long? OutputTokens { get; init; }
     public long? LatencyMs { get; init; }

--- a/src/RockBot.Host/DreamService.cs
+++ b/src/RockBot.Host/DreamService.cs
@@ -2451,6 +2451,8 @@ internal sealed class DreamService : IHostedService, IDisposable
             userMessage.Append(
                 $"[{e.Timestamp:O}] tier={e.Tier} score={e.ComplexityScore:F3} context={e.Context}");
 
+            if (!string.IsNullOrEmpty(e.ModelId))
+                userMessage.Append($" model={e.ModelId}");
             if (e.MatchedHighKeywords.Count > 0)
                 userMessage.Append($" highKeywords=[{string.Join(",", e.MatchedHighKeywords)}]");
             if (e.MatchedLowKeywords.Count > 0)

--- a/src/RockBot.Subagent/SubagentRunner.cs
+++ b/src/RockBot.Subagent/SubagentRunner.cs
@@ -22,6 +22,7 @@ internal sealed class SubagentRunner(
     AgentContextBuilder agentContextBuilder,
     ILlmClient llmClient,
     ILlmTierSelector tierSelector,
+    TieredChatClientRegistry registry,
     IWorkingMemory workingMemory,
     MemoryTools memoryTools,
     ISkillStore skillStore,
@@ -317,6 +318,7 @@ internal sealed class SubagentRunner(
             MatchedHighKeywords = classification.MatchedHighKeywords,
             MatchedLowKeywords = classification.MatchedLowKeywords,
             PostInjectionTokenEstimate = postInjectionTokenEstimate,
+            ModelId = registry.GetModelId(classification.Tier),
             LatencyMs = subagentSw.ElapsedMilliseconds,
         });
 

--- a/tests/RockBot.Host.Tests/TierRoutingLoggerTests.cs
+++ b/tests/RockBot.Host.Tests/TierRoutingLoggerTests.cs
@@ -1,0 +1,95 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using RockBot.Host;
+
+namespace RockBot.Host.Tests;
+
+[TestClass]
+public class TierRoutingLoggerTests
+{
+    private static (TierRoutingLogger logger, string dir) CreateLogger()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "rb-routing-" + Path.GetRandomFileName());
+        Directory.CreateDirectory(dir);
+        var logger = new TierRoutingLogger(
+            Options.Create(new AgentProfileOptions { BasePath = dir }),
+            NullLogger<TierRoutingLogger>.Instance);
+        return (logger, dir);
+    }
+
+    [TestMethod]
+    public async Task AppendAndRead_RoundTripsModelId()
+    {
+        var (logger, dir) = CreateLogger();
+        try
+        {
+            await logger.AppendAsync(new TierRoutingEntry
+            {
+                Timestamp = DateTimeOffset.UtcNow,
+                PromptPreview = "test prompt",
+                Tier = ModelTier.Balanced,
+                Context = "user-message",
+                ComplexityScore = 0.42,
+                ModelId = "claude-sonnet-4-6",
+            });
+
+            var entries = await logger.ReadRecentAsync();
+            Assert.AreEqual(1, entries.Count);
+            Assert.AreEqual("claude-sonnet-4-6", entries[0].ModelId);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public async Task AppendAndRead_NullModelId_RoundTripsAsNull()
+    {
+        var (logger, dir) = CreateLogger();
+        try
+        {
+            await logger.AppendAsync(new TierRoutingEntry
+            {
+                Timestamp = DateTimeOffset.UtcNow,
+                PromptPreview = "test prompt",
+                Tier = ModelTier.Low,
+                Context = "user-message",
+                ComplexityScore = 0.10,
+                ModelId = null,
+            });
+
+            var entries = await logger.ReadRecentAsync();
+            Assert.AreEqual(1, entries.Count);
+            Assert.IsNull(entries[0].ModelId);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public async Task Read_LegacyEntryWithoutModelId_ParsesWithNullModelId()
+    {
+        // Simulates an entry written by a pre-ModelId version of the agent.
+        // The on-disk JSONL has no "modelId" property; deserialization must default to null.
+        var (logger, dir) = CreateLogger();
+        try
+        {
+            var legacyLine = """
+                {"timestamp":"2026-05-22T10:00:00+00:00","promptPreview":"legacy","tier":"Balanced","context":"user-message","complexityScore":0.5,"matchedHighKeywords":[],"matchedLowKeywords":[],"isFallbackTriggered":false}
+                """;
+            await File.WriteAllTextAsync(Path.Combine(dir, "tier-routing-log.jsonl"), legacyLine + "\n");
+
+            var entries = await logger.ReadRecentAsync();
+            Assert.AreEqual(1, entries.Count);
+            Assert.IsNull(entries[0].ModelId);
+            Assert.AreEqual("legacy", entries[0].PromptPreview);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+}

--- a/tests/RockBot.Subagent.Tests/SubagentManagerTests.cs
+++ b/tests/RockBot.Subagent.Tests/SubagentManagerTests.cs
@@ -48,6 +48,13 @@ public class SubagentManagerTests
         services.AddTransient<AgentLoopRunner>();
         services.AddTransient<SubagentRunner>();
 
+        // SubagentRunner now requires TieredChatClientRegistry to capture the
+        // configured model ID into routing telemetry. A stub registry backed by a
+        // no-op IChatClient is sufficient — GetModelId returns null when metadata
+        // is unavailable, which is the back-compat path for tests.
+        var stubChatClient = new NoopChatClient();
+        services.AddSingleton(new TieredChatClientRegistry(stubChatClient, stubChatClient, stubChatClient));
+
         // AgentProfile is required by SubagentRunner; provide a minimal stub.
         var stubDoc = new AgentProfileDocument("stub", null, [], "");
         var stubProfile = new AgentProfile(stubDoc, stubDoc);
@@ -251,6 +258,30 @@ public class SubagentManagerTests
             ChatOptions? options = null,
             CancellationToken cancellationToken = default) =>
             GetResponseAsync(messages, options, cancellationToken);
+    }
+
+    /// <summary>
+    /// Minimal IChatClient used to construct a TieredChatClientRegistry for SubagentRunner.
+    /// Never receives an actual call — exists only so DI can build the registry.
+    /// </summary>
+    private sealed class NoopChatClient : IChatClient
+    {
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options = null, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new ChatResponse([new ChatMessage(ChatRole.Assistant, "")]));
+
+#pragma warning disable CS1998 // async without await is intentional for the yield-break empty stream
+        public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            yield break;
+        }
+#pragma warning restore CS1998
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+        public void Dispose() { }
     }
 
     /// <summary>LLM client that blocks until the TCS is completed or the token is cancelled.</summary>


### PR DESCRIPTION
## Summary

Schema-only prep for the upcoming `TierRoutingAnalyzer`. Adds a nullable `ModelId` field to `TierRoutingEntry`, populated at all three writer sites using `firstResponse.ModelId` where available, falling back to `TieredChatClientRegistry.GetModelId(tier)`. DreamService's routing-review prompt surfaces `model=<id>` per entry. Field is nullable so existing JSONL parses unchanged.

This is the first of four PRs in a stack — see the PR description chain below.

## Stack

1. **This PR** — `ModelId` schema (this branch)
2. `feat/tier-routing-analyzer` — `TierRoutingAnalyzer` + DreamService refactor (pre-aggregates the dream prompt → ~7,500 tokens drops to ~2,000, prompt cost decoupled from entry count)
3. `feat/consolidate-introspection-mcp` — retire `McpServer.RoutingStats`, move tools into the existing `McpServer.Introspection` sidecar, add `get_routing_summary`
4. `feat/tier-routing-log-cap` — raise the hardcoded 200-entry cap on `tier-routing-log.jsonl` to 1500, make it configurable via helm

## Test plan
- [x] Schema change is back-compat — added a unit test that loads a legacy entry with no `modelId` field and confirms it parses as null
- [x] `dotnet build RockBot.slnx` clean
- [x] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)