### PR TITLE
Fix non-terminating stash retrieve loop on explicit working-memory reads

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.12.29</Version>
+<Version>0.12.30</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.Host/AgentLoopRunner.cs
+++ b/src/RockBot.Host/AgentLoopRunner.cs
@@ -1664,6 +1664,14 @@ public sealed partial class AgentLoopRunner(
         if (maxChars <= 0 || resultStr.Length <= maxChars)
             return resultStr;
 
+        // Explicit working-memory retrievals (GetFromWorkingMemory and friends) must never
+        // be re-capped/re-stashed: doing so parks the retrieved content under the retrieval
+        // call's *new* id and tells the model to fetch that, producing a non-terminating
+        // retrieve→re-stash→retrieve loop. The agent asked for this content by name, so hand
+        // it back in full. See StashExemptTools.
+        if (StashExemptTools.Contains(toolName))
+            return resultStr;
+
         // No callId or no stash state → head-only truncation. The model can't recover
         // the elided content (nothing to register), so we don't promise it can.
         if (string.IsNullOrEmpty(callId) || stashState is null)

--- a/src/RockBot.Host/ChunkingAIFunction.cs
+++ b/src/RockBot.Host/ChunkingAIFunction.cs
@@ -27,13 +27,6 @@ public sealed class ChunkingAIFunction(
     private readonly int _chunkMaxLength = Math.Max(chunkingThreshold, 20_000);
     private static readonly TimeSpan ToolResultChunkTtl = TimeSpan.FromMinutes(20);
 
-    private static readonly HashSet<string> ChunkingExemptTools = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "GetFromWorkingMemory",
-        "SearchWorkingMemory",
-        "ListWorkingMemory",
-    };
-
     public override string Name => inner.Name;
     public override string Description => inner.Description;
     public override JsonElement JsonSchema => inner.JsonSchema;
@@ -45,7 +38,7 @@ public sealed class ChunkingAIFunction(
         var result = await inner.InvokeAsync(arguments, cancellationToken);
         var resultStr = result?.ToString() ?? string.Empty;
 
-        if (ChunkingExemptTools.Contains(inner.Name))
+        if (StashExemptTools.Contains(inner.Name))
             return result;
 
         if (resultStr.Length <= chunkingThreshold)

--- a/src/RockBot.Host/StashExemptTools.cs
+++ b/src/RockBot.Host/StashExemptTools.cs
@@ -1,0 +1,37 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Working-memory read tools whose results are <i>explicit</i> retrievals of content the
+/// agent already chose to load (or enumerate). Their results must never be re-chunked,
+/// re-capped, or re-stashed.
+///
+/// <para><b>Why.</b> The chunk/cap/stash machinery replaces an oversized tool result with
+/// a head + elision marker + tail surface and parks the full original in working memory
+/// under a key derived from the <i>call id</i>, telling the model to fetch it via
+/// <c>GetFromWorkingMemory</c>. If that retrieval result is itself oversized and gets
+/// re-stashed, it lands under the retrieval call's <i>new</i> id — so the model, dutifully
+/// fetching the newly-advertised key, retrieves a slightly larger reference, which is
+/// re-stashed under yet another id, and so on. The result is a retrieve→re-stash→retrieve
+/// loop that makes no progress until the surrounding iteration/timeout budget kills it.
+/// (Observed 2026-06-10: a communications-briefing subagent burned its full 15-minute
+/// budget in exactly this loop after pulling a ~15k-char multi-account email payload.)</para>
+///
+/// <para>Exempting these tools means an explicit retrieval is honoured in full and left
+/// alone — matching the long-standing chunking exemption these same tools already had.</para>
+/// </summary>
+internal static class StashExemptTools
+{
+    private static readonly HashSet<string> Names = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "GetFromWorkingMemory",
+        "SearchWorkingMemory",
+        "ListWorkingMemory",
+    };
+
+    /// <summary>
+    /// True when <paramref name="toolName"/> is an explicit working-memory read whose
+    /// result must not be re-chunked, re-capped, or re-stashed.
+    /// </summary>
+    public static bool Contains(string? toolName) =>
+        !string.IsNullOrEmpty(toolName) && Names.Contains(toolName);
+}

--- a/src/RockBot.Host/ToolResultTrimmer.cs
+++ b/src/RockBot.Host/ToolResultTrimmer.cs
@@ -74,7 +74,13 @@ internal static class ToolResultTrimmer
                     if (messages[i].Contents[j] is FunctionResultContent frc)
                     {
                         var len = frc.Result?.ToString()?.Length ?? 0;
-                        if (len > bestLen) { bestMsg = i; bestContent = j; bestLen = len; }
+                        if (len <= bestLen) continue;
+                        // Never re-stash an explicit working-memory retrieval — re-stashing
+                        // mints a fresh key on every pass and loops the model forever
+                        // re-fetching its own growing reference. See StashExemptTools.
+                        if (StashExemptTools.Contains(ExtractToolNameForCallId(messages, frc.CallId)))
+                            continue;
+                        bestMsg = i; bestContent = j; bestLen = len;
                     }
                 }
             }

