### PR TITLE
WorkIQ MCP auth: UI-tier device-code flow (Phase 3 of #441)

### DIFF
--- a/RockBot.slnx
+++ b/RockBot.slnx
@@ -31,6 +31,7 @@
     <Project Path="src/RockBot.UserProxy/RockBot.UserProxy.csproj" />
     <Project Path="src/RockBot.UserProxy.Cli/RockBot.UserProxy.Cli.csproj" />
     <Project Path="src/RockBot.UserProxy.Blazor/RockBot.UserProxy.Blazor.csproj" />
+    <Project Path="src/RockBot.UserProxy.WorkIqAuth/RockBot.UserProxy.WorkIqAuth.csproj" />
     <Project Path="src/RockBot.Memory/RockBot.Memory.csproj" />
     <Project Path="src/RockBot.Skills/RockBot.Skills.csproj" />
     <Project Path="src/RockBot.Observation/RockBot.Observation.csproj" />
@@ -63,6 +64,7 @@
     <Project Path="tests/RockBot.Wisp.Tests/RockBot.Wisp.Tests.csproj" />
     <Project Path="tests/RockBot.Llm.Copilot.Tests/RockBot.Llm.Copilot.Tests.csproj" />
     <Project Path="tests/RockBot.UserProxy.Blazor.Tests/RockBot.UserProxy.Blazor.Tests.csproj" />
+    <Project Path="tests/RockBot.UserProxy.WorkIqAuth.Tests/RockBot.UserProxy.WorkIqAuth.Tests.csproj" />
     <Project Path="tests/RockBot.A2A.IntegrationTests/RockBot.A2A.IntegrationTests.csproj" />
     <Project Path="tests/RockBot.A2A.Gateway.Tests/RockBot.A2A.Gateway.Tests.csproj" />
     <Project Path="tests/RockBot.Observation.Tests/RockBot.Observation.Tests.csproj" />

--- a/deploy/helm/rockbot/templates/blazor/deployment.yaml
+++ b/deploy/helm/rockbot/templates/blazor/deployment.yaml
@@ -55,6 +55,34 @@ spec:
                 secretKeyRef:
                   name: {{ include "rockbot.secretName" . }}
                   key: RabbitMq__Password
+            {{- if .Values.workiq.enabled }}
+            # WorkIQ device-code flow needs the same Entra app registration
+            # values the agent uses. Cache itself never lands on the Blazor pod.
+            - name: WorkIQ__TenantId
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "rockbot.configmapName" . }}
+                  key: WorkIQ__TenantId
+            - name: WorkIQ__ClientId
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "rockbot.configmapName" . }}
+                  key: WorkIQ__ClientId
+            {{- if .Values.workiq.scopes }}
+            - name: WorkIQ__Scopes
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "rockbot.configmapName" . }}
+                  key: WorkIQ__Scopes
+            {{- end }}
+            {{- if .Values.workiq.authority }}
+            - name: WorkIQ__Authority
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "rockbot.configmapName" . }}
+                  key: WorkIQ__Authority
+            {{- end }}
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /

--- a/src/RockBot.Agent/McpBridge/Auth/MsalTokenProvider.cs
+++ b/src/RockBot.Agent/McpBridge/Auth/MsalTokenProvider.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.Identity.Client;
 using RockBot.Messaging;
 using RockBot.Tools.Mcp.Auth;
+using RockBot.UserProxy.WorkIqAuth;
 
 namespace RockBot.Agent.McpBridge.Auth;
 

--- a/src/RockBot.Agent/McpBridge/Auth/TokenCacheStore.cs
+++ b/src/RockBot.Agent/McpBridge/Auth/TokenCacheStore.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Identity.Client;
 using RockBot.Messaging;
+using RockBot.UserProxy.WorkIqAuth;
 
 namespace RockBot.Agent.McpBridge.Auth;
 

--- a/src/RockBot.Agent/RockBot.Agent.csproj
+++ b/src/RockBot.Agent/RockBot.Agent.csproj
@@ -57,6 +57,7 @@
     <ProjectReference Include="..\RockBot.Messaging.RabbitMQ\RockBot.Messaging.RabbitMQ.csproj" />
     <ProjectReference Include="..\RockBot.Scripts.Remote\RockBot.Scripts.Remote.csproj" />
     <ProjectReference Include="..\RockBot.UserProxy.Abstractions\RockBot.UserProxy.Abstractions.csproj" />
+    <ProjectReference Include="..\RockBot.UserProxy.WorkIqAuth\RockBot.UserProxy.WorkIqAuth.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/RockBot.UserProxy.Blazor/Components/WorkIqConnect.razor
+++ b/src/RockBot.UserProxy.Blazor/Components/WorkIqConnect.razor
@@ -1,0 +1,138 @@
+@using Microsoft.JSInterop
+@using RockBot.UserProxy.Blazor.Services
+@using RockBot.UserProxy.WorkIqAuth
+@inject WorkIqDeviceCodeFlow Flow
+@inject WorkIqAuthUiService UiState
+@inject ILogger<WorkIqConnect> Logger
+@inject IJSRuntime JS
+@implements IDisposable
+
+<div class="workiq-connect">
+    @if (_state == ConnectState.NotStarted)
+    {
+        <button class="btn btn-primary" @onclick="StartFlow">Connect M365</button>
+        @if (_lastError is not null)
+        {
+            <div class="mt-2 alert alert-danger small" role="alert">
+                @_lastError
+            </div>
+        }
+    }
+    else if (_state == ConnectState.InProgress && _challenge is not null)
+    {
+        <div class="workiq-challenge">
+            <p class="mb-2">@_challenge.Message</p>
+            <div class="d-flex align-items-center gap-2 mb-2">
+                <code class="user-code">@_challenge.UserCode</code>
+                <button class="btn btn-sm btn-outline-secondary" @onclick="CopyCode"
+                        title="Copy code">📋</button>
+            </div>
+            <p class="small mb-2">
+                Open <a href="@_challenge.VerificationUrl" target="_blank" rel="noopener noreferrer">
+                    @_challenge.VerificationUrl
+                </a> and enter the code.
+            </p>
+            <p class="small text-muted mb-2">
+                Code expires at @_challenge.ExpiresOn.LocalDateTime.ToString("t").
+            </p>
+            <button class="btn btn-sm btn-outline-secondary" @onclick="Cancel">Cancel</button>
+        </div>
+    }
+    else if (_state == ConnectState.Success)
+    {
+        <div class="alert alert-success" role="alert">
+            Connected to Microsoft 365.
+        </div>
+    }
+    else if (_state == ConnectState.Failed)
+    {
+        <div class="alert alert-danger" role="alert">
+            <p class="mb-2"><strong>Sign-in failed.</strong></p>
+            <p class="mb-2 small">@_lastError</p>
+            <button class="btn btn-sm btn-secondary" @onclick="Reset">Try again</button>
+        </div>
+    }
+</div>
+
+@code {
+    private ConnectState _state = ConnectState.NotStarted;
+    private DeviceCodeChallenge? _challenge;
+    private string? _lastError;
+    private CancellationTokenSource? _cts;
+    private Task? _completionTask;
+
+    private async Task StartFlow()
+    {
+        _state = ConnectState.InProgress;
+        _lastError = null;
+        _cts = new CancellationTokenSource();
+        try
+        {
+            var (challenge, completion) = await Flow.BeginAsync(_cts.Token);
+            _challenge = challenge;
+            _completionTask = completion;
+            StateHasChanged();
+            await completion;
+
+            _state = ConnectState.Success;
+            UiState.MarkConnected();
+        }
+        catch (WorkIqAuthFlowException ex)
+        {
+            Logger.LogWarning(ex, "WorkIQ device-code flow failed ({Code})", ex.Code);
+            _lastError = ex.Message;
+            _state = ConnectState.Failed;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Unexpected error during WorkIQ device-code flow");
+            _lastError = ex.Message;
+            _state = ConnectState.Failed;
+        }
+        finally
+        {
+            _cts?.Dispose();
+            _cts = null;
+        }
+    }
+
+    private void Cancel()
+    {
+        _cts?.Cancel();
+    }
+
+    private void Reset()
+    {
+        _state = ConnectState.NotStarted;
+        _lastError = null;
+        _challenge = null;
+        _completionTask = null;
+    }
+
+    private async Task CopyCode()
+    {
+        if (_challenge is null) return;
+        try
+        {
+            await JS.InvokeVoidAsync("navigator.clipboard.writeText", _challenge.UserCode);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogDebug(ex, "Clipboard copy failed");
+        }
+    }
+
+    public void Dispose()
+    {
+        _cts?.Cancel();
+        _cts?.Dispose();
+    }
+
+    private enum ConnectState
+    {
+        NotStarted,
+        InProgress,
+        Success,
+        Failed
+    }
+}

