### PR TITLE
WorkIQ MCP auth: bridge bearer-injection + MSAL plumbing (Phase 1+2 of #441)

### DIFF
--- a/deploy/helm/rockbot/templates/agent/deployment.yaml
+++ b/deploy/helm/rockbot/templates/agent/deployment.yaml
@@ -95,6 +95,12 @@ spec:
               # Runtime directories
               mkdir -p /data/agent/memory /data/agent/skills
 
+              # Secrets directory (workiq token cache and any future per-user
+              # credential material). Mode 0700 keeps it private to the rockbot
+              # user even though the PVC is single-tenant.
+              mkdir -p /data/agent/secrets
+              chmod 700 /data/agent/secrets
+
               # Hand ownership to the rockbot user so the main container (non-root)
               # can read and write the volume. The user exists in the image.
               chown -R rockbot:rockbot /data/agent

--- a/deploy/helm/rockbot/templates/configmap.yaml
+++ b/deploy/helm/rockbot/templates/configmap.yaml
@@ -51,6 +51,21 @@ data:
   {{- end }}
   ModelBehaviors__BasePath: "/data/agent/model-behaviors"
 
+  {{- if .Values.workiq.enabled }}
+  # ── Microsoft Work IQ auth (MSAL) ──────────────────────────────────────────
+  # When set, the agent registers the "workiq" token provider profile so
+  # mcp.json entries with auth.profile=workiq receive a bearer token on every
+  # request. Cache lives at /data/agent/secrets/workiq-cache.bin.
+  WorkIQ__TenantId: {{ required "workiq.tenantId is required when workiq.enabled=true" .Values.workiq.tenantId | quote }}
+  WorkIQ__ClientId: {{ required "workiq.clientId is required when workiq.enabled=true" .Values.workiq.clientId | quote }}
+  {{- if .Values.workiq.scopes }}
+  WorkIQ__Scopes: {{ join "," .Values.workiq.scopes | quote }}
+  {{- end }}
+  {{- if .Values.workiq.authority }}
+  WorkIQ__Authority: {{ .Values.workiq.authority | quote }}
+  {{- end }}
+  {{- end }}
+
   # ── Runtime ───────────────────────────────────────────────────────────────
   DOTNET_ENVIRONMENT: "Production"
 

--- a/deploy/helm/rockbot/values.yaml
+++ b/deploy/helm/rockbot/values.yaml
@@ -93,6 +93,24 @@ storage:
   # Holds soul.md, directives.md, mcp.json, memory/, skills/, and other agent data
   agentDataSize: 10Gi
 
+# ── Microsoft Work IQ (M365 MCP servers) auth ────────────────────────────────
+# When enabled, the agent registers an MSAL-backed token provider for the
+# "workiq" auth profile so mcp.json entries with auth.profile=workiq receive a
+# bearer token on every request. Token cache is populated by the UI tier
+# (Blazor/CLI) after the user completes interactive consent.
+workiq:
+  enabled: false
+  # Entra tenant ID (GUID). Required when workiq.enabled=true.
+  tenantId: ""
+  # Public client application ID registered in Entra. Shared between UI and agent.
+  clientId: ""
+  # Delegated scopes to request at silent acquisition. Typically per-server
+  # scopes like "WorkIQ-MailServer/.default", "WorkIQ-Calendar/.default", etc.
+  scopes: []
+  # Optional override of the OAuth authority URL (defaults to public cloud
+  # tenant URL). Set for sovereign clouds.
+  authority: ""
+
 # ── Telemetry (OpenTelemetry) ─────────────────────────────────────────────────
 telemetry:
   enabled: true

--- a/src/RockBot.Agent/McpBridge/Auth/MsalTokenProvider.cs
+++ b/src/RockBot.Agent/McpBridge/Auth/MsalTokenProvider.cs
@@ -1,0 +1,119 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Identity.Client;
+using RockBot.Messaging;
+using RockBot.Tools.Mcp.Auth;
+
+namespace RockBot.Agent.McpBridge.Auth;
+
+/// <summary>
+/// MSAL-backed <see cref="ITokenProvider"/> for the <c>workiq</c> profile.
+/// Acquires tokens silently from a cache populated by the UI tier; on cache
+/// invalidation, publishes <see cref="WorkIqAuthExpired"/> so the UI can
+/// prompt the user to reconnect.
+/// </summary>
+public sealed class MsalTokenProvider : ITokenProvider
+{
+    private readonly IPublicClientApplication _msal;
+    private readonly MsalTokenProviderOptions _options;
+    private readonly IMessagePublisher _publisher;
+    private readonly ILogger<MsalTokenProvider> _logger;
+
+    public MsalTokenProvider(
+        IPublicClientApplication msal,
+        IOptions<MsalTokenProviderOptions> options,
+        IMessagePublisher publisher,
+        ILogger<MsalTokenProvider> logger)
+    {
+        _msal = msal;
+        _options = options.Value;
+        _publisher = publisher;
+        _logger = logger;
+    }
+
+    public async Task<string> GetAccessTokenAsync(bool forceRefresh, CancellationToken cancellationToken)
+    {
+        IEnumerable<IAccount> accounts;
+        try
+        {
+            accounts = await _msal.GetAccountsAsync().WaitAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            throw new TokenAcquisitionException(
+                TokenAcquisitionException.Codes.Unknown,
+                "Failed to enumerate MSAL accounts.",
+                ex);
+        }
+
+        var account = accounts.FirstOrDefault();
+        if (account is null)
+        {
+            throw new TokenAcquisitionException(
+                TokenAcquisitionException.Codes.NotAuthenticated,
+                "No Work IQ account has consented yet. Open the UI and click 'Connect M365' to complete initial authentication.");
+        }
+
+        try
+        {
+            var builder = _msal.AcquireTokenSilent(_options.Scopes, account);
+            if (forceRefresh) builder = builder.WithForceRefresh(true);
+            var result = await builder.ExecuteAsync(cancellationToken);
+            return result.AccessToken;
+        }
+        catch (MsalUiRequiredException ex)
+        {
+            _logger.LogWarning(ex,
+                "MSAL silent token acquisition for account {AccountId} requires interactive re-consent ({Classification})",
+                account.HomeAccountId?.Identifier, ex.Classification);
+
+            await PublishExpiredAsync(account, ex.Message, cancellationToken);
+
+            throw new TokenAcquisitionException(
+                TokenAcquisitionException.Codes.ReauthRequired,
+                "Work IQ token refresh failed — the user must re-consent. " +
+                "Open the UI and click 'Reconnect M365' to restore access.",
+                ex);
+        }
+        catch (MsalServiceException ex)
+        {
+            _logger.LogWarning(ex,
+                "MSAL service error during silent token acquisition: {ErrorCode}", ex.ErrorCode);
+            throw new TokenAcquisitionException(
+                TokenAcquisitionException.Codes.IdentityProviderUnreachable,
+                $"Microsoft identity service returned an error ({ex.ErrorCode}). This may be transient.",
+                ex);
+        }
+        catch (TokenAcquisitionException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new TokenAcquisitionException(
+                TokenAcquisitionException.Codes.Unknown,
+                "Unexpected error acquiring Work IQ access token.",
+                ex);
+        }
+    }
+
+    private async Task PublishExpiredAsync(IAccount account, string reason, CancellationToken ct)
+    {
+        try
+        {
+            var message = new WorkIqAuthExpired
+            {
+                AccountId = account.HomeAccountId?.Identifier ?? account.Username ?? "unknown",
+                Reason = reason
+            };
+            var envelope = message.ToEnvelope(source: "agent.workiq");
+            await _publisher.PublishAsync(WorkIqAuthTopics.Expired, envelope, ct);
+        }
+        catch (Exception ex)
+        {
+            // Do not let publication failure shadow the original auth failure —
+            // the caller still needs to see the TokenAcquisitionException.
+            _logger.LogWarning(ex, "Failed to publish WorkIqAuthExpired notification");
+        }
+    }
+}

--- a/src/RockBot.Agent/McpBridge/Auth/MsalTokenProviderOptions.cs
+++ b/src/RockBot.Agent/McpBridge/Auth/MsalTokenProviderOptions.cs
@@ -1,0 +1,44 @@
+namespace RockBot.Agent.McpBridge.Auth;
+
+/// <summary>
+/// Configuration for the MSAL-backed token provider used by the
+/// <c>workiq</c> profile. Bound from the <c>WorkIQ</c> configuration section.
+/// </summary>
+public sealed class MsalTokenProviderOptions
+{
+    /// <summary>Entra tenant ID (GUID). Required when WorkIQ is enabled.</summary>
+    public string TenantId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Public-client application ID registered in Entra. Shared between
+    /// the UI tier (which performs interactive consent) and the agent
+    /// (which silently refreshes the resulting cache).
+    /// </summary>
+    public string ClientId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Delegated scopes to request at silent acquisition. For Work IQ these
+    /// look like <c>WorkIQ-MailServer/.default</c>; the exact list depends on
+    /// which Work IQ servers are enabled.
+    /// </summary>
+    public List<string> Scopes { get; set; } = [];
+
+    /// <summary>
+    /// Path on disk where the MSAL token cache is persisted. Defaults to the
+    /// shared agent secrets directory under the PVC mount.
+    /// </summary>
+    public string CacheFilePath { get; set; } = "/data/agent/secrets/workiq-cache.bin";
+
+    /// <summary>
+    /// Optional override of the OAuth authority URL. Defaults to
+    /// <c>https://login.microsoftonline.com/{TenantId}</c>. Override for
+    /// sovereign clouds (US Gov, China, etc.).
+    /// </summary>
+    public string? Authority { get; set; }
+
+    /// <summary>
+    /// When true, this provider is registered with the bridge's token registry.
+    /// Used by the host to gate the entire WorkIQ DI block on a single setting.
+    /// </summary>
+    public bool Enabled => !string.IsNullOrWhiteSpace(TenantId) && !string.IsNullOrWhiteSpace(ClientId);
+}

--- a/src/RockBot.Agent/McpBridge/Auth/TokenCacheStore.cs
+++ b/src/RockBot.Agent/McpBridge/Auth/TokenCacheStore.cs
@@ -1,0 +1,198 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Identity.Client;
+using RockBot.Messaging;
+
+namespace RockBot.Agent.McpBridge.Auth;
+
+/// <summary>
+/// Persists the MSAL token cache to the agent's PVC. Bridges the UI tier
+/// (which performs interactive consent and publishes <see cref="WorkIqAuthCacheUpdated"/>)
+/// and the in-process <see cref="IPublicClientApplication"/> that performs silent
+/// refresh on every Work IQ request.
+/// </summary>
+/// <remarks>
+/// <para>Two write paths into <see cref="MsalTokenProviderOptions.CacheFilePath"/>:</para>
+/// <list type="number">
+/// <item>UI tier publishes a fresh cache after consent — handled by <see cref="HandleCacheUpdatedAsync"/>.</item>
+/// <item>
+/// MSAL rotates the cache during silent refresh — handled by
+/// <see cref="OnAfterAccess"/>, registered via
+/// <see cref="ITokenCache.SetAfterAccess"/> when this service starts.
+/// </item>
+/// </list>
+/// </remarks>
+public sealed class TokenCacheStore : IHostedService
+{
+    private readonly IMessageSubscriber _subscriber;
+    private readonly IPublicClientApplication _msal;
+    private readonly MsalTokenProviderOptions _options;
+    private readonly ILogger<TokenCacheStore> _logger;
+
+    private readonly SemaphoreSlim _fileLock = new(1, 1);
+    private ISubscription? _subscription;
+
+    public TokenCacheStore(
+        IMessageSubscriber subscriber,
+        IPublicClientApplication msal,
+        IOptions<MsalTokenProviderOptions> options,
+        ILogger<TokenCacheStore> logger)
+    {
+        _subscriber = subscriber;
+        _msal = msal;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        EnsureCacheDirectory();
+
+        // Wire MSAL cache callbacks so silent-refresh rotations are persisted.
+        _msal.UserTokenCache.SetBeforeAccess(OnBeforeAccess);
+        _msal.UserTokenCache.SetAfterAccess(OnAfterAccess);
+
+        // Subscribe to UI-published cache updates.
+        _subscription = await _subscriber.SubscribeAsync(
+            WorkIqAuthTopics.CacheUpdated,
+            "agent.workiq.cache",
+            HandleCacheUpdatedAsync,
+            cancellationToken);
+
+        _logger.LogInformation(
+            "TokenCacheStore ready (cache path: {Path})", _options.CacheFilePath);
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        if (_subscription is not null)
+            await _subscription.DisposeAsync();
+    }
+
+    private async Task<MessageResult> HandleCacheUpdatedAsync(MessageEnvelope envelope, CancellationToken ct)
+    {
+        var message = envelope.GetPayload<WorkIqAuthCacheUpdated>();
+        if (message is null || message.CacheBytes.Length == 0)
+        {
+            _logger.LogWarning("Received empty WorkIqAuthCacheUpdated; ignoring");
+            return MessageResult.DeadLetter;
+        }
+
+        await _fileLock.WaitAsync(ct);
+        try
+        {
+            await File.WriteAllBytesAsync(_options.CacheFilePath, message.CacheBytes, ct);
+            ApplyRestrictivePermissions(_options.CacheFilePath);
+            _logger.LogInformation(
+                "Persisted WorkIQ token cache for account {AccountId} ({Bytes} bytes, {Scopes} scope(s))",
+                message.AccountId, message.CacheBytes.Length, message.Scopes.Count);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Failed to persist WorkIQ token cache to {Path}", _options.CacheFilePath);
+            return MessageResult.Retry;
+        }
+        finally
+        {
+            _fileLock.Release();
+        }
+
+        return MessageResult.Ack;
+    }
+
+    private void OnBeforeAccess(TokenCacheNotificationArgs args)
+    {
+        // MSAL calls this before reading the in-memory cache. Load from disk if present.
+        if (!File.Exists(_options.CacheFilePath)) return;
+
+        try
+        {
+            var bytes = File.ReadAllBytes(_options.CacheFilePath);
+            if (bytes.Length > 0)
+                args.TokenCache.DeserializeMsalV3(bytes);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to load WorkIQ token cache from {Path}; treating as empty",
+                _options.CacheFilePath);
+        }
+    }
+
+    private void OnAfterAccess(TokenCacheNotificationArgs args)
+    {
+        // MSAL only signals HasStateChanged when the cache actually changed
+        // (e.g. silent refresh-token rotation). Skip the write otherwise.
+        if (!args.HasStateChanged) return;
+
+        try
+        {
+            var bytes = args.TokenCache.SerializeMsalV3();
+            _fileLock.Wait();
+            try
+            {
+                File.WriteAllBytes(_options.CacheFilePath, bytes);
+                ApplyRestrictivePermissions(_options.CacheFilePath);
+            }
+            finally
+            {
+                _fileLock.Release();
+            }
+            _logger.LogDebug(
+                "Persisted MSAL cache rotation ({Bytes} bytes)", bytes.Length);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to persist rotated MSAL cache to {Path}",
+                _options.CacheFilePath);
+        }
+    }
+
+    private void EnsureCacheDirectory()
+    {
+        var dir = Path.GetDirectoryName(_options.CacheFilePath);
+        if (string.IsNullOrEmpty(dir) || Directory.Exists(dir)) return;
+
+        try
+        {
+            Directory.CreateDirectory(dir);
+            ApplyRestrictiveDirectoryPermissions(dir);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to create cache directory {Dir}; cache persistence may fail",
+                dir);
+        }
+    }
+
+    private static void ApplyRestrictivePermissions(string path)
+    {
+        if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS()) return;
+        try
+        {
+            File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        }
+        catch
+        {
+            // Best-effort; the file is on a private PVC so this is defense-in-depth.
+        }
+    }
+
+    private static void ApplyRestrictiveDirectoryPermissions(string path)
+    {
+        if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS()) return;
+        try
+        {
+            File.SetUnixFileMode(path,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+        catch
+        {
+            // Best-effort; the directory lives on a private PVC.
+        }
+    }
+}

