### PR TITLE
Add WorkIqAuth csproj to Blazor Dockerfile restore layer

### DIFF
--- a/src/RockBot.UserProxy.Blazor/Dockerfile
+++ b/src/RockBot.UserProxy.Blazor/Dockerfile
@@ -18,6 +18,7 @@ COPY RockBot.slnx Directory.Build.props ./
 COPY src/RockBot.UserProxy.Blazor/RockBot.UserProxy.Blazor.csproj src/RockBot.UserProxy.Blazor/
 COPY src/RockBot.UserProxy/RockBot.UserProxy.csproj src/RockBot.UserProxy/
 COPY src/RockBot.UserProxy.Abstractions/RockBot.UserProxy.Abstractions.csproj src/RockBot.UserProxy.Abstractions/
+COPY src/RockBot.UserProxy.WorkIqAuth/RockBot.UserProxy.WorkIqAuth.csproj src/RockBot.UserProxy.WorkIqAuth/
 COPY src/RockBot.Messaging.RabbitMQ/RockBot.Messaging.RabbitMQ.csproj src/RockBot.Messaging.RabbitMQ/
 COPY src/RockBot.Messaging.Abstractions/RockBot.Messaging.Abstractions.csproj src/RockBot.Messaging.Abstractions/
 


### PR DESCRIPTION
## Summary
- Adds `RockBot.UserProxy.WorkIqAuth/RockBot.UserProxy.WorkIqAuth.csproj` to the layer-cached restore copy in `src/RockBot.UserProxy.Blazor/Dockerfile`
- Without this, `docker build` fails on the `dotnet build` stage with `NETSDK1004: Assets file '/src/src/RockBot.UserProxy.WorkIqAuth/obj/project.assets.json' not found` because the WorkIqAuth project (added during recent WorkIQ MCP auth work) is now a transitive dep of the Blazor app but its csproj was never copied for the restore step

## Test plan
- [x] `docker build -f src/RockBot.UserProxy.Blazor/Dockerfile -t rockylhotka/rockbot-blazor:0.12.23 .` completes successfully
- [x] `docker push` succeeds; `helm upgrade --set blazor.image.tag=0.12.23` rolls out cleanly; pod runs

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)