--- a/src/RockBot.UserProxy.Blazor/Components/WorkIqReconnectBanner.razor
+++ b/src/RockBot.UserProxy.Blazor/Components/WorkIqReconnectBanner.razor
@@ -1,0 +1,50 @@
+@using RockBot.UserProxy.Blazor.Services
+@inject WorkIqAuthUiService UiState
+@implements IDisposable
+
+@if (UiState.IsExpiredBannerVisible)
+{
+    <div class="alert alert-warning workiq-reconnect-banner d-flex justify-content-between align-items-center mb-0"
+         role="alert">
+        <div>
+            <strong>M365 connection expired.</strong>
+            @if (!string.IsNullOrWhiteSpace(UiState.CurrentReason))
+            {
+                <span class="ms-2 small text-muted">@UiState.CurrentReason</span>
+            }
+        </div>
+        <div class="d-flex gap-2">
+            <button class="btn btn-sm btn-warning" @onclick="OnReconnect">Reconnect</button>
+            <button class="btn btn-sm btn-link" @onclick="OnDismiss"
+                    title="Dismiss">✕</button>
+        </div>
+    </div>
+}
+
+@code {
+    /// <summary>
+    /// Invoked when the user clicks Reconnect. Parents should open their
+    /// connect dialog/modal in response.
+    /// </summary>
+    [Parameter] public EventCallback OnReconnectClicked { get; set; }
+
+    protected override void OnInitialized()
+    {
+        UiState.StateChanged += HandleStateChanged;
+    }
+
+    private void HandleStateChanged() => InvokeAsync(StateHasChanged);
+
+    private async Task OnReconnect()
+    {
+        if (OnReconnectClicked.HasDelegate)
+            await OnReconnectClicked.InvokeAsync();
+    }
+
+    private void OnDismiss() => UiState.DismissExpiredBanner();
+
+    public void Dispose()
+    {
+        UiState.StateChanged -= HandleStateChanged;
+    }
+}

--- a/src/RockBot.UserProxy.Blazor/Pages/Chat.razor
+++ b/src/RockBot.UserProxy.Blazor/Pages/Chat.razor
@@ -4,6 +4,7 @@
 @inject UserProxyService ProxyService
 @inject ChatStateService ChatState
 @inject IJSRuntime JSRuntime
+@inject WorkIqAuthUiService WorkIqAuth
 @implements IDisposable
 
 <PageTitle>@(ChatState.AgentName ?? "RockBot") Chat</PageTitle>
@@ -53,6 +54,9 @@
                     🔗
                 </span>
             }
+            <button class="btn btn-sm btn-outline-light" @onclick="ToggleWorkIqModal" title="Connect Microsoft 365">
+                M365
+            </button>
             <button class="btn btn-sm btn-outline-light" @onclick="ToggleSavedModal" title="Saved responses">
                 📋
             </button>
@@ -63,6 +67,8 @@
                   title="@(ProxyService.IsConnected ? "Connected to message bus" : "Disconnected from message bus")"></span>
         </div>
     </div>
+
+    <WorkIqReconnectBanner OnReconnectClicked="OpenWorkIqModalFromBanner" />
 
     <div class="chat-messages flex-grow-1 overflow-auto p-3" @ref="messagesContainer">
         @foreach (var message in ChatState.Messages)
@@ -236,6 +242,21 @@
         }
     </div>
 
+    @if (_showWorkIqModal)
+    {
+        <div class="modal-overlay" @onclick="ToggleWorkIqModal">
+            <div class="saved-modal" @onclick:stopPropagation="true">
+                <div class="saved-view-header d-flex justify-content-between align-items-center">
+                    <h5 class="mb-0">Connect Microsoft 365</h5>
+                    <button class="btn btn-sm btn-link" @onclick="ToggleWorkIqModal" title="Close">✕</button>
+                </div>
+                <div class="p-3">
+                    <WorkIqConnect />
+                </div>
+            </div>
+        </div>
+    }
+
     @if (_showSavedModal)
     {
         <div class="modal-overlay" @onclick="ToggleSavedModal">
@@ -339,6 +360,7 @@
     private string? _savingMessageId;
     private string _saveLabel = string.Empty;
     private bool _showSavedModal;
+    private bool _showWorkIqModal;
     private IReadOnlyList<SavedResponseSummary>? _savedItems;
     private GetSavedResponseResponse? _viewingItem;
 
@@ -626,6 +648,16 @@
     private void HandleSaveLabelKeyDown(KeyboardEventArgs e)
     {
         if (e.Key == "Escape") CancelSave();
+    }
+
+    private void ToggleWorkIqModal()
+    {
+        _showWorkIqModal = !_showWorkIqModal;
+    }
+
+    private void OpenWorkIqModalFromBanner()
+    {
+        _showWorkIqModal = true;
     }
 
     private async Task ToggleSavedModal()

--- a/src/RockBot.UserProxy.Blazor/Pages/_Imports.razor
+++ b/src/RockBot.UserProxy.Blazor/Pages/_Imports.razor
@@ -1,2 +1,3 @@
 @using RockBot.UserProxy.Blazor.Pages
+@using RockBot.UserProxy.Blazor.Components
 @using Microsoft.AspNetCore.Components.Web

--- a/src/RockBot.UserProxy.Blazor/Program.cs
+++ b/src/RockBot.UserProxy.Blazor/Program.cs
@@ -3,6 +3,7 @@ using RockBot.Messaging.RabbitMQ;
 using RockBot.UserProxy;
 using RockBot.UserProxy.Blazor.Components;
 using RockBot.UserProxy.Blazor.Services;
+using RockBot.UserProxy.WorkIqAuth;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -18,6 +19,13 @@ builder.Services.AddUserProxy(opts =>
 });
 builder.Services.AddSingleton<IUserFrontend, BlazorUserFrontend>();
 builder.Services.AddSingleton<ChatStateService>();
+
+// WorkIQ device-code flow + expired-notification listener. Always registered;
+// the flow itself fails fast with a NotConfigured error if WorkIQ settings
+// are not present in configuration, so deployments without WorkIQ pay only
+// the cost of an idle bus subscription.
+builder.Services.AddWorkIqAuthClient(builder.Configuration);
+builder.Services.AddScoped<WorkIqAuthUiService>();
 
 var app = builder.Build();
 

--- a/src/RockBot.UserProxy.Blazor/RockBot.UserProxy.Blazor.csproj
+++ b/src/RockBot.UserProxy.Blazor/RockBot.UserProxy.Blazor.csproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <ProjectReference Include="..\RockBot.UserProxy.Abstractions\RockBot.UserProxy.Abstractions.csproj" />
     <ProjectReference Include="..\RockBot.UserProxy\RockBot.UserProxy.csproj" />
+    <ProjectReference Include="..\RockBot.UserProxy.WorkIqAuth\RockBot.UserProxy.WorkIqAuth.csproj" />
     <ProjectReference Include="..\RockBot.Messaging.RabbitMQ\RockBot.Messaging.RabbitMQ.csproj" />
   </ItemGroup>
 

