### PR TITLE
WorkIQ MCP auth: re-consent UX and failure-mode polish (#441)

### DIFF
--- a/deploy/workiq-setup.md
+++ b/deploy/workiq-setup.md
@@ -1,0 +1,105 @@
+# Work IQ — operational runbook
+
+This document is the operational reference for the WorkIQ integration. It covers
+how the agent authenticates to Microsoft 365, what users and operators see
+during normal operation, and how to recover from common failure modes.
+
+> Phase 4 will populate the bulk of this runbook (initial setup, smoke tests,
+> Entra registration walkthrough). Phase 5 added the **Re-consent flow** and
+> **Scheduled tasks during expiry** sections below. See
+> [`design/workiq-phase4-plan.md`](../design/workiq-phase4-plan.md) and
+> [`design/workiq-phase5-plan.md`](../design/workiq-phase5-plan.md) for context.
+
+## Re-consent flow
+
+WorkIQ tokens are refreshed silently by the agent. When the underlying refresh
+token is rejected by Microsoft (typically because it has been revoked, the
+account password changed, or admin policy invalidated the consent), the agent
+cannot recover automatically — the user must complete a fresh device-code flow
+in the Blazor UI.
+
+### What the user sees
+
+1. **In the Blazor app**, a yellow banner appears at the top of every page:
+
+   > **M365 connection expired.** *<reason from MSAL>*  [Reconnect] [✕]
+
+   The banner stays up across navigations until the user clicks **Reconnect**
+   (or dismisses it with **✕**). A second M365 expiry while dismissed will
+   re-show the banner.
+
+2. **In chat**, the next message that would have used a Work IQ tool comes
+   back with an `auth_required` error whose text reads:
+
+   > Microsoft 365 connection has expired. Open the Blazor app and click
+   > 'Reconnect M365' to restore access. Work IQ tools will fail until
+   > reconnection is complete.
+
+   The LLM treats this as non-retryable and surfaces it to the user
+   verbatim, reinforcing the banner.
+
+### Click sequence to recover
+
+1. Click **Reconnect** in the yellow banner (or open the M365 pill menu and
+   choose Reconnect).
+2. A modal opens with a device code and a sign-in URL.
+3. Open the URL in another browser tab (or on your phone), paste the code, and
+   complete Microsoft sign-in including any MFA challenge.
+4. The modal flips to **Connected to Microsoft 365.** within a few seconds.
+5. The banner clears across all open Blazor circuits.
+
+End-to-end time when the user is fast: ~30 seconds. The bottleneck is the
+Microsoft sign-in page, not the agent — once the user finishes there, the
+agent receives the fresh cache within ~1 second and Work IQ tools become
+available again.
+
+### What the agent does during expiry
+
+- The agent's `WorkIqHealthTracker` flips to **unhealthy** the moment silent
+  refresh fails. It republishes the MCP tool list with WorkIQ-backed servers
+  removed, so the LLM never sees those tools in subsequent sessions until
+  recovery. Direct tool calls that *do* still hit WorkIQ get back the
+  `auth_required` error described above.
+- Other (non-WorkIQ) MCP tools are unaffected.
+- In-flight LLM sessions keep their original tool list. A session that spans
+  the expiry will continue to try WorkIQ tools and receive `auth_required`
+  until it ends; the next session will not see those tools at all.
+
+### Verifying recovery (operator)
+
+Look for the agent log line that fires on every transition:
+
+```
+WorkIQ auth health changed: Healthy=False → True. Reason: cache_updated_from_ui.
+```
+
+Alternatively check the cache file's mtime on the agent's PVC:
+
+```bash
+POD=$(kubectl get pod -n rockbot -l app=rockbot-agent -o jsonpath='{.items[0].metadata.name}')
+MSYS_NO_PATHCONV=1 kubectl exec -n rockbot "$POD" -c agent -- ls -la /data/agent/secrets/workiq-cache.bin
+```
+
+A recent mtime confirms the new cache was written.
+
+## Scheduled tasks during expiry
+
+Patrols and other scheduled tasks share the agent's MCP tool list. The hide-
+tools mechanism described above applies to them as well:
+
+- While auth is unhealthy, WorkIQ-backed tools (e.g. `workiq-outlook-*`,
+  `workiq-onedrive-*`) are filtered out of the tool list that scheduled-task
+  sessions see at startup.
+- Patrols that would normally use those tools naturally skip those steps —
+  they see no WorkIQ tools, so the LLM never attempts them, and patrol
+  summaries do not contain `execution_failed` retries.
+- Patrols whose entire purpose is WorkIQ (e.g., an inbox-triage patrol) will
+  produce a short "nothing to do" summary while expired, rather than a long
+  error trail.
+- The moment the user reconnects, the next patrol cycle (or in-flight session
+  that re-derives its tool list) gains the WorkIQ tools back. No restart
+  needed.
+
+If you see a patrol attempting WorkIQ tools while the banner is up, that
+means the patrol started *before* the auth flip — its tool list is frozen for
+the life of the session. The next cycle will be clean.

--- a/design/workiq-phase5-plan.md
+++ b/design/workiq-phase5-plan.md
@@ -1,0 +1,344 @@
+# WorkIQ Phase 5 — Re-consent UX and failure-mode polish
+
+Tracking issue: [#441](https://github.com/MarimerLLC/rockbot/issues/441). Builds on
+[#442](https://github.com/MarimerLLC/rockbot/pull/442) (Phase 1+2),
+[#443](https://github.com/MarimerLLC/rockbot/pull/443) (Phase 3), and the Phase 4
+operational plan in [`workiq-phase4-plan.md`](workiq-phase4-plan.md).
+
+## Goal
+
+After Phase 4 lands and Work IQ tools work end-to-end, polish the failure
+modes so a token expiry feels like a clean recoverable event rather than a
+mystery. Three concrete deliverables:
+
+1. **Surface `MsalUiRequiredException` as an actionable `auth_required` tool
+   error.** Today it falls into the generic "execution failed, retryable"
+   bucket, so the LLM blindly retries instead of telling the user to reconnect.
+2. **Decide and implement scheduled-task behavior under expired auth.** Choose
+   between fail-fast, skip-task, or hide-tools approaches. Mark the answer in
+   one place so future Work IQ-adjacent tools follow the same convention.
+3. **Operational documentation** — re-consent troubleshooting in
+   `deploy/workiq-setup.md` (the runbook produced by Phase 4) so the first
+   time a user hits expiry they know what to expect.
+
+## What is and is not in this phase
+
+| In | Out |
+|---|---|
+| `TokenAcquisitionException` → `ToolError` path with `auth_required` code and actionable message | Multi-user re-consent flows |
+| Bus-level coordination so scheduled tasks know to skip Work IQ when auth is expired | New per-tool auth UIs |
+| Reconnect-button idempotency in Blazor (double-click guard) | Auth state persisted across agent pod restarts beyond what the cache file already gives us |
+| Observability metric / log line summarizing WorkIQ auth health | Telemetry dashboard work — leave to the operator |
+| Phase 4 runbook addendum for re-consent flow | Replacing Phase 3's banner with a different UI pattern |
+
+## Background: the gap we're closing
+
+Today's exception flow when MSAL silent refresh fails:
+
+```
+MsalTokenProvider.GetAccessTokenAsync
+  catch (MsalUiRequiredException) →
+      publish WorkIqAuthExpired         ✓ (UI banner appears)
+      throw TokenAcquisitionException(ReauthRequired)
+
+BearerInjectionHandler.ApplyBearerAsync
+  → TokenAcquisitionException bubbles up unchanged
+
+McpBridgeService.HandleToolInvokeAsync
+  catch (Exception ex) when FindAuthChallenge(ex) is not null  ← MISSES
+      (FindAuthChallenge only walks for McpAuthChallengeException)
+  catch (Exception ex)
+      → reconnect-and-retry path (won't help; token is the problem)
+      → ToolError { Code=ExecutionFailed, IsRetryable=true }
+```
+
+The LLM sees `execution_failed, retryable` and dutifully retries. The retry
+also fails. The agent eventually surfaces a generic "execution_failed" to the
+user. Meanwhile the Blazor banner *is* already up — but the chat reply
+doesn't reference it.
+
+We want:
+
+```
+McpBridgeService.HandleToolInvokeAsync
+  catch (Exception ex) when FindReauthRequired(ex) is not null
+      → ToolError {
+          Code = "auth_required",
+          Message = "Microsoft 365 connection has expired. Open the Blazor app
+                     and click 'Reconnect M365' to restore access. Work IQ tools
+                     will fail until reconnection is complete.",
+          IsRetryable = false
+        }
+```
+
+So the LLM stops retrying, returns a clear message to the user, and the chat
+reply reinforces the banner that's already on screen.
+
+## Deliverables
+
+### 1. ToolError mapping for `MsalUiRequiredException` upstream
+
+**Files touched:**
+
+- `src/RockBot.Agent/McpBridge/McpBridgeService.cs` — add a second walker
+  helper alongside `FindAuthChallenge`:
+  ```csharp
+  private static TokenAcquisitionException? FindReauthRequired(Exception? ex)
+  {
+      for (var cur = ex; cur is not null; cur = cur.InnerException)
+          if (cur is TokenAcquisitionException tae
+              && tae.Code == TokenAcquisitionException.Codes.ReauthRequired)
+              return tae;
+      return null;
+  }
+  ```
+  Add a new catch clause **before** the `FindAuthChallenge` one (order matters
+  because reauth-required is more specific than a generic 401 challenge):
+  ```csharp
+  catch (Exception ex) when (FindReauthRequired(ex) is { } reauth)
+  {
+      sw.Stop();
+      var error = new ToolError {
+          ToolCallId = request.ToolCallId,
+          ToolName = request.ToolName,
+          Code = ToolError.Codes.AuthRequired,
+          Message = "Microsoft 365 connection has expired. Open the Blazor "
+                    + "app and click 'Reconnect M365' to restore access. "
+                    + "Work IQ tools will fail until reconnection is complete.",
+          IsRetryable = false
+      };
+      await PublishResponseAsync(error, replyTo, envelope.CorrelationId, ct);
+      return MessageResult.Ack;
+  }
+  ```
+- Also handle `NotAuthenticated` (initial consent never completed) — different
+  message, same `auth_required` code, also non-retryable. Same walker pattern.
+
+**Tests:**
+
+- `tests/RockBot.Agent.Tests/McpBridge/Auth/` — add `MsalToolErrorMappingTests`
+  that drives the bridge service end-to-end with a stub `ITokenProvider` that
+  throws `TokenAcquisitionException(ReauthRequired)` and asserts the resulting
+  `ToolError` has the expected code and message. Requires extracting a small
+  test seam in `McpBridgeService` (or testing through a real bridge with a
+  registered fake server — the test harness pattern from Phase 2 can be
+  extended).
+
+### 2. Scheduled-task behavior under expired auth
+
+**The decision to make** — what happens when a patrol or scheduled task
+attempts a Work IQ tool while auth is expired?
+
+Three options, with my recommendation flagged:
+
+| Option | Behavior | Pros | Cons |
+|---|---|---|---|
+| **Fail-fast** | Tool call returns `auth_required`; patrol's reasoning sees it and either skips that step or reports failure in its summary. | Simplest; no new state to track. | Every patrol cycle generates noise in logs / notifications until the user reconnects. |
+| **Hide tools** *(recommended)* | When the agent knows WorkIQ is unauthenticated, the `workiq-*` tools are filtered out of the agent's tool list at session-start time. The LLM never sees them; never tries to call them. | Patrols stop generating noise; the LLM's reasoning naturally adapts. | Requires an in-process flag on the agent side (`IsWorkIqHealthy`) maintained by listening to `WorkIqAuthCacheUpdated` (set healthy) and the agent's own auth_required errors (set unhealthy). |
+| **Skip-task-class** | Patrol metadata declares which Work IQ servers it needs; the scheduled-task handler skips the whole patrol when any required server is unauthenticated. | Surgical — only patrols that need WorkIQ are affected. | Requires patrol authors to declare dependencies in metadata, which is a new convention. |
+
+**Recommended: Hide tools.** Justification:
+
+- The mechanism (filter tools by health) generalizes to any future
+  bearer-auth MCP server, not just WorkIQ.
+- It's invisible to patrol authors — they write patrols as if all tools
+  exist, and the framework silently degrades.
+- The user-visible signal (the Blazor banner) is unchanged regardless of
+  what the agent is internally doing.
+- It still surfaces an `auth_required` error if something *does* attempt
+  a Work IQ tool (the bridge layer keeps its catch from deliverable #1),
+  so a directly-typed tool call still produces a useful error.
+
+**Files touched:**
+
+- `src/RockBot.Agent/McpBridge/Auth/WorkIqHealthTracker.cs` — new singleton.
+  Subscribes to `WorkIqAuthCacheUpdated` (sets `IsHealthy = true`); exposes a
+  `MarkUnhealthy(string reason)` method called by `MsalTokenProvider` after
+  publishing `WorkIqAuthExpired`. Optionally exposes a `HealthChanged`
+  event so other components (tool registry filter) can react.
+- `src/RockBot.Agent/McpBridge/McpBridgeService.cs` — when building the tool
+  list to publish on `tool.meta.mcp.{agentName}`, filter out any server whose
+  `Auth.Profile == "workiq"` when `WorkIqHealthTracker.IsHealthy == false`.
+  Re-publish the tool list when health flips.
+- `src/RockBot.UserProxy.WorkIqAuth/WorkIqAuthMessages.cs` — possibly add a
+  `WorkIqAuthRestored` message so the agent's health tracker can flip back
+  to healthy without waiting for the next cache-updated round-trip. Actually,
+  `WorkIqAuthCacheUpdated` already serves this role — the agent assumes
+  health on receipt. No new message type needed.
+
+**Tests:**
+
+- `WorkIqHealthTrackerTests` — verifies state transitions on
+  `WorkIqAuthCacheUpdated` arrivals, on `MarkUnhealthy` calls, and that the
+  `HealthChanged` event fires.
+- Extend `McpServersIndexedHandlerTests` (or wherever the tool list publish
+  logic is) to confirm that tools from auth-profile servers are filtered when
+  the tracker is unhealthy.
+
+### 3. Reconnect-button idempotency in Blazor
+
+**The problem:** the `WorkIqConnect` razor component's "Connect M365" button
+calls `WorkIqDeviceCodeFlow.BeginAsync`. If the user double-clicks, two MSAL
+device-code flows kick off in parallel. Both complete (one succeeds, the
+other fails with `verification_code_expired`), the latter's failure trashes
+the success state.
+
+**Fix:**
+
+- `src/RockBot.UserProxy.Blazor/Components/WorkIqConnect.razor` — disable the
+  button when `_state == ConnectState.InProgress`, and use a `bool _starting`
+  guard during the `BeginAsync` call to handle the race where two clicks
+  fire before the first one transitions to `InProgress`.
+- Same guard in `WorkIqReconnectBanner`'s Reconnect button (it just opens
+  the modal but should also be guarded against double-fire).
+
+**Tests:**
+
+- Extend `WorkIqAuthUiServiceTests` with `WorkIqConnectGuardTests` — test
+  that a second call to BeginAsync while the first is pending is a no-op
+  (returns the existing challenge). May require a small async coordinator on
+  `WorkIqDeviceCodeFlow` to support this; alternative is to keep the guard
+  purely in the UI component.
+
+### 4. Observability — log + metric for WorkIQ auth health
+
+**Files touched:**
+
+- `WorkIqHealthTracker` (from deliverable #2) gets an `ILogger` and writes
+  a structured log line on every state change:
+  ```
+  WorkIQ auth health changed: Healthy=true → false. Reason: refresh_revoked.
+  ```
+- If the agent's telemetry pipeline supports custom metrics (check
+  `RockBot.Telemetry` for the right hook), emit `workiq.auth.healthy`
+  gauge (0/1). Otherwise the log line is enough — operators can filter
+  on it.
+
+**Tests:** the log assertion lives in `WorkIqHealthTrackerTests` (use a
+test logger that captures messages).
+
+### 5. Documentation
+
+**Files touched:**
+
+- `deploy/workiq-setup.md` (created by Phase 4) — add a new section,
+  "Re-consent flow":
+  - What the user sees when expiry happens (banner, chat error message).
+  - Exact click sequence to recover (M365 pill → Reconnect → device code →
+    sign in → confirmation).
+  - How long it takes (~30 seconds end-to-end if the user is fast).
+  - What the agent does during expiry (Work IQ tools hidden from LLM
+    reasoning; other tools unaffected).
+  - How operators verify recovery (`workiq.auth.healthy` log line or
+    direct cache file mtime check).
+- `deploy/workiq-setup.md` — add a "Scheduled tasks during expiry" subsection
+  documenting the hide-tools behavior so operators understand why patrols
+  stop calling WorkIQ until reconnect.
+
+No changes to `deploy/workiq-entra-app-registration.md` — that doc is
+shareable with IT and doesn't need Phase 5 detail.
+
+## Files / artifacts produced by this phase
+
+| Path | Status | Purpose |
+|---|---|---|
+| `src/RockBot.Agent/McpBridge/McpBridgeService.cs` | edited | New catch + walker for `TokenAcquisitionException(ReauthRequired)` and `NotAuthenticated` |
+| `src/RockBot.Agent/McpBridge/Auth/WorkIqHealthTracker.cs` | new | In-process auth-health flag + log emission |
+| `src/RockBot.Agent/McpBridge/Auth/MsalTokenProvider.cs` | edited | Call `WorkIqHealthTracker.MarkUnhealthy` alongside `WorkIqAuthExpired` publish |
+| `src/RockBot.Agent/McpBridge/Auth/TokenCacheStore.cs` | edited | Call `WorkIqHealthTracker.MarkHealthy` after successful cache write |
+| `src/RockBot.Agent/McpBridge/Auth/WorkIqAuthServiceCollectionExtensions.cs` | edited | Register `WorkIqHealthTracker` as singleton |
+| `src/RockBot.UserProxy.Blazor/Components/WorkIqConnect.razor` | edited | Double-click guard |
+| `src/RockBot.UserProxy.Blazor/Components/WorkIqReconnectBanner.razor` | edited | Same |
+| `tests/RockBot.Agent.Tests/McpBridge/Auth/MsalToolErrorMappingTests.cs` | new | Asserts ToolError shape |
+| `tests/RockBot.Agent.Tests/McpBridge/Auth/WorkIqHealthTrackerTests.cs` | new | State transitions + event firing |
+| `tests/RockBot.UserProxy.Blazor.Tests/WorkIqConnectGuardTests.cs` | new | Idempotency |
+| `deploy/workiq-setup.md` | edited | Re-consent flow + scheduled-task behavior sections |
+
+## Risks and open questions
+
+1. **Tool-list filtering is observable to the LLM.** When a patrol runs, the
+   tool list it sees depends on auth state at session-start. If auth flips
+   mid-session, the in-flight session keeps its tool list. That's acceptable
+   — the next session re-derives. But it means a long-running session that
+   spans an auth expiry will keep trying Work IQ tools and getting
+   `auth_required` until it ends. Probably fine; document the behavior.
+
+2. **`WorkIqAuthCacheUpdated` triggers tool re-publish.** Whenever a fresh
+   cache arrives the agent re-publishes the tool list with the workiq-*
+   tools restored. Currently the bridge publishes on
+   `ConnectServerAsync` completion and on management refreshes; adding a
+   trigger on cache-arrival is one new code path. Make sure the throttling
+   from Phase 2 still applies so a flood of cache-updates doesn't flood the
+   tool-list topic.
+
+3. **Health tracker is per-process.** If the agent pod restarts, the tracker
+   starts in an unknown state. We can recover by inspecting the cache file
+   on disk at startup: present + non-empty → assume healthy until proven
+   otherwise. Document the startup recovery.
+
+4. **Double-click guard could race with state-change.** The component-level
+   guard is fine for human-speed clicking; if we ever programmatically drive
+   the flow (e.g., auto-reconnect on banner click), we need stronger
+   serialization. Leave that to a follow-up if it ever matters.
+
+5. **Telemetry metric is optional.** If `RockBot.Telemetry` doesn't have a
+   clean hook for custom gauges, ship just the log line and revisit when the
+   observability work catches up. Don't block Phase 5 on telemetry plumbing.
+
+## Acceptance criteria
+
+- [ ] A tool call against a Work IQ server with a revoked refresh token
+  returns `ToolError { Code=auth_required, IsRetryable=false }` with a
+  message that mentions "Reconnect M365" — verifiable in unit tests and in
+  the docker-compose smoke (extend Smoke #3 from Phase 4 with chat-side
+  assertion).
+- [ ] The agent's published tool list excludes `workiq-*` tools while
+  auth is unhealthy, and re-includes them within ~1 second of a fresh
+  `WorkIqAuthCacheUpdated` arriving.
+- [ ] Patrol-run logs show patrols skipping WorkIQ-dependent steps
+  cleanly (no `execution_failed` retries) while auth is unhealthy.
+- [ ] Blazor's "Connect M365" and "Reconnect" buttons are no-ops on
+  rapid second clicks while a flow is in progress.
+- [ ] `deploy/workiq-setup.md` includes the re-consent flow and the
+  scheduled-task-behavior subsections.
+- [ ] One agent log line on every health flip:
+  `WorkIQ auth health changed: Healthy=<old> → <new>. Reason: <code>.`
+
+## Implementation order
+
+1. Add `WorkIqHealthTracker` + DI registration + log emission. No behavior
+   change yet — just the state holder.
+2. Wire `MsalTokenProvider` + `TokenCacheStore` into the tracker.
+3. Add the `FindReauthRequired` / `FindNotAuthenticated` walkers and catch
+   clauses in `McpBridgeService`. Tests.
+4. Add tool-list filtering in the bridge's publish path. Tests.
+5. Blazor button guards. Tests.
+6. Update Smoke #3 in `deploy/workiq-setup.md` (or `workiq-phase4-plan.md`
+   if Phase 4 hasn't landed yet) to include the new tool error message
+   assertion.
+7. Add the re-consent flow + scheduled-task subsections to
+   `deploy/workiq-setup.md`.
+8. Open the PR. No new external dependencies; everything is unit-tested.
+
+## Out of scope (genuinely)
+
+- **Auto-reconnect.** When the banner appears, the user clicks Reconnect.
+  We do not automatically initiate the flow because device-code requires
+  the user's eyes on the screen anyway.
+- **Multi-user expiry handling.** Single-user model.
+- **Per-tool re-auth.** A WorkIQ permission added later (e.g.,
+  `WorkIQ-Teams`) requires re-consent to add scopes. That re-consent
+  request is a separate UX from "your existing scopes expired" and is
+  worth its own follow-up issue.
+- **Token-broker microservice.** Still deferred.
+
+## References
+
+- [`design/workiq-integration.md`](workiq-integration.md) — original design
+- [`design/workiq-phase4-plan.md`](workiq-phase4-plan.md) — preceding phase
+- [PR #442](https://github.com/MarimerLLC/rockbot/pull/442) — Phase 1+2 code
+- [PR #443](https://github.com/MarimerLLC/rockbot/pull/443) — Phase 3 code
+- `src/RockBot.Agent/McpBridge/McpBridgeService.cs:1601` — current
+  `FindAuthChallenge` walker that the new `FindReauthRequired` walker mirrors
+- `src/RockBot.Agent/McpBridge/Auth/MsalTokenProvider.cs:65` — current
+  `MsalUiRequiredException` catch that the new health tracker hooks into

--- a/src/RockBot.Agent/McpBridge/Auth/MsalTokenProvider.cs
+++ b/src/RockBot.Agent/McpBridge/Auth/MsalTokenProvider.cs
@@ -19,17 +19,20 @@ public sealed class MsalTokenProvider : ITokenProvider
     private readonly MsalTokenProviderOptions _options;
     private readonly IMessagePublisher _publisher;
     private readonly ILogger<MsalTokenProvider> _logger;
+    private readonly WorkIqHealthTracker? _healthTracker;
 
     public MsalTokenProvider(
         IPublicClientApplication msal,
         IOptions<MsalTokenProviderOptions> options,
         IMessagePublisher publisher,
-        ILogger<MsalTokenProvider> logger)
+        ILogger<MsalTokenProvider> logger,
+        WorkIqHealthTracker? healthTracker = null)
     {
         _msal = msal;
         _options = options.Value;
         _publisher = publisher;
         _logger = logger;
+        _healthTracker = healthTracker;
     }
 
     public async Task<string> GetAccessTokenAsync(bool forceRefresh, CancellationToken cancellationToken)
@@ -68,6 +71,7 @@ public sealed class MsalTokenProvider : ITokenProvider
                 "MSAL silent token acquisition for account {AccountId} requires interactive re-consent ({Classification})",
                 account.HomeAccountId?.Identifier, ex.Classification);
 
+            _healthTracker?.MarkUnhealthy($"refresh_revoked:{ex.Classification}");
             await PublishExpiredAsync(account, ex.Message, cancellationToken);
 
             throw new TokenAcquisitionException(

--- a/src/RockBot.Agent/McpBridge/Auth/TokenCacheStore.cs
+++ b/src/RockBot.Agent/McpBridge/Auth/TokenCacheStore.cs
@@ -30,6 +30,7 @@ public sealed class TokenCacheStore : IHostedService
     private readonly IPublicClientApplication _msal;
     private readonly MsalTokenProviderOptions _options;
     private readonly ILogger<TokenCacheStore> _logger;
+    private readonly WorkIqHealthTracker? _healthTracker;
 
     private readonly SemaphoreSlim _fileLock = new(1, 1);
     private ISubscription? _subscription;
@@ -38,12 +39,14 @@ public sealed class TokenCacheStore : IHostedService
         IMessageSubscriber subscriber,
         IPublicClientApplication msal,
         IOptions<MsalTokenProviderOptions> options,
-        ILogger<TokenCacheStore> logger)
+        ILogger<TokenCacheStore> logger,
+        WorkIqHealthTracker? healthTracker = null)
     {
         _subscriber = subscriber;
         _msal = msal;
         _options = options.Value;
         _logger = logger;
+        _healthTracker = healthTracker;
     }
 
     public async Task StartAsync(CancellationToken cancellationToken)
@@ -88,6 +91,7 @@ public sealed class TokenCacheStore : IHostedService
             _logger.LogInformation(
                 "Persisted WorkIQ token cache for account {AccountId} ({Bytes} bytes, {Scopes} scope(s))",
                 message.AccountId, message.CacheBytes.Length, message.Scopes.Count);
+            _healthTracker?.MarkHealthy("cache_updated_from_ui");
         }
         catch (Exception ex)
         {
@@ -143,6 +147,7 @@ public sealed class TokenCacheStore : IHostedService
             }
             _logger.LogDebug(
                 "Persisted MSAL cache rotation ({Bytes} bytes)", bytes.Length);
+            _healthTracker?.MarkHealthy("msal_cache_rotated");
         }
         catch (Exception ex)
         {

--- a/src/RockBot.Agent/McpBridge/Auth/WorkIqAuthServiceCollectionExtensions.cs
+++ b/src/RockBot.Agent/McpBridge/Auth/WorkIqAuthServiceCollectionExtensions.cs
@@ -52,6 +52,7 @@ public static class WorkIqAuthServiceCollectionExtensions
             return builder.Build();
         });
 
