### PR TITLE
Stop the agent log/CPU runaway: terminate the tool-result trim loop + cap append-only logs

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.12.26</Version>
+<Version>0.12.27</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/deploy/helm/rockbot/templates/configmap.yaml
+++ b/deploy/helm/rockbot/templates/configmap.yaml
@@ -28,6 +28,16 @@ data:
   AgentProfile__BasePath: "/data/agent"
   AgentProfile__TierRoutingLogMaxEntries: {{ .Values.agent.tierRoutingLogMaxEntries | default 1500 | quote }}
   Memory__BasePath: "/data/agent/memory"
+
+  # ── Append-only JSONL log retention (applied once per dream cycle) ─────────
+  # `dig` (not `default`) so an explicit false / 0 — which disable a dimension —
+  # are honoured rather than swallowed, while a wholly-absent block (e.g. a
+  # --reuse-values upgrade) still falls back to the chart defaults below.
+  {{- $logRetention := .Values.agent.logRetention | default dict }}
+  Dream__LogRetentionEnabled: {{ dig "enabled" true $logRetention | quote }}
+  Dream__LogRetentionMaxFileAge: {{ dig "maxFileAge" "30.00:00:00" $logRetention | quote }}
+  Dream__LogRetentionMaxFilesPerDirectory: {{ dig "maxFilesPerDirectory" 1000 $logRetention | quote }}
+  Dream__LogRetentionMaxLinesPerFile: {{ dig "maxLinesPerFile" 10000 $logRetention | quote }}
   Skill__BasePath: "/data/agent/skills"
   McpBridge__ConfigPath: "/data/agent/mcp.json"
   LlmPricing__ConfigPath: "/data/agent/llm-pricing.json"

--- a/deploy/helm/rockbot/values.yaml
+++ b/deploy/helm/rockbot/values.yaml
@@ -20,6 +20,28 @@ agent:
   # get_routing_summary tool). Once the cap is reached the logger trims the oldest
   # entries on every append. ~500 bytes per entry, so 1500 ≈ 750 KB on disk.
   tierRoutingLogMaxEntries: 1500
+  # Append-only JSONL log retention, applied once per dream cycle (see
+  # docs/dream-service.md → "Log retention"). Covers skill-usage, tool-call,
+  # feedback (per-session directories) and skill-resource-usage,
+  # wisp-executions (single files). Values below are sized from observed live
+  # traffic; raise them if you query these logs further back in time.
+  logRetention:
+    enabled: true
+    # Per-session directory logs: delete {sessionId}.jsonl files whose last-write
+    # time is older than this. Floor it at the widest dream query window (skill
+    # usage looks back 30 days) so pruning never starves a pass. TimeSpan format
+    # "d.hh:mm:ss". Set to "0" to disable age pruning.
+    maxFileAge: "30.00:00:00"
+    # Per-session directory logs: backstop cap on file count after age pruning
+    # (oldest dropped first). Age pruning is the primary control; this only bites
+    # during a session storm. Set to 0 to disable count pruning.
+    maxFilesPerDirectory: 1000
+    # Per-file line cap. Applies to the single-file logs (wisp-executions.jsonl,
+    # skill-resource-usage.jsonl) AND to each per-session file — this is what bounds
+    # a persistent UI/CLI session's {id}.jsonl, which age/count pruning never reaps.
+    # At ~1.1 KB/line for wisp records, 10000 ≈ 11 MB, well above the 14-day window
+    # the wisp dream pass reads. Set to 0 to disable line trimming.
+    maxLinesPerFile: 10000
   resources:
     requests:
       cpu: 500m

--- a/docs/agent-host.md
+++ b/docs/agent-host.md
@@ -155,6 +155,11 @@ One JSON object per line. Per-session semaphores prevent concurrent write races.
 `QueryRecentAsync` scans all JSONL files to find entries since a given timestamp — used by the
 dream cycle to gather quality signals for memory consolidation and skill optimization.
 
+These per-session files (along with the skill-usage and tool-call logs) are append-only and are
+capped by the dream cycle's [log-retention pass](dream-service.md#pass-0--log-retention) — aged
+files are deleted, the directory is held under a file-count cap, and each surviving file is
+line-trimmed (so a persistent UI/CLI session that never ages out is still bounded).
+
 ### `SessionSummaryService`
 
 Background hosted service that evaluates completed sessions:

--- a/docs/dream-service.md
+++ b/docs/dream-service.md
@@ -33,9 +33,40 @@ Startup
 
 ## Passes
 
-Each dream cycle runs five passes in sequence. Passes that depend on optional services
-(`IConversationLog`, `IFeedbackStore`, `ISkillUsageStore`) are skipped when those services are
-not registered.
+Each dream cycle runs a log-retention pass followed by five knowledge passes in sequence.
+Passes that depend on optional services (`IConversationLog`, `IFeedbackStore`,
+`ISkillUsageStore`) are skipped when those services are not registered.
+
+### Pass 0 — Log retention
+
+Runs **first and unconditionally**, before the knowledge passes — and crucially before the
+"fewer than two memories → early return" guard, so the append-only logs are capped on every
+cycle even when there is nothing to consolidate.
+
+The agent's append-only JSONL telemetry logs (skill-usage, tool-call, feedback,
+skill-resource-usage, wisp-executions) have no rotation of their own, so without this pass
+they grow forever. The pass resolves every registered `IPrunableLog` and applies the
+configured `LogRetentionPolicy`. Each log knows its own on-disk shape and delegates the file
+work to the shared `JsonlLogRetention` helper:
+
+| Log | Shape | Retention applied |
+|---|---|---|
+| skill-usage, tool-call, feedback | per-session directory of `{sessionId}.jsonl` | delete files older than `LogRetentionMaxFileAge` (by last-write time); cap the directory at `LogRetentionMaxFilesPerDirectory` (oldest dropped first); then line-trim each surviving file to `LogRetentionMaxLinesPerFile` under that session's write lock |
+| skill-resource-usage, wisp-executions | single append-only file | trim to the last `LogRetentionMaxLinesPerFile` lines (atomic temp-file rewrite, serialized against the writer) |
+
+Retention is best-effort: a failure pruning one log is logged and does not abort the sweep or
+the rest of the dream cycle. A non-positive value disables the corresponding dimension.
+
+The per-session line-trim is what bounds a *persistent* session file — `blazor-session.jsonl`,
+`cli-session.jsonl` — that age/count pruning alone never reaps, because such a file is written
+continuously (never aged out by last-write time) and is never the oldest file (never
+count-pruned). On a long-running deployment the UI session's tool-call log is the largest single
+file; line-trimming holds it to `LogRetentionMaxLinesPerFile`. Trimming reuses the store's own
+per-session semaphore, so it can never race a concurrent append. (Scope matches age/count
+pruning — top-level `{sessionId}.jsonl` files only; namespaced session files in subdirectories
+are not swept.)
+
+**Enabled/disabled by:** `DreamOptions.LogRetentionEnabled` (default `true`).
 
 ### Pass 1 — Memory consolidation
 
@@ -269,8 +300,22 @@ public sealed class DreamOptions
     // Feature flags
     public bool PreferenceInferenceEnabled { get; set; } = true;
     public bool SkillGapEnabled { get; set; } = true;