--- a/src/RockBot.Agent/McpBridge/Auth/WorkIqAuthMessages.cs
+++ b/src/RockBot.Agent/McpBridge/Auth/WorkIqAuthMessages.cs
@@ -1,0 +1,60 @@
+namespace RockBot.Agent.McpBridge.Auth;
+
+/// <summary>
+/// Topic constants for Work IQ auth-related bus messages.
+/// </summary>
+public static class WorkIqAuthTopics
+{
+    /// <summary>
+    /// UI tier publishes a fresh MSAL cache to this topic after the user
+    /// completes interactive consent. The agent's <c>TokenCacheStore</c>
+    /// subscribes and persists the bytes to its PVC.
+    /// </summary>
+    public const string CacheUpdated = "auth.workiq.cache";
+
+    /// <summary>
+    /// The agent publishes to this topic when <c>AcquireTokenSilent</c>
+    /// throws <c>MsalUiRequiredException</c>, signalling that the UI must
+    /// prompt the user to reconnect.
+    /// </summary>
+    public const string Expired = "auth.workiq.expired";
+}
+
+/// <summary>
+/// Carries a serialized MSAL token cache from the UI tier (Blazor / CLI)
+/// to the agent after the user completes interactive consent.
+/// </summary>
+/// <remarks>
+/// <see cref="CacheBytes"/> contains credential material (refresh token).
+/// Never log this message's body and never persist it outside the agent's
+/// secrets directory. The bus is already trusted with comparable secrets
+/// (LLM prompts, working memory).
+/// </remarks>
+public sealed record WorkIqAuthCacheUpdated
+{
+    /// <summary>Opaque MSAL cache bytes — pass through to MSAL, do not parse.</summary>
+    public required byte[] CacheBytes { get; init; }
+
+    /// <summary>
+    /// MSAL account identifier (HomeAccountId) shipped alongside for diagnostics
+    /// without forcing the agent to instantiate MSAL just to inspect the cache.
+    /// </summary>
+    public required string AccountId { get; init; }
+
+    /// <summary>Scopes the cache was issued for, for diagnostics only.</summary>
+    public List<string> Scopes { get; init; } = [];
+}
+
+/// <summary>
+/// Published by the agent when the MSAL cache can no longer produce a token
+/// silently — typically because the refresh token has been revoked or aged out.
+/// The UI tier subscribes to surface a reconnect prompt to the user.
+/// </summary>
+public sealed record WorkIqAuthExpired
+{
+    /// <summary>MSAL account identifier whose refresh token has expired.</summary>
+    public required string AccountId { get; init; }
+
+    /// <summary>Human-readable explanation suitable for logs and UI messages.</summary>
+    public string? Reason { get; init; }
+}