+        services.AddSingleton<WorkIqHealthTracker>();
         services.AddSingleton<MsalTokenProvider>();
         services.AddSingleton<TokenProviderRegistration>(sp =>
             new TokenProviderRegistration("workiq", sp.GetRequiredService<MsalTokenProvider>()));

--- a/src/RockBot.Agent/McpBridge/Auth/WorkIqHealthTracker.cs
+++ b/src/RockBot.Agent/McpBridge/Auth/WorkIqHealthTracker.cs
@@ -1,0 +1,116 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace RockBot.Agent.McpBridge.Auth;
+
+/// <summary>
+/// Tracks whether the WorkIQ MSAL cache can currently produce tokens. Other
+/// components consult <see cref="IsHealthy"/> to decide whether to expose
+/// WorkIQ-backed tools to the LLM; when unhealthy, those tools are filtered
+/// out of the published tool list so patrols and chat sessions never invoke
+/// them and get back stale <c>auth_required</c> errors.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The tracker is per-process. On agent startup it inspects the cache file
+/// on disk: a non-empty file implies the user has consented at least once
+/// and we optimistically mark healthy. The first failed silent refresh will
+/// flip it back to unhealthy via <see cref="MarkUnhealthy"/>, and the first
+/// successful cache write — either from MSAL rotation or from a UI-pushed
+/// <c>WorkIqAuthCacheUpdated</c> — flips it back to healthy.
+/// </para>
+/// </remarks>
+public sealed class WorkIqHealthTracker
+{
+    private readonly ILogger<WorkIqHealthTracker> _logger;
+    private readonly object _gate = new();
+
+    private bool _isHealthy;
+    private string? _lastReason;
+
+    public WorkIqHealthTracker(
+        IOptions<MsalTokenProviderOptions> options,
+        ILogger<WorkIqHealthTracker> logger)
+    {
+        _logger = logger;
+
+        // Optimistically assume healthy if the cache file exists and is non-empty —
+        // it means the user consented at some point. The first failed refresh will
+        // correct the state via MarkUnhealthy.
+        var path = options.Value.CacheFilePath;
+        try
+        {
+            if (!string.IsNullOrEmpty(path) && File.Exists(path) && new FileInfo(path).Length > 0)
+            {
+                _isHealthy = true;
+                _lastReason = "startup_cache_present";
+            }
+        }
+        catch
+        {
+            // Best-effort startup inspection — stay unhealthy on any IO error.
+        }
+    }
+
+    /// <summary>True when the agent believes a silent token refresh can succeed.</summary>
+    public bool IsHealthy
+    {
+        get { lock (_gate) return _isHealthy; }
+    }
+
+    /// <summary>Most recent reason string for diagnostics.</summary>
+    public string? LastReason
+    {
+        get { lock (_gate) return _lastReason; }
+    }
+
+    /// <summary>
+    /// Raised on every transition (both healthy → unhealthy and unhealthy → healthy).
+    /// Subscribers run synchronously on the thread that called <see cref="MarkHealthy"/>
+    /// or <see cref="MarkUnhealthy"/>; keep handlers cheap.
+    /// </summary>
+    public event Action<HealthChangedArgs>? HealthChanged;
+
+    /// <summary>
+    /// Flip to healthy. No-op when already healthy. Called by
+    /// <see cref="TokenCacheStore"/> after a successful cache write.
+    /// </summary>
+    public void MarkHealthy(string reason)
+    {
+        Transition(newHealthy: true, reason);
+    }
+
+    /// <summary>
+    /// Flip to unhealthy. No-op when already unhealthy. Called by
+    /// <see cref="MsalTokenProvider"/> when silent refresh fails with
+    /// <see cref="Microsoft.Identity.Client.MsalUiRequiredException"/>.
+    /// </summary>
+    public void MarkUnhealthy(string reason)
+    {
+        Transition(newHealthy: false, reason);
+    }
+
+    private void Transition(bool newHealthy, string reason)
+    {
+        bool changed;
+        bool oldHealthy;
+        lock (_gate)
+        {
+            oldHealthy = _isHealthy;
+            changed = oldHealthy != newHealthy;
+            _isHealthy = newHealthy;
+            _lastReason = reason;
+        }
+
+        if (!changed) return;
+
+        _logger.LogInformation(
+            "WorkIQ auth health changed: Healthy={Old} → {New}. Reason: {Reason}.",
+            oldHealthy, newHealthy, reason);
+
+        HealthChanged?.Invoke(new HealthChangedArgs(oldHealthy, newHealthy, reason));
+    }
+
+    /// <summary>Arguments for <see cref="HealthChanged"/>.</summary>
+    public sealed record HealthChangedArgs(bool OldValue, bool NewValue, string Reason);
+}

