### PR TITLE
DreamService: pre-aggregate routing review with TierRoutingAnalyzer

### DIFF
--- a/src/RockBot.Agent/agent/routing-dream.md
+++ b/src/RockBot.Agent/agent/routing-dream.md
@@ -1,84 +1,96 @@
 # Routing Dream Directive
 
 You are a tier-routing self-correction assistant for an LLM agent framework.
-Review the routing decisions and telemetry provided. Each entry includes:
 
-- **tier**: the selected model tier (Low / Balanced / High)
-- **score**: the pre-injection complexity score [0,1] that drove the decision
-- **highKeywords / lowKeywords**: signals matched in the raw user prompt (Option A classification)
-- **postInjectionTokens**: estimated tokens after memory recall and tool guide injection
-- **inputTokens / outputTokens**: actual LLM token usage
-- **toolCalls / tools**: how many tool calls fired and which tools
-- **latencyMs**: request latency
-- **fallback=true**: model fallback was triggered by quota/API error — exclude from quality signals
-- **prompt**: first 150 chars of the user prompt
+The user message is a **pre-aggregated JSON analysis** (`schemaVersion: 1`), not a stream
+of raw routing entries. A deterministic analyzer has already done all the statistical heavy
+lifting — clustering, detection-rule application, keyword frequency math, threshold scans,
+and cost projection. Your job is **judgment**, not aggregation.
 
-## Detection Patterns
+**If `schemaVersion` is anything other than `1`, refuse to proceed** — return
+`{"noChangeNeeded": true, "antiPatterns": []}` and stop. A version mismatch means the
+directive and analyzer have drifted and you cannot reliably interpret the input.
 
-### 1. Panic Escalation
-A Low-tier session that triggered many tool calls (toolCalls ≥ 3) indicates the model likely
-struggled to close the task. Prompts of that shape should be routed Balanced. Look for recurring
-prompt shapes that consistently produce high tool call counts at the Low tier.
+## What the analysis contains
 
-### 2. Token Surprise (informational only — DO NOT adjust thresholds)
-When `postInjectionTokens` is much larger than the complexity score suggests (e.g., score < 0.20
-but postInjectionTokens > 15000), the pre-injection classification measured the user's intent correctly
-but post-assembly context (memory recall, skill injection, tool guides) inflated the prompt.
+- **`globalStats`** — per-tier counts, percentages, avg latency/tokens, fallback rate
+- **`clusters`** — groups of similar routing decisions (same keyword signature + tier +
+  tool-call bucket), sorted by count desc
+- **`flaggedClusters`** — clusters that tripped a deterministic detection rule, each
+  carrying a `flag`, `rationale`, and projected cost at the current and alternate tier
+- **`keywordCandidates.highSignalCandidates` / `.lowSignalCandidates`** — words appearing
+  disproportionately in High- or Low-tier prompts (frequency ratio ≥ 3, count ≥ 5),
+  pre-filtered to exclude words already matched by the selector
+- **`thresholdScans`** — "what if" projections for `lowCeiling` and `balancedCeiling`
+  at ±0.05, including how many entries would flip tier and the projected USD cost delta
+- **`projectedCost`** — total spend across the window plus per-tier breakdown
+- **`fallbackExcludedCount`** — fallback-triggered entries are already excluded from
+  clusters, flagged clusters, and keyword candidates; do not filter them yourself
 
-**This is expected and NOT a misroute.** Post-injection token count reflects the orchestration
-layer's context assembly, not user intent complexity. A trivial prompt like "what time is it?"
-legitimately expands to 15k+ tokens after injection — that does not make it a Balanced-tier task.
+## Your three jobs
 
-Use `postInjectionTokens` ONLY as a safety cap: if the final prompt exceeds the selected tier's
-model context window, upgrade the tier. Never use post-injection size to adjust `lowCeiling`,
-`balancedCeiling`, or keyword lists. The routing decision is about cognitive complexity of the
-user's request, not the assembled context size.
+### 1. Validate flagged clusters
 
-**Built-in guards handle trivial prompt protection:**
-- A trivial guard forces Low tier when score < `trivialGuardCeiling` (default 0.15), word count ≤ 20,
-  and no high-signal keywords match — regardless of threshold tuning.
-- A user-origin bias reduces the score by `userOriginBias` (default 0.10) for user-originated
-  messages, since user prompts are semantically simpler than subagent task descriptions.
+For each entry in `flaggedClusters`:
 
-These guards are NOT tuneable via this config — they are code-level protections against threshold drift.
+- **panicEscalation** — Low tier with avg tool calls ≥ 3. The model likely struggled.
+  Check `samplePrompt` and `count`: if this looks like a real recurring shape (not a fluke),
+  the cluster's `alternateTier` (Balanced) is the correct routing direction.
+- **tokenSurprise** — Low complexity score but high post-injection tokens. **Informational
+  only** — DO NOT adjust thresholds for this. Post-injection size is an orchestration-layer
+  concern, not a routing-quality signal. A trivial prompt like "what time is it?" legitimately
+  expands to 15k+ tokens after memory and tool-guide injection.
+- **lowOutputAtHigh** — High tier producing <200 output tokens, suggesting over-routing.
+  The `alternateTier` (Balanced) is likely the correct direction.
 
-### 3. Capability Fingerprints
-Recurring prompt shapes consistently routed to the wrong tier. Identify keywords in those prompts
-that should be added to `highSignalKeywords` or `lowSignalKeywords`. These learned associations
-replace static keyword guesses with evidence-backed routing rules.
+If `projectedCostCurrentTier` and `projectedCostAlternateTier` are both present, prefer
+the cheaper option when quality signals don't strongly favor the current tier.
 
-**CRITICAL — keyword quality rules:**
-Keywords must indicate *cognitive complexity*, NOT topic or domain. The tier selector asks
-"how hard is this to think about?", not "what is this about?".
+### 2. Filter keyword candidates with the cognitive-complexity rule
 
-Good high-signal keywords describe **reasoning difficulty**: "analyze", "architect", "trade-off",
-"compare and contrast", "step by step", "threat model", "prove", "optimize".
+The analyzer surfaces words by **statistical correlation**, not by meaning. Before
+accepting any candidate from `highSignalCandidates` or `lowSignalCandidates`, apply
+this test:
 
-Bad high-signal keywords describe **topics or tools**: "calendar", "email", "todo", "mcp server",
-"working memory", "retrieve", "schedule", "flight", "health report", "skill". These words appear
-in both trivial and complex prompts — they tell you the *domain*, not the *difficulty*. A prompt
-like "check my calendar" is trivially simple despite containing "calendar".
+> **"Would a prompt containing ONLY this word and a simple verb be complex?"**
 
-Before adding a keyword, apply this test: "Would a prompt containing ONLY this word and a simple
-verb be complex?" If "check my [keyword]" or "list the [keyword]" would be simple, the word is a
-topic indicator and MUST NOT be added to highSignalKeywords.
+If `"check my [keyword]"` or `"list the [keyword]"` would be **simple**, the word is a
+**topic indicator** (calendar, email, todo, schedule, flight, mcp, working, memory) and
+**MUST NOT** be added — topic keyword pollution is the #1 cause of over-routing to High
+tier. Reject these candidates even when the frequency ratio is dramatic.
 
-When a topic-heavy prompt was misrouted, the correct fix is to adjust **thresholds**, not to add
-topic words as high-signal keywords. Topic keyword pollution is the #1 cause of over-routing to
-High tier.
+**Good high-signal keywords describe reasoning difficulty**: `analyze`, `architect`,
+`trade-off`, `compare and contrast`, `threat model`, `prove`, `optimize`, `step by step`.
 
-### 4. Cost-Aware Correction
-If a class of prompts routed Low produces many tool calls and high token usage, routing them to
-Balanced upfront is more efficient. Calculate: (Low tier token cost × retries) vs. (Balanced tier
-token cost × 1). If Balanced would have been cheaper overall, adjust thresholds.
+**Good low-signal keywords describe trivial intent**: `time`, `today`, `what's`, `weather`,
+`hello`, `thanks`.
 
-## Exclusions
+Return your accepted additions in the `config.highSignalKeywords` / `config.lowSignalKeywords`
+arrays. These are **merged** with the compiled defaults — return ONLY your additions, not
+the full default list. Never return empty lists; only include words you are actually adding.
 
-**Exclude sessions with `fallback=true`** from all quality-signal reasoning. These represent
-infrastructure errors (quota exhaustion, API failures), not genuine routing quality failures.
-Including them would pollute routing heuristics with noise.
+### 3. Pick threshold shifts from `thresholdScans`
 