--- a/src/RockBot.Agent/McpBridge/Auth/WorkIqAuthServiceCollectionExtensions.cs
+++ b/src/RockBot.Agent/McpBridge/Auth/WorkIqAuthServiceCollectionExtensions.cs
@@ -1,0 +1,67 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.Identity.Client;
+using RockBot.Tools.Mcp.Auth;
+
+namespace RockBot.Agent.McpBridge.Auth;
+
+/// <summary>
+/// Service collection helpers for the WorkIQ auth profile.
+/// </summary>
+public static class WorkIqAuthServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the MSAL public-client app, the WorkIQ <see cref="ITokenProvider"/>,
+    /// the cache-syncing hosted service, and binds <see cref="MsalTokenProviderOptions"/>
+    /// from the <c>WorkIQ</c> configuration section.
+    /// </summary>
+    /// <remarks>
+    /// Call sites should gate this registration on <c>WorkIQ:TenantId</c> being
+    /// non-empty so deployments without WorkIQ avoid the MSAL dependency at runtime.
+    /// </remarks>
+    public static IServiceCollection AddWorkIqAuth(
+        this IServiceCollection services, IConfiguration configuration)
+    {
+        services.Configure<MsalTokenProviderOptions>(opts =>
+        {
+            var section = configuration.GetSection("WorkIQ");
+            opts.TenantId = section["TenantId"] ?? string.Empty;
+            opts.ClientId = section["ClientId"] ?? string.Empty;
+            opts.Authority = section["Authority"];
+            opts.CacheFilePath = section["CacheFilePath"]
+                ?? "/data/agent/secrets/workiq-cache.bin";
+
+            var scopesValue = section["Scopes"];
+            if (!string.IsNullOrWhiteSpace(scopesValue))
+            {
+                opts.Scopes = scopesValue
+                    .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                    .ToList();
+            }
+        });
+
+        services.AddSingleton<IPublicClientApplication>(sp =>
+        {
+            var opts = sp.GetRequiredService<IOptions<MsalTokenProviderOptions>>().Value;
+            var builder = PublicClientApplicationBuilder.Create(opts.ClientId);
+            if (!string.IsNullOrWhiteSpace(opts.Authority))
+                builder = builder.WithAuthority(opts.Authority);
+            else if (!string.IsNullOrWhiteSpace(opts.TenantId))
+                builder = builder.WithAuthority(AzureCloudInstance.AzurePublic, opts.TenantId);
+            return builder.Build();
+        });
+
+        services.AddSingleton<MsalTokenProvider>();
+        services.AddSingleton<TokenProviderRegistration>(sp =>
+            new TokenProviderRegistration("workiq", sp.GetRequiredService<MsalTokenProvider>()));
+        services.AddHostedService<TokenCacheStore>();
+
+        // Register the registry only once even if AddWorkIqAuth is paired with
+        // future providers. TryAdd ensures other providers can layer their
+        // TokenProviderRegistration entries without re-registering the registry.
+        services.AddSingleton<ITokenProviderRegistry, TokenProviderRegistry>();
+
+        return services;
+    }
+}

--- a/src/RockBot.Agent/McpBridge/McpBridgeServerConfig.cs
+++ b/src/RockBot.Agent/McpBridge/McpBridgeServerConfig.cs
@@ -65,6 +65,14 @@ public sealed class McpBridgeServerConfig
     public AttachmentManifest? Attachments { get; set; }
 
     /// <summary>
+    /// Optional bearer-token authentication. When set, the bridge resolves
+    /// <see cref="McpServerAuthConfig.Profile"/> against the token provider
+    /// registry and wires a <c>BearerInjectionHandler</c> into the HTTP client
+    /// so every request carries a fresh access token.
+    /// </summary>
+    public McpServerAuthConfig? Auth { get; set; }
+
+    /// <summary>
     /// Whether this config uses HTTP-based transport (SSE or streamable HTTP).
     /// </summary>
     public bool IsSse => Type?.ToLowerInvariant() is "sse" or "http" or "streamable-http";
@@ -90,7 +98,10 @@ public sealed class McpBridgeServerConfig
             .Select(kvp => $"{kvp.Key.ToLowerInvariant()}={kvp.Value}"));
         var allowedTools = string.Join("", AllowedTools.OrderBy(s => s, StringComparer.OrdinalIgnoreCase));
         var deniedTools = string.Join("", DeniedTools.OrderBy(s => s, StringComparer.OrdinalIgnoreCase));
-        return string.Join("", type, url, transportMode, command, args, env, headers, allowedTools, deniedTools);
+        // Include the auth profile so an authenticated entry is never deduped
+        // against an unauthenticated one at the same URL.
+        var authProfile = Auth?.Profile?.Trim().ToLowerInvariant() ?? string.Empty;
+        return string.Join("", type, url, transportMode, command, args, env, headers, allowedTools, deniedTools, authProfile);
     }
 
     /// <summary>

--- a/src/RockBot.Agent/McpBridge/McpBridgeService.cs
+++ b/src/RockBot.Agent/McpBridge/McpBridgeService.cs
@@ -10,6 +10,7 @@ using RockBot.Host;
 using RockBot.Messaging;
 using RockBot.Tools;
 using RockBot.Tools.Mcp;
+using RockBot.Tools.Mcp.Auth;
 
 namespace RockBot.Agent.McpBridge;
 
@@ -26,6 +27,7 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
     private readonly string _configPath;
     private readonly ILogger<McpBridgeService> _logger;
     private readonly ILlmClient? _llmClient;
+    private readonly ITokenProviderRegistry? _tokenProviders;
 
     private readonly Dictionary<string, McpClient> _clients = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, McpBridgeServerConfig> _serverConfigs = new(StringComparer.OrdinalIgnoreCase);
@@ -62,7 +64,8 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
         AgentIdentity identity,
         IOptions<McpBridgeOptions> options,
         ILogger<McpBridgeService> logger,
-        ILlmClient? llmClient = null)
+        ILlmClient? llmClient = null,
+        ITokenProviderRegistry? tokenProviders = null)
     {
         _publisher = publisher;
         _subscriber = subscriber;
@@ -73,6 +76,7 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
             : Path.Combine(AppContext.BaseDirectory, _options.ConfigPath);
         _logger = logger;
         _llmClient = llmClient;
+        _tokenProviders = tokenProviders;
     }
 
     public async Task StartAsync(CancellationToken cancellationToken)
@@ -371,16 +375,10 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
                 };
 
                 HttpClientTransport transport;
-                if (config.Headers.Count > 0)
+                var customClient = TryBuildHttpClient(name, config);
+                if (customClient is not null)
                 {
-                    var httpClient = new HttpClient();
-                    foreach (var (key, rawValue) in config.Headers)
-                    {
-                        var expanded = ExpandEnvVars(rawValue);
-                        if (!string.IsNullOrEmpty(expanded))
-                            httpClient.DefaultRequestHeaders.TryAddWithoutValidation(key, expanded);
-                    }
-                    transport = new HttpClientTransport(transportOptions, httpClient, loggerFactory: null, ownsHttpClient: true);
+                    transport = new HttpClientTransport(transportOptions, customClient, loggerFactory: null, ownsHttpClient: true);
                 }
                 else
                 {
@@ -486,13 +484,9 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
         if (_attachmentGateways.TryGetValue(serverName, out var entry))
             return entry.Gateway;
 
-        var http = new HttpClient();
-        foreach (var (key, rawValue) in config.Headers)
-        {
-            var expanded = ExpandEnvVars(rawValue);
-            if (!string.IsNullOrEmpty(expanded))
-                http.DefaultRequestHeaders.TryAddWithoutValidation(key, expanded);
-        }
+        // Reuse the same client-construction logic so attachment uploads carry
+        // the same auth and headers as MCP tool calls.
+        var http = TryBuildHttpClient(serverName, config) ?? new HttpClient();
 
         var gateway = new AttachmentGateway(
             _attachmentStorage.Value,
@@ -503,6 +497,56 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
 
         _attachmentGateways[serverName] = new AttachmentGatewayEntry(gateway, http);
         return gateway;
+    }
+
+    /// <summary>
+    /// Builds an <see cref="HttpClient"/> for a server config that needs custom
+    /// headers, bearer auth, or both. Returns <c>null</c> when neither applies,
+    /// signalling that the caller can use the transport's default client.
+    /// </summary>
+    private HttpClient? TryBuildHttpClient(string serverName, McpBridgeServerConfig config)
+    {
+        var hasHeaders = config.Headers.Count > 0;
+        var hasAuth = config.Auth is not null;
+        if (!hasHeaders && !hasAuth) return null;
+
+        HttpClient httpClient;
+        if (hasAuth)
+        {
+            if (_tokenProviders is null)
+            {
+                throw new InvalidOperationException(
+                    $"MCP server '{serverName}' requires auth profile '{config.Auth!.Profile}' " +
+                    $"but no ITokenProviderRegistry is registered in DI. " +
+                    $"Add a token provider (e.g. services.AddWorkIqAuth(...)) before connecting.");
+            }
+
+            var provider = _tokenProviders.Get(config.Auth!.Profile);
+            var bearerHandler = new BearerInjectionHandler(provider, new SocketsHttpHandler());
+            httpClient = new HttpClient(bearerHandler);
+        }
+        else
+        {
+            httpClient = new HttpClient();
+        }
+
+        foreach (var (key, rawValue) in config.Headers)
+        {
+            // Never let static headers clobber the auth handler's bearer.
+            if (hasAuth && string.Equals(key, "Authorization", StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogWarning(
+                    "MCP server '{Server}' has both static 'Authorization' header and auth profile '{Profile}'; ignoring the static header in favor of the bearer-injecting auth handler",
+                    serverName, config.Auth!.Profile);
+                continue;
+            }
+
+            var expanded = ExpandEnvVars(rawValue);
+            if (!string.IsNullOrEmpty(expanded))
+                httpClient.DefaultRequestHeaders.TryAddWithoutValidation(key, expanded);
+        }
+
+        return httpClient;
     }
 
     private void InvalidateAttachmentGateway(string serverName)
@@ -917,6 +961,27 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
             };
 
             await PublishResponseAsync(error, replyTo, envelope.CorrelationId, ct);
+        }
+        catch (Exception ex) when (FindAuthChallenge(ex) is { } authChallenge)
+        {
+            sw.Stop();
+            _logger.LogWarning(
+                "← MCP {Server}/{Tool} AUTH REQUIRED after {ElapsedMs}ms: {Detail}",
+                serverName, request.ToolName, sw.ElapsedMilliseconds, authChallenge.Message);
+
+            // The bearer token couldn't authenticate even after a forced refresh —
+            // reconnecting will not help; the user must re-consent interactively.
+            var error = new ToolError
+            {
+                ToolCallId = request.ToolCallId,
+                ToolName = request.ToolName,
+                Code = ToolError.Codes.AuthRequired,
+                Message = authChallenge.Message,
+                IsRetryable = false
+            };
+
+            await PublishResponseAsync(error, replyTo, envelope.CorrelationId, ct);
+            return MessageResult.Ack;
         }
         catch (Exception ex)
         {
@@ -1530,6 +1595,21 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
             catch { /* Best-effort cleanup */ }
         }
         _attachmentGateways.Clear();