--- a/src/RockBot.UserProxy.Blazor/Services/WorkIqAuthUiService.cs
+++ b/src/RockBot.UserProxy.Blazor/Services/WorkIqAuthUiService.cs
@@ -1,0 +1,72 @@
+using RockBot.UserProxy.WorkIqAuth;
+
+namespace RockBot.UserProxy.Blazor.Services;
+
+/// <summary>
+/// Scoped state holder for WorkIQ connection state in the Blazor UI.
+/// Components bind to <see cref="StateChanged"/> to re-render when status
+/// transitions occur (connect started, completed, or expired).
+/// </summary>
+public sealed class WorkIqAuthUiService : IDisposable
+{
+    private readonly IWorkIqAuthStatusListener _listener;
+
+    public WorkIqAuthUiService(IWorkIqAuthStatusListener listener)
+    {
+        _listener = listener;
+        _listener.Expired += OnExpired;
+
+        // Initialize from any expiration that happened before this circuit started.
+        if (_listener.LastExpired is { } existing)
+            CurrentReason = existing.Reason;
+    }
+
+    /// <summary>
+    /// Fires when the connection state or banner content changes.
+    /// Components handle this to call StateHasChanged.
+    /// </summary>
+    public event Action? StateChanged;
+
+    /// <summary>
+    /// When true, the banner is visible. Cleared by <see cref="DismissExpiredBanner"/>
+    /// or after a successful re-consent via <see cref="MarkConnected"/>.
+    /// </summary>
+    public bool IsExpiredBannerVisible { get; private set; }
+
+    /// <summary>
+    /// Most recent expiration reason, surfaced in the banner.
+    /// </summary>
+    public string? CurrentReason { get; private set; }
+
+    /// <summary>Hide the banner; called when the user dismisses it.</summary>
+    public void DismissExpiredBanner()
+    {
+        if (!IsExpiredBannerVisible) return;
+        IsExpiredBannerVisible = false;
+        StateChanged?.Invoke();
+    }
+
+    /// <summary>
+    /// Called by the connect component on successful sign-in to clear any
+    /// outstanding expired notification.
+    /// </summary>
+    public void MarkConnected()
+    {
+        _listener.ClearLastExpired();
+        IsExpiredBannerVisible = false;
+        CurrentReason = null;
+        StateChanged?.Invoke();
+    }
+
+    private void OnExpired(object? sender, WorkIqAuthExpired e)
+    {
+        CurrentReason = e.Reason;
+        IsExpiredBannerVisible = true;
+        StateChanged?.Invoke();
+    }
+
+    public void Dispose()
+    {
+        _listener.Expired -= OnExpired;
+    }
+}

--- a/src/RockBot.UserProxy.Cli/Auth/WorkIqAuthCommand.cs
+++ b/src/RockBot.UserProxy.Cli/Auth/WorkIqAuthCommand.cs
@@ -1,0 +1,83 @@
+using Microsoft.Extensions.DependencyInjection;
+using RockBot.UserProxy.WorkIqAuth;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace RockBot.UserProxy.Cli.Auth;
+
+/// <summary>
+/// <c>rockbot auth workiq</c> — drives the MSAL device-code flow to sign the
+/// user into Microsoft 365 (Work IQ) and publishes the resulting token cache
+/// to the agent.
+/// </summary>
+internal sealed class WorkIqAuthCommand : AsyncCommand<CommonSettings.Plain>
+{
+    public override async Task<int> ExecuteAsync(CommandContext context, CommonSettings.Plain settings)
+    {
+        using var host = HostFactory.Build(
+            settings,
+            useRichFrontend: true,
+            configure: builder => builder.Services.AddWorkIqAuthClient(builder.Configuration));
+
+        await host.StartAsync();
+        try
+        {
+            var flow = host.Services.GetRequiredService<WorkIqDeviceCodeFlow>();
+            using var cts = new CancellationTokenSource();
+            using var ctrlC = ConfigureCancellation(cts);
+
+            var (challenge, completion) = await flow.BeginAsync(cts.Token);
+
+            AnsiConsole.MarkupLine(
+                $"[bold]Open[/] [link]{challenge.VerificationUrl}[/] [bold]and enter code[/]");
+            var codePanel = new Panel(new Markup($"[bold yellow]{challenge.UserCode}[/]"))
+                .Padding(2, 1)
+                .BorderStyle(Style.Parse("yellow"));
+            AnsiConsole.Write(codePanel);
+            AnsiConsole.MarkupLine($"[grey]Code expires at {challenge.ExpiresOn.LocalDateTime:t}.[/]");
+            AnsiConsole.MarkupLine("[grey]Press Ctrl+C to cancel.[/]");
+
+            await AnsiConsole.Status()
+                .Spinner(Spinner.Known.Dots)
+                .StartAsync("Waiting for sign-in to complete...", async _ => await completion);
+
+            AnsiConsole.MarkupLine("[green]Signed in. Token cache published to the agent.[/]");
+            return 0;
+        }
+        catch (WorkIqAuthFlowException ex)
+        {
+            AnsiConsole.MarkupLine($"[red]Sign-in failed[/] ({ex.Code}): {ex.Message.EscapeMarkup()}");
+            return ex.Code switch
+            {
+                WorkIqAuthFlowException.Codes.UserCancelled => 130, // SIGINT convention
+                WorkIqAuthFlowException.Codes.NotConfigured => 78,  // EX_CONFIG
+                _ => 1
+            };
+        }
+        catch (Exception ex)
+        {
+            AnsiConsole.MarkupLine($"[red]Unexpected error:[/] {ex.Message.EscapeMarkup()}");
+            return 1;
+        }
+        finally
+        {
+            await host.StopAsync();
+        }
+    }
+
+    private static IDisposable ConfigureCancellation(CancellationTokenSource cts)
+    {
+        ConsoleCancelEventHandler handler = (_, args) =>
+        {
+            args.Cancel = true;
+            cts.Cancel();
+        };
+        Console.CancelKeyPress += handler;
+        return new CancelHandlerSubscription(handler);
+    }
+
+    private sealed class CancelHandlerSubscription(ConsoleCancelEventHandler handler) : IDisposable
+    {
+        public void Dispose() => Console.CancelKeyPress -= handler;
+    }
+}

--- a/src/RockBot.UserProxy.Cli/HostFactory.cs
+++ b/src/RockBot.UserProxy.Cli/HostFactory.cs
@@ -13,7 +13,10 @@ namespace RockBot.UserProxy.Cli;
 /// </summary>
 internal static class HostFactory
 {
-    public static IHost Build(CommonSettings settings, bool useRichFrontend)
+    public static IHost Build(
+        CommonSettings settings,
+        bool useRichFrontend,
+        Action<HostApplicationBuilder>? configure = null)
     {
         // Pass no args — CLI flags are already parsed by Spectre and applied
         // below as in-memory config; we don't want Microsoft's CommandLine
@@ -63,6 +66,8 @@ internal static class HostFactory
             builder.Services.AddSingleton<IUserFrontend, SpectreConsoleFrontend>();
         else
             builder.Services.AddSingleton<IUserFrontend, PlainConsoleFrontend>();
+
+        configure?.Invoke(builder);
 
         return builder.Build();
     }

--- a/src/RockBot.UserProxy.Cli/Program.cs
+++ b/src/RockBot.UserProxy.Cli/Program.cs
@@ -1,4 +1,5 @@
 using RockBot.UserProxy.Cli;
+using RockBot.UserProxy.Cli.Auth;
 using Spectre.Console.Cli;
 
 var app = new CommandApp<ChatCommand>();
@@ -27,6 +28,13 @@ app.Configure(config =>
 
     config.AddCommand<CancelCommand>("cancel")
         .WithDescription("Ask the agent to cancel in-flight work for a session.");
+
+    config.AddBranch("auth", auth =>
+    {
+        auth.SetDescription("Authentication flows that connect the agent to external services.");
+        auth.AddCommand<WorkIqAuthCommand>("workiq")
+            .WithDescription("Sign in to Microsoft 365 (Work IQ) via device code and publish the cache to the agent.");
+    });
 });
 
 return await app.RunAsync(args);

--- a/src/RockBot.UserProxy.Cli/RockBot.UserProxy.Cli.csproj
+++ b/src/RockBot.UserProxy.Cli/RockBot.UserProxy.Cli.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <ProjectReference Include="..\RockBot.UserProxy.Abstractions\RockBot.UserProxy.Abstractions.csproj" />
     <ProjectReference Include="..\RockBot.UserProxy\RockBot.UserProxy.csproj" />
