### PR TITLE
Gate High tier on genuine complexity, not verbosity (#471)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.12.31</Version>
+<Version>0.12.32</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.Llm/KeywordTierSelector.cs
+++ b/src/RockBot.Llm/KeywordTierSelector.cs
@@ -82,8 +82,15 @@ public sealed class KeywordTierSelector : ILlmTierSelector
         @"```|`[^`]+`|\bfunction\b|\bclass\b|\bdef\b|\bvoid\b|\bint\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
+    // Arithmetic detection deliberately treats '-' differently from the other
+    // operators: a bare hyphen between digits is almost always a *range*, not
+    // subtraction — clock times ("7:00-10:00"), ISO dates ("2025-01-01"), and
+    // numeric ranges ("7-10") would otherwise score as "math" and inflate the
+    // structural component of verbose-but-simple prompts. So '+', '*', '/', '^',
+    // '=' match with optional surrounding space, but '-' only counts when it is
+    // whitespace-flanked ("5 - 3"), which is how genuine subtraction is written.
     private static readonly Regex MathRegex = new(
-        @"\d+\s*[\+\-\*\/\^=]\s*\d+|∑|∫|√|≤|≥|∈|∀|∃|\bequation\b|\bformula\b|\bprove\b|\bderive\b",
+        @"\d+\s*[\+\*\/\^=]\s*\d+|\d+\s+-\s+\d+|∑|∫|√|≤|≥|∈|∀|∃|\bequation\b|\bformula\b|\bprove\b|\bderive\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     private static readonly Regex MultiStepRegex = new(
@@ -146,7 +153,14 @@ public sealed class KeywordTierSelector : ILlmTierSelector
             .Where(k => ContainsWholePhrase(lower, k))
             .ToArray();
 
-        var score = ComputeScore(promptText, config, matchedHigh.Length, matchedLow.Length);
+        // Structural signals computed once here so the high-tier gate below can
+        // reuse them without a second regex pass.
+        var hasCode      = CodeBlockRegex.IsMatch(promptText);
+        var hasMath      = MathRegex.IsMatch(promptText);
+        var hasMultiStep = MultiStepRegex.IsMatch(promptText);
+
+        var score = ComputeScore(promptText, matchedHigh.Length, matchedLow.Length,
+            hasCode, hasMath, hasMultiStep);
 
         // Origin bias: user messages get a slight push toward lower tiers.
         // Subagent operational tasks stay neutral since they carry genuine complexity signals.
@@ -157,6 +171,23 @@ public sealed class KeywordTierSelector : ILlmTierSelector
         var tier = score <= config.LowCeiling      ? ModelTier.Low
                  : score <= config.BalancedCeiling ? ModelTier.Balanced
                  :                                   ModelTier.High;
+
+        // High-tier gate: a prompt must show a genuine complexity signal — a
+        // matched high-signal keyword, a code block, or real math — before it can
+        // route High. Length and incidental multi-step phrasing ("then ...") alone
+        // must not escalate past Balanced. This prevents long, well-specified but
+        // cognitively simple operational task descriptions (e.g. PIM/tool-use
+        // subagent briefs: "search email ... then check the calendar ... add the
+        // missing events") from routing High purely on verbosity. The keyword list
+        // is the only real complexity signal we have; absent any hit, Balanced is
+        // the safe ceiling. See issue #471.
+        if (tier == ModelTier.High
+            && matchedHigh.Length == 0
+            && !hasCode
+            && !hasMath)
+        {
+            tier = ModelTier.Balanced;
+        }
 
         // Trivial guard: force Low for objectively simple prompts regardless of
         // dream-tuned thresholds. This prevents threshold drift from absorbing
@@ -264,23 +295,10 @@ public sealed class KeywordTierSelector : ILlmTierSelector
 
     // ── Scoring ───────────────────────────────────────────────────────────────
 
-    private static double ComputeScore(string prompt, EffectiveConfig config,
-        int? complexSignalCount = null, int? simplexSignalCount = null)
+    private static double ComputeScore(string prompt, int complexSignals, int simplexSignals,
+        bool hasCode, bool hasMath, bool hasMultiStep)
     {
-        var wordCount     = CountWords(prompt);
-        var hasCode       = CodeBlockRegex.IsMatch(prompt);
-        var hasMath       = MathRegex.IsMatch(prompt);
-        var hasMultiStep  = MultiStepRegex.IsMatch(prompt);
-
-        // Use pre-computed counts when available (avoids a second scan over the keyword lists)
-        var lower = complexSignalCount is null || simplexSignalCount is null
-            ? prompt.ToLowerInvariant()
-            : string.Empty;
-
-        var complexSignals = complexSignalCount
-            ?? config.HighSignalKeywords.Count(k => ContainsWholePhrase(lower, k));
-        var simplexSignals = simplexSignalCount
-            ?? config.LowSignalKeywords.Count(k => ContainsWholePhrase(lower, k));
+        var wordCount = CountWords(prompt);
 
         // Length component (0 – 0.40): longer prompts tend to be more complex.
         // Fine-grained buckets in the 10-30 word range so concise-but-complex task

--- a/tests/RockBot.Llm.Tests/KeywordTierSelectorTests.cs
+++ b/tests/RockBot.Llm.Tests/KeywordTierSelectorTests.cs
@@ -777,6 +777,89 @@ public class KeywordTierSelectorTests
             "Subagent baseline routing for trivial prompts stays at or below Balanced.");
     }
 
+    // ── Math-regex range false-positive (issue #471) ────────────────────────
+
+    [TestMethod]
+    [DataRow("7:00-10:00", DisplayName = "clock time range")]
+    [DataRow("the show runs 7:00-10:00 PM CT", DisplayName = "time range in a sentence")]
+    [DataRow("2025-01-01", DisplayName = "ISO date")]
+    [DataRow("events on 2026-07-11 and 2026-12-26", DisplayName = "ISO dates in a sentence")]
+    [DataRow("pick a number 7-10", DisplayName = "bare numeric range")]
+    public void Classify_HyphenatedRanges_DoNotCountAsMath(string prompt)
+    {
+        // A hyphen between digits with no surrounding whitespace is a range/date/time,
+        // not subtraction. It must not contribute the math structural bump that would
+        // otherwise inflate the score of verbose operational prompts.
+        var withRange = _selector.Classify(prompt);
+        var withoutRange = _selector.Classify(
+            new string(prompt.Where(c => !char.IsDigit(c) && c != '-' && c != ':').ToArray()));
+
+        Assert.AreEqual(withoutRange.ComplexityScore, withRange.ComplexityScore, 0.0001,
+            $"Hyphenated range \"{prompt}\" must not add a math structural bump");
+    }
+
+    [TestMethod]
+    public void Classify_GenuineSubtraction_StillCountsAsMath()
+    {
+        // Whitespace-flanked subtraction is real arithmetic and should still score
+        // higher than the same prompt with the math removed.
+        var withMath = _selector.Classify("compute the value when 50 - 8 changes");
+        var withoutMath = _selector.Classify("compute the value when the input changes");
+
+        Assert.IsTrue(withMath.ComplexityScore > withoutMath.ComplexityScore,
+            "Whitespace-flanked subtraction should still register as a math signal");
+    }
+
+    // ── High-tier gate: verbosity alone must not reach High (issue #471) ─────
+
+    [TestMethod]
+    public void Classify_LongOperationalBrief_NoComplexityKeywords_RoutesBalancedNotHigh()
+    {
+        // Reproducer modelled on the Red Fletcher patrol subagent brief that timed
+        // out: a long, well-specified PIM/tool-use task with a hyphenated time range
+        // and the word "then", but zero genuine complexity keywords. Previously
+        // scored 0.60 (length 0.40 + math 0.12 + multistep 0.08) → High. With both
+        // fixes it must stay at or below Balanced.
+        const string prompt =
+            "Search all email-capable calendar accounts for Red Fletcher concert " +
+            "announcements and add any missing upcoming shows to Rocky's calendars. " +
+            "A known confirmed show is at Amsterdam Bar and Hall on July 11 from " +
+            "7:00-10:00 PM CT; other dates include July 17, Oct 26, and Dec 26. " +
+            "Search the marimer-work, lhotka.net, rockyl, csla-store, xebia, and " +
+            "rockbotagent accounts for Red Fletcher and Bandsintown messages. " +
+            "Then check the rockyl and lhotka.net calendars for matching events " +
+            "before creating anything, avoid duplicates, use America/Chicago " +
+            "timezone, and read back each event after creating it to verify. " +
+            "Report which events were created or already existed.";
+
+        var result = _selector.Classify(prompt, new TierRoutingContext(Origin: "subagent"));
+
+        Assert.AreEqual(0, result.MatchedHighKeywords.Count,
+            "Test premise: this operational brief contains no high-signal complexity keywords");
+        Assert.IsTrue(result.Tier <= ModelTier.Balanced,
+            $"Verbose operational brief must not route High (got {result.Tier}, score {result.ComplexityScore:F3})");
+    }
+
+    [TestMethod]
+    public void Classify_LongBriefWithComplexityKeyword_StillRoutesHigh()
+    {
+        // The gate must not over-suppress: a long brief that DOES carry a genuine
+        // complexity keyword should still be allowed to reach High.
+        const string prompt =
+            "Analyze and design a comprehensive migration strategy for moving the " +
+            "scheduling subsystem to a distributed architecture. Evaluate the " +
+            "trade-offs between eventual and strong consistency, compare multiple " +
+            "approaches for coordination, and provide a thorough analysis with pros " +
+            "and cons including the security implications of each recommended path.";
+
+        var result = _selector.Classify(prompt);
+
+        Assert.IsTrue(result.MatchedHighKeywords.Count > 0,
+            "Test premise: this brief contains high-signal complexity keywords");
+        Assert.AreEqual(ModelTier.High, result.Tier,
+            "A long brief with genuine complexity keywords should still route High");
+    }
+
     [TestMethod]
     public void ActiveThreadOverride_MatchedHighKeyword_GateBlocksPromotion()
     {


### PR DESCRIPTION
Fixes #471.

## Problem

`KeywordTierSelector` routes long, well-specified but **cognitively simple** operational briefs (PIM / tool-use subagent tasks) to the **High** tier on verbosity plus regex false-positives. High-tier latency then blows subagent wall-clock budgets.

Concrete incident: the `red-fletcher-weekly-check` patrol subagent (`75c12c3dcf36`) spawned at High (`score=0.600`) and **timed out after 599s** mid-task; a recovery subagent (also High) finished it but cost a full retry. The task — email search + calendar dedup/create — needs no High-tier reasoning.

The `0.600` decomposed exactly as:

| Component | Value | Why |
|---|---|---|
| Length | 0.40 (max) | ~260-word brief maxes the length bucket |
| Keywords | 0.00 | zero high-signal complexity keywords matched |
| Structure | 0.20 | math regex false-positive on `7:00-10:00` (+0.12) + multi-step regex on "then" (+0.08) |

`0.40 + 0.20 = 0.60` > `balancedCeiling` (0.5) → High.

## Changes

1. **Math regex** treats `-` as subtraction only when whitespace-flanked (`5 - 3`). Ranges/dates/times written without spaces (`7:00-10:00`, `2025-01-01`, `7-10`) no longer score as math.
2. **High-tier gate**: a prompt may route High only with a genuine complexity signal — a matched high-signal keyword, a code block, or real math. Length + incidental multi-step phrasing alone now caps at Balanced. Mirrors the existing `matchedHigh.Length == 0` gating on the trivial-guard and active-thread-override paths.
3. Simplified `ComputeScore` to take the structural flags as parameters (computed once in `ClassifyCore`, reused by the gate) instead of re-running the regexes.

## Effect

- Reproducer test (modelled on the timed-out brief) drops 0.60 → 0.48 and routes Balanced; the gate keeps it robust even if structural noise pushed it back over the ceiling.
- `LongBriefWithComplexity_StillRoutesHigh` confirms the gate does not over-suppress genuinely complex briefs.

## Tests

New cases in `KeywordTierSelectorTests`:
- `Classify_HyphenatedRanges_DoNotCountAsMath` (5 DataRows: clock/ISO-date/numeric ranges)
- `Classify_GenuineSubtraction_StillCountsAsMath`
- `Classify_LongOperationalBrief_NoComplexityKeywords_RoutesBalancedNotHigh`
- `Classify_LongBriefWithComplexityKeyword_StillRoutesHigh`

Full `RockBot.Llm.Tests` suite green (73 passed).

## Deploy note

This is a **code change**, not a `tier-selector.json` tweak — it needs an agent-image rebuild/redeploy to take effect on the live cluster.

## Tradeoff

A genuinely hard task phrased with none of the listed high-signal keywords (and no code/math) now caps at Balanced instead of High. Acceptable: the selector is entirely keyword-based, so a zero-keyword prompt carries no signal it is hard, and the dream can add keywords to lift specific patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
