### PR TITLE
Bump version to 0.12.25

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.12.24</Version>
+<Version>0.12.25</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->


### PR DESCRIPTION
Bumps the version to `0.12.25` so the agent image can be rebuilt off the BM25-only startup fix (#454) under a fresh tag — keeping the running version observable in `kubectl describe` and avoiding reuse of the already-published `0.12.24` docker tag.

No code changes; version metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)