### PR TITLE
Add routing cost floor to stop the dream ratcheting balancedCeiling to its floor

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.12.23</Version>
+<Version>0.12.24</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.Agent/agent/routing-dream.md
+++ b/src/RockBot.Agent/agent/routing-dream.md
@@ -82,6 +82,14 @@ Apply a threshold shift only when **both** of these hold:
 - The cost delta is favorable, OR you have a clear quality reason (e.g., panic-escalation
   clusters dominating a tier)
 
+**Trust `projectedCostDelta`.** It now reflects a *routing cost floor*: the High tier is
+priced as a premium tier (≥ a fixed multiple of Balanced) even when High and Balanced
+currently share the same model. So a `balancedCeiling` **decrease** (which routes more
+traffic to High) will show a **positive (unfavorable)** delta, and an **increase** a
+**negative (favorable)** one. Do not read "same model today" as "free" — lowering
+`balancedCeiling` is treated as a real future cost. When High routing share is already
+high, prefer **raising** `balancedCeiling` to pull verbose-but-simple tasks back to Balanced.
+
 Adjustments must be **small (±0.05)**. Hard bounds the code clamps to:
 - `lowCeiling` ∈ [0.15, 0.40]
 - `balancedCeiling` ∈ [0.40, 0.80]

--- a/src/RockBot.Host.Abstractions/DreamOptions.cs
+++ b/src/RockBot.Host.Abstractions/DreamOptions.cs
@@ -78,6 +78,24 @@ public sealed class DreamOptions
     public bool TierRoutingReviewEnabled { get; set; } = true;
 
     /// <summary>
+    /// Routing cost floor for the tier-routing review pass. The High tier is priced at no less
+    /// than this multiple of the Balanced tier's real rate when projecting threshold-scan and
+    /// flagged-cluster costs. This stops the dream from reading a Balanced→High shift as
+    /// zero-cost — and ratcheting <c>balancedCeiling</c> to its floor — when High currently
+    /// shares Balanced's model. A genuinely premium High model keeps its real (higher) price.
+    /// Set to 1.0 to disable the floor. Default: 2.0.
+    /// </summary>
+    public double TierRoutingHighCostFloorMultiplier { get; set; } = 2.0;
+
+    /// <summary>
+    /// Target ceiling on the High-tier routing share (percent of routing decisions in the review
+    /// window). While the observed High share exceeds this, the review pass will NOT apply a
+    /// <c>balancedCeiling</c> decrease (which would push even more traffic to High) — a
+    /// deterministic backstop independent of the LLM's judgment. Default: 20 (%).
+    /// </summary>
+    public double TierRoutingHighTargetPct { get; set; } = 20.0;
+
+    /// <summary>
     /// Path to the routing dream directive file, relative to <see cref="AgentProfileOptions.BasePath"/>.
     /// When the file does not exist, a built-in fallback directive is used.
     /// </summary>

--- a/src/RockBot.Host.Abstractions/TierRoutingAnalyzer.cs
+++ b/src/RockBot.Host.Abstractions/TierRoutingAnalyzer.cs
@@ -35,11 +35,20 @@ public static class TierRoutingAnalyzer
     /// Run the analyzer over a snapshot of entries. The caller is responsible for
     /// any time-window filtering before calling — this method aggregates whatever it gets.
     /// </summary>