--- a/tests/RockBot.Host.Tests/AgentLoopRunnerTrimStashTests.cs
+++ b/tests/RockBot.Host.Tests/AgentLoopRunnerTrimStashTests.cs
@@ -267,6 +267,112 @@ public class AgentLoopRunnerTrimStashTests
         Assert.AreEqual(s, AgentLoopRunner.TruncateArgsSummary(s));
     }
 
+    [TestMethod]
+    [Timeout(10_000)]
+    public async Task Trim_OversizeRetrievalResult_IsNotReStashedAndDoesNotSpin()
+    {
+        // Regression for the 2026-06-10 communications-briefing runaway: an explicit
+        // GetFromWorkingMemory retrieval returned an oversized result, which the trim
+        // re-stashed under the *retrieval* call's id and advertised back to the model.
+        // The model re-fetched the new key, got a larger reference, which was re-stashed
+        // again — a retrieve→re-stash→retrieve loop that burned the whole subagent budget.
+        // Explicit working-memory reads must be left intact.
+        var wm = new TestWorkingMemory();
+        var runner = NewRunner(wm);
+        var stashState = new AgentLoopStashContext.State { SessionId = "sess-1" };
+
+        var bigRetrieval = new string('R', 4000);
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.System, "system prompt"),
+            new(ChatRole.User, "do the thing"),
+            BuildAssistantWithCall("GetFromWorkingMemory", "call-1"),
+            new(ChatRole.Tool, [new FunctionResultContent("call-1", bigRetrieval)]),
+        };
+
+        await runner.TrimLargeToolResultsAsync(messages, maxTokens: 200, "sess-1", stashState);
+
+        var frc = (FunctionResultContent)messages[3].Contents[0];
+        Assert.AreEqual(bigRetrieval, frc.Result?.ToString(),
+            "An explicit GetFromWorkingMemory retrieval must be left intact, not head+tail trimmed.");
+        Assert.IsTrue(stashState.Registry.IsEmpty,
+            "A retrieval result must never be re-stashed (that mints a fresh key and loops the model).");
+        Assert.AreEqual(0, wm.WriteCount, "Nothing should be written to working memory for a retrieval result.");
+    }
+
+    [TestMethod]
+    [Timeout(10_000)]
+    public async Task Trim_RetrievalAndNormalResult_TrimsNormalAndSkipsRetrieval()
+    {
+        // When both an exempt retrieval and a normal oversized result are over budget,
+        // the trim must skip the retrieval and reclaim space from the normal result.
+        var wm = new TestWorkingMemory();
+        var runner = NewRunner(wm);
+        var stashState = new AgentLoopStashContext.State { SessionId = "sess-1" };
+
+        var bigRetrieval = new string('R', 4000);
+        var biggerNormal = new string('N', 5000) + "NORMAL-TAIL";
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.System, "system prompt"),
+            new(ChatRole.User, "do the thing"),
+            BuildAssistantWithCall("GetFromWorkingMemory", "call-ret"),
+            new(ChatRole.Tool, [new FunctionResultContent("call-ret", bigRetrieval)]),
+            BuildAssistantWithCall("fetch_url", "call-norm"),
+            new(ChatRole.Tool, [new FunctionResultContent("call-norm", biggerNormal)]),
+        };
+
+        await runner.TrimLargeToolResultsAsync(messages, maxTokens: 200, "sess-1", stashState);
+
+        var retrieval = (FunctionResultContent)messages[3].Contents[0];
+        Assert.AreEqual(bigRetrieval, retrieval.Result?.ToString(),
+            "The retrieval result must be untouched.");
+
+        var normal = (FunctionResultContent)messages[5].Contents[0];
+        StringAssert.Contains(normal.Result?.ToString() ?? string.Empty, ElisionMarkerPrefix,
+            "The normal result must be head+tail trimmed to reclaim space.");
+
+        Assert.AreEqual(1, stashState.Registry.Snapshot().Count,
+            "Only the normal result should be stashed.");
+        Assert.AreEqual("call-norm", stashState.Registry.Snapshot()[0].CallId);
+    }
+
+    [TestMethod]
+    public async Task CapToolResult_RetrievalTool_ReturnsUnchangedWithoutStashing()
+    {
+        var wm = new TestWorkingMemory();
+        var stashState = new AgentLoopStashContext.State { SessionId = "sess-1" };
+        var big = new string('R', 4000);
+
+        var capped = await AgentLoopRunner.CapToolResultAsync(
+            big, callId: "call-1", toolName: "GetFromWorkingMemory",
+            workingMemory: wm, stashState: stashState,
+            maxChars: 1000, headRatio: 0.6, ttl: TimeSpan.FromMinutes(60),
+            logger: NullLogger<AgentLoopRunner>.Instance);
+
+        Assert.AreEqual(big, capped, "An explicit retrieval must be returned in full, not capped.");
+        Assert.IsTrue(stashState.Registry.IsEmpty, "A retrieval result must not be stashed.");
+        Assert.AreEqual(0, wm.WriteCount, "A retrieval result must not be written back to working memory.");
+    }
+
+    [TestMethod]
+    public async Task CapToolResult_NormalTool_CapsAndStashes()
+    {
+        var wm = new TestWorkingMemory();
+        var stashState = new AgentLoopStashContext.State { SessionId = "sess-1" };
+        var big = new string('N', 4000);
+
+        var capped = await AgentLoopRunner.CapToolResultAsync(
+            big, callId: "call-1", toolName: "fetch_url",
+            workingMemory: wm, stashState: stashState,
+            maxChars: 1000, headRatio: 0.6, ttl: TimeSpan.FromMinutes(60),
+            logger: NullLogger<AgentLoopRunner>.Instance);
+
+        Assert.IsTrue(capped.Length < big.Length, "A normal oversized result must be capped.");
+        StringAssert.Contains(capped, ElisionMarkerPrefix);
+        Assert.AreEqual(1, stashState.Registry.Snapshot().Count, "A normal capped result must be stashed.");
+    }
+
     // ── Helpers ──────────────────────────────────────────────────────────────
 
     private static AgentLoopRunner NewRunner(IWorkingMemory workingMemory)