+    <ProjectReference Include="..\RockBot.UserProxy.WorkIqAuth\RockBot.UserProxy.WorkIqAuth.csproj" />
     <ProjectReference Include="..\RockBot.Messaging.RabbitMQ\RockBot.Messaging.RabbitMQ.csproj" />
   </ItemGroup>
 

--- a/src/RockBot.UserProxy.WorkIqAuth/DeviceCodeChallenge.cs
+++ b/src/RockBot.UserProxy.WorkIqAuth/DeviceCodeChallenge.cs
@@ -1,0 +1,12 @@
+namespace RockBot.UserProxy.WorkIqAuth;
+
+/// <summary>
+/// User-facing challenge surfaced by the device-code flow. Callers render the
+/// <see cref="UserCode"/> and <see cref="VerificationUrl"/> for the user, who
+/// completes sign-in in a separate browser tab.
+/// </summary>
+public sealed record DeviceCodeChallenge(
+    string UserCode,
+    string VerificationUrl,
+    DateTimeOffset ExpiresOn,
+    string Message);

--- a/src/RockBot.UserProxy.WorkIqAuth/IWorkIqAuthStatusListener.cs
+++ b/src/RockBot.UserProxy.WorkIqAuth/IWorkIqAuthStatusListener.cs
@@ -1,0 +1,26 @@
+namespace RockBot.UserProxy.WorkIqAuth;
+
+/// <summary>
+/// UI-tier listener for <see cref="WorkIqAuthExpired"/> notifications from
+/// the agent. Components (banners, dialogs) subscribe to <see cref="Expired"/>
+/// to surface a reconnect prompt.
+/// </summary>
+public interface IWorkIqAuthStatusListener
+{
+    /// <summary>
+    /// Fires every time the agent publishes <see cref="WorkIqAuthExpired"/>.
+    /// </summary>
+    event EventHandler<WorkIqAuthExpired> Expired;
+
+    /// <summary>
+    /// The most recent expiration notification received, or <c>null</c> if
+    /// none has been received in this UI session.
+    /// </summary>
+    WorkIqAuthExpired? LastExpired { get; }
+
+    /// <summary>
+    /// Clears the most recent expiration notification — call when the user
+    /// has acknowledged it or completed a successful re-consent.
+    /// </summary>
+    void ClearLastExpired();
+}

--- a/src/RockBot.UserProxy.WorkIqAuth/RockBot.UserProxy.WorkIqAuth.csproj
+++ b/src/RockBot.UserProxy.WorkIqAuth/RockBot.UserProxy.WorkIqAuth.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>RockBot.UserProxy.WorkIqAuth</RootNamespace>
+    <IsPackable>true</IsPackable>
+    <Description>UI-tier MSAL device-code flow for Microsoft Work IQ. Acquires tokens on behalf of the user and ships the MSAL cache to the agent over the message bus.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="RockBot.UserProxy.WorkIqAuth.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\RockBot.Messaging.Abstractions\RockBot.Messaging.Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/RockBot.UserProxy.WorkIqAuth/WorkIqAuthClientServiceCollectionExtensions.cs
+++ b/src/RockBot.UserProxy.WorkIqAuth/WorkIqAuthClientServiceCollectionExtensions.cs
@@ -1,0 +1,49 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+
+namespace RockBot.UserProxy.WorkIqAuth;
+
+/// <summary>
+/// DI helpers for the UI-tier WorkIQ flow.
+/// </summary>
+public static class WorkIqAuthClientServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers <see cref="WorkIqClientSettings"/>, <see cref="WorkIqDeviceCodeFlow"/>,
+    /// and the <see cref="WorkIqAuthStatusListener"/> hosted service. Bind settings
+    /// from the <c>WorkIQ</c> configuration section.
+    /// </summary>
+    public static IServiceCollection AddWorkIqAuthClient(
+        this IServiceCollection services, IConfiguration configuration)
+    {
+        services.Configure<WorkIqClientSettings>(opts =>
+        {
+            var section = configuration.GetSection("WorkIQ");
+            opts.TenantId = section["TenantId"] ?? string.Empty;
+            opts.ClientId = section["ClientId"] ?? string.Empty;
+            opts.Authority = section["Authority"];
+
+            var scopesValue = section["Scopes"];
+            if (!string.IsNullOrWhiteSpace(scopesValue))
+            {
+                opts.Scopes = scopesValue
+                    .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                    .ToList();
+            }
+        });
+
+        services.AddSingleton<WorkIqDeviceCodeFlow>();
+
+        // The listener is registered as a singleton AND a hosted service. UI
+        // components inject IWorkIqAuthStatusListener; the hosted service
+        // role drives subscribe/unsubscribe via StartAsync/StopAsync.
+        services.AddSingleton<WorkIqAuthStatusListener>();
+        services.TryAddSingleton<IWorkIqAuthStatusListener>(
+            sp => sp.GetRequiredService<WorkIqAuthStatusListener>());
+        services.AddHostedService(sp => sp.GetRequiredService<WorkIqAuthStatusListener>());
+
+        return services;
+    }
+}

--- a/src/RockBot.UserProxy.WorkIqAuth/WorkIqAuthFlowException.cs
+++ b/src/RockBot.UserProxy.WorkIqAuth/WorkIqAuthFlowException.cs
@@ -1,0 +1,43 @@
+namespace RockBot.UserProxy.WorkIqAuth;
+
+/// <summary>
+/// Thrown when the UI-tier WorkIQ device-code flow cannot complete.
+/// The <see cref="Code"/> property carries a stable identifier UI code
+/// can switch on without parsing message text.
+/// </summary>
+public sealed class WorkIqAuthFlowException : Exception
+{
+    public string Code { get; }
+
+    public WorkIqAuthFlowException(string code, string message) : base(message)
+    {
+        Code = code;
+    }
+
+    public WorkIqAuthFlowException(string code, string message, Exception innerException)
+        : base(message, innerException)
+    {
+        Code = code;
+    }
+
+    public static class Codes
+    {
+        /// <summary>User cancelled before completing sign-in.</summary>
+        public const string UserCancelled = "user_cancelled";
+
+        /// <summary>Device code expired before the user signed in.</summary>
+        public const string ChallengeExpired = "challenge_expired";
+
+        /// <summary>Settings are missing TenantId or ClientId.</summary>
+        public const string NotConfigured = "not_configured";
+
+        /// <summary>MSAL returned an error during token acquisition.</summary>
+        public const string MsalError = "msal_error";
+
+        /// <summary>Publishing the cache to the bus failed.</summary>
+        public const string PublishFailed = "publish_failed";
+
+        /// <summary>Catch-all for unexpected failures.</summary>
+        public const string Unknown = "unknown";
+    }
+}

--- a/src/RockBot.UserProxy.WorkIqAuth/WorkIqAuthMessages.cs
+++ b/src/RockBot.UserProxy.WorkIqAuth/WorkIqAuthMessages.cs
@@ -1,4 +1,4 @@
-namespace RockBot.Agent.McpBridge.Auth;
+namespace RockBot.UserProxy.WorkIqAuth;
 
 /// <summary>
 /// Topic constants for Work IQ auth-related bus messages.

