### PR TITLE
TierRoutingLogger: configurable retention cap (default 1500)

### DIFF
--- a/deploy/helm/rockbot/templates/configmap.yaml
+++ b/deploy/helm/rockbot/templates/configmap.yaml
@@ -26,6 +26,7 @@ data:
 
   # ── Agent data paths (all under the PVC mount at /data/agent) ─────────────
   AgentProfile__BasePath: "/data/agent"
+  AgentProfile__TierRoutingLogMaxEntries: {{ .Values.agent.tierRoutingLogMaxEntries | default 1500 | quote }}
   Memory__BasePath: "/data/agent/memory"
   Skill__BasePath: "/data/agent/skills"
   McpBridge__ConfigPath: "/data/agent/mcp.json"

--- a/deploy/helm/rockbot/values.yaml
+++ b/deploy/helm/rockbot/values.yaml
@@ -15,6 +15,11 @@ agent:
   # e.g. "America/Chicago", "Europe/London", "Asia/Tokyo"
   # Defaults to UTC (the k8s node timezone) if unset.
   timezone: "America/Chicago"
+  # Retention cap for tier-routing-log.jsonl (the routing-decision telemetry log
+  # consumed by the dream self-correction pass and the introspection MCP server's
+  # get_routing_summary tool). Once the cap is reached the logger trims the oldest
+  # entries on every append. ~500 bytes per entry, so 1500 ≈ 750 KB on disk.
+  tierRoutingLogMaxEntries: 1500
   resources:
     requests:
       cpu: 500m

--- a/src/RockBot.Host.Abstractions/AgentProfileOptions.cs
+++ b/src/RockBot.Host.Abstractions/AgentProfileOptions.cs
@@ -75,4 +75,13 @@ public sealed class AgentProfileOptions
     /// Defaults to <c>"agent-name.md"</c>.
     /// </summary>
     public string AgentNamePath { get; set; } = "agent-name.md";
+
+    /// <summary>
+    /// Maximum number of entries retained in <c>tier-routing-log.jsonl</c>. The logger trims
+    /// the oldest entries on append once this cap is reached. Defaults to 1500 (~3 busy days
+    /// of history at typical volume); raised from the previous hardcoded 200 now that the
+    /// routing-review dream pass consumes a pre-aggregated digest whose prompt cost is
+    /// independent of entry count.
+    /// </summary>
+    public int TierRoutingLogMaxEntries { get; set; } = 1500;
 }

--- a/src/RockBot.Host/DreamService.cs
+++ b/src/RockBot.Host/DreamService.cs
@@ -2452,6 +2452,10 @@ internal sealed class DreamService : IHostedService, IDisposable
         if (_tierRoutingLogger is null || !_options.TierRoutingReviewEnabled)
             return;
 
+        // Pinned at 200 even though the cap is now configurable (default 1500). The analyzer's
+        // prompt cost is independent of entry count, so we could read more — but more entries
+        // also mean more file-IO and more cluster permutations, and 200 has been shown to
+        // surface every detection rule reliably. Bump if needed; do not silently widen.
         var entries = await _tierRoutingLogger.ReadRecentAsync(200);
         if (entries.Count < 10)
         {

--- a/src/RockBot.Host/TierRoutingLogger.cs
+++ b/src/RockBot.Host/TierRoutingLogger.cs
@@ -7,7 +7,9 @@ namespace RockBot.Host;
 
 /// <summary>
 /// Singleton. Appends tier-routing decisions to <c>{BasePath}/tier-routing-log.jsonl</c>
-/// (capped at 200 entries) and reads them back for the dream self-correction pass.
+/// and reads them back for the dream self-correction pass and the introspection MCP server.
+/// The retention cap is controlled by <see cref="AgentProfileOptions.TierRoutingLogMaxEntries"/>
+/// (default 1500); on append the oldest entries are trimmed once the cap is reached.
 /// </summary>
 public sealed class TierRoutingLogger
 {
@@ -20,6 +22,7 @@ public sealed class TierRoutingLogger
     };
 
     private readonly string _filePath;
+    private readonly int _maxEntries;
     private readonly SemaphoreSlim _writeLock = new(1, 1);
     private readonly ILogger<TierRoutingLogger> _logger;
 
@@ -32,12 +35,13 @@ public sealed class TierRoutingLogger
             basePath = Path.Combine(AppContext.BaseDirectory, basePath);
 
         _filePath = Path.Combine(basePath, "tier-routing-log.jsonl");
+        _maxEntries = Math.Max(1, profileOptions.Value.TierRoutingLogMaxEntries);
         _logger = logger;
     }
 
     /// <summary>