--- a/src/RockBot.Agent/McpBridge/McpBridgeService.cs
+++ b/src/RockBot.Agent/McpBridge/McpBridgeService.cs
@@ -8,6 +8,7 @@ using ModelContextProtocol.Protocol;
 using RockBot.Agent.McpBridge.Attachments;
 using RockBot.Host;
 using RockBot.Messaging;
+using RockBot.Agent.McpBridge.Auth;
 using RockBot.Tools;
 using RockBot.Tools.Mcp;
 using RockBot.Tools.Mcp.Auth;
@@ -28,12 +29,14 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
     private readonly ILogger<McpBridgeService> _logger;
     private readonly ILlmClient? _llmClient;
     private readonly ITokenProviderRegistry? _tokenProviders;
+    private readonly WorkIqHealthTracker? _healthTracker;
 
     private readonly Dictionary<string, McpClient> _clients = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, McpBridgeServerConfig> _serverConfigs = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, List<McpClientTool>> _serverTools = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, List<McpClientPrompt>> _serverPrompts = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, McpServerMetadata> _serverMetadata = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, McpServerSummary> _serverSummaries = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, AttachmentGatewayEntry> _attachmentGateways = new(StringComparer.OrdinalIgnoreCase);
     private readonly Lazy<IAttachmentStorage> _attachmentStorage = new(() => new AttachmentStorage());
     private readonly SemaphoreSlim _configPersistLock = new(1, 1);