--- a/src/RockBot.UserProxy.WorkIqAuth/WorkIqAuthStatusListener.cs
+++ b/src/RockBot.UserProxy.WorkIqAuth/WorkIqAuthStatusListener.cs
@@ -1,0 +1,79 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using RockBot.Messaging;
+
+namespace RockBot.UserProxy.WorkIqAuth;
+
+/// <summary>
+/// Default <see cref="IWorkIqAuthStatusListener"/> implementation: subscribes
+/// to <see cref="WorkIqAuthTopics.Expired"/> on the bus and fans the payload
+/// out to UI components via the <see cref="Expired"/> event.
+/// </summary>
+public sealed class WorkIqAuthStatusListener
+    : IWorkIqAuthStatusListener, IHostedService
+{
+    private readonly IMessageSubscriber _subscriber;
+    private readonly ILogger<WorkIqAuthStatusListener> _logger;
+    private ISubscription? _subscription;
+
+    public WorkIqAuthStatusListener(
+        IMessageSubscriber subscriber,
+        ILogger<WorkIqAuthStatusListener> logger)
+    {
+        _subscriber = subscriber;
+        _logger = logger;
+    }
+
+    public event EventHandler<WorkIqAuthExpired>? Expired;
+
+    public WorkIqAuthExpired? LastExpired { get; private set; }
+
+    public void ClearLastExpired() => LastExpired = null;
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        _subscription = await _subscriber.SubscribeAsync(
+            WorkIqAuthTopics.Expired,
+            $"ui.workiq.expired.{Guid.NewGuid():N}",
+            HandleAsync,
+            cancellationToken);
+        _logger.LogInformation("WorkIq auth status listener subscribed");
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        if (_subscription is not null)
+            await _subscription.DisposeAsync();
+    }
+
+    private Task<MessageResult> HandleAsync(MessageEnvelope envelope, CancellationToken ct)
+    {
+        WorkIqAuthExpired? payload;
+        try
+        {
+            payload = envelope.GetPayload<WorkIqAuthExpired>();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to deserialize WorkIqAuthExpired payload");
+            return Task.FromResult(MessageResult.DeadLetter);
+        }
+        if (payload is null)
+        {
+            _logger.LogWarning("Received null WorkIqAuthExpired payload");
+            return Task.FromResult(MessageResult.DeadLetter);
+        }
+
+        LastExpired = payload;
+        try
+        {
+            Expired?.Invoke(this, payload);
+        }
+        catch (Exception ex)
+        {
+            // Subscriber should never crash on a buggy UI handler.
+            _logger.LogWarning(ex, "WorkIq auth status subscriber threw");
+        }
+        return Task.FromResult(MessageResult.Ack);
+    }
+}

--- a/src/RockBot.UserProxy.WorkIqAuth/WorkIqClientSettings.cs
+++ b/src/RockBot.UserProxy.WorkIqAuth/WorkIqClientSettings.cs
@@ -1,0 +1,39 @@
+namespace RockBot.UserProxy.WorkIqAuth;
+
+/// <summary>
+/// Settings for the UI-tier WorkIQ MSAL flow. Bound from the <c>WorkIQ</c>
+/// configuration section. Mirrors the agent-side <c>MsalTokenProviderOptions</c>
+/// so the same Entra app registration values can be written once and consumed
+/// by every process that touches WorkIQ.
+/// </summary>
+public sealed class WorkIqClientSettings
+{
+    /// <summary>Entra tenant ID (GUID). Required.</summary>
+    public string TenantId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Public-client application ID registered in Entra. Shared between
+    /// the UI tier (which performs interactive consent) and the agent
+    /// (which silently refreshes the resulting cache).
+    /// </summary>
+    public string ClientId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Delegated scopes requested at consent. Typically per-server scopes
+    /// like <c>WorkIQ-MailServer/.default</c>, <c>WorkIQ-Calendar/.default</c>.
+    /// </summary>
+    public List<string> Scopes { get; set; } = [];
+
+    /// <summary>
+    /// Optional override of the OAuth authority URL. Defaults to
+    /// <c>https://login.microsoftonline.com/{TenantId}</c>. Override for
+    /// sovereign clouds (US Gov, China, etc.).
+    /// </summary>
+    public string? Authority { get; set; }
+
+    /// <summary>
+    /// Whether the settings are populated enough to run a flow.
+    /// </summary>
+    public bool Enabled =>
+        !string.IsNullOrWhiteSpace(TenantId) && !string.IsNullOrWhiteSpace(ClientId);
+}