-    /// Appends a routing entry. Keeps at most 200 lines total (oldest evicted).
-    /// Fire-and-forget safe: exceptions are caught and logged.
+    /// Appends a routing entry. Keeps at most <see cref="AgentProfileOptions.TierRoutingLogMaxEntries"/>
+    /// lines total (oldest evicted). Fire-and-forget safe: exceptions are caught and logged.
     /// </summary>
     public async Task AppendAsync(TierRoutingEntry entry)
     {
@@ -57,9 +61,10 @@ public sealed class TierRoutingLogger
                 existingLines = existingLines.Where(l => !string.IsNullOrWhiteSpace(l)).ToArray();
             }
 
-            // Keep last 199 non-empty lines + append new line = max 200 total
-            var linesToKeep = existingLines.Length >= 199
-                ? existingLines[^199..]
+            // Keep last (maxEntries - 1) non-empty lines + append new line = at most maxEntries total
+            var keepCount = _maxEntries - 1;
+            var linesToKeep = existingLines.Length > keepCount
+                ? existingLines[^keepCount..]
                 : existingLines;
 
             var allLines = linesToKeep.Append(newLine);

--- a/tests/RockBot.Host.Tests/TierRoutingLoggerTests.cs
+++ b/tests/RockBot.Host.Tests/TierRoutingLoggerTests.cs
@@ -7,12 +7,14 @@ namespace RockBot.Host.Tests;
 [TestClass]
 public class TierRoutingLoggerTests
 {
-    private static (TierRoutingLogger logger, string dir) CreateLogger()
+    private static (TierRoutingLogger logger, string dir) CreateLogger(int? maxEntries = null)
     {
         var dir = Path.Combine(Path.GetTempPath(), "rb-routing-" + Path.GetRandomFileName());
         Directory.CreateDirectory(dir);
+        var options = new AgentProfileOptions { BasePath = dir };
+        if (maxEntries.HasValue) options.TierRoutingLogMaxEntries = maxEntries.Value;
         var logger = new TierRoutingLogger(
-            Options.Create(new AgentProfileOptions { BasePath = dir }),
+            Options.Create(options),
             NullLogger<TierRoutingLogger>.Instance);
         return (logger, dir);
     }
@@ -62,6 +64,36 @@ public class TierRoutingLoggerTests
             var entries = await logger.ReadRecentAsync();
             Assert.AreEqual(1, entries.Count);
             Assert.IsNull(entries[0].ModelId);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public async Task AppendAsync_RespectsConfigurableCap_EvictsOldestEntries()
+    {
+        // With max=5, writing 7 entries should leave only the most recent 5.
+        var (logger, dir) = CreateLogger(maxEntries: 5);
+        try
+        {
+            for (var i = 0; i < 7; i++)
+            {
+                await logger.AppendAsync(new TierRoutingEntry
+                {
+                    Timestamp = DateTimeOffset.UtcNow.AddSeconds(i),
+                    PromptPreview = $"entry-{i}",
+                    Tier = ModelTier.Balanced,
+                    Context = "user-message",
+                    ComplexityScore = 0.30,
+                });
+            }
+
+            var entries = await logger.ReadRecentAsync(maxResults: 100);
+            Assert.AreEqual(5, entries.Count, "Cap should have evicted the oldest entries");
+            Assert.AreEqual("entry-2", entries[0].PromptPreview);
+            Assert.AreEqual("entry-6", entries[^1].PromptPreview);
         }
         finally
         {


### PR DESCRIPTION
## Summary

Lifts the long-hardcoded 200-entry cap on `tier-routing-log.jsonl`. The analyzer's prompt cost is now independent of entry count (PR 2), so holding more history costs the dream pass nothing while letting the introspection MCP server's `get_routing_summary` work over a meaningful 24-hour window without truncation.

- `AgentProfileOptions.TierRoutingLogMaxEntries` (default 1500, clamped to ≥1). At ~500 bytes per entry this is roughly 750 KB on disk — trivial on the agent PVC.
- `TierRoutingLogger` reads the option and uses (maxEntries - 1) as the trim point on every append, so file size stays bounded.
- `DreamService` keeps its explicit `ReadRecentAsync(200)` call with an inline comment explaining why we don't silently widen the dream prompt to match the cap — defense in depth, not a real prompt-cost concern after PR 2.
- **Helm:** new `agent.tierRoutingLogMaxEntries` value plumbed through to `AgentProfile__TierRoutingLogMaxEntries` in the configmap, so deploys can tune the cap without a code change.

## Base branch

This PR is **based on `feat/consolidate-introspection-mcp`** (the previous PR in the stack). Merge that one first.

## Known follow-up

`TierRoutingLogger` rewrites the entire file on every append under a semaphore. At 1500 entries this is still sub-millisecond on the typical PVC, but if append latency ever shows up in metrics, switching to append-with-periodic-rotation is the straightforward fix. Out of scope here.

## Test plan
- [x] One new unit test exercises the cap at a non-default value (set max=5, write 7 entries, assert only the most recent 5 remain with the right ordering)
- [x] `dotnet build RockBot.slnx` clean; Host tests 1006/1006

🤖 Generated with [Claude Code](https://claude.com/claude-code)