### PR TITLE
Fix: populate token/model fields in native-path routing log entries

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.12.28</Version>
+<Version>0.12.29</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.12.27</Version>
+<Version>0.12.28</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.Agent/UserMessageHandler.cs
+++ b/src/RockBot.Agent/UserMessageHandler.cs
@@ -425,10 +425,12 @@ internal sealed class UserMessageHandler(
             });
 
             var lastProgressAt = DateTimeOffset.UtcNow;
+            var nativeDiag = new LoopDiagnostics();
 
             var text = await agentLoopRunner.RunAsync(
                 chatMessages, chatOptions, sessionId, tier: classification.Tier,
                 complexityScore: classification.ComplexityScore,
+                diagnostics: nativeDiag,
                 onPreToolCall: async (desc, ct2) =>
                 {
                     await PublishReplyAsync($"Working on it — checking {desc}…", replyTo, correlationId, sessionId, isFinal: false, ct2);
@@ -470,7 +472,10 @@ internal sealed class UserMessageHandler(
                 MatchedHighKeywords = classification.MatchedHighKeywords,
                 MatchedLowKeywords = classification.MatchedLowKeywords,
                 PostInjectionTokenEstimate = postInjectionTokenEstimate,
-                ModelId = registry.GetModelId(classification.Tier),
+                ModelId = nativeDiag.ModelId ?? registry.GetModelId(classification.Tier),
+                InputTokens = nativeDiag.InputTokens > 0 ? nativeDiag.InputTokens : null,
+                OutputTokens = nativeDiag.OutputTokens > 0 ? nativeDiag.OutputTokens : null,
+                ToolCallCount = nativeDiag.ToolCalls > 0 ? nativeDiag.ToolCalls : null,
             });
 
             text = ResponseSanitizer.StripTrailingOffers(text);

--- a/src/RockBot.Host/AgentLoopRunner.cs
+++ b/src/RockBot.Host/AgentLoopRunner.cs
@@ -707,10 +707,13 @@ public sealed partial class AgentLoopRunner(
         }
 
         var nativeFinalText = ExtractAssistantText(response);
-        if (LoopDiagnosticsContext.Value is { } diagNative
-            && !string.IsNullOrWhiteSpace(nativeFinalText))
+        if (LoopDiagnosticsContext.Value is { } diagNative)
         {
-            diagNative.LastAssistantText = nativeFinalText;
+            if (!string.IsNullOrWhiteSpace(nativeFinalText))
+                diagNative.LastAssistantText = nativeFinalText;
+            diagNative.InputTokens = nativeInputTokens;
+            diagNative.OutputTokens = nativeOutputTokens;
+            diagNative.ModelId = response.ModelId;
         }
 
         return new LoopResult(nativeFinalText, LoopExitReason.ModelStopped);
@@ -894,6 +897,7 @@ public sealed partial class AgentLoopRunner(
         long totalOutputTokens = firstResponse?.Usage?.OutputTokenCount ?? 0;
         long totalToolCalls = 0;
         var tierTag = new KeyValuePair<string, object?>("rockbot.llm.tier", tier.ToString());
+        string? lastModelId = firstResponse?.ModelId;
 
         ChatResponse? pendingResponse = firstResponse;
         var anyToolCalled = false;
@@ -984,6 +988,7 @@ public sealed partial class AgentLoopRunner(
 
                 totalInputTokens += response.Usage?.InputTokenCount ?? 0;
                 totalOutputTokens += response.Usage?.OutputTokenCount ?? 0;
+                lastModelId = response.ModelId ?? lastModelId;
             }
 
             LogResponseMessages(response, iterationLabel: (iteration + 2).ToString());
@@ -1441,6 +1446,12 @@ public sealed partial class AgentLoopRunner(
             HostDiagnostics.TurnTokensInput.Record(totalInputTokens, tierTag);
             HostDiagnostics.TurnTokensOutput.Record(totalOutputTokens, tierTag);
             HostDiagnostics.TurnToolCalls.Record(totalToolCalls, tierTag);
+            if (LoopDiagnosticsContext.Value is { } diagTextFinal)
+            {
+                diagTextFinal.InputTokens = totalInputTokens;
+                diagTextFinal.OutputTokens = totalOutputTokens;
+                diagTextFinal.ModelId ??= lastModelId;
+            }
         }
     }
 

--- a/src/RockBot.Host/LoopDiagnostics.cs
+++ b/src/RockBot.Host/LoopDiagnostics.cs
@@ -36,4 +36,15 @@ public sealed class LoopDiagnostics
 
     /// <summary>When the most recently invoked tool completed; null if it never returned.</summary>
     public DateTimeOffset? LastToolCompletedAt { get; set; }
+
+    // ── Token usage (populated by AgentLoopRunner after the loop completes) ──
+
+    /// <summary>Total input tokens consumed across all loop iterations.</summary>
+    public long InputTokens { get; set; }
+
+    /// <summary>Total output tokens produced across all loop iterations.</summary>
+    public long OutputTokens { get; set; }
+
+    /// <summary>Model ID reported by the LLM for this loop run (last seen value when multiple responses occur).</summary>
+    public string? ModelId { get; set; }
 }


### PR DESCRIPTION
## Problem

The agent's daily cost guard reported \.00 cost — nothing was being priced, despite a populated pricing table.

**Root cause:** The native LLM path (`NativeToolLoopAsync` in `UserMessageHandler`) wrote `TierRoutingEntry` records with `ModelId` set but `InputTokens`/`OutputTokens` left null. `TierRoutingAnalyzer.BuildProjectedCost` skips any entry with null tokens, so every entry was unpriced → total cost collapsed to \.00.

## Fix

- Add `InputTokens`, `OutputTokens`, `ModelId` to `LoopDiagnostics` so the loop runner can surface token data to callers without changing `RunAsync`'s `Task<string>` return type.
- `RunNativeLoopAsync` populates those fields from the FICC response.
- `RunTextBasedLoopAsync` tracks `lastModelId` across iterations and populates the fields in its `finally` block alongside existing OTel recording.
- `NativeToolLoopAsync` passes a `LoopDiagnostics` to `RunAsync` and uses `diag.InputTokens` / `OutputTokens` / `ToolCalls` / `ModelId` when writing the routing entry (falls back to `registry.GetModelId` when the response carries no model ID).

## Validation

- All 1057 `RockBot.Host.Tests` pass.
- Deployed `rockbot-agent:0.12.29` to the cluster; new routing-log entries now carry token + model fields and cost attribution is non-zero.

Version bumped 0.12.27 → 0.12.29.