--- a/src/RockBot.UserProxy.WorkIqAuth/WorkIqDeviceCodeFlow.cs
+++ b/src/RockBot.UserProxy.WorkIqAuth/WorkIqDeviceCodeFlow.cs
@@ -1,0 +1,180 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Identity.Client;
+using RockBot.Messaging;
+
+namespace RockBot.UserProxy.WorkIqAuth;
+
+/// <summary>
+/// Drives the MSAL device-code flow from the UI tier and ships the resulting
+/// token cache to the agent via <see cref="WorkIqAuthCacheUpdated"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Why device-code for both Blazor and CLI: the Blazor app is server-rendered
+/// in a pod where MSAL cannot reach the user's browser via a loopback redirect.
+/// Device-code only needs the user to type a code into a separate browser tab,
+/// so it works identically from any UI surface.
+/// </para>
+/// <para>
+/// The flow holds the MSAL cache only for the lifetime of the call. Once the
+/// cache is published, the UI's <see cref="IPublicClientApplication"/> is
+/// disposed and no credential material remains on the UI side.
+/// </para>
+/// </remarks>
+public sealed class WorkIqDeviceCodeFlow
+{
+    private readonly WorkIqClientSettings _settings;
+    private readonly IMessagePublisher _publisher;
+    private readonly ILogger<WorkIqDeviceCodeFlow> _logger;
+
+    public WorkIqDeviceCodeFlow(
+        IOptions<WorkIqClientSettings> settings,
+        IMessagePublisher publisher,
+        ILogger<WorkIqDeviceCodeFlow> logger)
+    {
+        _settings = settings.Value;
+        _publisher = publisher;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Begins the device-code flow. Returns the user-facing challenge as soon
+    /// as MSAL produces it, along with a completion task the caller awaits
+    /// until the user finishes sign-in (or the flow fails).
+    /// </summary>
+    public async Task<(DeviceCodeChallenge Challenge, Task Completion)> BeginAsync(
+        CancellationToken cancellationToken)
+    {
+        if (!_settings.Enabled)
+        {
+            throw new WorkIqAuthFlowException(
+                WorkIqAuthFlowException.Codes.NotConfigured,
+                "WorkIQ is not configured. Set WorkIQ:TenantId and WorkIQ:ClientId before running this flow.");
+        }
+
+        var app = BuildPublicClientApp();
+        var challengeTcs = new TaskCompletionSource<DeviceCodeChallenge>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // Capture the serialized cache via MSAL's SetAfterAccess callback. The
+        // callback fires inside ExecuteAsync once the new tokens are cached.
+        byte[] capturedCache = [];
+        app.UserTokenCache.SetAfterAccess(args =>
+        {
+            if (args.HasStateChanged)
+                capturedCache = args.TokenCache.SerializeMsalV3();
+        });
+
+        var completion = Task.Run(async () =>
+        {
+            try
+            {
+                var result = await app.AcquireTokenWithDeviceCode(_settings.Scopes, dcr =>
+                {
+                    challengeTcs.TrySetResult(new DeviceCodeChallenge(
+                        UserCode: dcr.UserCode,
+                        VerificationUrl: dcr.VerificationUrl,
+                        ExpiresOn: dcr.ExpiresOn,
+                        Message: dcr.Message));
+                    return Task.CompletedTask;
+                }).ExecuteAsync(cancellationToken);
+
+                var bytes = SerializeCacheOverride is { } overrideFn
+                    ? overrideFn(app)
+                    : capturedCache;
+                await PublishCacheAsync(bytes, result.Account, cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw new WorkIqAuthFlowException(
+                    WorkIqAuthFlowException.Codes.UserCancelled,
+                    "Device-code sign-in was cancelled.");
+            }
+            catch (MsalClientException ex) when (ex.ErrorCode is "code_expired"
+                or "authorization_pending_timeout"
+                or "verification_code_expired")
+            {
+                throw new WorkIqAuthFlowException(
+                    WorkIqAuthFlowException.Codes.ChallengeExpired,
+                    "The device code expired before sign-in was completed. Start over.",
+                    ex);
+            }
+            catch (MsalException ex)
+            {
+                throw new WorkIqAuthFlowException(
+                    WorkIqAuthFlowException.Codes.MsalError,
+                    $"Microsoft identity service returned an error: {ex.ErrorCode}",
+                    ex);
+            }
+            catch (WorkIqAuthFlowException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw new WorkIqAuthFlowException(
+                    WorkIqAuthFlowException.Codes.Unknown,
+                    "Unexpected error during WorkIQ device-code flow.",
+                    ex);
+            }
+        }, cancellationToken);
+
+        // If the underlying task faults before MSAL ever issues a code, propagate
+        // the failure to the caller waiting on the challenge.
+        _ = completion.ContinueWith(t =>
+        {
+            if (t.IsFaulted && !challengeTcs.Task.IsCompleted)
+                challengeTcs.TrySetException(t.Exception!.InnerExceptions);
+        }, TaskScheduler.Default);
+
+        var challenge = await challengeTcs.Task;
+        return (challenge, completion);
+    }
+
+    private IPublicClientApplication BuildPublicClientApp()
+    {
+        var builder = PublicClientApplicationBuilder.Create(_settings.ClientId);
+        if (!string.IsNullOrWhiteSpace(_settings.Authority))
+            builder = builder.WithAuthority(_settings.Authority);
+        else
+            builder = builder.WithAuthority(AzureCloudInstance.AzurePublic, _settings.TenantId);
+        return builder.Build();
+    }
+
+    private async Task PublishCacheAsync(byte[] bytes, IAccount? account, CancellationToken ct)
+    {
+        try
+        {
+            var message = new WorkIqAuthCacheUpdated
+            {
+                CacheBytes = bytes,
+                AccountId = account?.HomeAccountId?.Identifier
+                    ?? account?.Username
+                    ?? "unknown",
+                Scopes = [.. _settings.Scopes]
+            };
+
+            var envelope = message.ToEnvelope(source: "ui.workiq");
+            await _publisher.PublishAsync(WorkIqAuthTopics.CacheUpdated, envelope, ct);
+
+            _logger.LogInformation(
+                "Published WorkIQ token cache for account {AccountId} ({Bytes} bytes)",
+                message.AccountId, bytes.Length);
+        }
+        catch (Exception ex)
+        {
+            throw new WorkIqAuthFlowException(
+                WorkIqAuthFlowException.Codes.PublishFailed,
+                "WorkIQ sign-in completed but the agent could not be notified. " +
+                "Verify the message bus is reachable and retry.",
+                ex);
+        }
+    }
+
+    /// <summary>
+    /// Test seam: when set, used instead of MSAL's real cache serialization.
+    /// Production code should leave this null.
+    /// </summary>
+    internal Func<IPublicClientApplication, byte[]>? SerializeCacheOverride { get; set; }
+}

--- a/tests/RockBot.Agent.Tests/McpBridge/Auth/TokenCacheStoreTests.cs
+++ b/tests/RockBot.Agent.Tests/McpBridge/Auth/TokenCacheStoreTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.Identity.Client;
 using RockBot.Agent.McpBridge.Auth;
 using RockBot.Messaging;
+using RockBot.UserProxy.WorkIqAuth;
 
 namespace RockBot.Agent.Tests.McpBridge.Auth;
 

--- a/tests/RockBot.Cli.Tests/WorkIqAuthCommandWiringTests.cs
+++ b/tests/RockBot.Cli.Tests/WorkIqAuthCommandWiringTests.cs
@@ -1,0 +1,50 @@
+using Microsoft.Extensions.DependencyInjection;
+using RockBot.UserProxy.Cli;
+using RockBot.UserProxy.WorkIqAuth;
+
+namespace RockBot.Cli.Tests;
+
+[TestClass]
+public sealed class WorkIqAuthCommandWiringTests
+{
+    [TestMethod]
+    public void HostFactory_WithWorkIqConfigure_ResolvesFlowAndListener()
+    {
+        // The CLI command passes `builder => builder.Services.AddWorkIqAuthClient(builder.Configuration)`
+        // to HostFactory.Build. Verify the resulting host can resolve the flow
+        // service the command depends on, without actually starting the host
+        // (which would require a real RabbitMQ).
+        var settings = new CommonSettings.Plain
+        {
+            RabbitMqHost = "localhost",
+            RabbitMqUser = "test",
+            RabbitMqPassword = "test"
+        };
+
+        using var host = HostFactory.Build(
+            settings,
+            useRichFrontend: true,
+            configure: b => b.Services.AddWorkIqAuthClient(b.Configuration));
+
+        Assert.IsNotNull(host.Services.GetService<WorkIqDeviceCodeFlow>());
+        Assert.IsNotNull(host.Services.GetService<IWorkIqAuthStatusListener>());
+    }
+
+    [TestMethod]
+    public void HostFactory_WithoutWorkIqConfigure_DoesNotRegisterFlow()
+    {
+        // Other commands (chat, info, etc.) should not pay for WorkIQ
+        // registration. Verify the flow service is absent unless the
+        // configure delegate explicitly adds it.
+        var settings = new CommonSettings.Plain
+        {
+            RabbitMqHost = "localhost",
+            RabbitMqUser = "test",
+            RabbitMqPassword = "test"
+        };
+
+        using var host = HostFactory.Build(settings, useRichFrontend: true);
+
+        Assert.IsNull(host.Services.GetService<WorkIqDeviceCodeFlow>());
+    }
+}

--- a/tests/RockBot.UserProxy.Blazor.Tests/WorkIqAuthUiServiceTests.cs
+++ b/tests/RockBot.UserProxy.Blazor.Tests/WorkIqAuthUiServiceTests.cs
@@ -1,0 +1,130 @@
+using RockBot.UserProxy.Blazor.Services;
+using RockBot.UserProxy.WorkIqAuth;
+
+namespace RockBot.UserProxy.Blazor.Tests;
+
+[TestClass]
+public class WorkIqAuthUiServiceTests
+{
+    [TestMethod]
+    public void NoExpired_BannerHidden()
+    {
+        var listener = new FakeListener();
+        var service = new WorkIqAuthUiService(listener);
+
+        Assert.IsFalse(service.IsExpiredBannerVisible);
+        Assert.IsNull(service.CurrentReason);
+    }
+
+    [TestMethod]
+    public void Listener_ExpiredEvent_ShowsBannerAndNotifies()
+    {
+        var listener = new FakeListener();
+        var service = new WorkIqAuthUiService(listener);
+        var notified = 0;
+        service.StateChanged += () => notified++;
+
+        listener.FireExpired(new WorkIqAuthExpired
+        {
+            AccountId = "acct@example.com",
+            Reason = "refresh revoked"
+        });
+
+        Assert.IsTrue(service.IsExpiredBannerVisible);
+        Assert.AreEqual("refresh revoked", service.CurrentReason);
+        Assert.AreEqual(1, notified);
+    }
+
+    [TestMethod]
+    public void DismissExpiredBanner_HidesAndNotifies()
+    {
+        var listener = new FakeListener();
+        var service = new WorkIqAuthUiService(listener);
+        listener.FireExpired(new WorkIqAuthExpired { AccountId = "acct" });
+        var notified = 0;
+        service.StateChanged += () => notified++;
+
+        service.DismissExpiredBanner();
+
+        Assert.IsFalse(service.IsExpiredBannerVisible);
+        Assert.AreEqual(1, notified);
+    }
+
+    [TestMethod]
+    public void DismissExpiredBanner_WhenAlreadyHidden_DoesNotNotify()
+    {
+        var listener = new FakeListener();
+        var service = new WorkIqAuthUiService(listener);
+        var notified = 0;
+        service.StateChanged += () => notified++;
+
+        service.DismissExpiredBanner();
+
+        Assert.AreEqual(0, notified);
+    }
+
+    [TestMethod]
+    public void MarkConnected_ClearsListenerStateAndBanner()
+    {
+        var listener = new FakeListener();
+        listener.SetLastExpired(new WorkIqAuthExpired { AccountId = "acct", Reason = "expired" });
+        var service = new WorkIqAuthUiService(listener);
+        // Constructor initialized CurrentReason from listener.LastExpired but didn't
+        // show the banner; we want MarkConnected to scrub both fields cleanly.
+        service.GetType(); // suppress unused warning, service is the SUT
+
+        service.MarkConnected();
+
+        Assert.IsNull(listener.LastExpired);
+        Assert.IsFalse(service.IsExpiredBannerVisible);
+        Assert.IsNull(service.CurrentReason);
+    }
+
+    [TestMethod]
+    public void Constructor_PicksUpPriorExpiration()
+    {
+        var listener = new FakeListener();
+        listener.SetLastExpired(new WorkIqAuthExpired
+        {
+            AccountId = "acct",
+            Reason = "expired before circuit started"
+        });
+
+        var service = new WorkIqAuthUiService(listener);
+
+        // Reason is restored; banner stays hidden until a new event fires
+        // because the prior expiration may have already been dismissed by
+        // another circuit.
+        Assert.AreEqual("expired before circuit started", service.CurrentReason);
+        Assert.IsFalse(service.IsExpiredBannerVisible);
+    }
+
+    [TestMethod]
+    public void Dispose_UnsubscribesFromListener()
+    {
+        var listener = new FakeListener();
+        var service = new WorkIqAuthUiService(listener);
+        var notified = 0;
+        service.StateChanged += () => notified++;
+
+        service.Dispose();
+        listener.FireExpired(new WorkIqAuthExpired { AccountId = "acct" });
+
+        Assert.AreEqual(0, notified);
+    }
+
+    private sealed class FakeListener : IWorkIqAuthStatusListener
+    {
+        public event EventHandler<WorkIqAuthExpired>? Expired;
+        public WorkIqAuthExpired? LastExpired { get; private set; }
+        public void ClearLastExpired() => LastExpired = null;
+
+        public void SetLastExpired(WorkIqAuthExpired msg) => LastExpired = msg;
+
+        public void FireExpired(WorkIqAuthExpired msg)
+        {
+            LastExpired = msg;
+            Expired?.Invoke(this, msg);
+        }
+    }
+}

--- a/tests/RockBot.UserProxy.WorkIqAuth.Tests/RockBot.UserProxy.WorkIqAuth.Tests.csproj
+++ b/tests/RockBot.UserProxy.WorkIqAuth.Tests/RockBot.UserProxy.WorkIqAuth.Tests.csproj
@@ -6,19 +6,22 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <RootNamespace>RockBot.Cli.Tests</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.*" />
     <PackageReference Include="MSTest.TestFramework" Version="3.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.*" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.*" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\RockBot.UserProxy.Cli\RockBot.UserProxy.Cli.csproj" />
     <ProjectReference Include="..\..\src\RockBot.UserProxy.WorkIqAuth\RockBot.UserProxy.WorkIqAuth.csproj" />
+    <ProjectReference Include="..\..\src\RockBot.Messaging.Abstractions\RockBot.Messaging.Abstractions.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/RockBot.UserProxy.WorkIqAuth.Tests/StubMessagePublisher.cs
+++ b/tests/RockBot.UserProxy.WorkIqAuth.Tests/StubMessagePublisher.cs
@@ -1,0 +1,16 @@
+using RockBot.Messaging;
+
+namespace RockBot.UserProxy.WorkIqAuth.Tests;
+
+internal sealed class StubMessagePublisher : IMessagePublisher
+{
+    public List<(string Topic, MessageEnvelope Envelope)> Published { get; } = new();
+
+    public Task PublishAsync(string topic, MessageEnvelope envelope, CancellationToken cancellationToken = default)
+    {
+        Published.Add((topic, envelope));
+        return Task.CompletedTask;
+    }
+
+    public ValueTask DisposeAsync() => default;
+}

--- a/tests/RockBot.UserProxy.WorkIqAuth.Tests/StubMessageSubscriber.cs
+++ b/tests/RockBot.UserProxy.WorkIqAuth.Tests/StubMessageSubscriber.cs
@@ -1,0 +1,33 @@
+using RockBot.Messaging;
+
+namespace RockBot.UserProxy.WorkIqAuth.Tests;
+
+internal sealed class StubMessageSubscriber : IMessageSubscriber
+{
+    public Func<MessageEnvelope, CancellationToken, Task<MessageResult>>? Handler { get; private set; }
+    public string? Topic { get; private set; }
+    public string? SubscriptionName { get; private set; }
+
+    public Task<ISubscription> SubscribeAsync(
+        string topic,
+        string subscriptionName,
+        Func<MessageEnvelope, CancellationToken, Task<MessageResult>> handler,
+        CancellationToken cancellationToken = default,
+        int dispatchConcurrency = 1)
+    {
+        Topic = topic;
+        SubscriptionName = subscriptionName;
+        Handler = handler;
+        return Task.FromResult<ISubscription>(new StubSubscription());
+    }
+
+    public ValueTask DisposeAsync() => default;
+
+    private sealed class StubSubscription : ISubscription
+    {
+        public string Topic => string.Empty;
+        public string SubscriptionName => string.Empty;
+        public bool IsActive => true;
+        public ValueTask DisposeAsync() => default;
+    }
+}

--- a/tests/RockBot.UserProxy.WorkIqAuth.Tests/WorkIqAuthStatusListenerTests.cs
+++ b/tests/RockBot.UserProxy.WorkIqAuth.Tests/WorkIqAuthStatusListenerTests.cs
@@ -1,0 +1,104 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using RockBot.Messaging;
+
+namespace RockBot.UserProxy.WorkIqAuth.Tests;
+
+[TestClass]
+public class WorkIqAuthStatusListenerTests
+{
+    [TestMethod]
+    public async Task Start_SubscribesToExpiredTopic()
+    {
+        var subscriber = new StubMessageSubscriber();
+        var listener = new WorkIqAuthStatusListener(
+            subscriber, NullLogger<WorkIqAuthStatusListener>.Instance);
+
+        await listener.StartAsync(CancellationToken.None);
+
+        Assert.AreEqual(WorkIqAuthTopics.Expired, subscriber.Topic);
+
+        await listener.StopAsync(CancellationToken.None);
+    }
+
+    [TestMethod]
+    public async Task ExpiredEvent_FiresOnEnvelopeDelivery()
+    {
+        var subscriber = new StubMessageSubscriber();
+        var listener = new WorkIqAuthStatusListener(
+            subscriber, NullLogger<WorkIqAuthStatusListener>.Instance);
+        await listener.StartAsync(CancellationToken.None);
+
+        WorkIqAuthExpired? captured = null;
+        listener.Expired += (_, msg) => captured = msg;
+
+        var payload = new WorkIqAuthExpired { AccountId = "acct@example.com", Reason = "refresh revoked" };
+        var result = await subscriber.Handler!(payload.ToEnvelope(source: "agent.workiq"), CancellationToken.None);
+
+        Assert.AreEqual(MessageResult.Ack, result);
+        Assert.IsNotNull(captured);
+        Assert.AreEqual("acct@example.com", captured!.AccountId);
+        Assert.AreEqual("refresh revoked", captured.Reason);
+        Assert.AreSame(captured, listener.LastExpired);
+
+        await listener.StopAsync(CancellationToken.None);
+    }
+
+    [TestMethod]
+    public async Task ExpiredEvent_MalformedPayload_DeadLetters()
+    {
+        var subscriber = new StubMessageSubscriber();
+        var listener = new WorkIqAuthStatusListener(
+            subscriber, NullLogger<WorkIqAuthStatusListener>.Instance);
+        await listener.StartAsync(CancellationToken.None);
+
+        // Publish an envelope with the wrong payload type. Provider-side
+        // GetPayload returns null for shape mismatch; the listener should
+        // dead-letter, not crash.
+        var bogus = new { Hello = "world" };
+        var result = await subscriber.Handler!(
+            bogus.ToEnvelope(source: "noise"), CancellationToken.None);
+
+        Assert.AreEqual(MessageResult.DeadLetter, result);
+        Assert.IsNull(listener.LastExpired);
+
+        await listener.StopAsync(CancellationToken.None);
+    }
+
+    [TestMethod]
+    public async Task ClearLastExpired_ResetsState()
+    {
+        var subscriber = new StubMessageSubscriber();
+        var listener = new WorkIqAuthStatusListener(
+            subscriber, NullLogger<WorkIqAuthStatusListener>.Instance);
+        await listener.StartAsync(CancellationToken.None);
+
+        var payload = new WorkIqAuthExpired { AccountId = "acct" };
+        await subscriber.Handler!(payload.ToEnvelope(source: "agent"), CancellationToken.None);
+        Assert.IsNotNull(listener.LastExpired);
+
+        listener.ClearLastExpired();
+        Assert.IsNull(listener.LastExpired);
+
+        await listener.StopAsync(CancellationToken.None);
+    }
+
+    [TestMethod]
+    public async Task ExpiredHandler_ExceptionDoesNotPropagate()
+    {
+        var subscriber = new StubMessageSubscriber();
+        var listener = new WorkIqAuthStatusListener(
+            subscriber, NullLogger<WorkIqAuthStatusListener>.Instance);
+        await listener.StartAsync(CancellationToken.None);
+
+        listener.Expired += (_, _) => throw new InvalidOperationException("buggy UI");
+
+        var payload = new WorkIqAuthExpired { AccountId = "acct" };
+        var result = await subscriber.Handler!(
+            payload.ToEnvelope(source: "agent"), CancellationToken.None);
+
+        // The listener must still ack — a buggy handler can't break the subscriber.
+        Assert.AreEqual(MessageResult.Ack, result);
+
+        await listener.StopAsync(CancellationToken.None);
+    }
+}

--- a/tests/RockBot.UserProxy.WorkIqAuth.Tests/WorkIqClientSettingsBindingTests.cs
+++ b/tests/RockBot.UserProxy.WorkIqAuth.Tests/WorkIqClientSettingsBindingTests.cs
@@ -1,0 +1,67 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using RockBot.Messaging;
+
+namespace RockBot.UserProxy.WorkIqAuth.Tests;
+
+[TestClass]
+public class WorkIqClientSettingsBindingTests
+{
+    [TestMethod]
+    public async Task AddWorkIqAuthClient_BindsTenantClientAndScopes()
+    {
+        var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["WorkIQ:TenantId"] = "00000000-0000-0000-0000-000000000002",
+            ["WorkIQ:ClientId"] = "00000000-0000-0000-0000-000000000001",
+            ["WorkIQ:Scopes"] = "scope-a, scope-b ,scope-c"
+        }).Build();
+
+        var services = BuildServices(config);
+        await using var provider = services.BuildServiceProvider();
+        var opts = provider.GetRequiredService<IOptions<WorkIqClientSettings>>().Value;
+
+        Assert.AreEqual("00000000-0000-0000-0000-000000000002", opts.TenantId);
+        Assert.AreEqual("00000000-0000-0000-0000-000000000001", opts.ClientId);
+        CollectionAssert.AreEqual(new[] { "scope-a", "scope-b", "scope-c" }, opts.Scopes);
+        Assert.IsTrue(opts.Enabled);
+    }
+
+    [TestMethod]
+    public async Task AddWorkIqAuthClient_NoConfig_LeavesSettingsDisabled()
+    {
+        var services = BuildServices(new ConfigurationBuilder().Build());
+        await using var provider = services.BuildServiceProvider();
+        var opts = provider.GetRequiredService<IOptions<WorkIqClientSettings>>().Value;
+
+        Assert.IsFalse(opts.Enabled);
+    }
+
+    [TestMethod]
+    public async Task AddWorkIqAuthClient_RegistersFlowAndListener()
+    {
+        var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["WorkIQ:TenantId"] = "tenant",
+            ["WorkIQ:ClientId"] = "client"
+        }).Build();
+
+        var services = BuildServices(config);
+        await using var provider = services.BuildServiceProvider();
+
+        Assert.IsNotNull(provider.GetService<WorkIqDeviceCodeFlow>());
+        Assert.IsNotNull(provider.GetService<IWorkIqAuthStatusListener>());
+    }
+
+    private static ServiceCollection BuildServices(IConfiguration config)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IMessagePublisher, StubMessagePublisher>();
+        services.AddSingleton<IMessageSubscriber, StubMessageSubscriber>();
+        services.AddWorkIqAuthClient(config);
+        return services;
+    }
+}

