### PR TITLE
Ignore deploy/values.personal.yaml.live* secret files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ nupkgs/
 # Helm personal values files contain secrets — never commit these
 deploy/values.personal.yaml
 deploy/values.*.personal.yaml
+deploy/values.personal.yaml.live*
 
 # Docker Compose .env files contain API keys — never commit these
 deploy/docker-compose/.env


### PR DESCRIPTION
Adds `deploy/values.personal.yaml.live*` to `.gitignore`.

These local Helm "live" values files carry secrets but weren't matched by the existing personal-values patterns (`deploy/values.personal.yaml`, `deploy/values.*.personal.yaml`), so they showed up as untracked and were at risk of accidental commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)