+    /// <param name="highTierCostFloorMultiplier">
+    /// Routing cost floor. For threshold-scan and flagged-cluster cost projections, the High
+    /// tier is priced at no less than this multiple of the Balanced tier's real rate. Prevents
+    /// the dream from reading a Balanced→High shift as zero-cost — and ratcheting balancedCeiling
+    /// to its floor — when High currently shares Balanced's model. <c>Math.Max</c> means a
+    /// genuinely premium High model keeps its real (higher) price. 1.0 disables the floor.
+    /// Does NOT affect <see cref="TierRoutingProjectedCost"/>, which always reports real spend.
+    /// </param>
     public static TierRoutingAnalysis Analyze(
         IReadOnlyList<TierRoutingEntry> entries,
         TierSelectorConfig? currentConfig = null,
         IReadOnlyList<LlmPricingRow>? pricing = null,
-        IReadOnlyDictionary<ModelTier, string?>? tierModelMap = null)
+        IReadOnlyDictionary<ModelTier, string?>? tierModelMap = null,
+        double highTierCostFloorMultiplier = 1.0)
     {
         var lowCeiling = currentConfig?.LowCeiling ?? DefaultLowCeiling;
         var balancedCeiling = currentConfig?.BalancedCeiling ?? DefaultBalancedCeiling;
@@ -65,9 +74,9 @@ public static class TierRoutingAnalyzer
 
         var globalStats = BuildGlobalStats(entries, fallbackCount);
         var clusters = BuildClusters(quality);
-        var flagged = FlagClusters(clusters, pricing, tierModelMap);
+        var flagged = FlagClusters(clusters, pricing, tierModelMap, highTierCostFloorMultiplier);
         var keywordCandidates = BuildKeywordCandidates(quality);
-        var scans = BuildThresholdScans(quality, lowCeiling, balancedCeiling, pricing, tierModelMap);
+        var scans = BuildThresholdScans(quality, lowCeiling, balancedCeiling, pricing, tierModelMap, highTierCostFloorMultiplier);
         var projectedCost = BuildProjectedCost(entries, pricing);
 
         return new TierRoutingAnalysis(
@@ -183,7 +192,8 @@ public static class TierRoutingAnalyzer
     private static IReadOnlyList<TierRoutingFlaggedCluster> FlagClusters(
         IReadOnlyList<TierRoutingCluster> clusters,
         IReadOnlyList<LlmPricingRow>? pricing,
-        IReadOnlyDictionary<ModelTier, string?>? tierModelMap)
+        IReadOnlyDictionary<ModelTier, string?>? tierModelMap,
+        double highTierCostFloorMultiplier)
     {
         var flagged = new List<TierRoutingFlaggedCluster>();
 
@@ -195,7 +205,7 @@ public static class TierRoutingAnalyzer
             {
                 flagged.Add(BuildFlagged(c, "panicEscalation",
                     $"Low tier averaging {c.AvgToolCalls:F1} tool calls across {c.Count} entries — model likely struggling.",
-                    ModelTier.Balanced, pricing, tierModelMap));
+                    ModelTier.Balanced, pricing, tierModelMap, highTierCostFloorMultiplier));
                 continue;
             }
 
@@ -204,7 +214,7 @@ public static class TierRoutingAnalyzer
             {
                 flagged.Add(BuildFlagged(c, "tokenSurprise",
                     $"Score {c.AvgComplexityScore:F2} but post-injection tokens {p} — context inflation, not user complexity. Informational only.",
-                    alternateTier: null, pricing, tierModelMap));
+                    alternateTier: null, pricing, tierModelMap, highTierCostFloorMultiplier));
                 continue;
             }
 
@@ -213,7 +223,7 @@ public static class TierRoutingAnalyzer
             {
                 flagged.Add(BuildFlagged(c, "lowOutputAtHigh",
                     $"High tier producing only {o} avg output tokens across {c.Count} entries — possible over-routing.",
-                    ModelTier.Balanced, pricing, tierModelMap));
+                    ModelTier.Balanced, pricing, tierModelMap, highTierCostFloorMultiplier));
             }
         }
 