--- a/tests/RockBot.UserProxy.WorkIqAuth.Tests/WorkIqDeviceCodeFlowTests.cs
+++ b/tests/RockBot.UserProxy.WorkIqAuth.Tests/WorkIqDeviceCodeFlowTests.cs
@@ -1,0 +1,32 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace RockBot.UserProxy.WorkIqAuth.Tests;
+
+[TestClass]
+public class WorkIqDeviceCodeFlowTests
+{
+    [TestMethod]
+    public async Task BeginAsync_NotConfigured_Throws()
+    {
+        var flow = new WorkIqDeviceCodeFlow(
+            Options.Create(new WorkIqClientSettings()),
+            new StubMessagePublisher(),
+            NullLogger<WorkIqDeviceCodeFlow>.Instance);
+
+        var ex = await Assert.ThrowsExactlyAsync<WorkIqAuthFlowException>(
+            () => flow.BeginAsync(CancellationToken.None));
+
+        Assert.AreEqual(WorkIqAuthFlowException.Codes.NotConfigured, ex.Code);
+        StringAssert.Contains(ex.Message, "WorkIQ:TenantId");
+    }
+
+    [TestMethod]
+    public void Settings_Enabled_RequiresBothTenantAndClient()
+    {
+        Assert.IsFalse(new WorkIqClientSettings().Enabled);
+        Assert.IsFalse(new WorkIqClientSettings { TenantId = "t" }.Enabled);
+        Assert.IsFalse(new WorkIqClientSettings { ClientId = "c" }.Enabled);
+        Assert.IsTrue(new WorkIqClientSettings { TenantId = "t", ClientId = "c" }.Enabled);
+    }
+}