+
+    // Append-only JSONL log retention (Pass 0)
+    public bool LogRetentionEnabled { get; set; } = true;
+    public TimeSpan LogRetentionMaxFileAge { get; set; } = TimeSpan.FromDays(30);  // per-session dirs
+    public int LogRetentionMaxFilesPerDirectory { get; set; } = 1000;              // per-session dirs
+    public int LogRetentionMaxLinesPerFile { get; set; } = 50_000;                 // single-file logs
 }
 ```
+
+In Kubernetes these are bound from the `Dream` configuration section via the agent ConfigMap
+(`Dream__LogRetentionEnabled`, `Dream__LogRetentionMaxFileAge`,
+`Dream__LogRetentionMaxFilesPerDirectory`, `Dream__LogRetentionMaxLinesPerFile`), driven by the
+`agent.logRetention.*` Helm values. The Helm chart ships tighter, traffic-sized values than the
+code defaults (`maxLinesPerFile: 10000` ≈ 11 MB for the wisp log at ~1.1 KB/line). Floor
+`maxFileAge` at the widest dream query window (skill usage looks back 30 days) so age pruning
+never starves a downstream pass.
 
 ---
 

--- a/src/RockBot.Agent/Program.cs
+++ b/src/RockBot.Agent/Program.cs
@@ -276,7 +276,7 @@ builder.Services.AddRockBotHost(agent =>
     agent.WithKnowledgeGraph();
     agent.WithFailureClusterStore();
     agent.WithRepairTickets();
-    agent.WithDreaming();
+    agent.WithDreaming(opts => builder.Configuration.GetSection("Dream").Bind(opts));
     agent.AddToolHandler();
     agent.AddMcpToolProxy();
     agent.AddFileSystemTools(opts => builder.Configuration.GetSection("FileSystem").Bind(opts));

--- a/src/RockBot.Host.Abstractions/DreamOptions.cs
+++ b/src/RockBot.Host.Abstractions/DreamOptions.cs
@@ -278,4 +278,36 @@ public sealed class DreamOptions
     /// discoverable via keyword search.
     /// </summary>
     public float ImportanceDecayFloor { get; set; } = 0.10f;
+
+    /// <summary>
+    /// Whether the log-retention pass runs each dream cycle. When enabled, the dream
+    /// prunes the append-only JSONL logs (skill-usage, tool-call, feedback,
+    /// skill-resource-usage, wisp-executions) so they don't grow without bound.
+    /// Disable to retain every log line/file indefinitely. Default: true.
+    /// </summary>
+    public bool LogRetentionEnabled { get; set; } = true;
+
+    /// <summary>
+    /// Per-session JSONL log files (one <c>{sessionId}.jsonl</c> per session for the
+    /// skill-usage, tool-call, and feedback logs) older than this — by last-write
+    /// time — are deleted by the retention pass. Set to <see cref="TimeSpan.Zero"/>
+    /// or negative to disable age-based pruning. Default: 30 days.
+    /// </summary>
+    public TimeSpan LogRetentionMaxFileAge { get; set; } = TimeSpan.FromDays(30);
+
+    /// <summary>
+    /// Ceiling on the number of per-session JSONL files kept in each session-log
+    /// directory. After age pruning, if more remain, the oldest are deleted until the
+    /// count is within this cap. Set to zero or negative to disable count-based
+    /// pruning. Default: 1000.
+    /// </summary>
+    public int LogRetentionMaxFilesPerDirectory { get; set; } = 1000;
+
+    /// <summary>
+    /// Ceiling on the number of lines retained in each single-file append-only log
+    /// (skill-resource-usage.jsonl, wisp-executions.jsonl). When a file exceeds this,
+    /// the retention pass rewrites it keeping only the most recent lines. Set to zero
+    /// or negative to disable trimming. Default: 50,000.
+    /// </summary>
+    public int LogRetentionMaxLinesPerFile { get; set; } = 50_000;
 }

--- a/src/RockBot.Host.Abstractions/DreamOptions.cs
+++ b/src/RockBot.Host.Abstractions/DreamOptions.cs
@@ -304,10 +304,13 @@ public sealed class DreamOptions
     public int LogRetentionMaxFilesPerDirectory { get; set; } = 1000;
 
     /// <summary>
-    /// Ceiling on the number of lines retained in each single-file append-only log
-    /// (skill-resource-usage.jsonl, wisp-executions.jsonl). When a file exceeds this,
-    /// the retention pass rewrites it keeping only the most recent lines. Set to zero
-    /// or negative to disable trimming. Default: 50,000.
+    /// Ceiling on the number of lines retained in any single JSONL log file. Applies to
+    /// the single-file append-only logs (skill-resource-usage.jsonl,
+    /// wisp-executions.jsonl) and to each individual per-session file (e.g. a persistent
+    /// UI/CLI session's <c>{sessionId}.jsonl</c> that age/count pruning never reaps
+    /// because it is continuously written). When a file exceeds this, the retention pass
+    /// rewrites it keeping only the most recent lines. Set to zero or negative to disable
+    /// trimming. Default: 50,000.
     /// </summary>
     public int LogRetentionMaxLinesPerFile { get; set; } = 50_000;
 }

--- a/src/RockBot.Host/AgentLoopRunner.cs
+++ b/src/RockBot.Host/AgentLoopRunner.cs
@@ -1458,7 +1458,7 @@ public sealed partial class AgentLoopRunner(
     /// the corresponding working-memory key in the system stash registry, never in
     /// (untrusted) tool output.
     /// </summary>
-    private static string BuildElisionMarker(string callId) =>
+    internal static string BuildElisionMarker(string callId) =>
         $"[content elided to fit context window — id={callId}]";
 
     /// <summary>
@@ -1467,108 +1467,16 @@ public sealed partial class AgentLoopRunner(
     /// <c>stash/{sessionId}/{callId}</c> so the model can recover it via
     /// <c>GetFromWorkingMemory</c> using a key surfaced in the system stash registry.
     /// </summary>
-    internal async Task TrimLargeToolResultsAsync(
+    internal Task TrimLargeToolResultsAsync(
         List<ChatMessage> messages,
         int maxTokens,
         string? sessionId,
-        AgentLoopStashContext.State stashState)
-    {
-        const int CharsPerToken = 4;
-        var charBudget = (int)(maxTokens * CharsPerToken * 0.9);
-        var headRatio = Math.Clamp(hostOptions.Value.ToolResultStashHeadTailRatio, 0.0, 1.0);
-        var ttl = TimeSpan.FromMinutes(Math.Max(1, hostOptions.Value.ToolResultStashTtlMinutes));
-
-        while (true)
-        {
-            var totalChars = messages.Sum(EstimateMessageChars);
-            if (totalChars <= charBudget)
-                break;
-
-            int bestMsg = -1, bestContent = -1, bestLen = 0;
-            for (var i = 0; i < messages.Count; i++)
-            {
-                if (messages[i].Role != ChatRole.Tool) continue;
-                for (var j = 0; j < messages[i].Contents.Count; j++)
-                {
-                    if (messages[i].Contents[j] is FunctionResultContent frc)
-                    {
-                        var len = frc.Result?.ToString()?.Length ?? 0;
-                        if (len > bestLen) { bestMsg = i; bestContent = j; bestLen = len; }
-                    }
-                }
-            }
-
-            if (bestMsg < 0)
-                break;
-
-            var old = (FunctionResultContent)messages[bestMsg].Contents[bestContent];
-            var oldStr = old.Result?.ToString() ?? string.Empty;
-            var excess = totalChars - charBudget;
-
-            // No callId: fall back to the legacy head-only behaviour (no stash, no
-            // registry entry) — the model has no way to retrieve the elided content
-            // anyway, so the marker would only be misleading.
-            if (string.IsNullOrEmpty(old.CallId))
-            {
-                var legacyTarget = Math.Max(200, oldStr.Length - excess - 60);
-                var legacyTrimmed = oldStr[..legacyTarget] + "\n[truncated to fit context window]";
-                messages[bestMsg].Contents[bestContent] =
-                    new FunctionResultContent(old.CallId, legacyTrimmed);
-                logger.LogInformation(
-                    "Trimmed tool result (no callId, legacy mode): {Before:N0} → {After:N0} chars",
-                    bestLen, legacyTrimmed.Length);
-                continue;
-            }
-
-            var marker = BuildElisionMarker(old.CallId);
-            // Total surface = head + marker + tail. Budget the surface so the trimmed
-            // message ends up shorter than the original by at least the excess.
-            var surfaceBudget = Math.Max(200, oldStr.Length - excess - 60 - marker.Length);
-            if (surfaceBudget >= oldStr.Length) surfaceBudget = oldStr.Length - 1;
-            var headLen = (int)Math.Round(surfaceBudget * headRatio);
-            var tailLen = surfaceBudget - headLen;
-            if (headLen < 0) headLen = 0;
-            if (tailLen < 0) tailLen = 0;
-            if (headLen + tailLen >= oldStr.Length) headLen = Math.Max(0, oldStr.Length - tailLen - 1);
-
-            var head = headLen > 0 ? oldStr[..headLen] : string.Empty;
-            var tail = tailLen > 0 ? oldStr[^tailLen..] : string.Empty;
-            var trimmed = string.Concat(head, "\n\n", marker, "\n\n", tail);
-
-            // First trim of this callId: stash the full original and register the entry
-            // so the next RefreshStashRegistryContext call surfaces it.
-            if (!stashState.Registry.Contains(old.CallId))
-            {
-                var stashKey = BuildStashKey(sessionId, old.CallId);
-                try
-                {
-                    await workingMemory.SetAsync(
-                        stashKey, oldStr, ttl,
-                        category: "tool-result-stash",
-                        tags: ["stash", "tool-result"]);
-                }
-                catch (Exception ex)
-                {
-                    logger.LogWarning(ex,
-                        "Failed to stash original tool result for call {CallId}; trimming without stash",
-                        old.CallId);
-                }
-
-                stashState.ArgsSummaries.TryGetValue(old.CallId, out var argsSummary);
-                stashState.Registry.Add(new ToolResultStashRegistry.Entry(
-                    CallId: old.CallId,
-                    ToolName: ExtractToolNameForCallId(messages, old.CallId),
-                    ArgsSummary: argsSummary ?? "(args unavailable)",
-                    Key: stashKey));
-            }
-
-            messages[bestMsg].Contents[bestContent] = new FunctionResultContent(old.CallId, trimmed);
-
-            logger.LogInformation(
-                "Trimmed tool result for call {CallId}: {Before:N0} → {After:N0} chars (head {Head}, tail {Tail})",
-                old.CallId, bestLen, trimmed.Length, headLen, tailLen);
-        }
-    }
+        AgentLoopStashContext.State stashState) =>
+        ToolResultTrimmer.TrimAsync(
+            messages, maxTokens, sessionId, stashState, workingMemory,
+            hostOptions.Value.ToolResultStashHeadTailRatio,
+            hostOptions.Value.ToolResultStashTtlMinutes,
+            logger);
 
     /// <summary>
     /// Working-memory key under which a trimmed tool result's original content is
@@ -1802,29 +1710,6 @@ public sealed partial class AgentLoopRunner(
             callId, toolName, resultStr.Length, trimmed.Length, headLen, tailLen);
 
         return trimmed;
-    }
-
-    /// <summary>
-    /// Walks <paramref name="messages"/> looking for the assistant <see cref="FunctionCallContent"/>
-    /// whose <see cref="FunctionCallContent.CallId"/> matches <paramref name="callId"/>, and
-    /// returns its tool name. Falls back to <c>"(unknown)"</c> when no match is found —
-    /// trimmed results without a discoverable origin still get an entry, just with a less
-    /// helpful label.
-    /// </summary>
-    private static string ExtractToolNameForCallId(List<ChatMessage> messages, string callId)
-    {
-        foreach (var msg in messages)
-        {
-            foreach (var content in msg.Contents)
-            {
-                if (content is FunctionCallContent fcc &&
-                    string.Equals(fcc.CallId, callId, StringComparison.Ordinal))
-                {
-                    return fcc.Name;
-                }
-            }
-        }
-        return "(unknown)";
     }
 
     /// <summary>

--- a/src/RockBot.Host/AgentMemoryExtensions.cs
+++ b/src/RockBot.Host/AgentMemoryExtensions.cs
@@ -106,9 +106,12 @@ public static class AgentMemoryExtensions
         builder.Services.TryAddSingleton<EmbeddingTextPreparer>();
         builder.Services.AddSingleton<ISkillStore, FileSkillStore>();
         builder.Services.AddSingleton<ISkillUsageStore, FileSkillUsageStore>();
+        builder.Services.AddSingleton<IPrunableLog>(sp => (IPrunableLog)sp.GetRequiredService<ISkillUsageStore>());
         builder.Services.AddSingleton<ISkillResourceUsageStore, FileSkillResourceUsageStore>();
+        builder.Services.AddSingleton<IPrunableLog>(sp => (IPrunableLog)sp.GetRequiredService<ISkillResourceUsageStore>());
         builder.Services.Configure<ToolCallLogOptions>(_ => { });
         builder.Services.AddSingleton<IToolCallLog, FileToolCallLog>();
+        builder.Services.AddSingleton<IPrunableLog>(sp => (IPrunableLog)sp.GetRequiredService<IToolCallLog>());
         builder.Services.AddSingleton<IHostedService, StarterSkillService>();
 
         return builder;
@@ -191,6 +194,7 @@ public static class AgentMemoryExtensions
             builder.Services.Configure<FeedbackOptions>(_ => { });
 
         builder.Services.AddSingleton<IFeedbackStore, FileFeedbackStore>();
+        builder.Services.AddSingleton<IPrunableLog>(sp => (IPrunableLog)sp.GetRequiredService<IFeedbackStore>());
         builder.Services.AddSingleton<SessionSummaryService>();
         builder.Services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<SessionSummaryService>());
 

--- a/src/RockBot.Host/DreamService.cs
+++ b/src/RockBot.Host/DreamService.cs
@@ -51,6 +51,7 @@ internal sealed class DreamService : IHostedService, IDisposable
     private readonly IRepairTicketVerifier? _repairTicketVerifier;
     private readonly RepairTicketOptions? _repairOptions;
     private readonly IReadOnlyList<IToolSkillProvider> _toolSkillProviders;
+    private readonly IReadOnlyList<IPrunableLog> _prunableLogs;
     private Timer? _timer;
     private CronExpression? _cron;
     private string? _dreamDirective;
@@ -102,7 +103,8 @@ internal sealed class DreamService : IHostedService, IDisposable
         IRepairTicketVerifier? repairTicketVerifier = null,
         IOptions<RepairTicketOptions>? repairOptions = null,
         IEnumerable<IToolSkillProvider>? toolSkillProviders = null,
-        TieredChatClientRegistry? tieredRegistry = null)
+        TieredChatClientRegistry? tieredRegistry = null,
+        IEnumerable<IPrunableLog>? prunableLogs = null)
     {
         _memory = memory;
         _skillStore = skillStores.FirstOrDefault();
@@ -139,6 +141,7 @@ internal sealed class DreamService : IHostedService, IDisposable
             _repairAppliers = map;
         }
         _toolSkillProviders = toolSkillProviders?.ToList() ?? (IReadOnlyList<IToolSkillProvider>)Array.Empty<IToolSkillProvider>();
+        _prunableLogs = prunableLogs?.ToList() ?? (IReadOnlyList<IPrunableLog>)Array.Empty<IPrunableLog>();
     }
 
     public Task StartAsync(CancellationToken cancellationToken)
@@ -492,6 +495,11 @@ internal sealed class DreamService : IHostedService, IDisposable
         try
         {
             var ct = slot.Token;
+
+            // Log retention runs first and unconditionally — append-only JSONL logs
+            // must be capped even on cycles where there's nothing to consolidate (the
+            // memory-count check below can early-return).
+            await RunLogRetentionPassAsync(ct);
 
             var all = await _memory.SearchAsync(new MemorySearchCriteria(MaxResults: 1000));
 
@@ -3804,6 +3812,47 @@ internal sealed class DreamService : IHostedService, IDisposable
     /// is rethrown so DreamAsync's outer handler can log a single
     /// "preempted by user request" line — see issue #333.
     /// </summary>
+    /// <summary>
+    /// Prunes every registered append-only JSONL log so they don't grow forever.
+    /// Each log knows its own on-disk shape and applies the policy via the shared
+    /// <see cref="JsonlLogRetention"/> helper; a failure in one log is logged and
+    /// does not abort the sweep. Gated by <see cref="DreamOptions.LogRetentionEnabled"/>.
+    /// </summary>
+    private async Task RunLogRetentionPassAsync(CancellationToken ct)
+    {
+        if (!_options.LogRetentionEnabled || _prunableLogs.Count == 0)
+            return;
+
+        await RunPassAsync("log retention", async () =>
+        {
+            var policy = new LogRetentionPolicy(
+                MaxFileAge: _options.LogRetentionMaxFileAge,
+                MaxFilesPerDirectory: _options.LogRetentionMaxFilesPerDirectory,
+                MaxLinesPerFile: _options.LogRetentionMaxLinesPerFile);
+
+            var total = 0;
+            foreach (var log in _prunableLogs)
+            {
+                ct.ThrowIfCancellationRequested();
+                try
+                {
+                    total += await log.PruneAsync(policy, ct);
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "DreamService: log retention failed for {Log}", log.GetType().Name);
+                }
+            }
+
+            if (total > 0)
+                _logger.LogInformation("DreamService: log retention removed {Total} stale log file(s)/line(s)", total);
+        });
+    }
+
     private async Task RunPassAsync(string passName, Func<Task> body)
     {
         try

--- a/src/RockBot.Host/FileFeedbackStore.cs
+++ b/src/RockBot.Host/FileFeedbackStore.cs
@@ -9,7 +9,7 @@ namespace RockBot.Host;
 /// File-based feedback store. Each session's entries are appended to a separate JSONL file:
 /// <c>{basePath}/{sessionId}.jsonl</c>. One JSON object per line.
 /// </summary>
-internal sealed class FileFeedbackStore : IFeedbackStore
+internal sealed class FileFeedbackStore : IFeedbackStore, IPrunableLog
 {
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -53,6 +53,15 @@ internal sealed class FileFeedbackStore : IFeedbackStore
             sem.Release();
         }
     }
+
+    /// <summary>
+    /// Per-session JSONL files accumulate one file per session forever. Retention
+    /// drops whole session files older than the configured window, then caps the
+    /// total file count.
+    /// </summary>
+    public Task<int> PruneAsync(LogRetentionPolicy policy, CancellationToken ct = default)
+        => JsonlLogRetention.PruneAgedFilesAsync(
+            _basePath, policy.MaxFileAge, policy.MaxFilesPerDirectory, "*.jsonl", _logger, ct);
 
     public async Task<IReadOnlyList<FeedbackEntry>> GetBySessionAsync(string sessionId, CancellationToken cancellationToken = default)
     {

--- a/src/RockBot.Host/FileFeedbackStore.cs
+++ b/src/RockBot.Host/FileFeedbackStore.cs
@@ -56,12 +56,21 @@ internal sealed class FileFeedbackStore : IFeedbackStore, IPrunableLog
 
     /// <summary>
     /// Per-session JSONL files accumulate one file per session forever. Retention
-    /// drops whole session files older than the configured window, then caps the
-    /// total file count.
+    /// drops whole session files older than the configured window, caps the total
+    /// file count, then line-trims any surviving file (e.g. a persistent UI/CLI
+    /// session that never ages out) to the per-file line budget under that session's
+    /// write lock so the trim can't race an append.
     /// </summary>
-    public Task<int> PruneAsync(LogRetentionPolicy policy, CancellationToken ct = default)
-        => JsonlLogRetention.PruneAgedFilesAsync(
+    public async Task<int> PruneAsync(LogRetentionPolicy policy, CancellationToken ct = default)
+    {
+        var removed = await JsonlLogRetention.PruneAgedFilesAsync(
             _basePath, policy.MaxFileAge, policy.MaxFilesPerDirectory, "*.jsonl", _logger, ct);
+        removed += await JsonlLogRetention.TrimSessionFilesAsync(
+            _basePath, policy.MaxLinesPerFile, "*.jsonl",
+            id => _writeLocks.GetOrAdd(id, _ => new SemaphoreSlim(1, 1)),
+            _logger, ct);
+        return removed;
+    }
 
     public async Task<IReadOnlyList<FeedbackEntry>> GetBySessionAsync(string sessionId, CancellationToken cancellationToken = default)
     {

--- a/src/RockBot.Host/FileSkillResourceUsageStore.cs
+++ b/src/RockBot.Host/FileSkillResourceUsageStore.cs
@@ -10,7 +10,7 @@ namespace RockBot.Host;
 /// Mirrors <c>FileWispExecutionLog</c>'s shape — append-only, single-writer
 /// semaphore, lazy reads.
 /// </summary>
-internal sealed class FileSkillResourceUsageStore : ISkillResourceUsageStore
+internal sealed class FileSkillResourceUsageStore : ISkillResourceUsageStore, IPrunableLog
 {
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -44,6 +44,24 @@ internal sealed class FileSkillResourceUsageStore : ISkillResourceUsageStore
         {
             var line = JsonSerializer.Serialize(evt, JsonOptions);
             await File.AppendAllTextAsync(_filePath, line + Environment.NewLine, ct);
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
+    }
+
+    /// <summary>
+    /// Single append-only file shared across all sessions. Retention trims it to the
+    /// last <see cref="LogRetentionPolicy.MaxLinesPerFile"/> lines, serialized against
+    /// the append writer so a trim never races a checkout record.
+    /// </summary>
+    public async Task<int> PruneAsync(LogRetentionPolicy policy, CancellationToken ct = default)
+    {
+        await _writeLock.WaitAsync(ct);
+        try
+        {
+            return await JsonlLogRetention.TrimToLastLinesAsync(_filePath, policy.MaxLinesPerFile, _logger, ct);
         }
         finally
         {

--- a/src/RockBot.Host/FileSkillUsageStore.cs
+++ b/src/RockBot.Host/FileSkillUsageStore.cs
@@ -9,7 +9,7 @@ namespace RockBot.Host;
 /// File-based skill usage store. Each session's invocation events are appended to a separate JSONL file:
 /// <c>{basePath}/{sessionId}.jsonl</c>. One JSON object per line.
 /// </summary>
-internal sealed class FileSkillUsageStore : ISkillUsageStore
+internal sealed class FileSkillUsageStore : ISkillUsageStore, IPrunableLog
 {
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -52,6 +52,15 @@ internal sealed class FileSkillUsageStore : ISkillUsageStore
             sem.Release();
         }
     }
+
+    /// <summary>
+    /// Per-session JSONL files accumulate one file per session forever. Retention
+    /// drops whole session files older than the configured window, then caps the
+    /// total file count.
+    /// </summary>
+    public Task<int> PruneAsync(LogRetentionPolicy policy, CancellationToken ct = default)
+        => JsonlLogRetention.PruneAgedFilesAsync(
+            _basePath, policy.MaxFileAge, policy.MaxFilesPerDirectory, "*.jsonl", _logger, ct);
 
     public async Task<IReadOnlyList<SkillInvocationEvent>> GetBySessionAsync(string sessionId, CancellationToken ct = default)
     {

--- a/src/RockBot.Host/FileSkillUsageStore.cs
+++ b/src/RockBot.Host/FileSkillUsageStore.cs
@@ -55,12 +55,21 @@ internal sealed class FileSkillUsageStore : ISkillUsageStore, IPrunableLog
 
     /// <summary>
     /// Per-session JSONL files accumulate one file per session forever. Retention
-    /// drops whole session files older than the configured window, then caps the
-    /// total file count.
+    /// drops whole session files older than the configured window, caps the total
+    /// file count, then line-trims any surviving file (e.g. a persistent UI/CLI
+    /// session that never ages out) to the per-file line budget under that session's
+    /// write lock so the trim can't race an append.
     /// </summary>
-    public Task<int> PruneAsync(LogRetentionPolicy policy, CancellationToken ct = default)
-        => JsonlLogRetention.PruneAgedFilesAsync(
+    public async Task<int> PruneAsync(LogRetentionPolicy policy, CancellationToken ct = default)
+    {
+        var removed = await JsonlLogRetention.PruneAgedFilesAsync(
             _basePath, policy.MaxFileAge, policy.MaxFilesPerDirectory, "*.jsonl", _logger, ct);
+        removed += await JsonlLogRetention.TrimSessionFilesAsync(
+            _basePath, policy.MaxLinesPerFile, "*.jsonl",
+            id => _writeLocks.GetOrAdd(id, _ => new SemaphoreSlim(1, 1)),
+            _logger, ct);
+        return removed;
+    }
 
     public async Task<IReadOnlyList<SkillInvocationEvent>> GetBySessionAsync(string sessionId, CancellationToken ct = default)
     {

--- a/src/RockBot.Host/FileToolCallLog.cs
+++ b/src/RockBot.Host/FileToolCallLog.cs
@@ -55,12 +55,21 @@ internal sealed class FileToolCallLog : IToolCallLog, IPrunableLog
 
     /// <summary>
     /// Per-session JSONL files accumulate one file per session forever. Retention
-    /// drops whole session files older than the configured window, then caps the
-    /// total file count.
+    /// drops whole session files older than the configured window, caps the total
+    /// file count, then line-trims any surviving file (e.g. a persistent UI/CLI
+    /// session that never ages out) to the per-file line budget under that session's
+    /// write lock so the trim can't race an append.
     /// </summary>
-    public Task<int> PruneAsync(LogRetentionPolicy policy, CancellationToken ct = default)
-        => JsonlLogRetention.PruneAgedFilesAsync(
+    public async Task<int> PruneAsync(LogRetentionPolicy policy, CancellationToken ct = default)
+    {
+        var removed = await JsonlLogRetention.PruneAgedFilesAsync(
             _basePath, policy.MaxFileAge, policy.MaxFilesPerDirectory, "*.jsonl", _logger, ct);
+        removed += await JsonlLogRetention.TrimSessionFilesAsync(
+            _basePath, policy.MaxLinesPerFile, "*.jsonl",
+            id => _writeLocks.GetOrAdd(id, _ => new SemaphoreSlim(1, 1)),
+            _logger, ct);
+        return removed;
+    }
 
     public async Task<IReadOnlyList<ToolCallEvent>> GetBySessionAsync(string sessionId, CancellationToken ct = default)
     {

--- a/src/RockBot.Host/FileToolCallLog.cs
+++ b/src/RockBot.Host/FileToolCallLog.cs
@@ -9,7 +9,7 @@ namespace RockBot.Host;
 /// File-based tool-call log. Each session's tool invocations are appended to a separate JSONL file:
 /// <c>{basePath}/{sessionId}.jsonl</c>. One JSON object per line.
 /// </summary>
-internal sealed class FileToolCallLog : IToolCallLog
+internal sealed class FileToolCallLog : IToolCallLog, IPrunableLog
 {
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -52,6 +52,15 @@ internal sealed class FileToolCallLog : IToolCallLog
             sem.Release();
         }
     }
+
+    /// <summary>
+    /// Per-session JSONL files accumulate one file per session forever. Retention
+    /// drops whole session files older than the configured window, then caps the
+    /// total file count.
+    /// </summary>
+    public Task<int> PruneAsync(LogRetentionPolicy policy, CancellationToken ct = default)
+        => JsonlLogRetention.PruneAgedFilesAsync(
+            _basePath, policy.MaxFileAge, policy.MaxFilesPerDirectory, "*.jsonl", _logger, ct);
 
     public async Task<IReadOnlyList<ToolCallEvent>> GetBySessionAsync(string sessionId, CancellationToken ct = default)
     {

--- a/src/RockBot.Host/IPrunableLog.cs
+++ b/src/RockBot.Host/IPrunableLog.cs
@@ -1,0 +1,30 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Retention knobs applied by the dream cycle's log-retention pass.
+/// Single-file append-only logs honour <see cref="MaxLinesPerFile"/>;
+/// per-session directory logs (one <c>{id}.jsonl</c> per session) honour
+/// <see cref="MaxFileAge"/> and <see cref="MaxFilesPerDirectory"/>.
+/// A non-positive value disables the corresponding dimension.
+/// </summary>
+public sealed record LogRetentionPolicy(
+    TimeSpan MaxFileAge,
+    int MaxFilesPerDirectory,
+    int MaxLinesPerFile);
+
+/// <summary>
+/// Opt-in contract for append-only logs that can prune themselves. The file-backed
+/// JSONL stores implement this; <see cref="DreamService"/> resolves every registered
+/// instance and invokes <see cref="PruneAsync"/> once per dream cycle so the logs
+/// don't grow without bound. Implementations know their own on-disk layout and
+/// delegate the actual file work to <see cref="JsonlLogRetention"/>.
+/// </summary>
+public interface IPrunableLog
+{
+    /// <summary>
+    /// Applies <paramref name="policy"/> to this log and returns the number of files
+    /// or lines removed. Best-effort: implementations log and swallow I/O failures
+    /// rather than throwing, so one failing log never aborts the retention sweep.
+    /// </summary>
+    Task<int> PruneAsync(LogRetentionPolicy policy, CancellationToken ct = default);
+}

--- a/src/RockBot.Host/JsonlLogRetention.cs
+++ b/src/RockBot.Host/JsonlLogRetention.cs
@@ -127,6 +127,68 @@ public static class JsonlLogRetention
         }
     }
 
+    /// <summary>
+    /// Line-trims every <paramref name="searchPattern"/> file directly under
+    /// <paramref name="directory"/> to its last <paramref name="maxLines"/> lines.
+    /// Where <see cref="PruneAgedFilesAsync"/> drops whole stale files, this bounds a
+    /// <em>persistent</em> session file (e.g. a long-lived UI or CLI session's
+    /// <c>{id}.jsonl</c>) that age/count pruning never touches because it is written
+    /// continuously — never aged out, never the oldest file. Each file is trimmed while
+    /// holding the writer's own per-session lock, obtained via <paramref name="lockFor"/>
+    /// keyed by the session id (the file name without extension), so a trim never races
+    /// an append. A non-positive <paramref name="maxLines"/> is a no-op. Returns the
+    /// total number of lines removed across all files.
+    /// </summary>
+    public static async Task<int> TrimSessionFilesAsync(
+        string directory,
+        int maxLines,
+        string searchPattern,
+        Func<string, SemaphoreSlim> lockFor,
+        ILogger logger,
+        CancellationToken ct = default)
+    {
+        if (maxLines <= 0 || !Directory.Exists(directory))
+            return 0;
+
+        var removed = 0;
+        try
+        {
+            foreach (var file in new DirectoryInfo(directory)
+                         .EnumerateFiles(searchPattern, SearchOption.TopDirectoryOnly))
+            {
+                ct.ThrowIfCancellationRequested();
+
+                // A file of N bytes can hold at most N+1 lines, so anything smaller than
+                // the line budget cannot exceed it — skip without opening (most session
+                // files are tiny; only the rare persistent file needs a read).
+                if (file.Length < maxLines)
+                    continue;
+
+                var sessionId = Path.GetFileNameWithoutExtension(file.Name);
+                var sem = lockFor(sessionId);
+                await sem.WaitAsync(ct);
+                try
+                {
+                    removed += await TrimToLastLinesAsync(file.FullName, maxLines, logger, ct);
+                }
+                finally
+                {
+                    sem.Release();
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "JSONL retention: failed to line-trim session files in {Directory}", directory);
+        }
+
+        return removed;
+    }
+
     private static bool TryDelete(FileInfo file, ILogger logger)
     {
         try

--- a/src/RockBot.Host/JsonlLogRetention.cs
+++ b/src/RockBot.Host/JsonlLogRetention.cs
@@ -1,0 +1,143 @@
+using Microsoft.Extensions.Logging;
+
+namespace RockBot.Host;
+
+/// <summary>
+/// Shared retention utilities for JSONL logs, invoked from the dream cycle. Two
+/// shapes are supported: per-session directories of <c>{id}.jsonl</c> files (pruned
+/// by age, then by count) and single append-only files (trimmed to a trailing line
+/// budget). All operations are best-effort — I/O failures are logged and swallowed
+/// so a retention sweep never aborts the caller.
+/// </summary>
+public static class JsonlLogRetention
+{
+    /// <summary>
+    /// Deletes <paramref name="searchPattern"/> files directly under
+    /// <paramref name="directory"/> that are older than <paramref name="maxAge"/>
+    /// (by last-write time), then, if more than <paramref name="maxFiles"/> remain,
+    /// deletes the oldest until the count is within budget. A non-positive
+    /// <paramref name="maxAge"/> disables age pruning; a non-positive
+    /// <paramref name="maxFiles"/> disables count pruning. Returns the number of
+    /// files deleted.
+    /// </summary>
+    public static Task<int> PruneAgedFilesAsync(
+        string directory,
+        TimeSpan maxAge,
+        int maxFiles,
+        string searchPattern,
+        ILogger logger,
+        CancellationToken ct = default)
+    {
+        if (!Directory.Exists(directory))
+            return Task.FromResult(0);
+
+        var deleted = 0;
+        try
+        {
+            var files = new DirectoryInfo(directory)
+                .EnumerateFiles(searchPattern, SearchOption.TopDirectoryOnly)
+                .ToList();
+
+            // Age-based pruning: drop files not written within the retention window.
+            if (maxAge > TimeSpan.Zero)
+            {
+                var cutoff = DateTime.UtcNow - maxAge;
+                foreach (var file in files.ToList())
+                {
+                    ct.ThrowIfCancellationRequested();
+                    if (file.LastWriteTimeUtc >= cutoff)
+                        continue;
+                    if (TryDelete(file, logger))
+                    {
+                        files.Remove(file);
+                        deleted++;
+                    }
+                }
+            }
+
+            // Count-based pruning: keep the most recently written maxFiles.
+            if (maxFiles > 0 && files.Count > maxFiles)
+            {
+                var oldestFirst = files.OrderBy(f => f.LastWriteTimeUtc).ToList();
+                var toRemove = files.Count - maxFiles;
+                for (var i = 0; i < toRemove; i++)
+                {
+                    ct.ThrowIfCancellationRequested();
+                    if (TryDelete(oldestFirst[i], logger))
+                        deleted++;
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "JSONL retention: failed to prune directory {Directory}", directory);
+        }
+
+        if (deleted > 0)
+            logger.LogInformation("JSONL retention: deleted {Count} file(s) from {Directory}", deleted, directory);
+
+        return Task.FromResult(deleted);
+    }
+
+    /// <summary>
+    /// Rewrites <paramref name="filePath"/> to retain only its last
+    /// <paramref name="maxLines"/> lines when it exceeds that budget. A non-positive
+    /// <paramref name="maxLines"/> is a no-op. The rewrite is atomic (temp file +
+    /// move). Returns the number of lines removed. Callers that also append to this
+    /// file MUST serialize this call against their writer.
+    /// </summary>
+    public static async Task<int> TrimToLastLinesAsync(
+        string filePath,
+        int maxLines,
+        ILogger logger,
+        CancellationToken ct = default)
+    {
+        if (maxLines <= 0 || !File.Exists(filePath))
+            return 0;
+
+        try
+        {
+            var lines = await File.ReadAllLinesAsync(filePath, ct);
+            if (lines.Length <= maxLines)
+                return 0;
+
+            var keep = lines[^maxLines..];
+            var tempPath = filePath + ".tmp";
+            await File.WriteAllLinesAsync(tempPath, keep, ct);
+            File.Move(tempPath, filePath, overwrite: true);
+
+            var removed = lines.Length - keep.Length;
+            logger.LogInformation(
+                "JSONL retention: trimmed {Removed} line(s) from {Path} (kept last {Kept})",
+                removed, filePath, keep.Length);
+            return removed;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "JSONL retention: failed to trim {Path}", filePath);
+            return 0;
+        }
+    }
+
+    private static bool TryDelete(FileInfo file, ILogger logger)
+    {
+        try
+        {
+            file.Delete();
+            return true;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "JSONL retention: failed to delete {Path}", file.FullName);
+            return false;
+        }
+    }
+}

--- a/src/RockBot.Host/RockBotFunctionInvokingChatClient.cs
+++ b/src/RockBot.Host/RockBotFunctionInvokingChatClient.cs
@@ -478,113 +478,14 @@ public class RockBotFunctionInvokingChatClient : FunctionInvokingChatClient
     /// Falls back to the legacy head-only behaviour when no stash context is bound or
     /// the tool result has no callId.
     /// </summary>
-    private async Task TrimLargeToolResultsAsync(List<ChatMessage> messages, int maxTokens)
+    private Task TrimLargeToolResultsAsync(List<ChatMessage> messages, int maxTokens)
     {
-        const int CharsPerToken = 4;
-        var charBudget = (int)(maxTokens * CharsPerToken * 0.9);
         var stashState = AgentLoopStashContext.Value;
-        var headRatio = Math.Clamp(_hostOptions.Value.ToolResultStashHeadTailRatio, 0.0, 1.0);
-        var ttl = TimeSpan.FromMinutes(Math.Max(1, _hostOptions.Value.ToolResultStashTtlMinutes));
-
-        while (true)
-        {
-            var totalChars = messages.Sum(EstimateMessageChars);
-            if (totalChars <= charBudget)
-                break;
-
-            int bestMsg = -1, bestContent = -1, bestLen = 0;
-            for (var i = 0; i < messages.Count; i++)
-            {
-                if (messages[i].Role != ChatRole.Tool) continue;
-                for (var j = 0; j < messages[i].Contents.Count; j++)
-                {
-                    if (messages[i].Contents[j] is FunctionResultContent frc)
-                    {
-                        var len = frc.Result?.ToString()?.Length ?? 0;
-                        if (len > bestLen) { bestMsg = i; bestContent = j; bestLen = len; }
-                    }
-                }
-            }
-
-            if (bestMsg < 0)
-                break;
-
-            var old = (FunctionResultContent)messages[bestMsg].Contents[bestContent];
-            var oldStr = old.Result?.ToString() ?? string.Empty;
-            var excess = totalChars - charBudget;
-
-            if (stashState is null || string.IsNullOrEmpty(old.CallId))
-            {
-                var legacyTarget = Math.Max(200, oldStr.Length - excess - 60);
-                var legacyTrimmed = oldStr[..legacyTarget] + "\n[truncated to fit context window]";
-                messages[bestMsg].Contents[bestContent] =
-                    new FunctionResultContent(old.CallId, legacyTrimmed);
-                _logger.LogInformation(
-                    "Trimmed tool result (legacy mode): {Before:N0} → {After:N0} chars",
-                    bestLen, legacyTrimmed.Length);
-                continue;
-            }
-
-            var marker = $"[content elided to fit context window — id={old.CallId}]";
-            var surfaceBudget = Math.Max(200, oldStr.Length - excess - 60 - marker.Length);
-            if (surfaceBudget >= oldStr.Length) surfaceBudget = oldStr.Length - 1;
-            var headLen = (int)Math.Round(surfaceBudget * headRatio);
-            var tailLen = surfaceBudget - headLen;
-            if (headLen < 0) headLen = 0;
-            if (tailLen < 0) tailLen = 0;
-            if (headLen + tailLen >= oldStr.Length) headLen = Math.Max(0, oldStr.Length - tailLen - 1);
-
-            var head = headLen > 0 ? oldStr[..headLen] : string.Empty;
-            var tail = tailLen > 0 ? oldStr[^tailLen..] : string.Empty;
-            var trimmed = string.Concat(head, "\n\n", marker, "\n\n", tail);
-
-            if (!stashState.Registry.Contains(old.CallId))
-            {
-                var stashKey = AgentLoopRunner.BuildStashKey(stashState.SessionId, old.CallId);
-                try
-                {
-                    await _workingMemory.SetAsync(
-                        stashKey, oldStr, ttl,
-                        category: "tool-result-stash",
-                        tags: ["stash", "tool-result"]);
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogWarning(ex,
-                        "Failed to stash original tool result for call {CallId}; trimming without stash",
-                        old.CallId);
-                }
-
-                stashState.ArgsSummaries.TryGetValue(old.CallId, out var argsSummary);
-                stashState.Registry.Add(new ToolResultStashRegistry.Entry(
-                    CallId: old.CallId,
-                    ToolName: ExtractToolNameForCallId(messages, old.CallId),
-                    ArgsSummary: argsSummary ?? "(args unavailable)",
-                    Key: stashKey));
-            }
-
-            messages[bestMsg].Contents[bestContent] = new FunctionResultContent(old.CallId, trimmed);
-
-            _logger.LogInformation(
-                "Trimmed tool result for call {CallId}: {Before:N0} → {After:N0} chars (head {Head}, tail {Tail})",
-                old.CallId, bestLen, trimmed.Length, headLen, tailLen);
-        }
-    }
-
-    private static string ExtractToolNameForCallId(List<ChatMessage> messages, string callId)
-    {
-        foreach (var msg in messages)
-        {
-            foreach (var content in msg.Contents)
-            {
-                if (content is FunctionCallContent fcc &&
-                    string.Equals(fcc.CallId, callId, StringComparison.Ordinal))
-                {
-                    return fcc.Name;
-                }
-            }
-        }
-        return "(unknown)";
+        return ToolResultTrimmer.TrimAsync(
+            messages, maxTokens, stashState?.SessionId, stashState, _workingMemory,
+            _hostOptions.Value.ToolResultStashHeadTailRatio,
+            _hostOptions.Value.ToolResultStashTtlMinutes,
+            _logger);
     }
 
     /// <summary>
@@ -648,14 +549,6 @@ public class RockBotFunctionInvokingChatClient : FunctionInvokingChatClient
 
         return (orphanedCalls, orphanedResults);
     }
-
-    private static int EstimateMessageChars(ChatMessage m) =>
-        m.Contents.Sum(static c => c switch
-        {
-            TextContent tc => tc.Text?.Length ?? 0,
-            FunctionResultContent frc => frc.Result?.ToString()?.Length ?? 0,
-            _ => 50
-        });
 
     private static bool TryParseContextOverflow(string message, out int maxTokens, out int usedTokens)
     {

--- a/src/RockBot.Host/ToolResultTrimmer.cs
+++ b/src/RockBot.Host/ToolResultTrimmer.cs
@@ -1,0 +1,198 @@
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using RockBot.Tools;
+
+namespace RockBot.Host;
+
+/// <summary>
+/// Canonical implementation of the head+tail+stash context-window trim, shared by the
+/// native tool-calling path (<see cref="RockBotFunctionInvokingChatClient"/>) and the
+/// text-based loop (<see cref="AgentLoopRunner"/>). Both paths previously carried
+/// byte-identical copies of this loop; the copies drifted only in field names, and a
+/// non-termination bug had to be diagnosed and fixed in two places. It now lives here
+/// once.
+/// </summary>
+internal static class ToolResultTrimmer
+{
+    private const int CharsPerToken = 4;
+
+    /// <summary>
+    /// Repeatedly replaces the largest tool result with a head+tail surface (stashing the
+    /// full original in working memory under <c>stash/{sessionId}/{callId}</c>) until the
+    /// estimated context size fits <paramref name="maxTokens"/>.
+    ///
+    /// <para><b>Termination.</b> The loop is bounded three ways, any one of which is
+    /// sufficient: (1) it stops once the budget is met; (2) it stops when the largest
+    /// remaining tool result cannot be shrunk (already at the elision floor, where
+    /// re-adding the marker would keep it the same size or grow it) — since the largest
+    /// can't shrink, nothing smaller can bring the total under budget either; (3) a hard
+    /// pass cap as defence-in-depth. Without (2)/(3), a context whose <i>non-tool</i>
+    /// content alone exceeds the budget (system prompt + injected skill bodies + the
+    /// stash registry) re-trims the same floor-sized results forever — the 2026-06-05
+    /// incident: 400k+ identical "Trimmed tool result" log lines, CPU pegged at ~2
+    /// cores, until the pod was killed.</para>
+    /// </summary>
+    public static async Task TrimAsync(
+        List<ChatMessage> messages,
+        int maxTokens,
+        string? sessionId,
+        AgentLoopStashContext.State? stashState,
+        IWorkingMemory workingMemory,
+        double headTailRatio,
+        int stashTtlMinutes,
+        ILogger logger)
+    {
+        var charBudget = (int)(maxTokens * CharsPerToken * 0.9);
+        var headRatio = Math.Clamp(headTailRatio, 0.0, 1.0);
+        var ttl = TimeSpan.FromMinutes(Math.Max(1, stashTtlMinutes));
+
+        // Defence-in-depth pass cap. The no-progress breaks below are the real guarantee;
+        // this catches any future edit that reintroduces a non-shrinking path.
+        var maxPasses = messages.Count * 4 + 32;
+
+        for (var pass = 0; ; pass++)
+        {
+            if (pass >= maxPasses)
+            {
+                logger.LogWarning(
+                    "Tool-result trim exceeded {MaxPasses} passes without reaching the {Budget:N0}-char " +
+                    "budget; stopping to avoid a non-terminating loop. Context may still exceed the limit.",
+                    maxPasses, charBudget);
+                break;
+            }
+
+            var totalChars = messages.Sum(AgentLoopRunner.EstimateMessageChars);
+            if (totalChars <= charBudget)
+                break;
+
+            int bestMsg = -1, bestContent = -1, bestLen = 0;
+            for (var i = 0; i < messages.Count; i++)
+            {
+                if (messages[i].Role != ChatRole.Tool) continue;
+                for (var j = 0; j < messages[i].Contents.Count; j++)
+                {
+                    if (messages[i].Contents[j] is FunctionResultContent frc)
+                    {
+                        var len = frc.Result?.ToString()?.Length ?? 0;
+                        if (len > bestLen) { bestMsg = i; bestContent = j; bestLen = len; }
+                    }
+                }
+            }
+
+            if (bestMsg < 0)
+                break;
+
+            var old = (FunctionResultContent)messages[bestMsg].Contents[bestContent];
+            var oldStr = old.Result?.ToString() ?? string.Empty;
+            var excess = totalChars - charBudget;
+
+            // No callId or no stash state → legacy head-only truncation. The model has no
+            // way to retrieve elided content (nothing registered), so the elision marker
+            // would only mislead.
+            if (stashState is null || string.IsNullOrEmpty(old.CallId))
+            {
+                // Clamp the slice length so the 200-char floor can never index past the
+                // end of a short result (which would throw).
+                var legacyTarget = Math.Min(oldStr.Length, Math.Max(200, oldStr.Length - excess - 60));
+                var legacyTrimmed = oldStr[..legacyTarget] + "\n[truncated to fit context window]";
+                if (legacyTrimmed.Length >= oldStr.Length)
+                {
+                    logger.LogWarning(
+                        "Tool-result trim (legacy) cannot reach budget: total {Total:N0} > budget {Budget:N0} " +
+                        "chars, but the largest tool result ({Len:N0} chars) is already at the elision floor. " +
+                        "Stopping to avoid a non-terminating loop; context may still exceed the limit.",
+                        totalChars, charBudget, oldStr.Length);
+                    break;
+                }
+                messages[bestMsg].Contents[bestContent] =
+                    new FunctionResultContent(old.CallId, legacyTrimmed);
+                logger.LogInformation(
+                    "Trimmed tool result (no callId, legacy mode): {Before:N0} → {After:N0} chars",
+                    bestLen, legacyTrimmed.Length);
+                continue;
+            }
+
+            var marker = AgentLoopRunner.BuildElisionMarker(old.CallId);
+            // Total surface = head + marker + tail. Budget the surface so the trimmed
+            // message ends up shorter than the original by at least the excess.
+            var surfaceBudget = Math.Max(200, oldStr.Length - excess - 60 - marker.Length);
+            if (surfaceBudget >= oldStr.Length) surfaceBudget = oldStr.Length - 1;
+            var headLen = (int)Math.Round(surfaceBudget * headRatio);
+            var tailLen = surfaceBudget - headLen;
+            if (headLen < 0) headLen = 0;
+            if (tailLen < 0) tailLen = 0;
+            if (headLen + tailLen >= oldStr.Length) headLen = Math.Max(0, oldStr.Length - tailLen - 1);
+
+            var head = headLen > 0 ? oldStr[..headLen] : string.Empty;
+            var tail = tailLen > 0 ? oldStr[^tailLen..] : string.Empty;
+            var trimmed = string.Concat(head, "\n\n", marker, "\n\n", tail);
+
+            // No-progress guard: the largest tool result is already at/under the elision
+            // floor, so rewriting it (re-adding the marker) does not shrink it. Since we
+            // always pick the largest result, nothing smaller can reach the budget either.
+            if (trimmed.Length >= oldStr.Length)
+            {
+                logger.LogWarning(
+                    "Tool-result trim cannot reach budget: total {Total:N0} > budget {Budget:N0} chars, " +
+                    "but the largest tool result ({Len:N0} chars, call {CallId}) is already at the elision " +
+                    "floor. Stopping to avoid a non-terminating loop; context may still exceed the limit.",
+                    totalChars, charBudget, oldStr.Length, old.CallId);
+                break;
+            }
+
+            // First trim of this callId: stash the full original and register the entry
+            // so the next RefreshStashRegistryContext call surfaces it.
+            if (!stashState.Registry.Contains(old.CallId))
+            {
+                var stashKey = AgentLoopRunner.BuildStashKey(sessionId, old.CallId);
+                try
+                {
+                    await workingMemory.SetAsync(
+                        stashKey, oldStr, ttl,
+                        category: "tool-result-stash",
+                        tags: ["stash", "tool-result"]);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(ex,
+                        "Failed to stash original tool result for call {CallId}; trimming without stash",
+                        old.CallId);
+                }
+
+                stashState.ArgsSummaries.TryGetValue(old.CallId, out var argsSummary);
+                stashState.Registry.Add(new ToolResultStashRegistry.Entry(
+                    CallId: old.CallId,
+                    ToolName: ExtractToolNameForCallId(messages, old.CallId),
+                    ArgsSummary: argsSummary ?? "(args unavailable)",
+                    Key: stashKey));
+            }
+
+            messages[bestMsg].Contents[bestContent] = new FunctionResultContent(old.CallId, trimmed);
+
+            logger.LogInformation(
+                "Trimmed tool result for call {CallId}: {Before:N0} → {After:N0} chars (head {Head}, tail {Tail})",
+                old.CallId, bestLen, trimmed.Length, headLen, tailLen);
+        }
+    }
+
+    /// <summary>
+    /// Walks <paramref name="messages"/> for the assistant <see cref="FunctionCallContent"/>
+    /// whose CallId matches <paramref name="callId"/> and returns its tool name. Falls back
+    /// to <c>"(unknown)"</c> when no match is found.
+    /// </summary>
+    private static string ExtractToolNameForCallId(List<ChatMessage> messages, string callId)
+    {
+        foreach (var msg in messages)
+        {
+            foreach (var content in msg.Contents)
+            {
+                if (content is FunctionCallContent fcc &&
+                    string.Equals(fcc.CallId, callId, StringComparison.Ordinal))
+                {
+                    return fcc.Name;
+                }
+            }
+        }
+        return "(unknown)";
+    }
+}

--- a/src/RockBot.Wisp/FileWispExecutionLog.cs
+++ b/src/RockBot.Wisp/FileWispExecutionLog.cs
@@ -8,7 +8,7 @@ namespace RockBot.Wisp;
 /// File-based wisp execution log. All records are appended to a single JSONL file:
 /// <c>{basePath}/wisp-executions.jsonl</c>. One JSON object per line.
 /// </summary>
-internal sealed class FileWispExecutionLog : IWispExecutionLog
+internal sealed class FileWispExecutionLog : IWispExecutionLog, IPrunableLog
 {
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -36,6 +36,24 @@ internal sealed class FileWispExecutionLog : IWispExecutionLog
             var line = JsonSerializer.Serialize(record, JsonOptions);
             await File.AppendAllTextAsync(_filePath, line + Environment.NewLine, ct);
             _logger.LogDebug("Wisp execution logged [{WispId}] success={Success}", record.WispId, record.Succeeded);
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
+    }
+
+    /// <summary>
+    /// Single append-only file shared across all sessions. Retention trims it to the
+    /// last <see cref="LogRetentionPolicy.MaxLinesPerFile"/> lines, serialized against
+    /// the append writer so a trim never races an execution record.
+    /// </summary>
+    public async Task<int> PruneAsync(LogRetentionPolicy policy, CancellationToken ct = default)
+    {
+        await _writeLock.WaitAsync(ct);
+        try
+        {
+            return await JsonlLogRetention.TrimToLastLinesAsync(_filePath, policy.MaxLinesPerFile, _logger, ct);
         }
         finally
         {

--- a/src/RockBot.Wisp/WispServiceCollectionExtensions.cs
+++ b/src/RockBot.Wisp/WispServiceCollectionExtensions.cs
@@ -22,6 +22,7 @@ public static class WispServiceCollectionExtensions
 
         builder.Services.AddSingleton<WispExecutor>();
         builder.Services.AddSingleton<IWispExecutionLog, FileWispExecutionLog>();
+        builder.Services.AddSingleton<IPrunableLog>(sp => (IPrunableLog)sp.GetRequiredService<IWispExecutionLog>());
         builder.Services.AddHostedService<WispToolRegistrar>();
         builder.Services.AddSingleton<IToolSkillProvider, WispToolSkillProvider>();
 

--- a/tests/RockBot.Host.Tests/AgentLoopRunnerTrimStashTests.cs
+++ b/tests/RockBot.Host.Tests/AgentLoopRunnerTrimStashTests.cs
@@ -124,6 +124,61 @@ public class AgentLoopRunnerTrimStashTests
     }
 
     [TestMethod]
+    [Timeout(10_000)]
+    public async Task Trim_NonToolContentExceedsBudget_TerminatesInsteadOfSpinning()
+    {
+        // Regression for the 2026-06-05 runaway: when the non-tool content (here a huge
+        // system message) alone exceeds the char budget and every tool result is small
+        // enough to sit at the elision floor, the old `while(true)` could never reach the
+        // budget and re-trimmed the same floor-sized results forever (400k+ "Trimmed tool
+        // result" log lines, CPU pegged). The [Timeout] makes a re-introduced infinite
+        // loop fail rather than hang the suite.
+        var wm = new TestWorkingMemory();
+        var runner = NewRunner(wm);
+        var stashState = new AgentLoopStashContext.State { SessionId = "sess-1" };
+
+        var messages = new List<ChatMessage>
+        {
+            // Non-trimmable: a system message far larger than any budget the trim targets.
+            new(ChatRole.System, new string('S', 50_000)),
+            new(ChatRole.User, "do the thing"),
+            BuildAssistantWithCall("fetch_url", "call-1"),
+            new(ChatRole.Tool, [new FunctionResultContent("call-1", new string('A', 2_000))]),
+        };
+
+        // Tiny budget (≈720 chars) that the system message alone blows past — unreachable
+        // by trimming tool results. The call must return rather than spin.
+        await runner.TrimLargeToolResultsAsync(messages, maxTokens: 200, "sess-1", stashState);
+
+        // The tool result should have been trimmed at least once (down toward the floor),
+        // and the message list must not have grown.
+        Assert.AreEqual(4, messages.Count, "Trim must not add or remove messages.");
+        var frc = (FunctionResultContent)messages[3].Contents[0];
+        Assert.IsTrue((frc.Result?.ToString()?.Length ?? 0) <= 2_000,
+            "The tool result must not have grown past its original size.");
+    }
+
+    [TestMethod]
+    [Timeout(10_000)]
+    public async Task Trim_NoToolResultsButOverBudget_TerminatesImmediately()
+    {
+        // Only non-tool content over budget and nothing to trim — must break out at once.
+        var wm = new TestWorkingMemory();
+        var runner = NewRunner(wm);
+        var stashState = new AgentLoopStashContext.State { SessionId = "sess-1" };
+
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.System, new string('S', 50_000)),
+            new(ChatRole.User, "do the thing"),
+        };
+
+        await runner.TrimLargeToolResultsAsync(messages, maxTokens: 200, "sess-1", stashState);
+
+        Assert.AreEqual(2, messages.Count);
+    }
+
+    [TestMethod]
     public void RefreshStashRegistryContext_InsertsSystemMessageWithKey()
     {
         var registry = new ToolResultStashRegistry();

--- a/tests/RockBot.Host.Tests/DreamOptionsRetentionBindingTests.cs
+++ b/tests/RockBot.Host.Tests/DreamOptionsRetentionBindingTests.cs
@@ -1,0 +1,67 @@
+using Microsoft.Extensions.Configuration;
+
+namespace RockBot.Host.Tests;
+
+/// <summary>
+/// Guards the config wiring added so the Helm ConfigMap's <c>Dream__LogRetention*</c>
+/// keys actually reach <see cref="DreamOptions"/>. The agent binds the <c>Dream</c>
+/// section via <c>GetSection("Dream").Bind(opts)</c>; these tests reproduce that bind
+/// against the exact string shapes the ConfigMap emits — in particular the
+/// <c>TimeSpan</c> "d.hh:mm:ss" form, which silently falls back to the default if the
+/// binder can't parse it.
+/// </summary>
+[TestClass]
+public class DreamOptionsRetentionBindingTests
+{
+    private static DreamOptions Bind(Dictionary<string, string?> values)
+    {
+        var config = new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+        var opts = new DreamOptions();
+        config.GetSection("Dream").Bind(opts);
+        return opts;
+    }
+
+    [TestMethod]
+    public void Binds_RetentionKnobs_FromConfigMapStringShapes()
+    {
+        // Exactly what configmap.yaml renders (env vars use "__" as the section separator).
+        var opts = Bind(new Dictionary<string, string?>
+        {
+            ["Dream:LogRetentionEnabled"] = "false",
+            ["Dream:LogRetentionMaxFileAge"] = "30.00:00:00",
+            ["Dream:LogRetentionMaxFilesPerDirectory"] = "1000",
+            ["Dream:LogRetentionMaxLinesPerFile"] = "10000",
+        });
+
+        Assert.IsFalse(opts.LogRetentionEnabled);
+        Assert.AreEqual(TimeSpan.FromDays(30), opts.LogRetentionMaxFileAge);
+        Assert.AreEqual(1000, opts.LogRetentionMaxFilesPerDirectory);
+        Assert.AreEqual(10_000, opts.LogRetentionMaxLinesPerFile);
+    }
+
+    [TestMethod]
+    public void MissingSection_LeavesCodeDefaults()
+    {
+        var opts = Bind(new Dictionary<string, string?> { ["Other:Key"] = "x" });
+
+        Assert.IsTrue(opts.LogRetentionEnabled);
+        Assert.AreEqual(TimeSpan.FromDays(30), opts.LogRetentionMaxFileAge);
+        Assert.AreEqual(1000, opts.LogRetentionMaxFilesPerDirectory);
+        Assert.AreEqual(50_000, opts.LogRetentionMaxLinesPerFile);
+    }
+
+    [TestMethod]
+    public void ZeroValues_DisableDimensions_AndBind()
+    {
+        var opts = Bind(new Dictionary<string, string?>
+        {
+            ["Dream:LogRetentionMaxFileAge"] = "0",
+            ["Dream:LogRetentionMaxFilesPerDirectory"] = "0",
+            ["Dream:LogRetentionMaxLinesPerFile"] = "0",
+        });
+
+        Assert.AreEqual(TimeSpan.Zero, opts.LogRetentionMaxFileAge);
+        Assert.AreEqual(0, opts.LogRetentionMaxFilesPerDirectory);
+        Assert.AreEqual(0, opts.LogRetentionMaxLinesPerFile);
+    }
+}

--- a/tests/RockBot.Host.Tests/JsonlLogRetentionTests.cs
+++ b/tests/RockBot.Host.Tests/JsonlLogRetentionTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 
@@ -208,6 +209,74 @@ public class JsonlLogRetentionTests
         Assert.AreEqual(15, removed);
         var path = Path.Combine(_tempDir, "skill-resource-usage.jsonl");
         Assert.AreEqual(10, (await File.ReadAllLinesAsync(path)).Length);
+    }
+
+    // ── TrimSessionFilesAsync ─────────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task TrimSessionFiles_TrimsOverBudget_SkipsUnderBudget_AndLocksBySession()
+    {
+        var dir = Path.Combine(_tempDir, "sessions");
+        Directory.CreateDirectory(dir);
+
+        // Persistent session: over the line budget — must be trimmed.
+        var big = Path.Combine(dir, "blazor-session.jsonl");
+        await File.WriteAllLinesAsync(big, Enumerable.Range(0, 100).Select(i => $"{{\"n\":{i}}}").ToArray());
+
+        // Ephemeral session: under the byte gate — must be left untouched.
+        var small = Path.Combine(dir, "subagent-x.jsonl");
+        await File.WriteAllLinesAsync(small, new[] { "a", "b", "c" });
+
+        var locks = new ConcurrentDictionary<string, SemaphoreSlim>();
+        var removed = await JsonlLogRetention.TrimSessionFilesAsync(
+            dir, maxLines: 10, "*.jsonl",
+            id => locks.GetOrAdd(id, _ => new SemaphoreSlim(1, 1)),
+            NullLogger.Instance);
+
+        Assert.AreEqual(90, removed);
+        var keptBig = await File.ReadAllLinesAsync(big);
+        Assert.AreEqual(10, keptBig.Length);
+        Assert.AreEqual("{\"n\":90}", keptBig[0]);
+        Assert.AreEqual("{\"n\":99}", keptBig[^1]);
+        Assert.AreEqual(3, (await File.ReadAllLinesAsync(small)).Length);
+        // The trim acquired the writer's lock for the over-budget session, keyed by
+        // file name without extension — i.e. the exact SessionId the store writes under.
+        Assert.IsTrue(locks.ContainsKey("blazor-session"));
+    }
+
+    [TestMethod]
+    public async Task TrimSessionFiles_NonPositiveMaxLines_IsNoOp()
+    {
+        var dir = Path.Combine(_tempDir, "sessions");
+        Directory.CreateDirectory(dir);
+        var f = Path.Combine(dir, "s.jsonl");
+        await File.WriteAllLinesAsync(f, Enumerable.Range(0, 50).Select(i => i.ToString()).ToArray());
+
+        var removed = await JsonlLogRetention.TrimSessionFilesAsync(
+            dir, maxLines: 0, "*.jsonl", _ => new SemaphoreSlim(1, 1), NullLogger.Instance);
+
+        Assert.AreEqual(0, removed);
+        Assert.AreEqual(50, (await File.ReadAllLinesAsync(f)).Length);
+    }
+
+    [TestMethod]
+    public async Task PerSessionStore_PruneAsync_LineTrimsPersistentSessionFile()
+    {
+        var skillOptions = Options.Create(new SkillOptions { UsageBasePath = Path.Combine(_tempDir, "skill-usage") });
+        var profileOptions = Options.Create(new AgentProfileOptions { BasePath = _tempDir });
+        var store = new FileSkillUsageStore(skillOptions, profileOptions, NullLogger<FileSkillUsageStore>.Instance);
+
+        // A single, continuously-written session — age (fresh mtime) and count (only
+        // file) never reap it; only the per-file line trim bounds it.
+        for (var i = 0; i < 30; i++)
+            await store.AppendAsync(new SkillInvocationEvent(
+                Id: i.ToString(), SkillName: "x", SessionId: "blazor-session", Timestamp: DateTimeOffset.UtcNow));
+
+        var removed = await store.PruneAsync(new LogRetentionPolicy(
+            MaxFileAge: TimeSpan.FromDays(30), MaxFilesPerDirectory: 1000, MaxLinesPerFile: 10));
+
+        Assert.AreEqual(20, removed);
+        Assert.AreEqual(10, (await store.GetBySessionAsync("blazor-session")).Count);
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────

--- a/tests/RockBot.Host.Tests/JsonlLogRetentionTests.cs
+++ b/tests/RockBot.Host.Tests/JsonlLogRetentionTests.cs
@@ -1,0 +1,222 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace RockBot.Host.Tests;
+
+[TestClass]
+public class JsonlLogRetentionTests
+{
+    private string _tempDir = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "rockbot-retention-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    // ── TrimToLastLinesAsync ──────────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task Trim_KeepsLastLines_AndReturnsRemovedCount()
+    {
+        var path = Path.Combine(_tempDir, "global.jsonl");
+        var lines = Enumerable.Range(0, 100).Select(i => $"{{\"n\":{i}}}").ToArray();
+        await File.WriteAllLinesAsync(path, lines);
+
+        var removed = await JsonlLogRetention.TrimToLastLinesAsync(path, maxLines: 10, NullLogger.Instance);
+
+        Assert.AreEqual(90, removed);
+        var kept = await File.ReadAllLinesAsync(path);
+        Assert.AreEqual(10, kept.Length);
+        Assert.AreEqual("{\"n\":90}", kept[0]);
+        Assert.AreEqual("{\"n\":99}", kept[^1]);
+    }
+
+    [TestMethod]
+    public async Task Trim_UnderBudget_IsNoOp()
+    {
+        var path = Path.Combine(_tempDir, "global.jsonl");
+        var lines = Enumerable.Range(0, 5).Select(i => $"line-{i}").ToArray();
+        await File.WriteAllLinesAsync(path, lines);
+
+        var removed = await JsonlLogRetention.TrimToLastLinesAsync(path, maxLines: 10, NullLogger.Instance);
+
+        Assert.AreEqual(0, removed);
+        Assert.AreEqual(5, (await File.ReadAllLinesAsync(path)).Length);
+    }
+
+    [TestMethod]
+    public async Task Trim_NonPositiveMaxLines_IsNoOp()
+    {
+        var path = Path.Combine(_tempDir, "global.jsonl");
+        await File.WriteAllLinesAsync(path, new[] { "a", "b", "c" });
+
+        var removed = await JsonlLogRetention.TrimToLastLinesAsync(path, maxLines: 0, NullLogger.Instance);
+
+        Assert.AreEqual(0, removed);
+        Assert.AreEqual(3, (await File.ReadAllLinesAsync(path)).Length);
+    }
+
+    [TestMethod]
+    public async Task Trim_MissingFile_ReturnsZero()
+    {
+        var path = Path.Combine(_tempDir, "does-not-exist.jsonl");
+        var removed = await JsonlLogRetention.TrimToLastLinesAsync(path, maxLines: 10, NullLogger.Instance);
+        Assert.AreEqual(0, removed);
+    }
+
+    [TestMethod]
+    public async Task Trim_LeavesNoTempFileBehind()
+    {
+        var path = Path.Combine(_tempDir, "global.jsonl");
+        await File.WriteAllLinesAsync(path, Enumerable.Range(0, 50).Select(i => i.ToString()).ToArray());
+
+        await JsonlLogRetention.TrimToLastLinesAsync(path, maxLines: 5, NullLogger.Instance);
+
+        Assert.IsFalse(File.Exists(path + ".tmp"));
+    }
+
+    // ── PruneAgedFilesAsync ───────────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task Prune_DeletesFilesOlderThanMaxAge()
+    {
+        var dir = Path.Combine(_tempDir, "sessions");
+        Directory.CreateDirectory(dir);
+
+        var oldFile = WriteSessionFile(dir, "old", ageDays: 40);
+        var freshFile = WriteSessionFile(dir, "fresh", ageDays: 1);
+
+        var deleted = await JsonlLogRetention.PruneAgedFilesAsync(
+            dir, maxAge: TimeSpan.FromDays(30), maxFiles: 0, "*.jsonl", NullLogger.Instance);
+
+        Assert.AreEqual(1, deleted);
+        Assert.IsFalse(File.Exists(oldFile));
+        Assert.IsTrue(File.Exists(freshFile));
+    }
+
+    [TestMethod]
+    public async Task Prune_CapsFileCount_KeepingNewest()
+    {
+        var dir = Path.Combine(_tempDir, "sessions");
+        Directory.CreateDirectory(dir);
+
+        // Five files, all within the age window, distinct ages so ordering is deterministic.
+        var paths = new List<(string path, int age)>();
+        for (var i = 0; i < 5; i++)
+            paths.Add((WriteSessionFile(dir, $"s{i}", ageDays: i), i));
+
+        var deleted = await JsonlLogRetention.PruneAgedFilesAsync(
+            dir, maxAge: TimeSpan.Zero, maxFiles: 2, "*.jsonl", NullLogger.Instance);
+
+        Assert.AreEqual(3, deleted);
+        // The two most recently written (smallest age) survive.
+        Assert.IsTrue(File.Exists(paths[0].path));
+        Assert.IsTrue(File.Exists(paths[1].path));
+        Assert.IsFalse(File.Exists(paths[4].path));
+    }
+
+    [TestMethod]
+    public async Task Prune_AgeThenCount_Combined()
+    {
+        var dir = Path.Combine(_tempDir, "sessions");
+        Directory.CreateDirectory(dir);
+
+        WriteSessionFile(dir, "ancient", ageDays: 100);
+        var keep1 = WriteSessionFile(dir, "k1", ageDays: 1);
+        var keep2 = WriteSessionFile(dir, "k2", ageDays: 2);
+        var dropByCount = WriteSessionFile(dir, "k3", ageDays: 3);
+
+        // Age prunes "ancient"; then count cap of 2 drops the oldest survivor.
+        var deleted = await JsonlLogRetention.PruneAgedFilesAsync(
+            dir, maxAge: TimeSpan.FromDays(30), maxFiles: 2, "*.jsonl", NullLogger.Instance);
+
+        Assert.AreEqual(2, deleted);
+        Assert.IsTrue(File.Exists(keep1));
+        Assert.IsTrue(File.Exists(keep2));
+        Assert.IsFalse(File.Exists(dropByCount));
+    }
+
+    [TestMethod]
+    public async Task Prune_DisabledDimensions_NoOp()
+    {
+        var dir = Path.Combine(_tempDir, "sessions");
+        Directory.CreateDirectory(dir);
+        WriteSessionFile(dir, "old", ageDays: 100);
+        WriteSessionFile(dir, "new", ageDays: 1);
+
+        var deleted = await JsonlLogRetention.PruneAgedFilesAsync(
+            dir, maxAge: TimeSpan.Zero, maxFiles: 0, "*.jsonl", NullLogger.Instance);
+
+        Assert.AreEqual(0, deleted);
+        Assert.AreEqual(2, Directory.GetFiles(dir, "*.jsonl").Length);
+    }
+
+    [TestMethod]
+    public async Task Prune_MissingDirectory_ReturnsZero()
+    {
+        var deleted = await JsonlLogRetention.PruneAgedFilesAsync(
+            Path.Combine(_tempDir, "nope"), TimeSpan.FromDays(1), 1, "*.jsonl", NullLogger.Instance);
+        Assert.AreEqual(0, deleted);
+    }
+
+    // ── Store integration ─────────────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task PerSessionStore_PruneAsync_DropsAgedSessionFiles()
+    {
+        var skillOptions = Options.Create(new SkillOptions { UsageBasePath = Path.Combine(_tempDir, "skill-usage") });
+        var profileOptions = Options.Create(new AgentProfileOptions { BasePath = _tempDir });
+        var store = new FileSkillUsageStore(skillOptions, profileOptions, NullLogger<FileSkillUsageStore>.Instance);
+
+        await store.AppendAsync(new SkillInvocationEvent(
+            Id: "a", SkillName: "x", SessionId: "stale", Timestamp: DateTimeOffset.UtcNow));
+        await store.AppendAsync(new SkillInvocationEvent(
+            Id: "b", SkillName: "y", SessionId: "fresh", Timestamp: DateTimeOffset.UtcNow));
+
+        var dir = Path.Combine(_tempDir, "skill-usage");
+        File.SetLastWriteTimeUtc(Path.Combine(dir, "stale.jsonl"), DateTime.UtcNow.AddDays(-40));
+
+        var removed = await store.PruneAsync(new LogRetentionPolicy(
+            MaxFileAge: TimeSpan.FromDays(30), MaxFilesPerDirectory: 0, MaxLinesPerFile: 0));
+
+        Assert.AreEqual(1, removed);
+        Assert.AreEqual(0, (await store.GetBySessionAsync("stale")).Count);
+        Assert.AreEqual(1, (await store.GetBySessionAsync("fresh")).Count);
+    }
+
+    [TestMethod]
+    public async Task SingleFileStore_PruneAsync_TrimsToLineBudget()
+    {
+        var profileOptions = Options.Create(new AgentProfileOptions { BasePath = _tempDir });
+        var store = new FileSkillResourceUsageStore(profileOptions, NullLogger<FileSkillResourceUsageStore>.Instance);
+
+        for (var i = 0; i < 25; i++)
+            await store.RecordCheckoutAsync("skill", $"file-{i}.txt", "session", DateTimeOffset.UtcNow);
+
+        var removed = await store.PruneAsync(new LogRetentionPolicy(
+            MaxFileAge: TimeSpan.Zero, MaxFilesPerDirectory: 0, MaxLinesPerFile: 10));
+
+        Assert.AreEqual(15, removed);
+        var path = Path.Combine(_tempDir, "skill-resource-usage.jsonl");
+        Assert.AreEqual(10, (await File.ReadAllLinesAsync(path)).Length);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static string WriteSessionFile(string dir, string name, int ageDays)
+    {
+        var path = Path.Combine(dir, $"{name}.jsonl");
+        File.WriteAllText(path, "{\"x\":1}" + Environment.NewLine);
+        File.SetLastWriteTimeUtc(path, DateTime.UtcNow.AddDays(-ageDays));
+        return path;
+    }
+}


### PR DESCRIPTION
## Why

Two related failures let `rockbot-agent` consume unbounded resources with nothing stopping it.

### 1. Non-terminating tool-result trim loop (the 2026-06-05 incident) — new in this PR

**Symptom (from the on-call investigation):** the agent pod pegged at ~2 cores with **407,597 identical "Trimmed tool result … (head 120, tail 80)" log lines in a 5-minute window**, re-processing the same ~5 call IDs forever. Every MCP session starved (todo was just the one the user noticed); the downstream MCP services were provably healthy. 0 restarts, 42h uptime → in-memory wedge. `kubectl delete pod` cleared it, but that's a band-aid.

**Root cause:** `TrimLargeToolResultsAsync` looped on `while(true)` until the estimated context fit the char budget, always re-trimming the single largest tool result. When the **non-tool** content alone (system prompt + injected skill bodies + the stash registry) already exceeded the budget, *and* every tool result was already at the ~200-char elision floor — where re-adding the elision marker keeps a result the same size or **larger** — the total never dropped below budget and the loop spun forever. (`head 120 / tail 80` is exactly the 200-char floor at the default `0.6` head ratio — the fingerprint of a loop stuck on floor-sized results.)

**Fix:** three independent termination guarantees —
1. stop when the budget is met (unchanged);
2. **stop when the largest tool result can no longer shrink** — since we always pick the largest, nothing smaller can reach the budget either;
3. a hard pass cap as defence-in-depth.

Also clamps the legacy slice length so the 200-char floor can't index past a short result and throw.

**De-duplication (requested in review):** the trim loop existed as two byte-identical copies — the native `RockBotFunctionInvokingChatClient` path and the text-based `AgentLoopRunner` path — that had already drifted. Both are now thin forwarders to a single canonical `ToolResultTrimmer.TrimAsync`, so this class of bug can't be half-fixed again.

### 2. Append-only JSONL log growth — earlier commits on this branch

A shared dream-driven retention pass caps the append-only JSONL logs, wired to k8s config, plus line-trimming of persistent session files.

## Tests

- Two new `[Timeout]` regression tests reproduce the wedge (huge non-tool content + a tiny budget) and **hang on the old loop, pass on the new one**.
- All `AgentLoopRunnerTrimStashTests` pass (11/11), confirming the head+tail+stash behaviour is unchanged for the normal trim path.

## Follow-ups (not in this PR)

The investigation surfaced adjacent gaps worth separate work: `spawn_wisps` results embed fresh GUIDs, so `RepetitiveToolCallDetector` (keyed on tool+args+result) never fires for wisp dispatch; there's no cross-loop/cross-session circuit breaker on wisp volume; and `FileWispExecutionLog.ReadAllAsync` re-parses the entire JSONL on every successful wisp (O(n²) under load).

🤖 Generated with [Claude Code](https://claude.com/claude-code)