### PR DESCRIPTION
## Problem

The 2026-06-10 10am communications briefing cron job spent 15 minutes and timed out. Investigation of the live k8s cluster showed **calendar-mcp was healthy and fast** (yesterday's IMAP fix #69 / image `1.4.1` works — email/calendar calls complete in 1–6s). The timeout was a **non-terminating stash retrieve loop** in the agent host.

When a tool result is too large, the host trims it (head + elision marker + tail) and stashes the full original in working memory under `stash/{session}/{callId}`, telling the model to fetch it via `GetFromWorkingMemory`. But the retrieval result was *itself* oversized, so the per-call cap (`CapToolResultAsync`) and watermark trimmer (`ToolResultTrimmer`) re-stashed it under the **retrieval call's new id** and advertised that key back. The model fetched it, got a larger reference, which was re-stashed again — looping ~35s/iteration until the budget killed it:

```
GetFromWorkingMemory(stash/.../call_iz7u7s2) -> big -> re-stashed as call_V5QImO2
GetFromWorkingMemory(stash/.../call_V5QImO2) -> big -> re-stashed as call_Qm6TZL
GetFromWorkingMemory(stash/.../call_Qm6TZL)  -> ... (until 15-min timeout)
```

The earlier `llm-high-tier-cost-guard` subagent hit the identical loop.

## Fix

`ChunkingAIFunction` already exempted the working-memory read tools (`GetFromWorkingMemory`/`SearchWorkingMemory`/`ListWorkingMemory`) from re-chunking for exactly this reason. This PR centralizes that exemption in a shared `StashExemptTools` set and honors it in **all three** paths:

- **`StashExemptTools`** (new) — single source of truth.
- **`ChunkingAIFunction`** — uses the shared set (removed private duplicate).
- **`CapToolResultAsync`** — returns explicit-retrieval results unchanged.
- **`ToolResultTrimmer.TrimAsync`** — skips exempt results when picking the largest result to trim.

An explicit retrieval is now always returned in full and never re-stashed.

## Tests

Added 4 regression tests (with `[Timeout]` guards mirroring the real loop). `RockBot.Host.Tests`: **1061 passed, 0 failed**.

## Deployment

Version bumped `0.12.29 -> 0.12.30`. Image `rockylhotka/rockbot-agent:0.12.30` built, pushed, and deployed to the live `rockbot` namespace via `kubectl set image` for testing; calendar-mcp confirms `Client (RockBot.Agent 0.12.30.0)` is live.