@@ -65,7 +68,8 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
         IOptions<McpBridgeOptions> options,
         ILogger<McpBridgeService> logger,
         ILlmClient? llmClient = null,
-        ITokenProviderRegistry? tokenProviders = null)
+        ITokenProviderRegistry? tokenProviders = null,
+        WorkIqHealthTracker? healthTracker = null)
     {
         _publisher = publisher;
         _subscriber = subscriber;
@@ -77,6 +81,7 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
         _logger = logger;
         _llmClient = llmClient;
         _tokenProviders = tokenProviders;
+        _healthTracker = healthTracker;
     }
 
     public async Task StartAsync(CancellationToken cancellationToken)
@@ -102,6 +107,13 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
             HandleManagementRequestAsync,
             cancellationToken);
 
+        // Wire health-tracker changes so workiq-* tools appear/disappear
+        // from the published tool list as the auth cache becomes valid/invalid.
+        if (_healthTracker is not null)
+        {
+            _healthTracker.HealthChanged += OnAuthHealthChanged;
+        }
+
         // Load config and connect to servers
         await LoadConfigAndConnectAsync(cancellationToken);
         _startupCompletedAt = DateTimeOffset.UtcNow;
@@ -121,6 +133,9 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
     {
         _configWatcher?.Dispose();
         _configWatcher = null;
+
+        if (_healthTracker is not null)
+            _healthTracker.HealthChanged -= OnAuthHealthChanged;
 
         if (_sweepCts is not null)
         {
@@ -427,9 +442,23 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
                     name, metadata.ImplementationName ?? "(unknown)", metadata.Version ?? "(unknown)",
                     filteredTools.Count, prompts.Count);
 
-                // Build and publish server summary
+                // Build summary and cache so a future health flip can re-publish without
+                // re-running the (LLM-driven) summary generation.
                 var summary = await GenerateSummaryAsync(name, metadata, filteredTools, prompts, ct);
-                await PublishServersIndexedAsync([summary], [], ct);
+                _serverSummaries[name] = summary;
+
+                if (IsServerHiddenByAuth(config))
+                {
+                    _logger.LogInformation(
+                        "MCP server {Name} uses auth profile '{Profile}' which is currently unhealthy; suppressing publish until auth recovers",
+                        name, config.Auth?.Profile);
+                    // Make sure the agent's prior view of this server (if any) is cleared.
+                    await PublishServersIndexedAsync([], [name], ct);
+                }
+                else
+                {
+                    await PublishServersIndexedAsync([summary], [], ct);
+                }
                 return;
             }
             catch (OperationCanceledException) when (ct.IsCancellationRequested)