+    }
+
+    /// <summary>
+    /// Walks the exception chain looking for an <see cref="McpAuthChallengeException"/>.
+    /// The MCP client library may wrap the bearer handler's exception inside a transport
+    /// or protocol exception, so we search inner exceptions rather than relying on the
+    /// outer type.
+    /// </summary>
+    private static McpAuthChallengeException? FindAuthChallenge(Exception? ex)
+    {
+        for (var current = ex; current is not null; current = current.InnerException)
+        {
+            if (current is McpAuthChallengeException auth) return auth;
+        }
+        return null;
     }
 
     /// <summary>

--- a/src/RockBot.Agent/McpBridge/McpServerAuthConfig.cs
+++ b/src/RockBot.Agent/McpBridge/McpServerAuthConfig.cs
@@ -1,0 +1,15 @@
+namespace RockBot.Agent.McpBridge;
+
+/// <summary>
+/// Auth configuration for an MCP server. References a named token provider
+/// profile (resolved by <c>ITokenProviderRegistry</c>) so refresh tokens and
+/// client secrets never appear in <c>mcp.json</c>.
+/// </summary>
+public sealed class McpServerAuthConfig
+{
+    /// <summary>
+    /// Named auth profile. Resolved at connect time to an
+    /// <c>ITokenProvider</c> registered in DI.
+    /// </summary>
+    public required string Profile { get; set; }
+}

--- a/src/RockBot.Agent/Program.cs
+++ b/src/RockBot.Agent/Program.cs
@@ -9,6 +9,7 @@ using RockBot.Host;
 using RockBot.Llm;
 using RockBot.Messaging.RabbitMQ;
 using RockBot.Agent.McpBridge;
+using RockBot.Agent.McpBridge.Auth;
 using RockBot.Scripts.Remote;
 using RockBot.Agent;
 using RockBot.Memory;
@@ -375,6 +376,16 @@ builder.Services.Configure<LlmPricingOptions>(builder.Configuration.GetSection("
 // MCP bridge (replaces external RockBot.Tools.Mcp.Bridge process)
 builder.Services.Configure<McpBridgeOptions>(builder.Configuration.GetSection("McpBridge"));
 builder.Services.AddHostedService<McpBridgeService>();
+
+// WorkIQ auth (MSAL token provider + cache store) — registered only when
+// the host has been configured with an Entra tenant and client ID. Keeping
+// this conditional means deployments without WorkIQ never pull MSAL into
+// the runtime and never publish/subscribe on auth.workiq.* topics.
+if (!string.IsNullOrWhiteSpace(builder.Configuration["WorkIQ:TenantId"])
+    && !string.IsNullOrWhiteSpace(builder.Configuration["WorkIQ:ClientId"]))
+{
+    builder.Services.AddWorkIqAuth(builder.Configuration);
+}
 
 // Remote script runner — delegates script execution to the Script Manager pod via RabbitMQ
 builder.Services.AddRemoteScriptRunner("RockBot");

--- a/src/RockBot.Agent/RockBot.Agent.csproj
+++ b/src/RockBot.Agent/RockBot.Agent.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.*" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.3.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.*" />
     <PackageReference Include="ModelContextProtocol" Version="0.8.0-preview.1" />
   </ItemGroup>
 

--- a/src/RockBot.Tools.Abstractions/ToolError.cs
+++ b/src/RockBot.Tools.Abstractions/ToolError.cs
@@ -37,5 +37,12 @@ public sealed record ToolError
         public const string ExecutionFailed = "execution_failed";
         public const string Timeout = "timeout";
         public const string InvalidArguments = "invalid_arguments";
+
+        /// <summary>
+        /// The MCP server rejected the request because the bearer token is missing,
+        /// invalid, or revoked. Indicates the user must complete an interactive
+        /// auth flow (e.g. re-consent in the UI) before retrying.
+        /// </summary>
+        public const string AuthRequired = "auth_required";
     }
 }

--- a/src/RockBot.Tools.Mcp/Auth/BearerInjectionHandler.cs
+++ b/src/RockBot.Tools.Mcp/Auth/BearerInjectionHandler.cs
@@ -1,0 +1,89 @@
+using System.Net;
+using System.Net.Http.Headers;
+
+namespace RockBot.Tools.Mcp.Auth;
+
+/// <summary>
+/// HTTP message handler that attaches a bearer token from an
+/// <see cref="ITokenProvider"/> to every outgoing request. On a 401 response,
+/// it forces a token refresh and retries the request exactly once.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Two-attempt strategy:
+/// </para>
+/// <list type="number">
+/// <item>First attempt uses a (possibly cached) token from <see cref="ITokenProvider.GetAccessTokenAsync"/>.</item>
+/// <item>
+/// On 401, calls <see cref="ITokenProvider.GetAccessTokenAsync"/> with
+/// <c>forceRefresh: true</c> and retries once.
+/// </item>
+/// <item>If the second attempt also returns 401, throws <see cref="McpAuthChallengeException"/> carrying the parsed <c>WWW-Authenticate</c> challenge.</item>
+/// </list>
+/// <para>
+/// The first attempt's response body is disposed before retry to free any
+/// network resources; the second attempt's body is left intact for the caller.
+/// </para>
+/// </remarks>
+public sealed class BearerInjectionHandler : DelegatingHandler
+{
+    private readonly ITokenProvider _tokenProvider;
+
+    public BearerInjectionHandler(ITokenProvider tokenProvider)
+    {
+        _tokenProvider = tokenProvider;
+    }
+
+    public BearerInjectionHandler(ITokenProvider tokenProvider, HttpMessageHandler innerHandler)
+        : base(innerHandler)
+    {
+        _tokenProvider = tokenProvider;
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        await ApplyBearerAsync(request, forceRefresh: false, cancellationToken);
+        var response = await base.SendAsync(request, cancellationToken);
+
+        if (response.StatusCode != HttpStatusCode.Unauthorized)
+            return response;
+
+        // First attempt failed with 401 — discard the response and retry once
+        // with a forcibly refreshed token.
+        response.Dispose();
+
+        await ApplyBearerAsync(request, forceRefresh: true, cancellationToken);
+        var retryResponse = await base.SendAsync(request, cancellationToken);
+
+        if (retryResponse.StatusCode != HttpStatusCode.Unauthorized)
+            return retryResponse;
+
+        // Second 401 — give up and surface the parsed challenge so the caller
+        // can include the protected-resource-metadata URL in its error message.
+        var challengeHeader = retryResponse.Headers.WwwAuthenticate
+            .Select(h => h.Parameter is null ? h.Scheme : $"{h.Scheme} {h.Parameter}")
+            .FirstOrDefault();
+        WwwAuthenticateChallenge.TryParse(challengeHeader, out var challenge);
+
+        retryResponse.Dispose();
+
+        var detail = challenge?.ResourceMetadata is { } meta
+            ? $" The server's protected resource metadata is at {meta}."
+            : string.Empty;
+        var error = challenge?.Error is { } code
+            ? $" ({code}: {challenge.ErrorDescription})"
+            : string.Empty;
+
+        throw new McpAuthChallengeException(
+            $"MCP server rejected bearer token with 401 after a forced refresh.{error}{detail}",
+            challenge);
+    }
+
+    private async Task ApplyBearerAsync(
+        HttpRequestMessage request, bool forceRefresh, CancellationToken ct)
+    {
+        var token = await _tokenProvider.GetAccessTokenAsync(forceRefresh, ct);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+    }
+}

--- a/src/RockBot.Tools.Mcp/Auth/ITokenProvider.cs
+++ b/src/RockBot.Tools.Mcp/Auth/ITokenProvider.cs
@@ -1,0 +1,21 @@
+namespace RockBot.Tools.Mcp.Auth;
+
+/// <summary>
+/// Source of bearer access tokens for an authenticated MCP server. Implementations
+/// are responsible for caching, refreshing, and (when appropriate) signalling that
+/// re-consent is required out of band.
+/// </summary>
+public interface ITokenProvider
+{
+    /// <summary>
+    /// Returns a usable access token. When <paramref name="forceRefresh"/> is true,
+    /// any cached access token must be discarded and a fresh one acquired (typically
+    /// via refresh-token rotation). Implementations may still cache the resulting
+    /// token for subsequent non-forced calls.
+    /// </summary>
+    /// <exception cref="TokenAcquisitionException">
+    /// Thrown when a token cannot be obtained — for example, because the refresh
+    /// token has been revoked or the user has not yet completed initial consent.
+    /// </exception>
+    Task<string> GetAccessTokenAsync(bool forceRefresh, CancellationToken cancellationToken);
+}

--- a/src/RockBot.Tools.Mcp/Auth/ITokenProviderRegistry.cs
+++ b/src/RockBot.Tools.Mcp/Auth/ITokenProviderRegistry.cs
@@ -1,0 +1,17 @@
+namespace RockBot.Tools.Mcp.Auth;
+
+/// <summary>
+/// Lookup table for named <see cref="ITokenProvider"/> instances. MCP server
+/// configurations reference a provider by profile name (e.g. <c>"workiq"</c>)
+/// so credentials never appear in <c>mcp.json</c>.
+/// </summary>
+public interface ITokenProviderRegistry
+{
+    /// <summary>
+    /// Returns the provider registered under <paramref name="profile"/>.
+    /// </summary>
+    /// <exception cref="KeyNotFoundException">
+    /// Thrown when no provider is registered for the given profile name.
+    /// </exception>
+    ITokenProvider Get(string profile);
+}