@@ -222,18 +232,19 @@ public static class TierRoutingAnalyzer
 
     private static TierRoutingFlaggedCluster BuildFlagged(
         TierRoutingCluster cluster, string flag, string rationale, ModelTier? alternateTier,
-        IReadOnlyList<LlmPricingRow>? pricing, IReadOnlyDictionary<ModelTier, string?>? tierModelMap)
+        IReadOnlyList<LlmPricingRow>? pricing, IReadOnlyDictionary<ModelTier, string?>? tierModelMap,
+        double highTierCostFloorMultiplier)
     {
         decimal? currentCost = null;
         decimal? alternateCost = null;
         if (pricing is not null && tierModelMap is not null
             && cluster.AvgInputTokens is long ai && cluster.AvgOutputTokens is long ao)
         {
-            var perCallCurrent = TryPriceCall(tierModelMap.GetValueOrDefault(cluster.Tier), ai, ao, pricing);
+            var perCallCurrent = TryPriceCallForTier(cluster.Tier, ai, ao, tierModelMap, pricing, highTierCostFloorMultiplier);
             currentCost = perCallCurrent * cluster.Count;
             if (alternateTier is ModelTier alt)
             {
-                var perCallAlt = TryPriceCall(tierModelMap.GetValueOrDefault(alt), ai, ao, pricing);
+                var perCallAlt = TryPriceCallForTier(alt, ai, ao, tierModelMap, pricing, highTierCostFloorMultiplier);
                 alternateCost = perCallAlt * cluster.Count;
             }
         }
@@ -325,14 +336,15 @@ public static class TierRoutingAnalyzer
         IReadOnlyList<TierRoutingEntry> entries,
         double lowCeiling, double balancedCeiling,
         IReadOnlyList<LlmPricingRow>? pricing,
-        IReadOnlyDictionary<ModelTier, string?>? tierModelMap)
+        IReadOnlyDictionary<ModelTier, string?>? tierModelMap,
+        double highTierCostFloorMultiplier)
     {
         return new[]
         {
-            BuildScan(entries, "lowCeiling", +ThresholdScanDelta, lowCeiling, balancedCeiling, pricing, tierModelMap),
-            BuildScan(entries, "lowCeiling", -ThresholdScanDelta, lowCeiling, balancedCeiling, pricing, tierModelMap),
-            BuildScan(entries, "balancedCeiling", +ThresholdScanDelta, lowCeiling, balancedCeiling, pricing, tierModelMap),
-            BuildScan(entries, "balancedCeiling", -ThresholdScanDelta, lowCeiling, balancedCeiling, pricing, tierModelMap)
+            BuildScan(entries, "lowCeiling", +ThresholdScanDelta, lowCeiling, balancedCeiling, pricing, tierModelMap, highTierCostFloorMultiplier),
+            BuildScan(entries, "lowCeiling", -ThresholdScanDelta, lowCeiling, balancedCeiling, pricing, tierModelMap, highTierCostFloorMultiplier),
+            BuildScan(entries, "balancedCeiling", +ThresholdScanDelta, lowCeiling, balancedCeiling, pricing, tierModelMap, highTierCostFloorMultiplier),
+            BuildScan(entries, "balancedCeiling", -ThresholdScanDelta, lowCeiling, balancedCeiling, pricing, tierModelMap, highTierCostFloorMultiplier)
         };
     }
 
@@ -341,7 +353,8 @@ public static class TierRoutingAnalyzer
         string threshold, double delta,
         double lowCeiling, double balancedCeiling,
         IReadOnlyList<LlmPricingRow>? pricing,
-        IReadOnlyDictionary<ModelTier, string?>? tierModelMap)
+        IReadOnlyDictionary<ModelTier, string?>? tierModelMap,
+        double highTierCostFloorMultiplier)
     {
         // Round shifted thresholds to 4 decimals — bare double subtraction yields
         // 0.15 - 0.05 = 0.09999999999999998, which makes boundary entries (score 0.10)
@@ -370,8 +383,8 @@ public static class TierRoutingAnalyzer
             foreach (var (e, from, to) in flips)
             {
                 if (e.InputTokens is not long it || e.OutputTokens is not long ot) continue;
-                var fromCost = TryPriceCall(tierModelMap.GetValueOrDefault(from), it, ot, pricing);
-                var toCost = TryPriceCall(tierModelMap.GetValueOrDefault(to), it, ot, pricing);
+                var fromCost = TryPriceCallForTier(from, it, ot, tierModelMap, pricing, highTierCostFloorMultiplier);
+                var toCost = TryPriceCallForTier(to, it, ot, tierModelMap, pricing, highTierCostFloorMultiplier);
                 if (fromCost is null || toCost is null) continue;
                 accum += toCost.Value - fromCost.Value;
                 any = true;
@@ -442,11 +455,67 @@ public static class TierRoutingAnalyzer
             EntriesUnpricedCount: unpriced);
     }
 