@@ -468,6 +497,7 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
         _serverPrompts.Remove(name);
         _serverMetadata.Remove(name);
         _serverConfigs.Remove(name);
+        _serverSummaries.Remove(name);
         InvalidateAttachmentGateway(name);
 
         await PublishServersIndexedAsync([], [name], CancellationToken.None);
@@ -961,6 +991,28 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
             };
 
             await PublishResponseAsync(error, replyTo, envelope.CorrelationId, ct);
+        }
+        catch (Exception ex) when (FindReauthRequired(ex) is { } reauth)
+        {
+            sw.Stop();
+            _logger.LogWarning(
+                "← MCP {Server}/{Tool} REAUTH REQUIRED after {ElapsedMs}ms (code={Code}): {Detail}",
+                serverName, request.ToolName, sw.ElapsedMilliseconds, reauth.Code, reauth.Message);
+
+            // Silent refresh failed (or never consented). Reconnecting the MCP transport
+            // will not help — the user must complete an interactive flow in the UI before
+            // any Work IQ tool will succeed.
+            var error = new ToolError
+            {
+                ToolCallId = request.ToolCallId,
+                ToolName = request.ToolName,
+                Code = ToolError.Codes.AuthRequired,
+                Message = BuildReauthRequiredMessage(reauth),
+                IsRetryable = false
+            };
+
+            await PublishResponseAsync(error, replyTo, envelope.CorrelationId, ct);
+            return MessageResult.Ack;
         }
         catch (Exception ex) when (FindAuthChallenge(ex) is { } authChallenge)
         {
@@ -1588,6 +1640,7 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
         _serverPrompts.Clear();
         _serverMetadata.Clear();
         _serverConfigs.Clear();
+        _serverSummaries.Clear();
 
         foreach (var (_, entry) in _attachmentGateways)
         {
@@ -1610,6 +1663,107 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
             if (current is McpAuthChallengeException auth) return auth;
         }
         return null;
+    }
+
+    /// <summary>
+    /// Walks the exception chain looking for a <see cref="TokenAcquisitionException"/>
+    /// whose code indicates that the user must complete an interactive auth flow
+    /// (initial consent never happened, or refresh-token rotation failed). Surfaces
+    /// as a dedicated <c>auth_required</c> tool error so the LLM stops retrying and
+    /// reports a clear actionable message instead.
+    /// </summary>
+    internal static TokenAcquisitionException? FindReauthRequired(Exception? ex)
+    {
+        for (var current = ex; current is not null; current = current.InnerException)
+        {
+            if (current is TokenAcquisitionException tae
+                && (tae.Code == TokenAcquisitionException.Codes.ReauthRequired
+                    || tae.Code == TokenAcquisitionException.Codes.NotAuthenticated))
+            {
+                return tae;
+            }
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Maps a <see cref="TokenAcquisitionException"/> identified by
+    /// <see cref="FindReauthRequired"/> to the user-facing tool-error message.
+    /// Split out so unit tests can assert wording without spinning up the whole
+    /// bridge.
+    /// </summary>
+    internal static string BuildReauthRequiredMessage(TokenAcquisitionException reauth) =>
+        reauth.Code == TokenAcquisitionException.Codes.NotAuthenticated
+            ? "Microsoft 365 has not been connected yet. Open the Blazor app and click "
+              + "'Connect M365' to complete the initial sign-in. Work IQ tools will fail "
+              + "until consent is granted."
+            : "Microsoft 365 connection has expired. Open the Blazor app and click "
+              + "'Reconnect M365' to restore access. Work IQ tools will fail until "
+              + "reconnection is complete.";
+
+    /// <summary>
+    /// True when <paramref name="config"/> requires the WorkIQ auth profile and the
+    /// health tracker reports the cache cannot currently produce tokens. Callers use
+    /// this to suppress publishing the server's tools to the agent — so the LLM never
+    /// sees them and never makes calls that would just bounce back as auth_required.
+    /// </summary>
+    private bool IsServerHiddenByAuth(McpBridgeServerConfig config)
+    {
+        if (_healthTracker is null) return false;
+        if (config.Auth is null) return false;
+        if (!string.Equals(config.Auth.Profile, "workiq", StringComparison.OrdinalIgnoreCase))
+            return false;
+        return !_healthTracker.IsHealthy;
+    }
+
+    /// <summary>
+    /// Handler for <see cref="WorkIqHealthTracker.HealthChanged"/>. On the flip to
+    /// healthy, re-publish cached summaries for every workiq server so the agent
+    /// re-includes their tools. On the flip to unhealthy, publish removal entries
+    /// so the agent drops those tools from its working set.
+    /// </summary>
+    private void OnAuthHealthChanged(WorkIqHealthTracker.HealthChangedArgs args)
+    {
+        // Snapshot the affected servers under the same lock domain we use elsewhere.
+        // Modifications to _serverConfigs come from foreground async paths; reading
+        // the keys here is safe because we tolerate races (a server added/removed
+        // mid-flip just gets the next publish cycle).
+        var workiqServers = _serverConfigs
+            .Where(kvp => string.Equals(kvp.Value.Auth?.Profile, "workiq",
+                StringComparison.OrdinalIgnoreCase))
+            .Select(kvp => kvp.Key)
+            .ToList();
+
+        if (workiqServers.Count == 0) return;
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                if (args.NewValue)
+                {
+                    // Healthy again — re-publish each workiq server's cached summary.
+                    foreach (var name in workiqServers)
+                    {
+                        if (_serverSummaries.TryGetValue(name, out var summary))
+                        {
+                            await PublishServersIndexedAsync([summary], [], CancellationToken.None);
+                        }
+                    }
+                }
+                else
+                {
+                    // Unhealthy — tell the agent to drop these from its tool list.
+                    await PublishServersIndexedAsync([], workiqServers, CancellationToken.None);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Failed to republish MCP tool list after WorkIQ health flip to {New}",
+                    args.NewValue);
+            }
+        });
     }
 
     /// <summary>