--- a/src/RockBot.Tools.Mcp/Auth/McpAuthChallengeException.cs
+++ b/src/RockBot.Tools.Mcp/Auth/McpAuthChallengeException.cs
@@ -1,0 +1,19 @@
+namespace RockBot.Tools.Mcp.Auth;
+
+/// <summary>
+/// Thrown by <see cref="BearerInjectionHandler"/> when an MCP server returns
+/// 401 after both the initial request and the forced-refresh retry have
+/// failed. Carries the parsed <see cref="WwwAuthenticateChallenge"/> so
+/// upstream callers can surface the protected-resource-metadata URL and any
+/// RFC 6750 error details in their own error responses.
+/// </summary>
+public sealed class McpAuthChallengeException : HttpRequestException
+{
+    public WwwAuthenticateChallenge? Challenge { get; }
+
+    public McpAuthChallengeException(string message, WwwAuthenticateChallenge? challenge)
+        : base(message)
+    {
+        Challenge = challenge;
+    }
+}

--- a/src/RockBot.Tools.Mcp/Auth/TokenAcquisitionException.cs
+++ b/src/RockBot.Tools.Mcp/Auth/TokenAcquisitionException.cs
@@ -1,0 +1,43 @@
+namespace RockBot.Tools.Mcp.Auth;
+
+/// <summary>
+/// Thrown by an <see cref="ITokenProvider"/> when no usable access token can be
+/// produced — for example, when the underlying refresh token has been revoked
+/// or initial consent has not yet completed. Carries an actionable message
+/// suitable for surfacing in a tool error back to the LLM.
+/// </summary>
+public sealed class TokenAcquisitionException : Exception
+{
+    /// <summary>
+    /// Stable code identifying the failure category. Surfaced to upstream callers
+    /// so they can branch on the reason without parsing message text.
+    /// </summary>
+    public string Code { get; }
+
+    public TokenAcquisitionException(string code, string message)
+        : base(message)
+    {
+        Code = code;
+    }
+
+    public TokenAcquisitionException(string code, string message, Exception innerException)
+        : base(message, innerException)
+    {
+        Code = code;
+    }
+
+    public static class Codes
+    {
+        /// <summary>The user has not yet consented (no cache loaded).</summary>
+        public const string NotAuthenticated = "not_authenticated";
+
+        /// <summary>Refresh token was rejected; user must re-consent interactively.</summary>
+        public const string ReauthRequired = "reauth_required";
+
+        /// <summary>Token provider could not reach the identity provider.</summary>
+        public const string IdentityProviderUnreachable = "identity_provider_unreachable";
+
+        /// <summary>Anything else that prevented acquisition.</summary>
+        public const string Unknown = "unknown";
+    }
+}

--- a/src/RockBot.Tools.Mcp/Auth/TokenProviderRegistration.cs
+++ b/src/RockBot.Tools.Mcp/Auth/TokenProviderRegistration.cs
@@ -1,0 +1,7 @@
+namespace RockBot.Tools.Mcp.Auth;
+
+/// <summary>
+/// Binds a profile name to a token provider for registration in DI. The
+/// registry consumes these to build its profile lookup.
+/// </summary>
+public sealed record TokenProviderRegistration(string Profile, ITokenProvider Provider);

--- a/src/RockBot.Tools.Mcp/Auth/TokenProviderRegistry.cs
+++ b/src/RockBot.Tools.Mcp/Auth/TokenProviderRegistry.cs
@@ -1,0 +1,28 @@
+namespace RockBot.Tools.Mcp.Auth;
+
+/// <summary>
+/// Default <see cref="ITokenProviderRegistry"/> backed by an in-memory dictionary
+/// populated from the DI container's <see cref="TokenProviderRegistration"/> bindings.
+/// </summary>
+public sealed class TokenProviderRegistry : ITokenProviderRegistry
+{
+    private readonly Dictionary<string, ITokenProvider> _providers;
+
+    public TokenProviderRegistry(IEnumerable<TokenProviderRegistration> registrations)
+    {
+        _providers = registrations.ToDictionary(
+            r => r.Profile,
+            r => r.Provider,
+            StringComparer.OrdinalIgnoreCase);
+    }
+
+    public ITokenProvider Get(string profile)
+    {
+        if (_providers.TryGetValue(profile, out var provider))
+            return provider;
+
+        throw new KeyNotFoundException(
+            $"No token provider is registered for auth profile '{profile}'. " +
+            $"Known profiles: [{string.Join(", ", _providers.Keys)}].");
+    }
+}

--- a/src/RockBot.Tools.Mcp/Auth/WwwAuthenticateChallenge.cs
+++ b/src/RockBot.Tools.Mcp/Auth/WwwAuthenticateChallenge.cs
@@ -1,0 +1,109 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.RegularExpressions;
+
+namespace RockBot.Tools.Mcp.Auth;
+
+/// <summary>
+/// Parsed representation of an HTTP <c>WWW-Authenticate</c> response header.
+/// The MCP authorization spec uses this header to advertise authentication
+/// requirements via the <see cref="ResourceMetadata"/> URL (RFC 9728).
+/// RFC 6750's <c>error</c>, <c>error_description</c>, and <c>realm</c> are
+/// also exposed for diagnostics.
+/// </summary>
+/// <remarks>
+/// The parser is tolerant: malformed input produces <c>false</c> from
+/// <see cref="TryParse"/> rather than throwing. The intent is to never let
+/// a misbehaving server crash the bridge's auth path.
+/// </remarks>
+public sealed class WwwAuthenticateChallenge
+{
+    private static readonly Regex ParamPattern = new(
+        """(?<key>[a-zA-Z0-9_-]+)\s*=\s*(?:"(?<qval>(?:[^"\\]|\\.)*)"|(?<val>[^\s,]+))""",
+        RegexOptions.Compiled);
+
+    /// <summary>Authentication scheme (e.g. <c>Bearer</c>, <c>DPoP</c>).</summary>
+    public required string Scheme { get; init; }
+
+    /// <summary>
+    /// The <c>resource_metadata</c> parameter — RFC 9728 protected resource metadata URL.
+    /// The MCP OAuth spec uses this to advertise where clients can discover auth
+    /// requirements. May be null when the server has not adopted that part of the spec.
+    /// </summary>
+    public string? ResourceMetadata { get; init; }
+
+    /// <summary>RFC 6750 <c>realm</c> parameter, if present.</summary>
+    public string? Realm { get; init; }
+
+    /// <summary>RFC 6750 <c>scope</c> parameter (space-separated scope list), if present.</summary>
+    public string? Scope { get; init; }
+
+    /// <summary>RFC 6750 <c>error</c> parameter (e.g. <c>invalid_token</c>), if present.</summary>
+    public string? Error { get; init; }
+
+    /// <summary>RFC 6750 <c>error_description</c> parameter, if present.</summary>
+    public string? ErrorDescription { get; init; }
+
+    /// <summary>RFC 6750 <c>error_uri</c> parameter, if present.</summary>
+    public string? ErrorUri { get; init; }
+
+    /// <summary>The original header value, preserved for diagnostics and logging.</summary>
+    public required string RawValue { get; init; }
+
+    /// <summary>
+    /// Attempts to parse a <c>WWW-Authenticate</c> header value. Only the first
+    /// challenge is parsed; multi-challenge headers are rare in MCP usage and
+    /// the spec only requires Bearer.
+    /// </summary>
+    public static bool TryParse(string? headerValue, [NotNullWhen(true)] out WwwAuthenticateChallenge? challenge)
+    {
+        challenge = null;
+        if (string.IsNullOrWhiteSpace(headerValue))
+            return false;
+
+        var trimmed = headerValue.Trim();
+        var schemeEnd = trimmed.IndexOf(' ');
+        string scheme;
+        string paramSection;
+
+        if (schemeEnd < 0)
+        {
+            // Scheme alone with no parameters — valid for e.g. "Bearer"
+            scheme = trimmed;
+            paramSection = string.Empty;
+        }
+        else
+        {
+            scheme = trimmed[..schemeEnd];
+            paramSection = trimmed[(schemeEnd + 1)..];
+        }
+
+        if (string.IsNullOrEmpty(scheme))
+            return false;
+
+        var parameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (Match match in ParamPattern.Matches(paramSection))
+        {
+            var key = match.Groups["key"].Value;
+            var value = match.Groups["qval"].Success
+                ? UnescapeQuoted(match.Groups["qval"].Value)
+                : match.Groups["val"].Value;
+            parameters[key] = value;
+        }
+
+        challenge = new WwwAuthenticateChallenge
+        {
+            Scheme = scheme,
+            RawValue = headerValue,
+            ResourceMetadata = parameters.GetValueOrDefault("resource_metadata"),
+            Realm = parameters.GetValueOrDefault("realm"),
+            Scope = parameters.GetValueOrDefault("scope"),
+            Error = parameters.GetValueOrDefault("error"),
+            ErrorDescription = parameters.GetValueOrDefault("error_description"),
+            ErrorUri = parameters.GetValueOrDefault("error_uri")
+        };
+        return true;
+    }
+
+    private static string UnescapeQuoted(string value) =>
+        Regex.Replace(value, @"\\(.)", "$1");
+}

