### PR TITLE
Treat MCP management-tool registration race as transient, not Structural (#458)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.12.25</Version>
+<Version>0.12.26</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.Wisp/WispExecutor.cs
+++ b/src/RockBot.Wisp/WispExecutor.cs
@@ -29,6 +29,26 @@ internal sealed class WispExecutor(
     private const int ChunkMaxLength = 20_000;
     private const string NoCorrectionSentinel = "NO_CORRECTION";
     private static readonly TimeSpan WispChunkTtl = TimeSpan.FromMinutes(30);
+    private static readonly TimeSpan McpReadinessPollInterval = TimeSpan.FromMilliseconds(100);
+
+    /// <summary>
+    /// The MCP management tool names. These are registered as a single batch by
+    /// <c>McpServersIndexedHandler.RegisterManagementTools</c> on the first
+    /// <c>McpServersIndexed</c> message, so the presence of any one implies all are
+    /// present. Their absence in the tool registry is a transient startup/reconnect
+    /// readiness condition rather than a wisp-authoring (Structural) bug.
+    /// Keep this list in sync with <c>McpServersIndexedHandler.RegisterManagementTools</c>
+    /// (the csproj boundary prevents sharing a single constant).
+    /// </summary>
+    private static readonly HashSet<string> McpManagementToolNames = new(StringComparer.Ordinal)
+    {
+        "mcp_list_services",
+        "mcp_get_service_details",
+        "mcp_invoke_tool",
+        "mcp_register_server",
+        "mcp_unregister_server",
+        "mcp_get_prompt",
+    };
 
     internal static readonly string WispDirectives =
         """
@@ -395,10 +415,36 @@ internal sealed class WispExecutor(
         }
 
     invoke:
-        // Resolve the executor from the registry
-        var executor = toolRegistry.GetExecutor(route.ToolName!);
+        // Resolve the executor from the registry. MCP management tools (e.g.
+        // mcp_invoke_tool) are registered lazily on the first McpServersIndexed
+        // message from the bridge, so a step firing in the startup/reconnect window
+        // may find them absent. Briefly wait for them to appear before failing.
+        var executor = await ResolveExecutorWithReadinessAsync(route.ToolName!, ct);
         if (executor is null)
         {
+            var isManagementTool = McpManagementToolNames.Contains(route.ToolName!);
+            if (isManagementTool)
+            {
+                // Transient readiness race, not an authoring bug — classify as
+                // External (retryable) so it doesn't pollute the Structural signal.
+                logger.LogWarning(
+                    "Wisp {WispId} step {StepId}: MCP management tool '{Tool}' not registered after waiting {Wait} — treating as transient (MCP bridge index not yet received)",
+                    wispId, step.Id, route.ToolName, options.McpReadinessWait);
+                return new WispStepResult
+                {
+                    StepId = step.Id,
+                    StepIndex = index,
+                    IsSuccess = false,
+                    Error = new WispStepError
+                    {
+                        Category = FailureCategory.External,
+                        Message = $"MCP management tool '{route.ToolName}' is not registered yet (MCP bridge index not yet received); treating as transient.",
+                        ToolName = route.ToolName
+                    },
+                    Duration = stepSw.Elapsed
+                };
+            }
+
             return new WispStepResult
             {
                 StepId = step.Id,
@@ -859,6 +905,47 @@ internal sealed class WispExecutor(
         {
             return null;
         }
+    }
+
+    /// <summary>
+    /// Resolves the executor for <paramref name="toolName"/> from the registry,
+    /// briefly waiting for MCP management tools to register if they are absent.
+    /// Returns the executor as soon as it is available, or <c>null</c> if it never
+    /// appears within <see cref="WispOptions.McpReadinessWait"/>. Non-MCP tools (and
+    /// any tool when the wait is disabled) resolve in a single lookup with no delay.
+    /// </summary>
+    private async Task<IToolExecutor?> ResolveExecutorWithReadinessAsync(string toolName, CancellationToken ct)
+    {
+        var executor = toolRegistry.GetExecutor(toolName);
+        if (executor is not null)
+            return executor;
+
+        if (options.McpReadinessWait <= TimeSpan.Zero || !McpManagementToolNames.Contains(toolName))
+            return null;
+
+        var waitSw = Stopwatch.StartNew();
+        var logged = false;
+        while (waitSw.Elapsed < options.McpReadinessWait)
+        {
+            await Task.Delay(McpReadinessPollInterval, ct);
+            executor = toolRegistry.GetExecutor(toolName);
+            if (executor is not null)
+            {
+                logger.LogInformation(
+                    "MCP management tool '{Tool}' became available after waiting {Elapsed}ms for the bridge index",
+                    toolName, (int)waitSw.ElapsedMilliseconds);
+                return executor;
+            }
+            if (!logged)
+            {
+                logger.LogInformation(
+                    "Waiting up to {Wait} for MCP management tool '{Tool}' to register (bridge index not yet received)",
+                    options.McpReadinessWait, toolName);
+                logged = true;
+            }
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/src/RockBot.Wisp/WispOptions.cs
+++ b/src/RockBot.Wisp/WispOptions.cs
@@ -43,4 +43,15 @@ public sealed class WispOptions
     /// <c>patrol/{taskName}</c>; if that convention changes, update this default.
     /// </summary>
     public string ScheduledTaskSessionPrefix { get; set; } = "patrol/";
+
+    /// <summary>
+    /// How long a Direct MCP step waits for the MCP management tools to register
+    /// (event-gated on the first <c>McpServersIndexed</c> message from the bridge)
+    /// before treating their absence as a transient/<c>External</c> failure rather
+    /// than <c>Structural</c>. A step that fires inside the startup/reconnect
+    /// readiness window briefly waits and then proceeds once the tools appear.
+    /// <see cref="TimeSpan.Zero"/> disables the wait (resolve once, then reclassify
+    /// immediately).
+    /// </summary>
+    public TimeSpan McpReadinessWait { get; set; } = TimeSpan.FromSeconds(5);
 }

--- a/tests/RockBot.Wisp.Tests/WispExecutorTests.cs
+++ b/tests/RockBot.Wisp.Tests/WispExecutorTests.cs
@@ -125,6 +125,109 @@ public class WispExecutorTests
     }
 
     [TestMethod]
+    public async Task ExecuteAsync_McpManagementToolUnregistered_ClassifiesExternalNotStructural()
+    {
+        // mcp_invoke_tool is registered lazily on the first McpServersIndexed message.
+        // A Direct MCP step firing before that should be treated as a transient
+        // readiness race (External), not a wisp-authoring bug (Structural).
+        var (executor, _) = CreateExecutor(mcpReadinessWait: TimeSpan.Zero);
+
+        var definition = new WispDefinition
+        {
+            Description = "MCP before readiness",
+            Steps =
+            [
+                new WispStep
+                {
+                    Id = "mcp",
+                    Mode = StepMode.Direct,
+                    Gateway = GatewayType.Mcp,
+                    Server = "calendar",
+                    Tool = "list_events",
+                    Params = JsonDocument.Parse("""{"timeMin":"now"}""").RootElement
+                }
+            ]
+        };
+
+        var result = await executor.ExecuteAsync(definition, "wisp-mcp-race", CancellationToken.None);
+
+        Assert.IsFalse(result.IsSuccess);
+        Assert.AreEqual(1, result.StepResults.Count);
+        Assert.AreEqual(FailureCategory.External, result.StepResults[0].Error!.Category,
+            "An MCP management tool absent before the bridge index is transient, not Structural");
+        StringAssert.Contains(result.StepResults[0].Error!.Message, "not registered yet");
+    }
+
+    [TestMethod]
+    public async Task ExecuteAsync_McpManagementToolRegistersDuringWait_StepSucceeds()
+    {
+        // The readiness wait should let a step that fires just before the bridge
+        // index arrives proceed once mcp_invoke_tool registers, rather than failing.
+        var toolExecutor = new FakeToolExecutor(content: """{"events":[]}""");
+        var registry = new DelayedRegistrationToolRegistry(
+            "mcp_invoke_tool", toolExecutor, nullLookupsBeforeRegistered: 1);
+        var executor = CreateExecutorWith(registry, TimeSpan.FromSeconds(5));
+
+        var definition = new WispDefinition
+        {
+            Description = "MCP after readiness wait",
+            Steps =
+            [
+                new WispStep
+                {
+                    Id = "mcp",
+                    Mode = StepMode.Direct,
+                    Gateway = GatewayType.Mcp,
+                    Server = "calendar",
+                    Tool = "list_events",
+                    Params = JsonDocument.Parse("""{"timeMin":"now"}""").RootElement
+                }
+            ]
+        };
+
+        var result = await executor.ExecuteAsync(definition, "wisp-mcp-wait", CancellationToken.None);
+
+        Assert.IsTrue(result.IsSuccess, "Step should succeed once the tool registers during the wait");
+        Assert.AreEqual(1, result.StepResults.Count);
+        Assert.IsTrue(result.StepResults[0].IsSuccess);
+        Assert.IsTrue(registry.LookupCount >= 2, "The executor should have polled at least twice");
+    }
+
+    [TestMethod]
+    public async Task ExecuteAsync_NonMcpToolUnregistered_StaysStructuralWithoutWaiting()
+    {
+        // A genuinely-unknown non-MCP tool is an authoring bug. Even with the
+        // readiness wait enabled it must fail Structural immediately (no polling,
+        // no reclassification — the readiness path is scoped to MCP management tools).
+        var (executor, _) = CreateExecutor(mcpReadinessWait: TimeSpan.FromSeconds(30));
+
+        var definition = new WispDefinition
+        {
+            Description = "Unknown non-MCP tool",
+            Steps =
+            [
+                new WispStep
+                {
+                    Id = "search",
+                    Mode = StepMode.Direct,
+                    Gateway = GatewayType.Web,
+                    Tool = "web_search",
+                    Params = JsonDocument.Parse("""{"query": "test"}""").RootElement
+                }
+            ]
+        };
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        var result = await executor.ExecuteAsync(definition, "wisp-nonmcp", CancellationToken.None);
+        sw.Stop();
+
+        Assert.IsFalse(result.IsSuccess);
+        Assert.AreEqual(FailureCategory.Structural, result.StepResults[0].Error!.Category);
+        Assert.IsTrue(sw.Elapsed < TimeSpan.FromSeconds(5),
+            "A non-MCP tool must fail immediately without entering the readiness wait");
+    }
+
+    [TestMethod]
     public async Task ExecuteAsync_ToolReturnsError_AbortsAndClassifiesError()
     {
         var (executor, registry) = CreateExecutor();
@@ -902,17 +1005,33 @@ public class WispExecutorTests
 
     private static (WispExecutor Executor, FakeToolRegistry Registry) CreateExecutor(
         FakeWorkingMemory? memory = null,
-        string? sharedVolumePath = null)
+        string? sharedVolumePath = null,
+        TimeSpan? mcpReadinessWait = null)
     {
         var registry = new FakeToolRegistry();
         memory ??= new FakeWorkingMemory();
         var options = new WispOptions { SharedVolumePath = sharedVolumePath };
+        if (mcpReadinessWait is { } wait)
+            options.McpReadinessWait = wait;
         var logger = NullLogger<WispExecutor>.Instance;
 
         // WispExecutor needs AgentLoopRunner for LLM steps, but direct-mode tests
         // don't exercise that path. Pass null and rely on the test not calling LLM steps.
         var executor = new WispExecutor(registry, memory, agentLoopRunner: null!, options, logger);
         return (executor, registry);
+    }
+
+    /// <summary>
+    /// Builds an executor backed by an arbitrary <see cref="IToolRegistry"/> (e.g.
+    /// the delayed-registration double) with a specific MCP readiness wait.
+    /// </summary>
+    private static WispExecutor CreateExecutorWith(
+        IToolRegistry registry, TimeSpan mcpReadinessWait)
+    {
+        var options = new WispOptions { McpReadinessWait = mcpReadinessWait };
+        return new WispExecutor(
+            registry, new FakeWorkingMemory(), agentLoopRunner: null!, options,
+            NullLogger<WispExecutor>.Instance);
     }
 
     private static WispExecutor CreateExecutorWithCanceller(
@@ -1021,6 +1140,35 @@ internal sealed class FakeToolRegistry : IToolRegistry
 
     public bool Unregister(string toolName) =>
         _tools.Remove(toolName);
+}
+
+/// <summary>
+/// Registry double that simulates the MCP management-tool registration race:
+/// <see cref="GetExecutor"/> returns null for the first
+/// <see cref="_nullLookupsBeforeRegistered"/> lookups of the target tool, then the
+/// real executor — mimicking the first McpServersIndexed message arriving shortly
+/// after a wisp step begins. Count-based and deterministic (no wall-clock sleeps).
+/// </summary>
+internal sealed class DelayedRegistrationToolRegistry(
+    string toolName, IToolExecutor executor, int nullLookupsBeforeRegistered) : IToolRegistry
+{
+    private int _lookups;
+
+    public int LookupCount => _lookups;
+
+    public IReadOnlyList<ToolRegistration> GetTools() => [];
+
+    public IToolExecutor? GetExecutor(string name)
+    {
+        if (!string.Equals(name, toolName, StringComparison.Ordinal))
+            return null;
+        return _lookups++ < nullLookupsBeforeRegistered ? null : executor;
+    }
+
+    public void Register(ToolRegistration registration, IToolExecutor toolExecutor) =>
+        throw new NotSupportedException();
+
+    public bool Unregister(string name) => throw new NotSupportedException();
 }
 
 internal sealed class FakeWorkingMemory : IWorkingMemory


### PR DESCRIPTION
Fixes #458.

## Problem

The 6 MCP management tools (`mcp_invoke_tool`, `mcp_list_services`, etc.) are registered **lazily** by `McpServersIndexedHandler` on the *first* `McpServersIndexed` message from the MCP bridge. A wisp Direct MCP step always routes to `mcp_invoke_tool` (`GatewayRouter.RouteMcp`); if it fires in the startup/reconnect window before that message, `WispExecutor` resolved a null executor and hard-failed with `FailureCategory.Structural` — the "learnable authoring bug" category. That (a) failed the step outright instead of waiting, and (b) polluted the structural-failure signal used for wisp authoring-quality analysis and dream-time learning with what is really a transient readiness race (~4 such failures in a recent 14-day `wisp-executions.jsonl` window).

## Fix

Contained to `RockBot.Wisp`, combining both fixes the issue proposes:

- **Wait for readiness (root timing):** `WispExecutor` now resolves the executor via `ResolveExecutorWithReadinessAsync`. In steady state it's a single lookup (zero added latency). If a management tool is absent, it polls the registry (~100 ms interval, `Stopwatch` deadline) up to `WispOptions.McpReadinessWait` (default 5s) and proceeds as soon as the tool registers — so a step in the window **succeeds**.
- **Reclassify (floor):** if the tool never appears, the step fails as `FailureCategory.External` (transient/retryable) instead of `Structural`, so it no longer pollutes authoring metrics. Genuinely unknown / non-MCP tools still fail `Structural` immediately (no wait).

`WispOptions.McpReadinessWait = TimeSpan.Zero` disables the wait (resolve once, then reclassify).

## Out of scope (follow-ups)

- `WispExecutor.ClassifyToolError` maps post-invoke runtime errors containing `"not registered"` to `Structural` — same class of issue, distinct path; left untouched to avoid reclassifying genuine authoring typos.
- `CapabilityClaimVerifier` / `RepairTicketVerifier` already handle the race (`Uncertain`, uncached). `McpStepValidator` is unaffected (skips validation when no schema is found).

## Testing

- `dotnet test RockBot.slnx --filter "ClassName~WispExecutorTests"` → **25/25 passing** (3 new): management tool absent → `External`; tool registers during the wait → step succeeds; non-MCP tool stays `Structural` immediately.
- `dotnet build RockBot.slnx` → 0 errors.

Version bumped to 0.12.26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)