-## Response Format
+Each scan entry tells you exactly:
+- How many entries would flip if the threshold moved by ±0.05 (`entriesFlipped`)
+- Which direction (`directionDescription`)
+- A few `samplePrompts` so you can sanity-check the flips
+- The projected USD cost delta (`projectedCostDelta`) when pricing is available
+
+Apply a threshold shift only when **both** of these hold:
+- At least ~5 entries would flip in the desired direction
+- The cost delta is favorable, OR you have a clear quality reason (e.g., panic-escalation
+  clusters dominating a tier)
+
+Adjustments must be **small (±0.05)**. Hard bounds the code clamps to:
+- `lowCeiling` ∈ [0.15, 0.40]
+- `balancedCeiling` ∈ [0.40, 0.80]
+
+Trivial guard fields (`trivialGuardCeiling`, `userOriginBias`) are available in the config
+but should only be touched when there is clear evidence of *false Low-tier routing* — never
+to widen Balanced.
+
+## Response format
 
 Return ONLY a JSON object:
 
@@ -88,38 +100,36 @@ Return ONLY a JSON object:
   "config": {
     "version": 1,
     "notes": "YYYY-MM-DD: <what changed and why — be specific>",
-    "lowCeiling": 0.15,
+    "lowCeiling": 0.20,
     "balancedCeiling": 0.46,
-    "highSignalKeywords": ["complete", "keyword", "list"],
-    "lowSignalKeywords": ["complete", "keyword", "list"]
+    "highSignalKeywords": ["additions only — merged with compiled defaults"],
+    "lowSignalKeywords": ["additions only — merged with compiled defaults"]
   },
   "antiPatterns": [
     {
       "content": "Short description of systematic misroute pattern (≤ 120 chars)",
-      "detail": "Optional longer explanation with examples from the log"
+      "detail": "Optional longer explanation citing flagged clusters or scan results"
     }
   ]
 }
 ```
 
-When routing looks correct and no anti-patterns found:
+When the analysis shows healthy routing and no anti-patterns:
+
 ```json
 {"noChangeNeeded": true, "antiPatterns": []}
 ```
 
 ## Rules
 
-- `lowCeiling` must be in [0.15, 0.40]; `balancedCeiling` must be in [0.40, 0.80]
-  (values outside these ranges are clamped by the code — staying within them avoids surprises)
-- Keyword lists are **merged** with compiled defaults — return ONLY your additions/removals,
-  not the full default list. Compiled defaults cannot be removed via config; they are always present.
-  To suppress a compiled default keyword, open a code change instead.
-- Never return empty keyword lists; only include keywords you are adding beyond the defaults
 - `notes` must state today's date and describe what changed; do not leave it blank
-- Be **conservative**: only change what is clearly mis-routed; err on the side of no change
-- Small, incremental threshold adjustments (±0.05) are preferred over large rewrites
-- Always include `antiPatterns` — use an empty array when nothing systematic is detected
-- **DO NOT** adjust thresholds to compensate for post-injection token size — that is the
-  orchestration layer's concern, not a routing quality signal
-- The `trivialGuardCeiling` and `userOriginBias` fields are available in the config but should
-  only be adjusted when there is clear evidence of false Low-tier routing, not to widen Balanced
+- Be **conservative** — only change what is clearly mis-routed; err on the side of no change
+- Always include `antiPatterns` (use `[]` when nothing systematic is detected)
+- Keyword additions must pass the cognitive-complexity-vs-topic test — apply it explicitly
+- Every keyword must be at least 4 characters long; shorter words are silently dropped
+- Keywords are matched by word boundaries — `rest` will NOT match inside `restoration`
+- Never use personal names, proper nouns, or user-specific content as keywords
+- Prefer multi-word phrases (e.g., `security implication`) over single common words
+  (e.g., `security`) to reduce false-positive matches
+- Do NOT adjust thresholds to compensate for post-injection token size — `tokenSurprise`
+  flags are informational only

--- a/src/RockBot.Host.Abstractions/LlmPricingRow.cs
+++ b/src/RockBot.Host.Abstractions/LlmPricingRow.cs
@@ -1,0 +1,12 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Pricing for a single model prefix, matching the schema of <c>llm-pricing.json</c>.
+/// Cost = (inputTokens * <see cref="InputPerM"/> + outputTokens * <see cref="OutputPerM"/>) / 1_000_000.
+/// The first row whose <see cref="Prefix"/> is contained in the model ID wins
+/// (longest-prefix-first ordering, enforced by the on-disk file).
+/// </summary>
+public sealed record LlmPricingRow(
+    string Prefix,
+    decimal InputPerM,
+    decimal OutputPerM);

--- a/src/RockBot.Host.Abstractions/TierRoutingAnalysis.cs
+++ b/src/RockBot.Host.Abstractions/TierRoutingAnalysis.cs
@@ -1,0 +1,106 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Pre-aggregated analysis of a tier-routing log window. Produced by
+/// <see cref="TierRoutingAnalyzer.Analyze"/> and consumed by the dream
+/// routing-review pass and the introspection MCP server's summary tool.
+/// <para>
+/// The whole point of this record is to do the statistical heavy lifting
+/// in code so the LLM downstream can spend its tokens on judgment
+/// (validating flagged clusters, filtering keyword candidates) instead
+/// of recomputing aggregates from raw entries.
+/// </para>
+/// </summary>
+public sealed record TierRoutingAnalysis(
+    int SchemaVersion,
+    DateTimeOffset? WindowStart,
+    DateTimeOffset? WindowEnd,
+    int TotalEntries,
+    int FallbackExcludedCount,
+    TierRoutingGlobalStats GlobalStats,
+    IReadOnlyList<TierRoutingCluster> Clusters,
+    IReadOnlyList<TierRoutingFlaggedCluster> FlaggedClusters,
+    TierRoutingKeywordCandidates KeywordCandidates,
+    IReadOnlyList<TierRoutingThresholdScan> ThresholdScans,
+    TierRoutingProjectedCost ProjectedCost);
+
+public sealed record TierRoutingGlobalStats(
+    IReadOnlyList<TierRoutingTierStats> ByTier,
+    int UserMessageCount,
+    int SubagentCount,
+    int FallbackCount,
+    double FallbackPct);
+
+public sealed record TierRoutingTierStats(
+    ModelTier Tier,
+    int Count,
+    double Pct,
+    double AvgComplexityScore,
+    long? AvgLatencyMs,
+    long? AvgInputTokens,
+    long? AvgOutputTokens,
+    double AvgToolCalls);
+
+/// <summary>
+/// A group of entries with the same routing-shape signature (keyword set + tier + tool-call bucket).
+/// Used as the unit of LLM-visible analysis — N similar entries collapse into 1 line in the prompt.
+/// </summary>
+public sealed record TierRoutingCluster(
+    string Signature,
+    ModelTier Tier,
+    int Count,
+    string SamplePrompt,
+    double AvgComplexityScore,
+    double AvgToolCalls,
+    long? AvgInputTokens,
+    long? AvgOutputTokens,
+    int? AvgPostInjectionTokens,
+    int FallbackCount,
+    IReadOnlyList<string> MatchedHighKeywords,
+    IReadOnlyList<string> MatchedLowKeywords);
+
+/// <summary>
+/// A cluster that tripped one of the deterministic detection rules. The LLM's job is to
+/// validate whether this is a true misroute (vs. noise) and decide what to do about it.
+/// </summary>
+public sealed record TierRoutingFlaggedCluster(
+    TierRoutingCluster Cluster,
+    string Flag,
+    string Rationale,
+    decimal? ProjectedCostCurrentTier,
+    decimal? ProjectedCostAlternateTier,
+    ModelTier? AlternateTier);
+
+public sealed record TierRoutingKeywordCandidates(
+    IReadOnlyList<TierRoutingKeywordCandidate> HighSignalCandidates,
+    IReadOnlyList<TierRoutingKeywordCandidate> LowSignalCandidates);
+
+public sealed record TierRoutingKeywordCandidate(
+    string Keyword,
+    int HighTierCount,
+    int BalancedTierCount,
+    int LowTierCount,
+    double FrequencyRatio);
+
+/// <summary>
+/// A "what if" projection: counts how many entries in the window would flip tier
+/// if the threshold moved by the given delta. Lets the LLM pick a shift with
+/// deterministic impact data instead of guessing.
+/// </summary>
+public sealed record TierRoutingThresholdScan(
+    string Threshold,
+    double Delta,
+    int EntriesFlipped,
+    string DirectionDescription,
+    IReadOnlyList<string> SamplePrompts,
+    decimal? ProjectedCostDelta);
+
+public sealed record TierRoutingProjectedCost(
+    decimal TotalUsd,
+    IReadOnlyList<TierRoutingTierCost> ByTier,
+    int EntriesPricedCount,
+    int EntriesUnpricedCount);
+
+public sealed record TierRoutingTierCost(
+    ModelTier Tier,
+    decimal Usd);

--- a/src/RockBot.Host.Abstractions/TierRoutingAnalyzer.cs
+++ b/src/RockBot.Host.Abstractions/TierRoutingAnalyzer.cs
@@ -343,8 +343,12 @@ public static class TierRoutingAnalyzer
         IReadOnlyList<LlmPricingRow>? pricing,
         IReadOnlyDictionary<ModelTier, string?>? tierModelMap)
     {
-        var newLow = threshold == "lowCeiling" ? lowCeiling + delta : lowCeiling;
-        var newBal = threshold == "balancedCeiling" ? balancedCeiling + delta : balancedCeiling;
+        // Round shifted thresholds to 4 decimals — bare double subtraction yields
+        // 0.15 - 0.05 = 0.09999999999999998, which makes boundary entries (score 0.10)
+        // appear to flip when they wouldn't with the actual selector's <=  comparison.
+        // Config values are at most 2 decimal places, so 4 is plenty of precision.
+        var newLow = threshold == "lowCeiling" ? Math.Round(lowCeiling + delta, 4) : lowCeiling;
+        var newBal = threshold == "balancedCeiling" ? Math.Round(balancedCeiling + delta, 4) : balancedCeiling;
         var flips = new List<(TierRoutingEntry e, ModelTier from, ModelTier to)>();
 
         // Compare simulated(original) vs simulated(shifted) — both apply pure threshold

--- a/src/RockBot.Host.Abstractions/TierRoutingAnalyzer.cs
+++ b/src/RockBot.Host.Abstractions/TierRoutingAnalyzer.cs
@@ -1,0 +1,448 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Pure-logic analyzer over a window of <see cref="TierRoutingEntry"/> records.
+/// Produces a <see cref="TierRoutingAnalysis"/> containing every deterministic aggregate
+/// the downstream LLM would otherwise have to compute itself.
+/// <para>
+/// No I/O, no DI. Safe to call from agent host code, MCP sidecars, or tests.
+/// </para>
+/// </summary>
+public static class TierRoutingAnalyzer
+{
+    public const int CurrentSchemaVersion = 1;
+
+    // Defaults match the compiled defaults in KeywordTierSelector — used when the
+    // caller's TierSelectorConfig has nulls. Kept here so the analyzer never crashes
+    // on a fresh config that hasn't been tuned yet.
+    private const double DefaultLowCeiling = 0.15;
+    private const double DefaultBalancedCeiling = 0.46;
+    private const double ThresholdScanDelta = 0.05;
+
+    // Cluster flagging thresholds — must match the language in routing-dream.md.
+    private const int MinClusterSize = 3;
+    private const double PanicAvgToolCalls = 3.0;
+    private const double TokenSurpriseScoreMax = 0.20;
+    private const int TokenSurprisePostInjectionMin = 2000;
+    private const long LowOutputAtHighMaxOutputTokens = 200;
+
+    // Keyword candidate filters.
+    private const int KeywordMinCount = 5;
+    private const double KeywordMinFrequencyRatio = 3.0;
+    private const int KeywordMinLength = 4;
+
+    /// <summary>
+    /// Run the analyzer over a snapshot of entries. The caller is responsible for
+    /// any time-window filtering before calling — this method aggregates whatever it gets.
+    /// </summary>
+    public static TierRoutingAnalysis Analyze(
+        IReadOnlyList<TierRoutingEntry> entries,
+        TierSelectorConfig? currentConfig = null,
+        IReadOnlyList<LlmPricingRow>? pricing = null,
+        IReadOnlyDictionary<ModelTier, string?>? tierModelMap = null)
+    {
+        var lowCeiling = currentConfig?.LowCeiling ?? DefaultLowCeiling;
+        var balancedCeiling = currentConfig?.BalancedCeiling ?? DefaultBalancedCeiling;
+
+        if (entries.Count == 0)
+        {
+            return new TierRoutingAnalysis(
+                SchemaVersion: CurrentSchemaVersion,
+                WindowStart: null,
+                WindowEnd: null,
+                TotalEntries: 0,
+                FallbackExcludedCount: 0,
+                GlobalStats: BuildGlobalStats([], 0),
+                Clusters: [],
+                FlaggedClusters: [],
+                KeywordCandidates: new([], []),
+                ThresholdScans: [],
+                ProjectedCost: new(0m, [], 0, 0));
+        }
+
+        var quality = entries.Where(e => !e.IsFallbackTriggered).ToList();
+        var fallbackCount = entries.Count - quality.Count;
+
+        var globalStats = BuildGlobalStats(entries, fallbackCount);
+        var clusters = BuildClusters(quality);
+        var flagged = FlagClusters(clusters, pricing, tierModelMap);
+        var keywordCandidates = BuildKeywordCandidates(quality);
+        var scans = BuildThresholdScans(quality, lowCeiling, balancedCeiling, pricing, tierModelMap);
+        var projectedCost = BuildProjectedCost(entries, pricing);
+
+        return new TierRoutingAnalysis(
+            SchemaVersion: CurrentSchemaVersion,
+            WindowStart: entries.Min(e => e.Timestamp),
+            WindowEnd: entries.Max(e => e.Timestamp),
+            TotalEntries: entries.Count,
+            FallbackExcludedCount: fallbackCount,
+            GlobalStats: globalStats,
+            Clusters: clusters,
+            FlaggedClusters: flagged,
+            KeywordCandidates: keywordCandidates,
+            ThresholdScans: scans,
+            ProjectedCost: projectedCost);
+    }
+
+    // ── Global stats ──────────────────────────────────────────────────────────
+
+    private static TierRoutingGlobalStats BuildGlobalStats(
+        IReadOnlyList<TierRoutingEntry> entries, int fallbackCount)
+    {
+        var total = entries.Count;
+        var tiers = new[] { ModelTier.Low, ModelTier.Balanced, ModelTier.High };
+        var byTier = tiers.Select(t =>
+        {
+            var group = entries.Where(e => e.Tier == t).ToList();
+            var count = group.Count;
+            var pct = total > 0 ? Math.Round(count * 100.0 / total, 1) : 0.0;
+            var latency = group.Where(e => e.LatencyMs.HasValue).Select(e => e.LatencyMs!.Value).ToList();
+            var input = group.Where(e => e.InputTokens.HasValue).Select(e => e.InputTokens!.Value).ToList();
+            var output = group.Where(e => e.OutputTokens.HasValue).Select(e => e.OutputTokens!.Value).ToList();
+            var toolCalls = group.Where(e => e.ToolCallCount.HasValue).Select(e => e.ToolCallCount!.Value).ToList();
+            return new TierRoutingTierStats(
+                Tier: t,
+                Count: count,
+                Pct: pct,
+                AvgComplexityScore: count > 0 ? Math.Round(group.Average(e => e.ComplexityScore), 3) : 0.0,
+                AvgLatencyMs: latency.Count > 0 ? (long?)Math.Round(latency.Average()) : null,
+                AvgInputTokens: input.Count > 0 ? (long?)Math.Round(input.Average()) : null,
+                AvgOutputTokens: output.Count > 0 ? (long?)Math.Round(output.Average()) : null,
+                AvgToolCalls: toolCalls.Count > 0 ? Math.Round(toolCalls.Average(), 2) : 0.0);
+        }).ToList();
+
+        return new TierRoutingGlobalStats(
+            ByTier: byTier,
+            UserMessageCount: entries.Count(e => e.Context == "user-message"),
+            SubagentCount: entries.Count(e => e.Context == "subagent"),
+            FallbackCount: fallbackCount,
+            FallbackPct: total > 0 ? Math.Round(fallbackCount * 100.0 / total, 1) : 0.0);
+    }
+
+    // ── Clustering ────────────────────────────────────────────────────────────
+
+    private static IReadOnlyList<TierRoutingCluster> BuildClusters(IReadOnlyList<TierRoutingEntry> entries)
+    {
+        return entries
+            .GroupBy(BuildSignature)
+            .Select(g =>
+            {
+                var list = g.ToList();
+                var first = list[0];
+                var toolCalls = list.Where(e => e.ToolCallCount.HasValue).Select(e => (double)e.ToolCallCount!.Value).ToList();
+                var input = list.Where(e => e.InputTokens.HasValue).Select(e => e.InputTokens!.Value).ToList();
+                var output = list.Where(e => e.OutputTokens.HasValue).Select(e => e.OutputTokens!.Value).ToList();
+                var postInj = list.Where(e => e.PostInjectionTokenEstimate.HasValue)
+                    .Select(e => e.PostInjectionTokenEstimate!.Value).ToList();
+
+                return new TierRoutingCluster(
+                    Signature: g.Key,
+                    Tier: first.Tier,
+                    Count: list.Count,
+                    SamplePrompt: first.PromptPreview,
+                    AvgComplexityScore: Math.Round(list.Average(e => e.ComplexityScore), 3),
+                    AvgToolCalls: toolCalls.Count > 0 ? Math.Round(toolCalls.Average(), 2) : 0.0,
+                    AvgInputTokens: input.Count > 0 ? (long?)Math.Round(input.Average()) : null,
+                    AvgOutputTokens: output.Count > 0 ? (long?)Math.Round(output.Average()) : null,
+                    AvgPostInjectionTokens: postInj.Count > 0 ? (int?)Math.Round(postInj.Average()) : null,
+                    FallbackCount: list.Count(e => e.IsFallbackTriggered),
+                    MatchedHighKeywords: first.MatchedHighKeywords,
+                    MatchedLowKeywords: first.MatchedLowKeywords);
+            })
+            .OrderByDescending(c => c.Count)
+            .ToList();
+    }
+
+    private static string BuildSignature(TierRoutingEntry e)
+    {
+        var bucket = ToolCallBucket(e.ToolCallCount);
+        if (e.MatchedHighKeywords.Count > 0 || e.MatchedLowKeywords.Count > 0)
+        {
+            var hi = string.Join(",", e.MatchedHighKeywords.Order(StringComparer.Ordinal));
+            var lo = string.Join(",", e.MatchedLowKeywords.Order(StringComparer.Ordinal));
+            return $"{e.Tier}|hi={hi};lo={lo}|{bucket}";
+        }
+        // Fallback: cluster by first 3 normalized words of the prompt preview.
+        // Better than dumping every keyword-less prompt into one giant cluster.
+        var words = NormalizeWords(e.PromptPreview).Take(3);
+        var prefix = string.Join(" ", words);
+        return $"{e.Tier}|prefix={prefix}|{bucket}";
+    }
+
+    private static string ToolCallBucket(int? count) => count switch
+    {
+        null or 0 => "tools0",
+        1 => "tools1",
+        <= 3 => "tools2-3",
+        <= 6 => "tools4-6",
+        _ => "tools7+"
+    };
+
+    // ── Flagging ──────────────────────────────────────────────────────────────
+
+    private static IReadOnlyList<TierRoutingFlaggedCluster> FlagClusters(
+        IReadOnlyList<TierRoutingCluster> clusters,
+        IReadOnlyList<LlmPricingRow>? pricing,
+        IReadOnlyDictionary<ModelTier, string?>? tierModelMap)
+    {
+        var flagged = new List<TierRoutingFlaggedCluster>();
+
+        foreach (var c in clusters)
+        {
+            if (c.Count < MinClusterSize) continue;
+
+            if (c.Tier == ModelTier.Low && c.AvgToolCalls >= PanicAvgToolCalls)
+            {
+                flagged.Add(BuildFlagged(c, "panicEscalation",
+                    $"Low tier averaging {c.AvgToolCalls:F1} tool calls across {c.Count} entries — model likely struggling.",
+                    ModelTier.Balanced, pricing, tierModelMap));
+                continue;
+            }
+
+            if (c.AvgComplexityScore < TokenSurpriseScoreMax
+                && c.AvgPostInjectionTokens is int p && p > TokenSurprisePostInjectionMin)
+            {
+                flagged.Add(BuildFlagged(c, "tokenSurprise",
+                    $"Score {c.AvgComplexityScore:F2} but post-injection tokens {p} — context inflation, not user complexity. Informational only.",
+                    alternateTier: null, pricing, tierModelMap));
+                continue;
+            }
+
+            if (c.Tier == ModelTier.High
+                && c.AvgOutputTokens is long o && o < LowOutputAtHighMaxOutputTokens)
+            {
+                flagged.Add(BuildFlagged(c, "lowOutputAtHigh",
+                    $"High tier producing only {o} avg output tokens across {c.Count} entries — possible over-routing.",
+                    ModelTier.Balanced, pricing, tierModelMap));
+            }
+        }
+
+        return flagged;
+    }
+
+    private static TierRoutingFlaggedCluster BuildFlagged(
+        TierRoutingCluster cluster, string flag, string rationale, ModelTier? alternateTier,
+        IReadOnlyList<LlmPricingRow>? pricing, IReadOnlyDictionary<ModelTier, string?>? tierModelMap)
+    {
+        decimal? currentCost = null;
+        decimal? alternateCost = null;
+        if (pricing is not null && tierModelMap is not null
+            && cluster.AvgInputTokens is long ai && cluster.AvgOutputTokens is long ao)
+        {
+            var perCallCurrent = TryPriceCall(tierModelMap.GetValueOrDefault(cluster.Tier), ai, ao, pricing);
+            currentCost = perCallCurrent * cluster.Count;
+            if (alternateTier is ModelTier alt)
+            {
+                var perCallAlt = TryPriceCall(tierModelMap.GetValueOrDefault(alt), ai, ao, pricing);
+                alternateCost = perCallAlt * cluster.Count;
+            }
+        }
+
+        return new TierRoutingFlaggedCluster(cluster, flag, rationale,
+            currentCost, alternateCost, alternateTier);
+    }
+
+    // ── Keyword candidates ────────────────────────────────────────────────────
+
+    private static TierRoutingKeywordCandidates BuildKeywordCandidates(IReadOnlyList<TierRoutingEntry> entries)
+    {
+        // Exclude any token that already triggers a routing signal — we want NEW candidates.
+        var alreadyMatched = new HashSet<string>(
+            entries.SelectMany(e => e.MatchedHighKeywords.Concat(e.MatchedLowKeywords))
+                   .Select(k => k.ToLowerInvariant()),
+            StringComparer.Ordinal);
+
+        var counts = new Dictionary<string, (int hi, int bal, int lo)>(StringComparer.Ordinal);
+
+        foreach (var e in entries)
+        {
+            foreach (var token in NormalizeWords(e.PromptPreview).Distinct(StringComparer.Ordinal))
+            {
+                if (token.Length < KeywordMinLength) continue;
+                if (alreadyMatched.Contains(token)) continue;
+
+                var current = counts.GetValueOrDefault(token);
+                counts[token] = e.Tier switch
+                {
+                    ModelTier.High => (current.hi + 1, current.bal, current.lo),
+                    ModelTier.Balanced => (current.hi, current.bal + 1, current.lo),
+                    _ => (current.hi, current.bal, current.lo + 1)
+                };
+            }
+        }
+
+        var highCandidates = new List<TierRoutingKeywordCandidate>();
+        var lowCandidates = new List<TierRoutingKeywordCandidate>();
+
+        foreach (var (token, (hi, bal, lo)) in counts)
+        {
+            var total = hi + bal + lo;
+            if (total < KeywordMinCount) continue;
+
+            var highDenom = Math.Max(1, bal + lo);
+            var highRatio = (double)hi / highDenom;
+            if (hi >= KeywordMinCount && highRatio >= KeywordMinFrequencyRatio)
+            {
+                highCandidates.Add(new TierRoutingKeywordCandidate(token, hi, bal, lo, Math.Round(highRatio, 2)));
+                continue;
+            }
+
+            var lowDenom = Math.Max(1, hi + bal);
+            var lowRatio = (double)lo / lowDenom;
+            if (lo >= KeywordMinCount && lowRatio >= KeywordMinFrequencyRatio)
+            {
+                lowCandidates.Add(new TierRoutingKeywordCandidate(token, hi, bal, lo, Math.Round(lowRatio, 2)));
+            }
+        }
+
+        return new TierRoutingKeywordCandidates(
+            HighSignalCandidates: highCandidates.OrderByDescending(c => c.FrequencyRatio).ToList(),
+            LowSignalCandidates: lowCandidates.OrderByDescending(c => c.FrequencyRatio).ToList());
+    }
+
+    private static IEnumerable<string> NormalizeWords(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text)) yield break;
+        var current = new System.Text.StringBuilder();
+        foreach (var ch in text)
+        {
+            if (char.IsLetter(ch))
+            {
+                current.Append(char.ToLowerInvariant(ch));
+            }
+            else if (current.Length > 0)
+            {
+                yield return current.ToString();
+                current.Clear();
+            }
+        }
+        if (current.Length > 0) yield return current.ToString();
+    }
+
+    // ── Threshold scans ───────────────────────────────────────────────────────
+
+    private static IReadOnlyList<TierRoutingThresholdScan> BuildThresholdScans(
+        IReadOnlyList<TierRoutingEntry> entries,
+        double lowCeiling, double balancedCeiling,
+        IReadOnlyList<LlmPricingRow>? pricing,
+        IReadOnlyDictionary<ModelTier, string?>? tierModelMap)
+    {
+        return new[]
+        {
+            BuildScan(entries, "lowCeiling", +ThresholdScanDelta, lowCeiling, balancedCeiling, pricing, tierModelMap),
+            BuildScan(entries, "lowCeiling", -ThresholdScanDelta, lowCeiling, balancedCeiling, pricing, tierModelMap),
+            BuildScan(entries, "balancedCeiling", +ThresholdScanDelta, lowCeiling, balancedCeiling, pricing, tierModelMap),
+            BuildScan(entries, "balancedCeiling", -ThresholdScanDelta, lowCeiling, balancedCeiling, pricing, tierModelMap)
+        };
+    }
+
+    private static TierRoutingThresholdScan BuildScan(
+        IReadOnlyList<TierRoutingEntry> entries,
+        string threshold, double delta,
+        double lowCeiling, double balancedCeiling,
+        IReadOnlyList<LlmPricingRow>? pricing,
+        IReadOnlyDictionary<ModelTier, string?>? tierModelMap)
+    {
+        var newLow = threshold == "lowCeiling" ? lowCeiling + delta : lowCeiling;
+        var newBal = threshold == "balancedCeiling" ? balancedCeiling + delta : balancedCeiling;
+        var flips = new List<(TierRoutingEntry e, ModelTier from, ModelTier to)>();
+
+        // Compare simulated(original) vs simulated(shifted) — both apply pure threshold
+        // logic, so the diff isolates the threshold shift's impact from selector guards
+        // (trivial guard, user-origin bias) that affected the recorded e.Tier.
+        foreach (var e in entries)
+        {
+            var simulatedOriginal = SimulateTier(e.ComplexityScore, lowCeiling, balancedCeiling);
+            var simulatedShifted = SimulateTier(e.ComplexityScore, newLow, newBal);
+            if (simulatedShifted != simulatedOriginal)
+                flips.Add((e, simulatedOriginal, simulatedShifted));
+        }
+
+        decimal? costDelta = null;
+        if (pricing is not null && tierModelMap is not null)
+        {
+            decimal accum = 0m;
+            var any = false;
+            foreach (var (e, from, to) in flips)
+            {
+                if (e.InputTokens is not long it || e.OutputTokens is not long ot) continue;
+                var fromCost = TryPriceCall(tierModelMap.GetValueOrDefault(from), it, ot, pricing);
+                var toCost = TryPriceCall(tierModelMap.GetValueOrDefault(to), it, ot, pricing);
+                if (fromCost is null || toCost is null) continue;
+                accum += toCost.Value - fromCost.Value;
+                any = true;
+            }
+            if (any) costDelta = accum;
+        }
+
+        var directions = flips.GroupBy(f => $"{f.from}->{f.to}")
+            .OrderByDescending(g => g.Count())
+            .Select(g => $"{g.Key} ({g.Count()})");
+
+        return new TierRoutingThresholdScan(
+            Threshold: threshold,
+            Delta: delta,
+            EntriesFlipped: flips.Count,
+            DirectionDescription: string.Join(", ", directions),
+            SamplePrompts: flips.Take(5).Select(f => f.e.PromptPreview).ToList(),
+            ProjectedCostDelta: costDelta);
+    }
+
+    private static ModelTier SimulateTier(double score, double lowCeiling, double balancedCeiling)
+    {
+        if (score <= lowCeiling) return ModelTier.Low;
+        if (score <= balancedCeiling) return ModelTier.Balanced;
+        return ModelTier.High;
+    }
+
+    // ── Projected cost ────────────────────────────────────────────────────────
+
+    private static TierRoutingProjectedCost BuildProjectedCost(
+        IReadOnlyList<TierRoutingEntry> entries, IReadOnlyList<LlmPricingRow>? pricing)
+    {
+        if (pricing is null || pricing.Count == 0)
+            return new TierRoutingProjectedCost(0m, [], 0, entries.Count);
+
+        decimal total = 0m;
+        var byTier = new Dictionary<ModelTier, decimal>();
+        var priced = 0;
+        var unpriced = 0;
+
+        foreach (var e in entries)
+        {
+            if (e.InputTokens is not long it || e.OutputTokens is not long ot)
+            {
+                unpriced++;
+                continue;
+            }
+            var cost = TryPriceCall(e.ModelId, it, ot, pricing);
+            if (cost is null)
+            {
+                unpriced++;
+                continue;
+            }
+            total += cost.Value;
+            byTier[e.Tier] = byTier.GetValueOrDefault(e.Tier) + cost.Value;
+            priced++;
+        }
+
+        var byTierList = byTier
+            .Select(kv => new TierRoutingTierCost(kv.Key, Math.Round(kv.Value, 4)))
+            .OrderBy(c => c.Tier)
+            .ToList();
+
+        return new TierRoutingProjectedCost(
+            TotalUsd: Math.Round(total, 4),
+            ByTier: byTierList,
+            EntriesPricedCount: priced,
+            EntriesUnpricedCount: unpriced);
+    }
+
+    private static decimal? TryPriceCall(string? modelId, long inputTokens, long outputTokens, IReadOnlyList<LlmPricingRow> pricing)
+    {
+        if (string.IsNullOrEmpty(modelId)) return null;
+        var row = pricing.FirstOrDefault(p => modelId.Contains(p.Prefix, StringComparison.OrdinalIgnoreCase));
+        if (row is null) return null;
+        return (inputTokens * row.InputPerM + outputTokens * row.OutputPerM) / 1_000_000m;
+    }
+}

--- a/src/RockBot.Host/DreamService.cs
+++ b/src/RockBot.Host/DreamService.cs
@@ -70,6 +70,7 @@ internal sealed class DreamService : IHostedService, IDisposable
     private string? _toolSuccessLearningDirective;
     private string? _contradictionSweepDirective;
     private string? _repairTicketCreationDirective;
+    private IReadOnlyList<LlmPricingRow>? _pricingRows;
 
     public DreamService(
         ILongTermMemory memory,
@@ -318,6 +319,29 @@ internal sealed class DreamService : IHostedService, IDisposable
                 _logger.LogDebug("DreamService: tier routing directive not found at {Path}; using built-in", tierRoutingDirectivePath);
             else
                 _logger.LogDebug("DreamService: loaded tier routing directive from {Path}", tierRoutingDirectivePath);
+
+            // Load the pricing table so the routing analyzer can compute USD cost.
+            // Optional — if the file is missing or malformed, the analyzer returns null
+            // cost fields and the LLM proceeds without that signal. Reloaded on every
+            // LoadDirectives call so operator edits to llm-pricing.json take effect at
+            // the next dream cycle without restarting the agent.
+            var pricingPath = ResolvePath("llm-pricing.json", _profileOptions.BasePath);
+            if (File.Exists(pricingPath))
+            {
+                try
+                {
+                    var pricingJson = File.ReadAllText(pricingPath);
+                    _pricingRows = JsonSerializer.Deserialize<List<LlmPricingRow>>(pricingJson, JsonOptions);
+                    if (initialLoad)
+                        _logger.LogInformation(
+                            "DreamService: loaded {Count} pricing rows from {Path}",
+                            _pricingRows?.Count ?? 0, pricingPath);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "DreamService: failed to parse pricing file {Path}; cost analysis will be skipped", pricingPath);
+                }
+            }
         }
 
         if (_options.SequenceSkillDetectionEnabled && _toolCallLog is not null && _skillStore is not null)
@@ -2442,44 +2466,46 @@ internal sealed class DreamService : IHostedService, IDisposable
             entries.Count);
 
         var configPath = ResolvePath("tier-selector.json", _profileOptions.BasePath);
-
-        var userMessage = new StringBuilder();
-        userMessage.AppendLine("Recent tier-routing decisions to review:");
-        userMessage.AppendLine();
-        foreach (var e in entries)
+        TierSelectorConfig? currentConfig = null;
+        if (File.Exists(configPath))
         {
-            userMessage.Append(
-                $"[{e.Timestamp:O}] tier={e.Tier} score={e.ComplexityScore:F3} context={e.Context}");
-
-            if (!string.IsNullOrEmpty(e.ModelId))
-                userMessage.Append($" model={e.ModelId}");
-            if (e.MatchedHighKeywords.Count > 0)
-                userMessage.Append($" highKeywords=[{string.Join(",", e.MatchedHighKeywords)}]");
-            if (e.MatchedLowKeywords.Count > 0)
-                userMessage.Append($" lowKeywords=[{string.Join(",", e.MatchedLowKeywords)}]");
-            if (e.PostInjectionTokenEstimate.HasValue)
-                userMessage.Append($" postInjectionTokens={e.PostInjectionTokenEstimate}");
-            if (e.InputTokens.HasValue)
-                userMessage.Append($" inputTokens={e.InputTokens}");
-            if (e.OutputTokens.HasValue)
-                userMessage.Append($" outputTokens={e.OutputTokens}");
-            if (e.LatencyMs.HasValue)
-                userMessage.Append($" latencyMs={e.LatencyMs}");
-            if (e.ToolCallCount.HasValue)
-                userMessage.Append($" toolCalls={e.ToolCallCount}");
-            if (e.ToolsUsed is { Count: > 0 })
-                userMessage.Append($" tools=[{string.Join(",", e.ToolsUsed)}]");
-            if (e.IsFallbackTriggered)
-                userMessage.Append(" fallback=true");
-
-            userMessage.AppendLine($" prompt=\"{e.PromptPreview}\"");
+            try
+            {
+                var configJson = await File.ReadAllTextAsync(configPath);
+                currentConfig = JsonSerializer.Deserialize<TierSelectorConfig>(configJson, JsonOptions);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "DreamService: failed to parse tier-selector.json at {Path}", configPath);
+            }
         }
 
-        if (File.Exists(configPath))
+        // Pre-aggregate the raw entries into a structured analysis so the LLM
+        // works against deterministic statistics instead of recomputing them.
+        // This decouples prompt size from entry count — N entries collapse to ~M clusters.
+        var analysis = TierRoutingAnalyzer.Analyze(entries, currentConfig, _pricingRows);
+
+        var analysisJson = JsonSerializer.Serialize(analysis, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = true,
+            Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+        });
+
+        var userMessage = new StringBuilder();
+        userMessage.AppendLine("Pre-aggregated tier-routing analysis for review:");
+        userMessage.AppendLine();
+        userMessage.AppendLine(analysisJson);
+
+        if (currentConfig is not null)
         {
             userMessage.AppendLine();
             userMessage.AppendLine("Current tier-selector.json:");
-            userMessage.AppendLine(await File.ReadAllTextAsync(configPath));
+            userMessage.AppendLine(JsonSerializer.Serialize(currentConfig, new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                WriteIndented = true
+            }));
         }
 
         var result = await InvokeDreamPassAsync<TierRoutingReviewResultDto>(
@@ -4158,30 +4184,48 @@ internal sealed class DreamService : IHostedService, IDisposable
 
     private const string BuiltInTierRoutingDirective = """
         You are a tier-routing self-correction assistant for an LLM agent framework.
-        Review the routing decisions and telemetry provided. Each entry includes:
-        - tier: the selected model tier (Low / Balanced / High)
-        - score: the pre-injection complexity score [0,1] that drove the decision
-        - highKeywords / lowKeywords: signals matched in the raw user prompt (Option A classification)
-        - postInjectionTokens: estimated tokens after memory recall and tool guide injection
-        - inputTokens / outputTokens: actual LLM token usage
-        - toolCalls / tools: how many tool calls fired and which tools
-        - latencyMs: request latency
-        - fallback=true: model fallback was triggered by quota/API error — exclude from quality signals
-        - prompt: first 150 chars of the user prompt
+        The user message is a pre-aggregated JSON analysis (schemaVersion: 1) — NOT a stream
+        of raw routing entries. The analyzer has already done all the statistical heavy lifting;
+        your job is judgment.
 
-        Detection patterns to look for:
-        1. PANIC ESCALATION: A Low-tier session triggered many tool calls (toolCalls ≥ 3) — the model
-           likely struggled. Prompts of that shape should be routed Balanced.
-        2. TOKEN SURPRISE: postInjectionTokens >> complexity score (e.g., score < 0.20 but
-           postInjectionTokens > 2000). The pre-injection classification systematically underestimated
-           the actual context cost. Adjust thresholds or add keywords for that prompt shape.
-        3. CAPABILITY FINGERPRINTS: Recurring prompt shapes consistently mis-routed. Identify
-           keywords in those prompts that should be added to highSignalKeywords or lowSignalKeywords.
-        4. COST-AWARE CORRECTION: If a class of prompts routed Low produces many tool calls and high
-           token usage, routing them to Balanced upfront is more efficient.
+        Refuse to proceed if schemaVersion != 1.
 
-        IMPORTANT: Exclude sessions with fallback=true from all quality-signal reasoning — those
-        represent infrastructure errors, not genuine routing quality failures.
+        The analysis JSON contains:
+        - globalStats: per-tier counts, percentages, avg latency/tokens, fallback rate
+        - clusters: groups of similar routing decisions (same keyword signature + tier + tool-call bucket)
+        - flaggedClusters: clusters that tripped a deterministic detection rule
+          (panicEscalation | tokenSurprise | lowOutputAtHigh), each with a rationale and
+          projected cost at the current and alternate tier when pricing is available
+        - keywordCandidates: words appearing disproportionately in High- or Low-tier prompts
+          (frequencyRatio ≥ 3, count ≥ 5), already filtered to exclude words that are
+          currently matched keywords
+        - thresholdScans: "what if" projections showing how many entries would flip tier if
+          lowCeiling or balancedCeiling moved by ±0.05, with projected USD cost delta
+        - projectedCost: total USD spend across the window plus a per-tier breakdown
+        - fallbackExcludedCount: fallback-triggered entries are already excluded from
+          clusters/flagged/candidates — you don't need to filter them yourself
+
+        Your three jobs:
+
+        1. VALIDATE flagged clusters. For each flagged cluster, decide:
+           - Is this a true misroute, or noise? (samplePrompt + count + rationale guide this.)
+           - If true, the alternateTier field suggests the corrective direction.
+
+        2. FILTER keyword candidates. The analyzer surfaces statistical candidates; you apply
+           the cognitive-complexity-vs-topic rule. Apply this test BEFORE accepting any candidate:
+           "Would a prompt containing ONLY this word and a simple verb be complex?"
+           If "check my [keyword]" or "list the [keyword]" would be simple, the word is a TOPIC
+           indicator (calendar, email, todo, schedule, flight) and MUST NOT be added — topic
+           keyword pollution is the #1 cause of over-routing to High tier.
+           Good high-signal keywords describe REASONING DIFFICULTY: analyze, architect, trade-off,
+           compare and contrast, threat model, prove, optimize.
+
+        3. PICK threshold shifts from thresholdScans, if any. The scan tells you exactly how
+           many entries would flip and the projected cost delta. Apply a shift only when:
+           - At least ~5 entries would flip in the desired direction
+           - The cost delta is favorable (or you have an explicit quality reason)
+           Adjustments must be small (±0.05). Bounds: lowCeiling in [0.05, 0.30],
+           balancedCeiling in [lowCeiling+0.10, 0.70].
 
         Return ONLY a JSON object in this exact format:
         {

--- a/tests/RockBot.Host.Tests/TierRoutingAnalyzerTests.cs
+++ b/tests/RockBot.Host.Tests/TierRoutingAnalyzerTests.cs
@@ -1,0 +1,331 @@
+using RockBot.Host;
+
+namespace RockBot.Host.Tests;
+
+[TestClass]
+public class TierRoutingAnalyzerTests
+{
+    private static readonly DateTimeOffset BaseTime = new(2026, 5, 22, 10, 0, 0, TimeSpan.Zero);
+
+    private static TierRoutingEntry MakeEntry(
+        ModelTier tier = ModelTier.Balanced,
+        double score = 0.30,
+        int? toolCalls = 1,
+        long? inputTokens = 1000,
+        long? outputTokens = 500,
+        int? postInjectionTokens = 5000,
+        string promptPreview = "do a thing",
+        string[]? highKeywords = null,
+        string[]? lowKeywords = null,
+        bool fallback = false,
+        string context = "user-message",
+        string? modelId = "claude-sonnet-4-6",
+        int timestampOffsetMinutes = 0)
+    {
+        return new TierRoutingEntry
+        {
+            Timestamp = BaseTime.AddMinutes(timestampOffsetMinutes),
+            PromptPreview = promptPreview,
+            Tier = tier,
+            Context = context,
+            ComplexityScore = score,
+            MatchedHighKeywords = highKeywords ?? [],
+            MatchedLowKeywords = lowKeywords ?? [],
+            PostInjectionTokenEstimate = postInjectionTokens,
+            ModelId = modelId,
+            InputTokens = inputTokens,
+            OutputTokens = outputTokens,
+            ToolCallCount = toolCalls,
+            IsFallbackTriggered = fallback,
+        };
+    }
+
+    // ── Empty / minimal input ──────────────────────────────────────────────────
+
+    [TestMethod]
+    public void Analyze_EmptyEntries_ReturnsZeroedAnalysis()
+    {
+        var result = TierRoutingAnalyzer.Analyze([]);
+        Assert.AreEqual(0, result.TotalEntries);
+        Assert.AreEqual(0, result.Clusters.Count);
+        Assert.AreEqual(0, result.FlaggedClusters.Count);
+        Assert.AreEqual(0, result.ThresholdScans.Count);
+        Assert.AreEqual(TierRoutingAnalyzer.CurrentSchemaVersion, result.SchemaVersion);
+    }
+
+    // ── Detection rules ────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void Analyze_LowTierWithManyToolCalls_FlagsPanicEscalation()
+    {
+        var entries = Enumerable.Range(0, 4)
+            .Select(_ => MakeEntry(tier: ModelTier.Low, toolCalls: 4, promptPreview: "fix the bug"))
+            .ToList();
+
+        var result = TierRoutingAnalyzer.Analyze(entries);
+        Assert.AreEqual(1, result.FlaggedClusters.Count);
+        Assert.AreEqual("panicEscalation", result.FlaggedClusters[0].Flag);
+        Assert.AreEqual(ModelTier.Balanced, result.FlaggedClusters[0].AlternateTier);
+    }
+
+    [TestMethod]
+    public void Analyze_LowToolCallCount_DoesNotFlagPanic()
+    {
+        var entries = Enumerable.Range(0, 5)
+            .Select(_ => MakeEntry(tier: ModelTier.Low, toolCalls: 1))
+            .ToList();
+
+        var result = TierRoutingAnalyzer.Analyze(entries);
+        Assert.AreEqual(0, result.FlaggedClusters.Count);
+    }
+
+    [TestMethod]
+    public void Analyze_SmallCluster_DoesNotFlagEvenWithMatchingPattern()
+    {
+        // Only 2 entries — below MinClusterSize=3; should not flag.
+        var entries = Enumerable.Range(0, 2)
+            .Select(_ => MakeEntry(tier: ModelTier.Low, toolCalls: 5))
+            .ToList();
+
+        var result = TierRoutingAnalyzer.Analyze(entries);
+        Assert.AreEqual(0, result.FlaggedClusters.Count);
+    }
+
+    [TestMethod]
+    public void Analyze_LowScoreHighPostInjection_FlagsTokenSurprise()
+    {
+        var entries = Enumerable.Range(0, 3)
+            .Select(_ => MakeEntry(score: 0.10, postInjectionTokens: 15000, promptPreview: "what time is it"))
+            .ToList();
+
+        var result = TierRoutingAnalyzer.Analyze(entries);
+        Assert.AreEqual(1, result.FlaggedClusters.Count);
+        Assert.AreEqual("tokenSurprise", result.FlaggedClusters[0].Flag);
+        Assert.IsNull(result.FlaggedClusters[0].AlternateTier);
+    }
+
+    [TestMethod]
+    public void Analyze_HighTierLowOutput_FlagsOverRouting()
+    {
+        var entries = Enumerable.Range(0, 3)
+            .Select(_ => MakeEntry(
+                tier: ModelTier.High, score: 0.80, toolCalls: 1,
+                outputTokens: 50, promptPreview: "analyze this complex topic"))
+            .ToList();
+
+        var result = TierRoutingAnalyzer.Analyze(entries);
+        Assert.AreEqual(1, result.FlaggedClusters.Count);
+        Assert.AreEqual("lowOutputAtHigh", result.FlaggedClusters[0].Flag);
+        Assert.AreEqual(ModelTier.Balanced, result.FlaggedClusters[0].AlternateTier);
+    }
+
+    [TestMethod]
+    public void Analyze_FallbackEntries_ExcludedFromFlagging()
+    {
+        // Fallback entries should NOT contribute to flagged-cluster detection,
+        // but DO appear in global stats and FallbackExcludedCount.
+        var entries = Enumerable.Range(0, 5)
+            .Select(_ => MakeEntry(tier: ModelTier.Low, toolCalls: 5, fallback: true))
+            .ToList();
+
+        var result = TierRoutingAnalyzer.Analyze(entries);
+        Assert.AreEqual(5, result.TotalEntries);
+        Assert.AreEqual(5, result.FallbackExcludedCount);
+        Assert.AreEqual(0, result.FlaggedClusters.Count);
+    }
+
+    // ── Clustering ─────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void BuildClusters_SameKeywordsAndTier_GroupTogether()
+    {
+        var entries = new[]
+        {
+            MakeEntry(highKeywords: ["analyze"], toolCalls: 1),
+            MakeEntry(highKeywords: ["analyze"], toolCalls: 1, promptPreview: "different prompt text"),
+            MakeEntry(highKeywords: ["compare"], toolCalls: 1),
+        };
+
+        var result = TierRoutingAnalyzer.Analyze(entries);
+        // Two clusters: {"analyze"} count=2, {"compare"} count=1
+        Assert.AreEqual(2, result.Clusters.Count);
+        Assert.AreEqual(2, result.Clusters[0].Count);  // ordered by count desc
+        Assert.AreEqual(1, result.Clusters[1].Count);
+    }
+
+    [TestMethod]
+    public void BuildClusters_NoKeywords_UsesFirstThreeWordsFallback()
+    {
+        // No matched keywords — clustering must fall back to first 3 words to avoid
+        // a giant catch-all bucket.
+        var entries = new[]
+        {
+            MakeEntry(promptPreview: "check my calendar today please"),
+            MakeEntry(promptPreview: "check my calendar tomorrow if free"),
+            MakeEntry(promptPreview: "send an email to bob"),
+        };
+
+        var result = TierRoutingAnalyzer.Analyze(entries);
+        // First two share "check my calendar" prefix → 1 cluster; third → separate
+        Assert.AreEqual(2, result.Clusters.Count);
+        Assert.AreEqual(2, result.Clusters[0].Count);
+    }
+
+    [TestMethod]
+    public void BuildClusters_DifferentToolCallBuckets_StaySeparate()
+    {
+        var entries = new[]
+        {
+            MakeEntry(highKeywords: ["analyze"], toolCalls: 0),
+            MakeEntry(highKeywords: ["analyze"], toolCalls: 4),
+        };
+
+        var result = TierRoutingAnalyzer.Analyze(entries);
+        Assert.AreEqual(2, result.Clusters.Count);
+    }
+
+    // ── Keyword candidates ─────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void BuildKeywordCandidates_HighTierBiasedWord_SurfacesAsHighSignal()
+    {
+        var entries = new List<TierRoutingEntry>();
+        // 6 High-tier prompts containing "refactor", 1 Low-tier prompt containing "refactor"
+        for (var i = 0; i < 6; i++)
+            entries.Add(MakeEntry(tier: ModelTier.High, score: 0.80, promptPreview: "please refactor this module"));
+        entries.Add(MakeEntry(tier: ModelTier.Low, score: 0.10, promptPreview: "what time refactor"));
+
+        var result = TierRoutingAnalyzer.Analyze(entries);
+
+        var refactor = result.KeywordCandidates.HighSignalCandidates
+            .FirstOrDefault(c => c.Keyword == "refactor");
+        Assert.IsNotNull(refactor);
+        Assert.AreEqual(6, refactor.HighTierCount);
+    }
+
+    [TestMethod]
+    public void BuildKeywordCandidates_AlreadyMatchedKeyword_Excluded()
+    {
+        // If a word already shows up in MatchedHighKeywords, it should not be re-surfaced
+        // as a candidate (we want NEW candidates, not the ones already in use).
+        var entries = Enumerable.Range(0, 6)
+            .Select(_ => MakeEntry(
+                tier: ModelTier.High, score: 0.80,
+                promptPreview: "please analyze this complex topic",
+                highKeywords: ["analyze"]))
+            .ToList();
+
+        var result = TierRoutingAnalyzer.Analyze(entries);
+        var analyzeCandidate = result.KeywordCandidates.HighSignalCandidates
+            .FirstOrDefault(c => c.Keyword == "analyze");
+        Assert.IsNull(analyzeCandidate, "'analyze' is already a matched keyword; should not be re-surfaced");
+    }
+
+    // ── Threshold scans ────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void BuildThresholdScans_ShiftFlipsEntriesNearBoundary()
+    {
+        // With defaults: lowCeiling=0.15, balancedCeiling=0.46.
+        // An entry with score 0.18 simulates Balanced at original, Low at lowCeiling+0.05 (=0.20).
+        var entries = new[]
+        {
+            MakeEntry(tier: ModelTier.Balanced, score: 0.18),
+            MakeEntry(tier: ModelTier.Balanced, score: 0.19),
+            MakeEntry(tier: ModelTier.Low, score: 0.10),  // unaffected
+        };
+
+        var result = TierRoutingAnalyzer.Analyze(entries);
+        var lowCeilingUp = result.ThresholdScans.First(s => s.Threshold == "lowCeiling" && s.Delta > 0);
+        Assert.AreEqual(2, lowCeilingUp.EntriesFlipped);
+        StringAssert.Contains(lowCeilingUp.DirectionDescription, "Balanced->Low");
+    }
+
+    [TestMethod]
+    public void BuildThresholdScans_NoCostDelta_WhenPricingMissing()
+    {
+        var entries = new[]
+        {
+            MakeEntry(tier: ModelTier.Balanced, score: 0.18),
+        };
+
+        var result = TierRoutingAnalyzer.Analyze(entries);
+        Assert.IsTrue(result.ThresholdScans.All(s => s.ProjectedCostDelta is null));
+    }
+
+    // ── Projected cost ─────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void ProjectedCost_WithPricingAndModelId_ComputesPerCall()
+    {
+        var pricing = new[]
+        {
+            new LlmPricingRow("claude-sonnet-4", 3.00m, 15.00m),
+        };
+
+        var entries = new[]
+        {
+            MakeEntry(inputTokens: 1_000_000, outputTokens: 100_000, modelId: "claude-sonnet-4-6"),
+        };
+
+        var result = TierRoutingAnalyzer.Analyze(entries, pricing: pricing);
+        // 1M input × $3/M + 100k output × $15/M = $3.00 + $1.50 = $4.50
+        Assert.AreEqual(4.50m, result.ProjectedCost.TotalUsd);
+        Assert.AreEqual(1, result.ProjectedCost.EntriesPricedCount);
+        Assert.AreEqual(0, result.ProjectedCost.EntriesUnpricedCount);
+    }
+
+    [TestMethod]
+    public void ProjectedCost_UnknownModelId_CountsAsUnpriced()
+    {
+        var pricing = new[]
+        {
+            new LlmPricingRow("claude-sonnet-4", 3.00m, 15.00m),
+        };
+
+        var entries = new[]
+        {
+            MakeEntry(inputTokens: 1000, outputTokens: 500, modelId: "totally-unknown-model"),
+            MakeEntry(inputTokens: 1000, outputTokens: 500, modelId: null),
+        };
+
+        var result = TierRoutingAnalyzer.Analyze(entries, pricing: pricing);
+        Assert.AreEqual(0m, result.ProjectedCost.TotalUsd);
+        Assert.AreEqual(0, result.ProjectedCost.EntriesPricedCount);
+        Assert.AreEqual(2, result.ProjectedCost.EntriesUnpricedCount);
+    }
+
+    // ── Global stats ───────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void GlobalStats_TierPercentages_SumToHundred()
+    {
+        var entries = new[]
+        {
+            MakeEntry(tier: ModelTier.Low),
+            MakeEntry(tier: ModelTier.Balanced),
+            MakeEntry(tier: ModelTier.Balanced),
+            MakeEntry(tier: ModelTier.High),
+        };
+
+        var result = TierRoutingAnalyzer.Analyze(entries);
+        var sum = result.GlobalStats.ByTier.Sum(t => t.Pct);
+        Assert.AreEqual(100.0, sum, 0.1);
+    }
+
+    [TestMethod]
+    public void GlobalStats_FallbackPctIncludesAllEntries()
+    {
+        var entries = new[]
+        {
+            MakeEntry(fallback: true),
+            MakeEntry(fallback: true),
+            MakeEntry(fallback: false),
+            MakeEntry(fallback: false),
+        };
+
+        var result = TierRoutingAnalyzer.Analyze(entries);
+        Assert.AreEqual(50.0, result.GlobalStats.FallbackPct);
+        Assert.AreEqual(2, result.GlobalStats.FallbackCount);
+    }
+}

--- a/tests/RockBot.Host.Tests/TierRoutingAnalyzerTests.cs
+++ b/tests/RockBot.Host.Tests/TierRoutingAnalyzerTests.cs
@@ -242,6 +242,25 @@ public class TierRoutingAnalyzerTests
     }
 
     [TestMethod]
+    public void BuildThresholdScans_AtExactBoundary_NoFloatingPointFlips()
+    {
+        // Regression: 0.15 - 0.05 yields 0.09999999999999998 as a double, which made
+        // entries with score 0.10 falsely appear to flip when lowCeiling shifted by -0.05.
+        // After rounding the shifted threshold to 4 decimals, score 0.10 entries should
+        // remain Low (0.10 <= 0.10) and only entries strictly above the new ceiling flip.
+        var entries = new[]
+        {
+            MakeEntry(tier: ModelTier.Low, score: 0.10),  // at the new boundary — should NOT flip
+            MakeEntry(tier: ModelTier.Low, score: 0.10),  // at the new boundary — should NOT flip
+            MakeEntry(tier: ModelTier.Low, score: 0.11),  // above the new boundary — should flip
+        };
+
+        var result = TierRoutingAnalyzer.Analyze(entries);
+        var lowCeilingDown = result.ThresholdScans.First(s => s.Threshold == "lowCeiling" && s.Delta < 0);
+        Assert.AreEqual(1, lowCeilingDown.EntriesFlipped, "Only the score=0.11 entry should flip after rounding the shifted threshold");
+    }
+
+    [TestMethod]
     public void BuildThresholdScans_NoCostDelta_WhenPricingMissing()
     {
         var entries = new[]


### PR DESCRIPTION
## Summary

Adds a pure-logic `TierRoutingAnalyzer` in `Host.Abstractions` that clusters routing entries, applies the deterministic detection rules (`panicEscalation`, `tokenSurprise`, `lowOutputAtHigh`), computes keyword candidates by frequency ratio, runs threshold "what if" scans, and projects USD cost from the pricing table. `DreamService` now serializes the analysis as JSON instead of dumping 200 raw entry lines into the prompt.

**Decouples the routing-review prompt size from entry count** — the same ~20 clusters compress whether the window holds 200 or 1500 entries, so PR 4's cap bump will not inflate LLM cost. Estimated drop from ~7,500 to ~2,000 prompt tokens at current volume.

`routing-dream.md` and `BuiltInTierRoutingDirective` are rewritten for the new `schemaVersion: 1` input format; the LLM's job collapses to validating flagged clusters, filtering keyword candidates against the cognitive-complexity rule, and picking threshold shifts from the pre-computed scans. Output DTO (`TierRoutingReviewResultDto`) is unchanged so downstream save logic is untouched.

Includes a follow-up commit that fixes a floating-point edge in `BuildScan` — bare double subtraction yields `0.15 - 0.05 = 0.09999999999999998`, which made boundary entries falsely appear to flip. `Math.Round(_, 4)` on the shifted ceiling restores the user-meant semantics. Found during local docker validation, regression-tested.

## Base branch

This PR is **based on `feat/tier-routing-entry-modelid`** (the previous PR in the stack). Merge that one first.

## Test plan
- [x] 19 analyzer unit tests covering each detection rule, the keyword-set vs first-3-words clustering fallback, candidate filtering, threshold scan math, FP boundary regression, and cost projection with unknown/null model IDs
- [x] End-to-end validated via docker compose — synthetic 7-entry log produced the expected clusters/flags/scans
- [x] `dotnet build RockBot.slnx` clean; Host tests 1006/1006

🤖 Generated with [Claude Code](https://claude.com/claude-code)