### PR DESCRIPTION
Closes Phase 3 of #441. The UI tier (Blazor + CLI) drives the MSAL device-code flow against Entra, serializes the resulting cache, and publishes `WorkIqAuthCacheUpdated` to the agent. Out of scope here: Phase 4 (Entra app registration + end-to-end smoke), Phase 5 (re-consent polish).

## Summary

- **Same flow for Blazor and CLI.** Both surfaces use device-code so the Blazor server-rendered app needs no OAuth callback route or PKCE cookie — the user just types the displayed code into a browser tab.
- **New shared library `RockBot.UserProxy.WorkIqAuth`** holds the device-code orchestrator (`WorkIqDeviceCodeFlow`), settings (`WorkIqClientSettings`), the expired-notification listener (`WorkIqAuthStatusListener`), and the auth message contracts (`WorkIqAuthCacheUpdated`/`Expired`/`Topics` — relocated from `RockBot.Agent.McpBridge.Auth` so both sides reference the same types).
- **Blazor.** `WorkIqConnect.razor` covers the NotStarted/InProgress/Success/Failed states and a copy-code button. `WorkIqReconnectBanner.razor` appears above the chat header on `WorkIqAuthExpired`. `WorkIqAuthUiService` is scoped per circuit and bridges listener events to component re-renders. An "M365" pill in the chat header opens the connect modal.
- **CLI.** `rockbot auth workiq` renders the device code + URL with Spectre.Console, polls until completion, publishes the cache, and exits with stable codes (0 success, 130 user-cancelled, 78 not-configured, 1 other). `HostFactory.Build` gained an optional `configure` delegate so only this command pulls MSAL into the host's services.
- **Helm.** Blazor deployment env vars (`WorkIQ__TenantId/ClientId/Scopes/Authority`) gated on `workiq.enabled`. No new `values.yaml` keys — reuses the `workiq.*` block introduced in Phase 2.

## Test plan

- [x] Full `dotnet build RockBot.slnx` clean (0 errors)
- [x] Full `dotnet test RockBot.slnx` clean across all 20 test projects
- [x] New tests: 10 in `RockBot.UserProxy.WorkIqAuth.Tests` (settings binding, listener event flow + dead-letter on malformed payload, flow rejects not-configured); 7 in `RockBot.UserProxy.Blazor.Tests` (UI state service transitions, dispose unsubscribes); 2 in `RockBot.Cli.Tests` (host factory wires the flow only when configured)
- [x] Phase 2 tests still pass after the message-type relocation
- [x] `helm template` with `workiq.enabled=false` emits no WorkIQ env vars on Blazor
- [x] `helm template --set workiq.enabled=true ...` emits the four conditional env vars on the Blazor deployment
- [x] Grep confirms no log statements emit token bytes or cache contents

## Type relocation note

`WorkIqAuthCacheUpdated`, `WorkIqAuthExpired`, and `WorkIqAuthTopics` moved from `RockBot.Agent.McpBridge.Auth` → `RockBot.UserProxy.WorkIqAuth` so the UI tier doesn't depend on the agent project. Phase 2's agent files added one new `using RockBot.UserProxy.WorkIqAuth;` directive; behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)