+    /// <summary>
+    /// Prices a call by raw model ID at real pricing — no cost floor. Used for
+    /// <see cref="BuildProjectedCost"/>, which reports actual spend.
+    /// </summary>
     private static decimal? TryPriceCall(string? modelId, long inputTokens, long outputTokens, IReadOnlyList<LlmPricingRow> pricing)
     {
-        if (string.IsNullOrEmpty(modelId)) return null;
-        var row = pricing.FirstOrDefault(p => modelId.Contains(p.Prefix, StringComparison.OrdinalIgnoreCase));
+        var row = MatchRow(modelId, pricing);
         if (row is null) return null;
         return (inputTokens * row.InputPerM + outputTokens * row.OutputPerM) / 1_000_000m;
+    }
+
+    /// <summary>
+    /// Prices a call for a specific <see cref="ModelTier"/> with the routing cost floor applied
+    /// (see <see cref="EffectiveTierRates"/>). Used by the threshold-scan and flagged-cluster
+    /// projections that drive tuning decisions — NOT by real-spend reporting.
+    /// </summary>
+    private static decimal? TryPriceCallForTier(
+        ModelTier tier, long inputTokens, long outputTokens,
+        IReadOnlyDictionary<ModelTier, string?> tierModelMap,
+        IReadOnlyList<LlmPricingRow> pricing,
+        double highTierCostFloorMultiplier)
+    {
+        var rates = EffectiveTierRates(tier, tierModelMap, pricing, highTierCostFloorMultiplier);
+        if (rates is null) return null;
+        var (inPerM, outPerM) = rates.Value;
+        return (inputTokens * inPerM + outputTokens * outPerM) / 1_000_000m;
+    }
+
+    /// <summary>
+    /// Effective per-million-token rates for a tier. For the High tier, rates are floored at
+    /// <paramref name="highTierCostFloorMultiplier"/> × the Balanced tier's real rates so a
+    /// Balanced→High shift never projects as zero-cost when High shares Balanced's model.
+    /// <c>Math.Max</c> keeps a genuinely premium High model at its real (higher) price.
+    /// Returns <c>null</c> when the tier's model has no pricing row.
+    /// </summary>
+    private static (decimal InputPerM, decimal OutputPerM)? EffectiveTierRates(
+        ModelTier tier,
+        IReadOnlyDictionary<ModelTier, string?> tierModelMap,
+        IReadOnlyList<LlmPricingRow> pricing,
+        double highTierCostFloorMultiplier)
+    {
+        var row = MatchRow(tierModelMap.GetValueOrDefault(tier), pricing);
+        if (row is null) return null;
+
+        if (tier == ModelTier.High && highTierCostFloorMultiplier > 1.0)
+        {
+            var balanced = MatchRow(tierModelMap.GetValueOrDefault(ModelTier.Balanced), pricing);
+            if (balanced is not null)
+            {
+                var m = (decimal)highTierCostFloorMultiplier;
+                return (Math.Max(row.InputPerM, balanced.InputPerM * m),
+                        Math.Max(row.OutputPerM, balanced.OutputPerM * m));
+            }
+        }
+
+        return (row.InputPerM, row.OutputPerM);
+    }
+
+    private static LlmPricingRow? MatchRow(string? modelId, IReadOnlyList<LlmPricingRow> pricing)
+    {
+        if (string.IsNullOrEmpty(modelId)) return null;
+        return pricing.FirstOrDefault(p => modelId.Contains(p.Prefix, StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/src/RockBot.Host/DreamService.cs
+++ b/src/RockBot.Host/DreamService.cs
@@ -34,6 +34,7 @@ internal sealed class DreamService : IHostedService, IDisposable
     private readonly IKnowledgeGraph? _knowledgeGraph;
     private readonly IWorkingMemory? _workingMemory;
     private readonly ILlmClient _llmClient;
+    private readonly TieredChatClientRegistry? _tieredRegistry;
     private readonly IAgentWorkSerializer _workSerializer;
     private readonly IUserActivityMonitor _userActivityMonitor;
     private readonly AgentClock _clock;
@@ -100,7 +101,8 @@ internal sealed class DreamService : IHostedService, IDisposable
         IEnumerable<IRepairTargetApplier>? repairAppliers = null,
         IRepairTicketVerifier? repairTicketVerifier = null,
         IOptions<RepairTicketOptions>? repairOptions = null,
-        IEnumerable<IToolSkillProvider>? toolSkillProviders = null)
+        IEnumerable<IToolSkillProvider>? toolSkillProviders = null,
+        TieredChatClientRegistry? tieredRegistry = null)
     {
         _memory = memory;
         _skillStore = skillStores.FirstOrDefault();
@@ -114,6 +116,7 @@ internal sealed class DreamService : IHostedService, IDisposable
         _wispExecutionLog = wispExecutionLog;
         _workingMemory = workingMemory;
         _llmClient = llmClient;
+        _tieredRegistry = tieredRegistry;
         _workSerializer = workSerializer;
         _userActivityMonitor = userActivityMonitor;
         _clock = clock;
@@ -2484,10 +2487,26 @@ internal sealed class DreamService : IHostedService, IDisposable
             }
         }
 
