### PR TITLE
Fix BM25-only startup crash + make docker-compose build from source

### DIFF
--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -128,6 +128,9 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
 
   scripts-manager:
+    build:
+      context: ../..
+      dockerfile: Dockerfile.scripts-manager
     image: rockylhotka/rockbot-scripts-manager:latest
     user: root   # Required for Docker socket access
     depends_on:
@@ -164,6 +167,9 @@ services:
     volumes:
       - ${AGENT_DATA_PATH:-agent-data}:/data/agent
   blazor:
+    build:
+      context: ../..
+      dockerfile: src/RockBot.UserProxy.Blazor/Dockerfile
     image: rockylhotka/rockbot-blazor:latest
     depends_on:
       rabbitmq:

--- a/src/RockBot.Agent/Program.cs
+++ b/src/RockBot.Agent/Program.cs
@@ -405,8 +405,20 @@ builder.Services.AddRemoteScriptRunner("RockBot");
         ? profileBasePath
         : Path.Combine(AppContext.BaseDirectory, profileBasePath);
 
-    builder.Services.AddRockBotObservation();
-    builder.Services.AddDefaultObservationTargets(resolvedProfileBasePath);
+    // The observation/theory pipeline clusters proposed observations by vector
+    // similarity, so it hard-requires an IEmbeddingGenerator. Register it only
+    // when embeddings are configured; otherwise DreamService's optional
+    // coordinator stays null and the observation pass is skipped — keeping the
+    // BM25-only path startable, as documented.
+    if (embeddingOptions.IsConfigured)
+    {
+        builder.Services.AddRockBotObservation();
+        builder.Services.AddDefaultObservationTargets(resolvedProfileBasePath);
+    }
+    else
+    {
+        Console.WriteLine("No embedding config — observation/theory dream pass disabled (BM25-only mode).");
+    }
 }
 
 var app = builder.Build();


### PR DESCRIPTION
Two related fixes that surfaced while validating the `deploy/docker-compose` quick-start stack for a demo.

## 1. Skip observation dream pipeline when no embedding is configured

The agent crashes on startup when no embedding generator is configured (the BM25-only path, e.g. the docker-compose quick start):

```
System.InvalidOperationException: Unable to resolve service for type
'Microsoft.Extensions.AI.IEmbeddingGenerator`2[System.String,Microsoft.Extensions.AI.Embedding`1[System.Single]]'
while attempting to activate 'RockBot.Observation.ObservationExtractionPhase'.
```

The observation/theory pipeline clusters proposed observations by vector similarity, so `ObservationExtractionPhase` takes a **non-nullable** `IEmbeddingGenerator` constructor dependency. `Program.cs` called `AddRockBotObservation()` / `AddDefaultObservationTargets()` **unconditionally**, so DI attempted to construct the otherwise-optional `IObservationPipelineCoordinator` (which `DreamService` already accepts as nullable, defaulting to `null`) even when no embedding generator was registered — failing host startup.

This contradicts the documented promise that the BM25-only path is fully supported with "no functionality lost" — but in practice the agent wouldn't start at all without `Embedding:*` configured.

**Fix:** gate the observation registration on `EmbeddingOptions.IsConfigured`. When embeddings are absent, the coordinator isn't registered, `DreamService`'s nullable coordinator stays `null`, and the observation/theory dream pass is skipped — exactly as the existing optional-dependency design anticipates. A startup log line makes the skipped pass observable.

## 2. Build blazor and scripts-manager from source in docker-compose

The `blazor` and `scripts-manager` services only referenced an `:latest` image with no `build:` section, so `docker compose up --build` could never rebuild them from the working tree — they stayed on whatever stale `:latest` was cached locally (observed: `0.10.63` against a `0.12.24` agent), causing silent version skew over the message bus.

**Fix:** add `build:` sections (context = repo root) matching the existing `agent` and `introspection-mcp` services, so the whole stack builds from current source and stays version-consistent. Runtime behavior is unchanged unless `--build` is passed.

## Verification

Reproduced the startup crash with the `deploy/docker-compose` stack (no `EMBEDDING_*` set). After both fixes, `docker compose up -d --build` brings up all five services; the agent starts cleanly, connects to RabbitMQ, makes successful LLM calls, and the Blazor UI serves (including `_framework/blazor.web.js`). The embedding-configured path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)