--- a/tests/RockBot.Agent.Tests/McpBridge/Auth/MsalTokenProviderTests.cs
+++ b/tests/RockBot.Agent.Tests/McpBridge/Auth/MsalTokenProviderTests.cs
@@ -1,0 +1,73 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Identity.Client;
+using RockBot.Agent.McpBridge.Auth;
+using RockBot.Tools.Mcp.Auth;
+
+namespace RockBot.Agent.Tests.McpBridge.Auth;
+
+[TestClass]
+public class MsalTokenProviderTests
+{
+    [TestMethod]
+    public async Task GetAccessTokenAsync_WithoutCachedAccount_ThrowsNotAuthenticated()
+    {
+        var msal = PublicClientApplicationBuilder
+            .Create("00000000-0000-0000-0000-000000000001")
+            .WithAuthority(AzureCloudInstance.AzurePublic, "00000000-0000-0000-0000-000000000002")
+            .Build();
+
+        var options = Options.Create(new MsalTokenProviderOptions
+        {
+            TenantId = "00000000-0000-0000-0000-000000000002",
+            ClientId = "00000000-0000-0000-0000-000000000001",
+            Scopes = ["api://test/.default"]
+        });
+
+        var publisher = new StubMessagePublisher();
+        var provider = new MsalTokenProvider(
+            msal, options, publisher, NullLogger<MsalTokenProvider>.Instance);
+
+        var ex = await Assert.ThrowsExactlyAsync<TokenAcquisitionException>(
+            () => provider.GetAccessTokenAsync(forceRefresh: false, CancellationToken.None));
+
+        Assert.AreEqual(TokenAcquisitionException.Codes.NotAuthenticated, ex.Code);
+        StringAssert.Contains(ex.Message, "Connect M365");
+        // No account, so no expired notification — the user simply hasn't consented yet.
+        Assert.AreEqual(0, publisher.Published.Count);
+    }
+
+    [TestMethod]
+    public async Task AddWorkIqAuth_WiresUpTokenProviderRegistry()
+    {
+        var configValues = new Dictionary<string, string?>
+        {
+            ["WorkIQ:TenantId"] = "00000000-0000-0000-0000-000000000002",
+            ["WorkIQ:ClientId"] = "00000000-0000-0000-0000-000000000001",
+            ["WorkIQ:Scopes"] = "scope-a,scope-b"
+        };
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(configValues)
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddSingleton<RockBot.Messaging.IMessagePublisher>(new StubMessagePublisher());
+        services.AddLogging();
+        services.AddWorkIqAuth(config);
+
+        using var provider = services.BuildServiceProvider();
+
+        var registry = provider.GetRequiredService<ITokenProviderRegistry>();
+        var tokenProvider = registry.Get("workiq");
+        Assert.IsNotNull(tokenProvider);
+        Assert.IsInstanceOfType<MsalTokenProvider>(tokenProvider);
+
+        var opts = provider.GetRequiredService<IOptions<MsalTokenProviderOptions>>().Value;
+        CollectionAssert.AreEqual(new[] { "scope-a", "scope-b" }, opts.Scopes);
+        Assert.IsTrue(opts.Enabled);
+    }
+}

--- a/tests/RockBot.Agent.Tests/McpBridge/Auth/StubMessagePublisher.cs
+++ b/tests/RockBot.Agent.Tests/McpBridge/Auth/StubMessagePublisher.cs
@@ -1,0 +1,20 @@
+using RockBot.Messaging;
+
+namespace RockBot.Agent.Tests.McpBridge.Auth;
+
+/// <summary>
+/// Test stub for <see cref="IMessagePublisher"/>. Records all published
+/// envelopes so tests can assert on them.
+/// </summary>
+internal sealed class StubMessagePublisher : IMessagePublisher
+{
+    public List<(string Topic, MessageEnvelope Envelope)> Published { get; } = new();
+
+    public Task PublishAsync(string topic, MessageEnvelope envelope, CancellationToken cancellationToken = default)
+    {
+        Published.Add((topic, envelope));
+        return Task.CompletedTask;
+    }
+
+    public ValueTask DisposeAsync() => default;
+}

--- a/tests/RockBot.Agent.Tests/McpBridge/Auth/StubMessageSubscriber.cs
+++ b/tests/RockBot.Agent.Tests/McpBridge/Auth/StubMessageSubscriber.cs
@@ -1,0 +1,38 @@
+using RockBot.Messaging;
+
+namespace RockBot.Agent.Tests.McpBridge.Auth;
+
+/// <summary>
+/// Test stub for <see cref="IMessageSubscriber"/>. Captures the registered
+/// handler so tests can drive it directly, simulating bus delivery without
+/// spinning up RabbitMQ.
+/// </summary>
+internal sealed class StubMessageSubscriber : IMessageSubscriber
+{
+    public Func<MessageEnvelope, CancellationToken, Task<MessageResult>>? Handler { get; private set; }
+    public string? Topic { get; private set; }
+    public string? SubscriptionName { get; private set; }
+
+    public Task<ISubscription> SubscribeAsync(
+        string topic,
+        string subscriptionName,
+        Func<MessageEnvelope, CancellationToken, Task<MessageResult>> handler,
+        CancellationToken cancellationToken = default,
+        int dispatchConcurrency = 1)
+    {
+        Topic = topic;
+        SubscriptionName = subscriptionName;
+        Handler = handler;
+        return Task.FromResult<ISubscription>(new StubSubscription());
+    }
+
+    public ValueTask DisposeAsync() => default;
+
+    private sealed class StubSubscription : ISubscription
+    {
+        public string Topic => string.Empty;
+        public string SubscriptionName => string.Empty;
+        public bool IsActive => true;
+        public ValueTask DisposeAsync() => default;
+    }
+}

--- a/tests/RockBot.Agent.Tests/McpBridge/Auth/TokenCacheStoreTests.cs
+++ b/tests/RockBot.Agent.Tests/McpBridge/Auth/TokenCacheStoreTests.cs
@@ -1,0 +1,142 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Identity.Client;
+using RockBot.Agent.McpBridge.Auth;
+using RockBot.Messaging;
+
+namespace RockBot.Agent.Tests.McpBridge.Auth;
+
+[TestClass]
+public class TokenCacheStoreTests
+{
+    private string _cacheDir = null!;
+    private string _cachePath = null!;
+
+    [TestInitialize]
+    public void Init()
+    {
+        _cacheDir = Path.Combine(Path.GetTempPath(), "rockbot-tokencache-tests-" + Guid.NewGuid().ToString("N"));
+        _cachePath = Path.Combine(_cacheDir, "workiq-cache.bin");
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_cacheDir))
+            Directory.Delete(_cacheDir, recursive: true);
+    }
+
+    [TestMethod]
+    public async Task HandleCacheUpdated_PersistsBytesToDisk()
+    {
+        var ctx = await StartStoreAsync();
+
+        var payload = new WorkIqAuthCacheUpdated
+        {
+            CacheBytes = [1, 2, 3, 4, 5],
+            AccountId = "user@example.com",
+            Scopes = ["WorkIQ-Mail.Read"]
+        };
+        var envelope = payload.ToEnvelope(source: "ui");
+
+        var result = await ctx.Subscriber.Handler!.Invoke(envelope, CancellationToken.None);
+
+        Assert.AreEqual(MessageResult.Ack, result);
+        Assert.IsTrue(File.Exists(_cachePath));
+        CollectionAssert.AreEqual(new byte[] { 1, 2, 3, 4, 5 }, await File.ReadAllBytesAsync(_cachePath));
+
+        await ctx.Store.StopAsync(CancellationToken.None);
+    }
+
+    [TestMethod]
+    public async Task HandleCacheUpdated_EmptyPayload_DeadLetters()
+    {
+        var ctx = await StartStoreAsync();
+
+        var payload = new WorkIqAuthCacheUpdated
+        {
+            CacheBytes = [],
+            AccountId = "user"
+        };
+        var envelope = payload.ToEnvelope(source: "ui");
+
+        var result = await ctx.Subscriber.Handler!.Invoke(envelope, CancellationToken.None);
+
+        Assert.AreEqual(MessageResult.DeadLetter, result);
+        Assert.IsFalse(File.Exists(_cachePath));
+
+        await ctx.Store.StopAsync(CancellationToken.None);
+    }
+
+    [TestMethod]
+    public async Task Start_CreatesCacheDirectory()
+    {
+        Assert.IsFalse(Directory.Exists(_cacheDir));
+
+        var ctx = await StartStoreAsync();
+
+        Assert.IsTrue(Directory.Exists(_cacheDir));
+
+        await ctx.Store.StopAsync(CancellationToken.None);
+    }
+
+    [TestMethod]
+    public async Task Start_SubscribesToCorrectTopic()
+    {
+        var ctx = await StartStoreAsync();
+
+        Assert.AreEqual(WorkIqAuthTopics.CacheUpdated, ctx.Subscriber.Topic);
+
+        await ctx.Store.StopAsync(CancellationToken.None);
+    }
+
+    [TestMethod]
+    public async Task PersistedFile_HasUserRwPermissions_OnLinux()
+    {
+        if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS())
+        {
+            Assert.Inconclusive("Unix file mode is only meaningful on POSIX systems.");
+            return;
+        }
+
+        var ctx = await StartStoreAsync();
+
+        var payload = new WorkIqAuthCacheUpdated
+        {
+            CacheBytes = [42],
+            AccountId = "user"
+        };
+        await ctx.Subscriber.Handler!.Invoke(payload.ToEnvelope(source: "ui"), CancellationToken.None);
+
+        var mode = File.GetUnixFileMode(_cachePath);
+        Assert.AreEqual(UnixFileMode.UserRead | UnixFileMode.UserWrite, mode);
+
+        await ctx.Store.StopAsync(CancellationToken.None);
+    }
+
+    private async Task<StoreContext> StartStoreAsync()
+    {
+        var subscriber = new StubMessageSubscriber();
+        // PublicClientApplicationBuilder does not hit the network until you ask
+        // it to acquire a token, so this is safe in unit tests.
+        var msal = PublicClientApplicationBuilder
+            .Create("00000000-0000-0000-0000-000000000001")
+            .WithAuthority(AzureCloudInstance.AzurePublic, "00000000-0000-0000-0000-000000000002")
+            .Build();
+
+        var options = Options.Create(new MsalTokenProviderOptions
+        {
+            CacheFilePath = _cachePath,
+            TenantId = "00000000-0000-0000-0000-000000000002",
+            ClientId = "00000000-0000-0000-0000-000000000001"
+        });
+
+        var store = new TokenCacheStore(
+            subscriber, msal, options, NullLogger<TokenCacheStore>.Instance);
+        await store.StartAsync(CancellationToken.None);
+        return new StoreContext(store, subscriber, msal);
+    }
+
+    private sealed record StoreContext(
+        TokenCacheStore Store, StubMessageSubscriber Subscriber, IPublicClientApplication Msal);
+}