+        // Tier→model map lets the analyzer compute per-tier USD cost deltas on threshold scans
+        // and flagged clusters. Without it those deltas are null and the LLM has no cost signal
+        // to weigh against quality — which is how balancedCeiling drifted to its floor. The
+        // High cost floor (see DreamOptions) ensures a Balanced→High shift never projects as
+        // zero-cost when High currently shares Balanced's model.
+        IReadOnlyDictionary<ModelTier, string?>? tierModelMap = _tieredRegistry is null
+            ? null
+            : new Dictionary<ModelTier, string?>
+            {
+                [ModelTier.Low]      = _tieredRegistry.GetModelId(ModelTier.Low),
+                [ModelTier.Balanced] = _tieredRegistry.GetModelId(ModelTier.Balanced),
+                [ModelTier.High]     = _tieredRegistry.GetModelId(ModelTier.High),
+            };
+
         // Pre-aggregate the raw entries into a structured analysis so the LLM
         // works against deterministic statistics instead of recomputing them.
         // This decouples prompt size from entry count — N entries collapse to ~M clusters.
-        var analysis = TierRoutingAnalyzer.Analyze(entries, currentConfig, _pricingRows);
+        var analysis = TierRoutingAnalyzer.Analyze(
+            entries, currentConfig, _pricingRows, tierModelMap,
+            _options.TierRoutingHighCostFloorMultiplier);
 
         var analysisJson = JsonSerializer.Serialize(analysis, new JsonSerializerOptions
         {
@@ -2562,6 +2581,14 @@ internal sealed class DreamService : IHostedService, IDisposable
             return;
         }
 
+        // Deterministic ratchet-stop (nothing trusts the LLM): never apply a balancedCeiling
+        // DECREASE while the observed High-tier routing share already exceeds the target.
+        var highPct = analysis.GlobalStats.ByTier
+            .FirstOrDefault(t => t.Tier == ModelTier.High)?.Pct ?? 0.0;
+        result.Config.BalancedCeiling = GuardBalancedCeilingDecrease(
+            result.Config.BalancedCeiling, currentConfig?.BalancedCeiling,
+            highPct, _options.TierRoutingHighTargetPct, _logger);
+
         var writeOptions = new JsonSerializerOptions
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
@@ -2572,6 +2599,30 @@ internal sealed class DreamService : IHostedService, IDisposable
         _logger.LogInformation(
             "DreamService: tier routing review updated tier-selector.json — notes: {Notes}",
             result.Config.Notes ?? "(none)");
+    }
+
+    /// <summary>
+    /// Deterministic ratchet-stop for the tier-routing review pass. Returns the balancedCeiling
+    /// that should actually be written: the LLM's <paramref name="proposed"/> value, EXCEPT a
+    /// DECREASE is rejected (held at <paramref name="current"/>) while the observed High-tier
+    /// routing share exceeds <paramref name="targetPct"/>. A lower balancedCeiling pushes more
+    /// traffic into High, so honoring such a proposal while already over budget is the exact
+    /// drift this guard prevents. The cost floor makes the LLM unlikely to propose it; this
+    /// enforces it in code regardless. Exposed as <c>internal static</c> for unit testing.
+    /// </summary>
+    internal static double? GuardBalancedCeilingDecrease(
+        double? proposed, double? current, double highPct, double targetPct, ILogger logger)
+    {
+        if (highPct > targetPct
+            && proposed is double p && current is double c && p < c)
+        {
+            logger.LogWarning(
+                "DreamService: tier routing review — rejecting balancedCeiling decrease {From}→{To}; " +
+                "High routing share {HighPct:F1}% exceeds target {Target:F1}% (held at current)",
+                c, p, highPct, targetPct);
+            return c;
+        }
+        return proposed;
     }
 
     // ── Built-in sequence skill directive ────────────────────────────────────

