### PR TITLE
Pass Scripts__Container__FsGroup to the scripts manager

### DIFF
--- a/deploy/helm/rockbot/templates/manager/deployment.yaml
+++ b/deploy/helm/rockbot/templates/manager/deployment.yaml
@@ -82,6 +82,11 @@ spec:
                 configMapKeyRef:
                   name: {{ include "rockbot.configmapName" . }}
                   key: Scripts__Container__SharedVolumePath
+            - name: Scripts__Container__FsGroup
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "rockbot.configmapName" . }}
+                  key: Scripts__Container__FsGroup
             - name: DOTNET_ENVIRONMENT
               value: "Production"
           resources:


### PR DESCRIPTION
## Problem

Ephemeral script pods spawned by the scripts manager hit `permission denied` writing inside existing directories on the `rockbot-shared` PVC (seen during the 2026-06-11 10 AM communications check, when a subagent tried to create scratch dirs under `/rockbot/shared/attachments` and `/rockbot/shared/tmp`).

## Root cause

`templates/configmap.yaml` defines `Scripts__Container__FsGroup` (from `shared.fsGroup`, 2000) and `ContainerScriptHandler.BuildPodSpec` applies it as the pod-level `fsGroup` — but the manager deployment template never injected the configmap key as an env var. `ContainerScriptOptions.FsGroup` stayed null, so script pods ran as UID 1000 with no group 2000 membership:

- Writes inside setgid group-2000 dirs failed with permission denied.
- New top-level dirs they created on the PVC came out `ubuntu:root` (e.g. `teams-cache/`, `xebia-teams-cache/`), which other pods can't clean up.

## Fix

Add the missing `Scripts__Container__FsGroup` env entry to the manager deployment, mirroring the other `Scripts__Container__*` keys. Verified with `helm template` that the rendered deployment now carries the env var.

Helm-only change — no image rebuild required; the manager binary already reads the option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)