@@ -1642,6 +1796,9 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
     public async ValueTask DisposeAsync()
     {
         _configWatcher?.Dispose();
+
+        if (_healthTracker is not null)
+            _healthTracker.HealthChanged -= OnAuthHealthChanged;
 
         if (_sweepCts is not null)
         {

--- a/src/RockBot.UserProxy.Blazor/Components/WorkIqConnect.razor
+++ b/src/RockBot.UserProxy.Blazor/Components/WorkIqConnect.razor
@@ -10,7 +10,7 @@
 <div class="workiq-connect">
     @if (_state == ConnectState.NotStarted)
     {
-        <button class="btn btn-primary" @onclick="StartFlow">Connect M365</button>
+        <button class="btn btn-primary" @onclick="StartFlow" disabled="@_starting">Connect M365</button>
         @if (_lastError is not null)
         {
             <div class="mt-2 alert alert-danger small" role="alert">
@@ -60,9 +60,16 @@
     private string? _lastError;
     private CancellationTokenSource? _cts;
     private Task? _completionTask;
+    // Guard against a second click between the button render and the state
+    // transition into InProgress — without it, a fast double-click would start
+    // two device-code flows in parallel and the latter's failure would clobber
+    // the former's success.
+    private bool _starting;
 
     private async Task StartFlow()
     {
+        if (_starting || _state == ConnectState.InProgress) return;
+        _starting = true;
         _state = ConnectState.InProgress;
         _lastError = null;
         _cts = new CancellationTokenSource();
@@ -93,6 +100,7 @@
         {
             _cts?.Dispose();
             _cts = null;
+            _starting = false;
         }
     }
 

--- a/src/RockBot.UserProxy.Blazor/Components/WorkIqReconnectBanner.razor
+++ b/src/RockBot.UserProxy.Blazor/Components/WorkIqReconnectBanner.razor
@@ -14,7 +14,7 @@
             }
         </div>
         <div class="d-flex gap-2">
-            <button class="btn btn-sm btn-warning" @onclick="OnReconnect">Reconnect</button>
+            <button class="btn btn-sm btn-warning" @onclick="OnReconnect" disabled="@_reconnecting">Reconnect</button>
             <button class="btn btn-sm btn-link" @onclick="OnDismiss"
                     title="Dismiss">✕</button>
         </div>
@@ -28,6 +28,11 @@
     /// </summary>
     [Parameter] public EventCallback OnReconnectClicked { get; set; }
 
+    // Guard against rapid double-clicks while the parent's async handler
+    // (typically a modal open + flow start) is in flight. Without it, two
+    // OnReconnectClicked invocations would race the parent's flow state.
+    private bool _reconnecting;
+
     protected override void OnInitialized()
     {
         UiState.StateChanged += HandleStateChanged;
@@ -37,8 +42,17 @@
 
     private async Task OnReconnect()
     {
-        if (OnReconnectClicked.HasDelegate)
-            await OnReconnectClicked.InvokeAsync();
+        if (_reconnecting) return;
+        _reconnecting = true;
+        try
+        {
+            if (OnReconnectClicked.HasDelegate)
+                await OnReconnectClicked.InvokeAsync();
+        }
+        finally
+        {
+            _reconnecting = false;
+        }
     }
 
     private void OnDismiss() => UiState.DismissExpiredBanner();

--- a/tests/RockBot.Agent.Tests/McpBridge/Auth/MsalToolErrorMappingTests.cs
+++ b/tests/RockBot.Agent.Tests/McpBridge/Auth/MsalToolErrorMappingTests.cs
@@ -1,0 +1,102 @@
+using RockBot.Agent.McpBridge;
+using RockBot.Tools;
+using RockBot.Tools.Mcp.Auth;
+
+namespace RockBot.Agent.Tests.McpBridge.Auth;
+
+/// <summary>
+/// Verifies that <see cref="McpBridgeService"/>'s exception walker and message
+/// builder turn a <see cref="TokenAcquisitionException"/> into an actionable
+/// <see cref="ToolError"/> with <c>auth_required</c> and <c>IsRetryable=false</c>.
+///
+/// We deliberately test the walker + message builder in isolation rather than
+/// spinning up the whole bridge — the bridge's invoke path is exercised in the
+/// integration test suite, and the failure mode we care about (LLM blindly
+/// retrying because the error looked transient) is fully captured by the
+/// ToolError shape these helpers produce.
+/// </summary>
+[TestClass]
+public class MsalToolErrorMappingTests
+{
+    [TestMethod]
+    public void FindReauthRequired_DirectReauthException_Returns()
+    {
+        var ex = new TokenAcquisitionException(
+            TokenAcquisitionException.Codes.ReauthRequired, "refresh dead");
+
+        var found = McpBridgeService.FindReauthRequired(ex);
+
+        Assert.IsNotNull(found);
+        Assert.AreEqual(TokenAcquisitionException.Codes.ReauthRequired, found!.Code);
+    }
+
+    [TestMethod]
+    public void FindReauthRequired_DirectNotAuthenticatedException_Returns()
+    {
+        var ex = new TokenAcquisitionException(
+            TokenAcquisitionException.Codes.NotAuthenticated, "no account");
+
+        var found = McpBridgeService.FindReauthRequired(ex);
+
+        Assert.IsNotNull(found);
+        Assert.AreEqual(TokenAcquisitionException.Codes.NotAuthenticated, found!.Code);
+    }
+
+    [TestMethod]
+    public void FindReauthRequired_WrappedDeep_StillReturns()
+    {
+        // Simulates how the MCP client wraps a bearer-handler failure inside
+        // transport/protocol exception layers.
+        var inner = new TokenAcquisitionException(
+            TokenAcquisitionException.Codes.ReauthRequired, "refresh dead");
+        var middle = new HttpRequestException("send failed", inner);
+        var outer = new InvalidOperationException("tool call failed", middle);
+
+        var found = McpBridgeService.FindReauthRequired(outer);
+
+        Assert.IsNotNull(found);
+        Assert.AreEqual(TokenAcquisitionException.Codes.ReauthRequired, found!.Code);
+    }
+
+    [TestMethod]
+    public void FindReauthRequired_OtherTokenAcquisitionCode_ReturnsNull()
+    {
+        // IdentityProviderUnreachable is transient, NOT reauth-required, so the
+        // walker must skip it and let the generic error path handle it.
+        var ex = new TokenAcquisitionException(
+            TokenAcquisitionException.Codes.IdentityProviderUnreachable, "AAD down");
+
+        Assert.IsNull(McpBridgeService.FindReauthRequired(ex));
+    }
+
+    [TestMethod]
+    public void FindReauthRequired_UnrelatedException_ReturnsNull()
+    {
+        var ex = new InvalidOperationException("something else broke");
+        Assert.IsNull(McpBridgeService.FindReauthRequired(ex));
+    }
+
+    [TestMethod]
+    public void BuildReauthRequiredMessage_ReauthRequired_MentionsReconnect()
+    {
+        var ex = new TokenAcquisitionException(
+            TokenAcquisitionException.Codes.ReauthRequired, "msal said no");
+
+        var message = McpBridgeService.BuildReauthRequiredMessage(ex);
+
+        StringAssert.Contains(message, "Reconnect M365");
+        StringAssert.Contains(message, "Microsoft 365");
+    }
+
+    [TestMethod]
+    public void BuildReauthRequiredMessage_NotAuthenticated_MentionsConnect()
+    {
+        var ex = new TokenAcquisitionException(
+            TokenAcquisitionException.Codes.NotAuthenticated, "no cached account");
+
+        var message = McpBridgeService.BuildReauthRequiredMessage(ex);
+
+        StringAssert.Contains(message, "Connect M365");
+        StringAssert.Contains(message, "Microsoft 365");
+    }
+}

--- a/tests/RockBot.Agent.Tests/McpBridge/Auth/WorkIqHealthTrackerTests.cs
+++ b/tests/RockBot.Agent.Tests/McpBridge/Auth/WorkIqHealthTrackerTests.cs
@@ -1,0 +1,174 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using RockBot.Agent.McpBridge.Auth;
+
+namespace RockBot.Agent.Tests.McpBridge.Auth;
+
+[TestClass]
+public class WorkIqHealthTrackerTests
+{
+    private string _cacheDir = null!;
+    private string _cachePath = null!;
+
+    [TestInitialize]
+    public void Init()
+    {
+        _cacheDir = Path.Combine(Path.GetTempPath(), "rockbot-health-tracker-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_cacheDir);
+        _cachePath = Path.Combine(_cacheDir, "workiq-cache.bin");
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_cacheDir))
+            Directory.Delete(_cacheDir, recursive: true);
+    }
+
+    [TestMethod]
+    public void Initial_NoCacheFile_StartsUnhealthy()
+    {
+        var tracker = CreateTracker();
+        Assert.IsFalse(tracker.IsHealthy);
+    }
+
+    [TestMethod]
+    public void Initial_EmptyCacheFile_StartsUnhealthy()
+    {
+        File.WriteAllBytes(_cachePath, []);
+        var tracker = CreateTracker();
+        Assert.IsFalse(tracker.IsHealthy);
+    }
+
+    [TestMethod]
+    public void Initial_NonEmptyCacheFile_StartsHealthy()
+    {
+        File.WriteAllBytes(_cachePath, [1, 2, 3]);
+        var tracker = CreateTracker();
+        Assert.IsTrue(tracker.IsHealthy);
+        Assert.AreEqual("startup_cache_present", tracker.LastReason);
+    }
+
+    [TestMethod]
+    public void MarkUnhealthy_FromHealthy_FlipsAndRaisesEvent()
+    {
+        File.WriteAllBytes(_cachePath, [1, 2, 3]);
+        var tracker = CreateTracker();
+        WorkIqHealthTracker.HealthChangedArgs? captured = null;
+        tracker.HealthChanged += args => captured = args;
+
+        tracker.MarkUnhealthy("refresh_revoked:test");
+
+        Assert.IsFalse(tracker.IsHealthy);
+        Assert.AreEqual("refresh_revoked:test", tracker.LastReason);
+        Assert.IsNotNull(captured);
+        Assert.IsTrue(captured!.OldValue);
+        Assert.IsFalse(captured.NewValue);
+        Assert.AreEqual("refresh_revoked:test", captured.Reason);
+    }
+
+    [TestMethod]
+    public void MarkHealthy_FromUnhealthy_FlipsAndRaisesEvent()
+    {
+        var tracker = CreateTracker();
+        WorkIqHealthTracker.HealthChangedArgs? captured = null;
+        tracker.HealthChanged += args => captured = args;
+
+        tracker.MarkHealthy("cache_updated_from_ui");
+
+        Assert.IsTrue(tracker.IsHealthy);
+        Assert.AreEqual("cache_updated_from_ui", tracker.LastReason);
+        Assert.IsNotNull(captured);
+        Assert.IsFalse(captured!.OldValue);
+        Assert.IsTrue(captured.NewValue);
+    }
+
+    [TestMethod]
+    public void MarkHealthy_WhenAlreadyHealthy_DoesNotRaiseEvent()
+    {
+        File.WriteAllBytes(_cachePath, [1, 2, 3]);
+        var tracker = CreateTracker();
+        var raised = 0;
+        tracker.HealthChanged += _ => raised++;
+
+        tracker.MarkHealthy("again");
+
+        Assert.AreEqual(0, raised);
+        Assert.IsTrue(tracker.IsHealthy);
+    }
+
+    [TestMethod]
+    public void MarkUnhealthy_WhenAlreadyUnhealthy_DoesNotRaiseEvent()
+    {
+        var tracker = CreateTracker();
+        var raised = 0;
+        tracker.HealthChanged += _ => raised++;
+
+        tracker.MarkUnhealthy("still unhealthy");
+
+        Assert.AreEqual(0, raised);
+        Assert.IsFalse(tracker.IsHealthy);
+    }
+
+    [TestMethod]
+    public void Transition_EmitsLogLineOnFlip()
+    {
+        File.WriteAllBytes(_cachePath, [1, 2, 3]);
+        var capturing = new CapturingLogger();
+        var tracker = new WorkIqHealthTracker(BuildOptions(), capturing);
+
+        tracker.MarkUnhealthy("refresh_revoked");
+        tracker.MarkHealthy("cache_updated_from_ui");
+
+        var flipLines = capturing.Messages.Where(m => m.Contains("WorkIQ auth health changed")).ToList();
+        Assert.AreEqual(2, flipLines.Count, "expected one log line per actual transition");
+        StringAssert.Contains(flipLines[0], "Healthy=True");
+        StringAssert.Contains(flipLines[0], "False");
+        StringAssert.Contains(flipLines[0], "refresh_revoked");
+        StringAssert.Contains(flipLines[1], "cache_updated_from_ui");
+    }
+
+    [TestMethod]
+    public void NoOpTransition_DoesNotEmitLogLine()
+    {
+        var capturing = new CapturingLogger();
+        var tracker = new WorkIqHealthTracker(BuildOptions(), capturing);
+
+        tracker.MarkUnhealthy("first");
+        tracker.MarkUnhealthy("second");
+
+        var flipLines = capturing.Messages.Where(m => m.Contains("WorkIQ auth health changed")).ToList();
+        Assert.AreEqual(0, flipLines.Count, "starts unhealthy; two unhealthy calls should produce no log lines");
+    }
+
+    private WorkIqHealthTracker CreateTracker() =>
+        new(BuildOptions(), NullLogger<WorkIqHealthTracker>.Instance);
+
+    private IOptions<MsalTokenProviderOptions> BuildOptions() =>
+        Options.Create(new MsalTokenProviderOptions
+        {
+            CacheFilePath = _cachePath,
+            TenantId = "00000000-0000-0000-0000-000000000002",
+            ClientId = "00000000-0000-0000-0000-000000000001"
+        });
+
+    private sealed class CapturingLogger : ILogger<WorkIqHealthTracker>
+    {
+        public List<string> Messages { get; } = new();
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Messages.Add(formatter(state, exception));
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Phase 5 of the WorkIQ integration ([design/workiq-phase5-plan.md](design/workiq-phase5-plan.md)). Builds on #442/#443/#444. Closes three failure-mode gaps:

- **Actionable `auth_required` tool error.** `MsalUiRequiredException` and friends used to fall into the generic "execution failed, retryable" bucket, so the LLM blindly retried. New `FindReauthRequired` walker + catch clause in `McpBridgeService` produces `ToolError { Code=auth_required, IsRetryable=false }` with a message that names the Blazor Reconnect/Connect button.
- **Hide WorkIQ tools while auth is unhealthy.** New `WorkIqHealthTracker` singleton flips on cache writes / silent-refresh failures, emits a structured log on every transition, and raises `HealthChanged`. The bridge subscribes and republishes the tool list with workiq-* servers removed (or re-added) so patrols and chat sessions started during the unhealthy window never call them. Direct calls still get the `auth_required` error from above.
- **Blazor double-click guards.** `WorkIqConnect.razor` and `WorkIqReconnectBanner.razor` gain `_starting` / `_reconnecting` bools + `disabled` attributes so a fast second click can't kick off a parallel device-code flow that clobbers the first one's success state.

Also adds `deploy/workiq-setup.md` with the re-consent flow and scheduled-tasks-during-expiry sections (a stub Phase 4 can extend with its own initial-setup material).

## Test plan

- [x] `dotnet build RockBot.slnx` clean (only pre-existing CA1416 / NU190x warnings)
- [x] `dotnet test RockBot.slnx` — all new tests pass (9 `WorkIqHealthTrackerTests` + 7 `MsalToolErrorMappingTests`)
- [x] Full suite green except one pre-existing Windows file-move flake in `RepairTicketApplyPassTests.TimeoutBackoff_PassesEscalatingBudgets_ToVerifier` that passes in isolation (unrelated to this PR)
- [ ] Smoke against the live cluster: revoke the WorkIQ cache, confirm banner appears, confirm the next chat reply returns the `auth_required` text, confirm patrol logs stop trying workiq tools, reconnect, confirm tools come back within ~1 second
- [ ] Verify a deliberate double-click on Connect / Reconnect in the Blazor UI is a no-op

Note: the Blazor button guards live purely in the .razor (no bUnit in the project); the plan explicitly permitted the UI-only guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)