--- a/tests/RockBot.Host.Tests/DreamServiceRoutingGuardTests.cs
+++ b/tests/RockBot.Host.Tests/DreamServiceRoutingGuardTests.cs
@@ -1,0 +1,57 @@
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace RockBot.Host.Tests;
+
+/// <summary>
+/// Tests the deterministic ratchet-stop in the tier-routing review pass
+/// (<see cref="DreamService.GuardBalancedCeilingDecrease"/>). The guard is the
+/// "nothing trusts the LLM" backstop that prevents balancedCeiling from being driven
+/// to its floor while High-tier routing is already over budget.
+/// </summary>
+[TestClass]
+public class DreamServiceRoutingGuardTests
+{
+    [TestMethod]
+    public void Guard_OverBudget_RejectsBalancedCeilingDecrease()
+    {
+        // High share 66.7% >> 20% target, LLM wants to LOWER the ceiling (more High) — reject.
+        var result = DreamService.GuardBalancedCeilingDecrease(
+            proposed: 0.40, current: 0.50, highPct: 66.7, targetPct: 20.0, NullLogger.Instance);
+        Assert.AreEqual(0.50, result, "Must hold at current ceiling when over budget.");
+    }
+
+    [TestMethod]
+    public void Guard_OverBudget_AllowsBalancedCeilingIncrease()
+    {
+        // Raising the ceiling moves traffic High→Balanced — that's the correction; allow it.
+        var result = DreamService.GuardBalancedCeilingDecrease(
+            proposed: 0.55, current: 0.50, highPct: 66.7, targetPct: 20.0, NullLogger.Instance);
+        Assert.AreEqual(0.55, result);
+    }
+
+    [TestMethod]
+    public void Guard_UnderBudget_AllowsDecrease()
+    {
+        // Within budget — the LLM's judgment is honored, including a decrease.
+        var result = DreamService.GuardBalancedCeilingDecrease(
+            proposed: 0.40, current: 0.50, highPct: 10.0, targetPct: 20.0, NullLogger.Instance);
+        Assert.AreEqual(0.40, result);
+    }
+
+    [TestMethod]
+    public void Guard_NullProposal_PassesThrough()
+    {
+        var result = DreamService.GuardBalancedCeilingDecrease(
+            proposed: null, current: 0.50, highPct: 66.7, targetPct: 20.0, NullLogger.Instance);
+        Assert.IsNull(result);
+    }
+
+    [TestMethod]
+    public void Guard_NoCurrentConfig_PassesProposalThrough()
+    {
+        // No prior config to compare against — cannot be a "decrease"; honor the proposal.
+        var result = DreamService.GuardBalancedCeilingDecrease(
+            proposed: 0.40, current: null, highPct: 66.7, targetPct: 20.0, NullLogger.Instance);
+        Assert.AreEqual(0.40, result);
+    }
+}

--- a/tests/RockBot.Host.Tests/TierRoutingAnalyzerTests.cs
+++ b/tests/RockBot.Host.Tests/TierRoutingAnalyzerTests.cs
@@ -347,4 +347,95 @@ public class TierRoutingAnalyzerTests
         Assert.AreEqual(50.0, result.GlobalStats.FallbackPct);
         Assert.AreEqual(2, result.GlobalStats.FallbackCount);
     }