--- a/tests/RockBot.Agent.Tests/McpBridgeServerConfigTests.cs
+++ b/tests/RockBot.Agent.Tests/McpBridgeServerConfigTests.cs
@@ -165,4 +165,61 @@ public class McpBridgeServerConfigTests
 
         Assert.AreEqual(a.CanonicalIdentity(), b.CanonicalIdentity());
     }
+
+    // ── Auth profile ──────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void CanonicalIdentity_AuthProfile_DifferentiatesFromUnauthenticated()
+    {
+        // Same URL, but one carries an auth profile — must not be deduped against
+        // the other, since they call as different identities even at the same endpoint.
+        var unauth = new McpBridgeServerConfig { Type = "streamable-http", Url = "https://srv/" };
+        var auth = new McpBridgeServerConfig
+        {
+            Type = "streamable-http",
+            Url = "https://srv/",
+            Auth = new McpServerAuthConfig { Profile = "workiq" }
+        };
+
+        Assert.AreNotEqual(unauth.CanonicalIdentity(), auth.CanonicalIdentity());
+    }
+
+    [TestMethod]
+    public void CanonicalIdentity_DifferentAuthProfiles_AreDifferent()
+    {
+        // Same URL, different identities. Both registrations must be kept.
+        var a = new McpBridgeServerConfig
+        {
+            Type = "streamable-http",
+            Url = "https://srv/",
+            Auth = new McpServerAuthConfig { Profile = "workiq" }
+        };
+        var b = new McpBridgeServerConfig
+        {
+            Type = "streamable-http",
+            Url = "https://srv/",
+            Auth = new McpServerAuthConfig { Profile = "github" }
+        };
+
+        Assert.AreNotEqual(a.CanonicalIdentity(), b.CanonicalIdentity());
+    }
+
+    [TestMethod]
+    public void CanonicalIdentity_SameAuthProfile_CaseInsensitive_AreEqual()
+    {
+        var a = new McpBridgeServerConfig
+        {
+            Type = "streamable-http",
+            Url = "https://srv/",
+            Auth = new McpServerAuthConfig { Profile = "WorkIQ" }
+        };
+        var b = new McpBridgeServerConfig
+        {
+            Type = "streamable-http",
+            Url = "https://srv/",
+            Auth = new McpServerAuthConfig { Profile = "workiq" }
+        };
+
+        Assert.AreEqual(a.CanonicalIdentity(), b.CanonicalIdentity());
+    }
 }

--- a/tests/RockBot.Agent.Tests/RockBot.Agent.Tests.csproj
+++ b/tests/RockBot.Agent.Tests/RockBot.Agent.Tests.csproj
@@ -13,6 +13,11 @@
     <PackageReference Include="MSTest.TestAdapter" Version="3.*" />
     <PackageReference Include="MSTest.TestFramework" Version="3.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/RockBot.Tools.Tests/Auth/BearerInjectionHandlerTests.cs
+++ b/tests/RockBot.Tools.Tests/Auth/BearerInjectionHandlerTests.cs
@@ -1,0 +1,156 @@
+using System.Net;
+using System.Net.Http.Headers;
+using RockBot.Tools.Mcp.Auth;
+
+namespace RockBot.Tools.Tests.Auth;
+
+[TestClass]
+public class BearerInjectionHandlerTests
+{
+    [TestMethod]
+    public async Task SendAsync_InjectsBearerOnEveryRequest()
+    {
+        var provider = new RecordingProvider(_ => "token-A");
+        var inner = new StubInner(_ => new HttpResponseMessage(HttpStatusCode.OK));
+        var handler = new BearerInjectionHandler(provider, inner);
+        var client = new HttpClient(handler);
+
+        await client.GetAsync("https://srv/");
+        await client.GetAsync("https://srv/");
+        await client.GetAsync("https://srv/");
+
+        Assert.AreEqual(3, inner.AuthHeaders.Count);
+        foreach (var header in inner.AuthHeaders)
+        {
+            Assert.AreEqual("Bearer", header?.Scheme);
+            Assert.AreEqual("token-A", header?.Parameter);
+        }
+        Assert.AreEqual(3, provider.Calls.Count);
+        Assert.IsTrue(provider.Calls.All(forceRefresh => forceRefresh == false));
+    }
+
+    [TestMethod]
+    public async Task SendAsync_On401_ForcesRefreshAndRetriesOnce()
+    {
+        var tokens = new Queue<string>(["stale-token", "fresh-token"]);
+        var provider = new RecordingProvider(_ => tokens.Dequeue());
+
+        var responses = new Queue<HttpResponseMessage>([
+            new HttpResponseMessage(HttpStatusCode.Unauthorized),
+            new HttpResponseMessage(HttpStatusCode.OK)
+        ]);
+        var inner = new StubInner(_ => responses.Dequeue());
+
+        var handler = new BearerInjectionHandler(provider, inner);
+        var client = new HttpClient(handler);
+
+        var result = await client.GetAsync("https://srv/");
+
+        Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
+        Assert.AreEqual(2, inner.AuthHeaders.Count);
+        Assert.AreEqual("stale-token", inner.AuthHeaders[0]?.Parameter);
+        Assert.AreEqual("fresh-token", inner.AuthHeaders[1]?.Parameter);
+        CollectionAssert.AreEqual(new[] { false, true }, provider.Calls);
+    }
+
+    [TestMethod]
+    public async Task SendAsync_DoubleUnauthorized_ThrowsMcpAuthChallengeException()
+    {
+        var provider = new RecordingProvider(_ => "any-token");
+        var responses = new Queue<HttpResponseMessage>([
+            BuildUnauthorized("Bearer error=\"invalid_token\""),
+            BuildUnauthorized("Bearer resource_metadata=\"https://srv/.well-known/oauth-protected-resource\"")
+        ]);
+        var inner = new StubInner(_ => responses.Dequeue());
+
+        var handler = new BearerInjectionHandler(provider, inner);
+        var client = new HttpClient(handler);
+
+        var ex = await Assert.ThrowsExactlyAsync<McpAuthChallengeException>(
+            () => client.GetAsync("https://srv/"));
+
+        Assert.IsNotNull(ex.Challenge);
+        Assert.AreEqual("https://srv/.well-known/oauth-protected-resource", ex.Challenge.ResourceMetadata);
+        StringAssert.Contains(ex.Message, "https://srv/.well-known/oauth-protected-resource");
+        Assert.AreEqual(2, inner.AuthHeaders.Count);
+    }
+
+    [TestMethod]
+    public async Task SendAsync_DoubleUnauthorizedWithoutChallenge_ThrowsWithoutChallenge()
+    {
+        var provider = new RecordingProvider(_ => "any-token");
+        var responses = new Queue<HttpResponseMessage>([
+            new HttpResponseMessage(HttpStatusCode.Unauthorized),
+            new HttpResponseMessage(HttpStatusCode.Unauthorized)
+        ]);
+        var inner = new StubInner(_ => responses.Dequeue());
+
+        var handler = new BearerInjectionHandler(provider, inner);
+        var client = new HttpClient(handler);
+
+        var ex = await Assert.ThrowsExactlyAsync<McpAuthChallengeException>(
+            () => client.GetAsync("https://srv/"));
+
+        Assert.IsNull(ex.Challenge);
+    }
+
+    [TestMethod]
+    public async Task SendAsync_OverwritesExistingAuthorizationHeader()
+    {
+        var provider = new RecordingProvider(_ => "injected-token");
+        var inner = new StubInner(_ => new HttpResponseMessage(HttpStatusCode.OK));
+        var handler = new BearerInjectionHandler(provider, inner);
+        var client = new HttpClient(handler);
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, "https://srv/");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Basic", "caller-set-value");
+
+        await client.SendAsync(request);
+
+        Assert.AreEqual("Bearer", inner.AuthHeaders[0]?.Scheme);
+        Assert.AreEqual("injected-token", inner.AuthHeaders[0]?.Parameter);
+    }
+
+    private static HttpResponseMessage BuildUnauthorized(string wwwAuthenticate)
+    {
+        var resp = new HttpResponseMessage(HttpStatusCode.Unauthorized);
+        var spaceIdx = wwwAuthenticate.IndexOf(' ');
+        if (spaceIdx > 0)
+        {
+            resp.Headers.WwwAuthenticate.Add(new AuthenticationHeaderValue(
+                wwwAuthenticate[..spaceIdx], wwwAuthenticate[(spaceIdx + 1)..]));
+        }
+        else
+        {
+            resp.Headers.WwwAuthenticate.Add(new AuthenticationHeaderValue(wwwAuthenticate));
+        }
+        return resp;
+    }
+
+    private sealed class RecordingProvider(Func<bool, string> tokenFactory) : ITokenProvider
+    {
+        public List<bool> Calls { get; } = new();
+
+        public Task<string> GetAccessTokenAsync(bool forceRefresh, CancellationToken ct)
+        {
+            Calls.Add(forceRefresh);
+            return Task.FromResult(tokenFactory(forceRefresh));
+        }
+    }
+
+    private sealed class StubInner(Func<HttpRequestMessage, HttpResponseMessage> respond) : HttpMessageHandler
+    {
+        // We snapshot the Authorization header at send time because
+        // BearerInjectionHandler reuses the same HttpRequestMessage on retry,
+        // mutating headers in place. Capturing references would show the final
+        // state for every call.
+        public List<AuthenticationHeaderValue?> AuthHeaders { get; } = new();
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            AuthHeaders.Add(request.Headers.Authorization);
+            return Task.FromResult(respond(request));
+        }
+    }
+}