+
+    // ── Routing cost floor (High-tier over-routing guard) ──────────────────────
+
+    private static IReadOnlyDictionary<ModelTier, string?> ModelMap(string low, string balanced, string high) =>
+        new Dictionary<ModelTier, string?>
+        {
+            [ModelTier.Low] = low,
+            [ModelTier.Balanced] = balanced,
+            [ModelTier.High] = high,
+        };
+
+    [TestMethod]
+    public void CostFloor_SameModelHighAndBalanced_MakesShiftCostNonZeroWithCorrectSign()
+    {
+        // High and Balanced share a model, so real pricing shows a Balanced→High shift as
+        // zero-cost. The 2× floor must surface it as a POSITIVE (unfavorable) delta on the
+        // balancedCeiling-DOWN scan and a NEGATIVE (favorable) delta on the UP scan — the
+        // signal that stops the floor-ward ratchet and lets the dream climb back up.
+        var pricing = new[]
+        {
+            new LlmPricingRow("gpt-5.5", 5.00m, 30.00m),
+            new LlmPricingRow("mini", 0.75m, 4.50m),
+        };
+        var map = ModelMap(low: "mini", balanced: "gpt-5.5", high: "gpt-5.5");
+
+        var entries = new List<TierRoutingEntry>();
+        // scores in (0.41, 0.46] flip Balanced→High on the -0.05 scan
+        for (var i = 0; i < 3; i++)
+            entries.Add(MakeEntry(tier: ModelTier.Balanced, score: 0.44, promptPreview: $"balanced boundary {i}"));
+        // scores in (0.46, 0.51] flip High→Balanced on the +0.05 scan
+        for (var i = 0; i < 3; i++)
+            entries.Add(MakeEntry(tier: ModelTier.High, score: 0.49, promptPreview: $"high boundary {i}"));
+
+        var result = TierRoutingAnalyzer.Analyze(
+            entries, pricing: pricing, tierModelMap: map, highTierCostFloorMultiplier: 2.0);
+
+        var balDown = result.ThresholdScans.First(s => s.Threshold == "balancedCeiling" && s.Delta < 0);
+        var balUp = result.ThresholdScans.First(s => s.Threshold == "balancedCeiling" && s.Delta > 0);
+
+        Assert.IsNotNull(balDown.ProjectedCostDelta);
+        Assert.IsTrue(balDown.ProjectedCostDelta > 0m,
+            $"Balanced→High shift should project a positive (unfavorable) cost delta, was {balDown.ProjectedCostDelta}");
+        Assert.IsNotNull(balUp.ProjectedCostDelta);
+        Assert.IsTrue(balUp.ProjectedCostDelta < 0m,
+            $"High→Balanced shift should project a negative (favorable) cost delta, was {balUp.ProjectedCostDelta}");
+    }
+
+    [TestMethod]
+    public void CostFloor_Disabled_SameModelShiftProjectsZeroCost()
+    {
+        // Floor disabled (multiplier 1.0) + shared model → cost delta collapses to zero. This
+        // is exactly the "free ratchet" the floor exists to fix; pinned here as a regression.
+        var pricing = new[] { new LlmPricingRow("gpt-5.5", 5.00m, 30.00m) };
+        var map = ModelMap(low: "gpt-5.5", balanced: "gpt-5.5", high: "gpt-5.5");
+
+        var entries = Enumerable.Range(0, 3)
+            .Select(i => MakeEntry(tier: ModelTier.Balanced, score: 0.44, promptPreview: $"boundary {i}"))
+            .ToList();
+
+        var result = TierRoutingAnalyzer.Analyze(
+            entries, pricing: pricing, tierModelMap: map, highTierCostFloorMultiplier: 1.0);
+
+        var balDown = result.ThresholdScans.First(s => s.Threshold == "balancedCeiling" && s.Delta < 0);
+        Assert.AreEqual(0m, balDown.ProjectedCostDelta);
+    }
+
+    [TestMethod]
+    public void CostFloor_PremiumHighModel_UsesRealPriceNotDiscountedFloor()
+    {
+        // When High genuinely uses a model more expensive than 2× Balanced, Math.Max keeps the
+        // real (higher) price — the floor must never DISCOUNT a premium tier.
+        var pricing = new[]
+        {
+            new LlmPricingRow("gpt-5.5-pro", 30.00m, 180.00m),
+            new LlmPricingRow("gpt-5.5", 5.00m, 30.00m),
+        };
+        var map = ModelMap(low: "gpt-5.5", balanced: "gpt-5.5", high: "gpt-5.5-pro");
+
+        var entries = Enumerable.Range(0, 3)
+            .Select(i => MakeEntry(tier: ModelTier.Balanced, score: 0.44,
+                inputTokens: 1000, outputTokens: 500, promptPreview: $"boundary {i}"))
+            .ToList();
+
+        var result = TierRoutingAnalyzer.Analyze(
+            entries, pricing: pricing, tierModelMap: map, highTierCostFloorMultiplier: 2.0);
+
+        // Per call: High(pro)=(1000×30 + 500×180)/1e6 = 0.12 ; Balanced=(1000×5 + 500×30)/1e6 = 0.02.
+        // 3 entries flip Balanced→High on the -0.05 scan → delta = 3 × (0.12 - 0.02) = 0.30.
+        var balDown = result.ThresholdScans.First(s => s.Threshold == "balancedCeiling" && s.Delta < 0);
+        Assert.AreEqual(0.30m, balDown.ProjectedCostDelta);
+    }
 }