--- a/tests/RockBot.Tools.Tests/Auth/TokenProviderRegistryTests.cs
+++ b/tests/RockBot.Tools.Tests/Auth/TokenProviderRegistryTests.cs
@@ -1,0 +1,51 @@
+using RockBot.Tools.Mcp.Auth;
+
+namespace RockBot.Tools.Tests.Auth;
+
+[TestClass]
+public class TokenProviderRegistryTests
+{
+    [TestMethod]
+    public void Get_RegisteredProfile_ReturnsProvider()
+    {
+        var provider = new StubProvider("token-A");
+        var registry = new TokenProviderRegistry(
+            [new TokenProviderRegistration("workiq", provider)]);
+
+        Assert.AreSame(provider, registry.Get("workiq"));
+    }
+
+    [TestMethod]
+    public void Get_ProfileMatchIsCaseInsensitive()
+    {
+        var provider = new StubProvider("token-A");
+        var registry = new TokenProviderRegistry(
+            [new TokenProviderRegistration("workiq", provider)]);
+
+        Assert.AreSame(provider, registry.Get("WorkIQ"));
+        Assert.AreSame(provider, registry.Get("WORKIQ"));
+    }
+
+    [TestMethod]
+    public void Get_UnknownProfile_ThrowsWithKnownProfilesListed()
+    {
+        var registry = new TokenProviderRegistry(
+        [
+            new TokenProviderRegistration("workiq", new StubProvider("a")),
+            new TokenProviderRegistration("github", new StubProvider("b"))
+        ]);
+
+        var ex = Assert.ThrowsExactly<KeyNotFoundException>(
+            () => registry.Get("nonexistent"));
+
+        StringAssert.Contains(ex.Message, "nonexistent");
+        StringAssert.Contains(ex.Message, "workiq");
+        StringAssert.Contains(ex.Message, "github");
+    }
+
+    private sealed class StubProvider(string token) : ITokenProvider
+    {
+        public Task<string> GetAccessTokenAsync(bool forceRefresh, CancellationToken ct) =>
+            Task.FromResult(token);
+    }
+}

--- a/tests/RockBot.Tools.Tests/Auth/WwwAuthenticateChallengeTests.cs
+++ b/tests/RockBot.Tools.Tests/Auth/WwwAuthenticateChallengeTests.cs
@@ -1,0 +1,92 @@
+using RockBot.Tools.Mcp.Auth;
+
+namespace RockBot.Tools.Tests.Auth;
+
+[TestClass]
+public class WwwAuthenticateChallengeTests
+{
+    [TestMethod]
+    public void TryParse_McpResourceMetadataChallenge_ExtractsUrl()
+    {
+        var header = "Bearer resource_metadata=\"https://example.com/.well-known/oauth-protected-resource\"";
+
+        Assert.IsTrue(WwwAuthenticateChallenge.TryParse(header, out var challenge));
+        Assert.AreEqual("Bearer", challenge.Scheme);
+        Assert.AreEqual("https://example.com/.well-known/oauth-protected-resource", challenge.ResourceMetadata);
+        Assert.AreEqual(header, challenge.RawValue);
+    }
+
+    [TestMethod]
+    public void TryParse_Rfc6750ErrorChallenge_ExtractsErrorDetails()
+    {
+        var header = "Bearer realm=\"example\", error=\"invalid_token\", error_description=\"The access token expired\"";
+
+        Assert.IsTrue(WwwAuthenticateChallenge.TryParse(header, out var challenge));
+        Assert.AreEqual("Bearer", challenge.Scheme);
+        Assert.AreEqual("example", challenge.Realm);
+        Assert.AreEqual("invalid_token", challenge.Error);
+        Assert.AreEqual("The access token expired", challenge.ErrorDescription);
+    }
+
+    [TestMethod]
+    public void TryParse_CombinedMcpAndRfc6750_ExtractsBoth()
+    {
+        var header = "Bearer resource_metadata=\"https://srv/.well-known/oauth-protected-resource\", " +
+                     "error=\"invalid_token\", error_description=\"Token revoked\", " +
+                     "scope=\"WorkIQ.Mail.Read WorkIQ.Calendar.Read\"";
+
+        Assert.IsTrue(WwwAuthenticateChallenge.TryParse(header, out var challenge));
+        Assert.AreEqual("https://srv/.well-known/oauth-protected-resource", challenge.ResourceMetadata);
+        Assert.AreEqual("invalid_token", challenge.Error);
+        Assert.AreEqual("Token revoked", challenge.ErrorDescription);
+        Assert.AreEqual("WorkIQ.Mail.Read WorkIQ.Calendar.Read", challenge.Scope);
+    }
+
+    [TestMethod]
+    public void TryParse_SchemeOnly_ParsesWithNoParameters()
+    {
+        Assert.IsTrue(WwwAuthenticateChallenge.TryParse("Bearer", out var challenge));
+        Assert.AreEqual("Bearer", challenge.Scheme);
+        Assert.IsNull(challenge.ResourceMetadata);
+        Assert.IsNull(challenge.Error);
+    }
+
+    [TestMethod]
+    public void TryParse_UnquotedValues_ParsesCorrectly()
+    {
+        // RFC 7235 permits token values without quotes for simple identifiers
+        var header = "Bearer realm=example, error=invalid_token";
+
+        Assert.IsTrue(WwwAuthenticateChallenge.TryParse(header, out var challenge));
+        Assert.AreEqual("example", challenge.Realm);
+        Assert.AreEqual("invalid_token", challenge.Error);
+    }
+
+    [TestMethod]
+    public void TryParse_EscapedQuoteInValue_IsUnescaped()
+    {
+        var header = "Bearer error_description=\"Token \\\"expired\\\" yesterday\"";
+
+        Assert.IsTrue(WwwAuthenticateChallenge.TryParse(header, out var challenge));
+        Assert.AreEqual("Token \"expired\" yesterday", challenge.ErrorDescription);
+    }
+
+    [TestMethod]
+    public void TryParse_NullOrWhitespace_ReturnsFalse()
+    {
+        Assert.IsFalse(WwwAuthenticateChallenge.TryParse(null, out _));
+        Assert.IsFalse(WwwAuthenticateChallenge.TryParse("", out _));
+        Assert.IsFalse(WwwAuthenticateChallenge.TryParse("   ", out _));
+    }
+
+    [TestMethod]
+    public void TryParse_GarbageWithoutKeyValuePairs_ReturnsSchemeOnly()
+    {
+        // We accept the scheme even when parameters are missing or malformed,
+        // because servers in the wild send all kinds of nonsense and crashing
+        // the bridge over a malformed header would be worse than logging it.
+        Assert.IsTrue(WwwAuthenticateChallenge.TryParse("Bearer not-a-valid-param-section", out var challenge));
+        Assert.AreEqual("Bearer", challenge.Scheme);
+        Assert.IsNull(challenge.ResourceMetadata);
+    }
+}


### PR DESCRIPTION
Closes the Phase 1 + Phase 2 portions of #441. Out of scope here: UI MSAL flow (Phase 3), Entra registration + end-to-end smoke (Phase 4), re-consent UX (Phase 5) — each will land as a follow-up.

## Summary

- **Phase 1 — reusable bearer-auth infrastructure.** New `ITokenProvider` / `ITokenProviderRegistry` in `RockBot.Tools.Mcp.Auth`, `BearerInjectionHandler` (per-request inject + 401 forceRefresh retry + parsed challenge on second failure), `WwwAuthenticateChallenge` parser for the MCP OAuth spec's `resource_metadata` advertisement. `McpServerAuthConfig.Auth` flows through `McpBridgeService.ConnectServerAsync` and the attachment gateway via a shared `TryBuildHttpClient` helper. Adds `auth_required` to `ToolError.Codes` and surfaces parsed challenges in the resulting tool error.
- **Phase 2 — MSAL `workiq` profile.** `MsalTokenProvider` does `AcquireTokenSilent` and publishes `WorkIqAuthExpired` on `MsalUiRequiredException`. `TokenCacheStore` (hosted service) syncs the cache between the bus (`auth.workiq.cache`, populated by the future UI tier) and disk (`/data/agent/secrets/workiq-cache.bin`, mode 0600 on POSIX). `AddWorkIqAuth` DI extension; `Program.cs` registration gated on `WorkIQ:TenantId`+`ClientId`. Helm: `workiq.*` values (disabled by default), conditional `WorkIQ__*` configmap keys, init container creates `/data/agent/secrets` mode 0700.

## Test plan

- [x] Full `dotnet build RockBot.slnx` clean (0 errors)
- [x] Full `dotnet test RockBot.slnx` clean across all 19 test projects
- [x] New tests: 16 in `RockBot.Tools.Tests/Auth/` (challenge parser, bearer handler, registry); 7 in `RockBot.Agent.Tests/McpBridge/Auth/` (cache store, MSAL provider, DI wiring) — 1 skipped on Windows (Unix file mode)
- [x] 3 new tests added to `McpBridgeServerConfigTests` cover the `Auth.Profile` addition to `CanonicalIdentity`
- [x] `helm template` with default values renders cleanly (workiq disabled)
- [x] `helm template --set workiq.enabled=true ...` emits expected `WorkIQ__TenantId/ClientId/Scopes` configmap keys
- [x] Grep confirms no log statements emit token bytes or refresh-token material

## Deployment note for live cluster

Existing PVCs won't auto-create `/data/agent/secrets`. On upgrade, either let the agent pod restart (init container handles it) or `kubectl exec ... -- mkdir -m 0700 /data/agent/secrets && chown rockbot:rockbot /data/agent/secrets`. New deployments are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)