### PR DESCRIPTION
## Problem

The tier-routing review (dream) pass had walked `balancedCeiling` down to its **0.40 floor** and kept it there, over-routing **subagent** traffic to the High tier (19 of 20 all-time High routing decisions were subagent dispatches; only 1 was ever a user message). Two compounding defects caused it:

1. **No cost signal.** Neither `DreamService` nor the introspection summary tool ever passed `tierModelMap` to `TierRoutingAnalyzer.Analyze`, so every `thresholdScan.projectedCostDelta` was `null`. The directive's "apply when cost favorable **OR** quality reason" collapsed to *quality only*, and the "don't under-route" guidance won by default.
2. **"Free" ratchet.** Even with the map, High and Balanced currently share a model (`gpt-5.5`), so a Balanced→High shift projects a **$0** cost delta — read as harmless, never unfavorable. Lowering `balancedCeiling` was always free and raising it was never indicated → it ratcheted to the floor with no restoring force.

This is exactly the "same model today ≠ same model tomorrow" risk: the self-tuner had already pinned routing at maximum-High *because* High is currently free, so a future premium High model would inherit a maxed-out routing config.

## Fix

- **`TierRoutingAnalyzer`** — add a High-tier **cost floor**: for threshold-scan and flagged-cluster cost projections, price High at `>= multiplier × Balanced`'s real rate (`Math.Max`, so a genuinely premium High model keeps its real price). Real-spend reporting (`ProjectedCost`) is unchanged. Wire `tierModelMap` through both decision paths.
- **`DreamService`** — build the tier→model map from `TieredChatClientRegistry` and pass it + the configured multiplier to `Analyze`. Add a deterministic ratchet-stop (`GuardBalancedCeilingDecrease`) that refuses to lower `balancedCeiling` while observed High routing share exceeds the target — enforced in code, independent of the LLM.
- **`DreamOptions`** — `TierRoutingHighCostFloorMultiplier` (2.0), `TierRoutingHighTargetPct` (20).
- **`routing-dream.md`** — instruct the reviewer to trust `projectedCostDelta` and prefer **raising** `balancedCeiling` when High share is high.

After deploy, the pinned `balancedCeiling=0.40` self-corrects on subsequent dream cycles (a favorable +0.05 scan lets it climb), and the guard blocks further downward drift meanwhile.

## Tests

- Analyzer: cost-floor sign (Balanced→High positive / High→Balanced negative), zero-when-disabled regression, and premium-High-model-not-discounted cases.
- Guard: over-/under-budget, increase-allowed, and null-config cases.
- Full `RockBot.Host.Tests` suite green (**1037 passed**); solution builds with 0 errors.

## Notes / scope

- The MCP `RoutingStatsTools` summary tool keeps its existing 3-arg `Analyze` call (no floor) — its alert needs only counts; the floor is for the tuner. Wiring a model map into the sidecar would require a new PVC file.
- The in-code `BuiltInTierRoutingDirective` fallback is unchanged; only the PVC `routing-dream.md` ships to the live agent.
- `DreamService` is `AddSingleton`-registered and `TieredChatClientRegistry` is a registered singleton, so the new optional ctor param auto-injects with no new dependency cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)