### PR TITLE
Persist input/output tokens in routing-log entries (#452)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.12.33</Version>
+<Version>0.12.34</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.Agent/UserMessageHandler.cs
+++ b/src/RockBot.Agent/UserMessageHandler.cs
@@ -244,22 +244,9 @@ internal sealed class UserMessageHandler(
                 // calls that still need to be executed by the manual loop.
                 var (hasToolCalls, ackText) = GetFirstIterationAck(firstResponse, chatOptions);
 
-                // Routing telemetry written here for the text-based path (first iteration complete)
-                _ = tierRoutingLogger.AppendAsync(new TierRoutingEntry
-                {
-                    Timestamp = DateTimeOffset.UtcNow,
-                    PromptPreview = message.Content.Length > 150 ? message.Content[..150] : message.Content,
-                    Tier = tier,
-                    Context = "user-message",
-                    ComplexityScore = classification.ComplexityScore,
-                    MatchedHighKeywords = classification.MatchedHighKeywords,
-                    MatchedLowKeywords = classification.MatchedLowKeywords,
-                    PostInjectionTokenEstimate = postInjectionTokenEstimate,
-                    ModelId = firstResponse.ModelId ?? registry.GetModelId(tier),
-                    InputTokens = firstResponse.Usage?.InputTokenCount,
-                    OutputTokens = firstResponse.Usage?.OutputTokenCount,
-                    LatencyMs = routingSw.ElapsedMilliseconds,
-                });
+                // Routing telemetry is written at a terminal point (BackgroundToolLoopAsync
+                // after the loop, or the single-response branch below) so the entry carries
+                // the multi-iteration aggregate token usage rather than just iteration 1.
 
                 if (hasToolCalls)
                 {
@@ -276,7 +263,7 @@ internal sealed class UserMessageHandler(
                     turnActivityHandedOff = true;
                     context.Items[WipConstants.DeferredKey] = true;
                     _ = BackgroundToolLoopAsync(
-                        chatMessages, chatOptions, firstResponse, tier, classification.ComplexityScore,
+                        chatMessages, chatOptions, firstResponse, classification, postInjectionTokenEstimate,
                         message.SessionId, replyTo, correlationId, sessionHandle.Generation, wipMessageId, turnActivity, sessionCt);
                 }
                 else
@@ -296,7 +283,7 @@ internal sealed class UserMessageHandler(
                         turnActivityHandedOff = true;
                         context.Items[WipConstants.DeferredKey] = true;
                         _ = BackgroundToolLoopAsync(
-                            chatMessages, chatOptions, firstResponse, tier, classification.ComplexityScore,
+                            chatMessages, chatOptions, firstResponse, classification, postInjectionTokenEstimate,
                             message.SessionId, replyTo, correlationId, sessionHandle.Generation, wipMessageId, turnActivity, sessionCt);
                     }
                     else if (modelBehavior.NudgeOnHallucinatedToolCalls
@@ -313,11 +300,29 @@ internal sealed class UserMessageHandler(
                         turnActivityHandedOff = true;
                         context.Items[WipConstants.DeferredKey] = true;
                         _ = BackgroundToolLoopAsync(
-                            chatMessages, chatOptions, firstResponse, tier, classification.ComplexityScore,
+                            chatMessages, chatOptions, firstResponse, classification, postInjectionTokenEstimate,
                             message.SessionId, replyTo, correlationId, sessionHandle.Generation, wipMessageId, turnActivity, sessionCt);
                     }
                     else
                     {
+                        // Single-response text path (no background loop): firstResponse IS
+                        // the complete response, so its usage is the full per-turn aggregate.
+                        _ = tierRoutingLogger.AppendAsync(new TierRoutingEntry
+                        {
+                            Timestamp = DateTimeOffset.UtcNow,
+                            PromptPreview = message.Content.Length > 150 ? message.Content[..150] : message.Content,
+                            Tier = tier,
+                            Context = "user-message",
+                            ComplexityScore = classification.ComplexityScore,
+                            MatchedHighKeywords = classification.MatchedHighKeywords,
+                            MatchedLowKeywords = classification.MatchedLowKeywords,
+                            PostInjectionTokenEstimate = postInjectionTokenEstimate,
+                            ModelId = firstResponse.ModelId ?? registry.GetModelId(tier),
+                            InputTokens = firstResponse.Usage?.InputTokenCount,
+                            OutputTokens = firstResponse.Usage?.OutputTokenCount,
+                            LatencyMs = routingSw.ElapsedMilliseconds,
+                        });
+
                         await conversationMemory.AddTurnAsync(
                             message.SessionId,
                             new ConversationTurn("assistant", text, DateTimeOffset.UtcNow)
@@ -531,8 +536,8 @@ internal sealed class UserMessageHandler(
         List<ChatMessage> chatMessages,
         ChatOptions chatOptions,
         ChatResponse firstResponse,
-        ModelTier tier,
-        double? complexityScore,
+        TierClassification classification,
+        int? postInjectionTokenEstimate,
         string sessionId,
         string replyTo,
         string? correlationId,
@@ -541,8 +546,10 @@ internal sealed class UserMessageHandler(
         System.Diagnostics.Activity? turnActivity,
         CancellationToken ct)
     {
+        var tier = classification.Tier;
         var loopSw = System.Diagnostics.Stopwatch.StartNew();
         var bgTierTag = new KeyValuePair<string, object?>("rockbot.llm.tier", tier.ToString());
+        var bgDiag = new LoopDiagnostics();
 
         // Subscribe to fallback events so the user sees model switches in the UI.
         var fallbackClient = registry.GetClient(tier)
@@ -574,7 +581,8 @@ internal sealed class UserMessageHandler(
 
             var finalContent = await agentLoopRunner.RunAsync(
                 chatMessages, chatOptions, sessionId, firstResponse: firstResponse, tier: tier,
-                complexityScore: complexityScore,
+                complexityScore: classification.ComplexityScore,
+                diagnostics: bgDiag,
                 onPreToolCall: async (desc, ct2) =>
                 {
                     await PublishReplyAsync($"Working on it — checking {desc}…", replyTo, correlationId, sessionId, isFinal: false, ct2);
@@ -600,6 +608,26 @@ internal sealed class UserMessageHandler(
                     lastProgressAt = DateTimeOffset.UtcNow;
                 },
                 cancellationToken: ct);
+
+            // Routing telemetry written here (terminal point) so the entry carries the
+            // multi-iteration aggregate token usage accumulated across the whole loop.
+            _ = tierRoutingLogger.AppendAsync(new TierRoutingEntry
+            {
+                Timestamp = DateTimeOffset.UtcNow,
+                PromptPreview = chatMessages.FirstOrDefault(m => m.Role == ChatRole.User)?.Text is { } p
+                    ? (p.Length > 150 ? p[..150] : p)
+                    : "",
+                Tier = tier,
+                Context = "user-message",
+                ComplexityScore = classification.ComplexityScore,
+                MatchedHighKeywords = classification.MatchedHighKeywords,
+                MatchedLowKeywords = classification.MatchedLowKeywords,
+                PostInjectionTokenEstimate = postInjectionTokenEstimate,
+                ModelId = bgDiag.ModelId ?? registry.GetModelId(tier),
+                InputTokens = bgDiag.InputTokens > 0 ? bgDiag.InputTokens : null,
+                OutputTokens = bgDiag.OutputTokens > 0 ? bgDiag.OutputTokens : null,
+                ToolCallCount = bgDiag.ToolCalls > 0 ? bgDiag.ToolCalls : null,
+            });
 
             await conversationMemory.AddTurnAsync(
                 sessionId,

--- a/src/RockBot.Subagent/SubagentRunner.cs
+++ b/src/RockBot.Subagent/SubagentRunner.cs
@@ -318,7 +318,10 @@ internal sealed class SubagentRunner(
             MatchedHighKeywords = classification.MatchedHighKeywords,
             MatchedLowKeywords = classification.MatchedLowKeywords,
             PostInjectionTokenEstimate = postInjectionTokenEstimate,
-            ModelId = registry.GetModelId(classification.Tier),
+            ModelId = diagnostics.ModelId ?? registry.GetModelId(classification.Tier),
+            InputTokens = diagnostics.InputTokens > 0 ? diagnostics.InputTokens : null,
+            OutputTokens = diagnostics.OutputTokens > 0 ? diagnostics.OutputTokens : null,
+            ToolCallCount = diagnostics.ToolCalls > 0 ? diagnostics.ToolCalls : null,
             LatencyMs = subagentSw.ElapsedMilliseconds,
         });
 


### PR DESCRIPTION
Fixes #452.

## Problem

`tier-routing-log.jsonl` entries were written with `inputTokens`/`outputTokens` always null, so the dream's cost-aware tuning had no per-entry cost data. This silently disabled #451's High-tier cost floor and the `lowOutputAtHigh` over-routing rule, and made `TierRoutingAnalyzer`'s threshold scans return a null `projectedCostDelta` on every run — the ceiling was climbing purely on the LLM's quality judgment, never on the cost signal #451 was built to provide.

Of the three write sites named in the issue, the native user-message path was already fixed by #466. Two remained:

- **`SubagentRunner.cs`** — the dominant High-tier routing source — omitted tokens entirely, even though a fully-populated `LoopDiagnostics` was already in scope from `AgentLoopRunner.RunAsync`.
- **Text-based user-message path** (`UserMessageHandler.cs`) — wrote the entry after iteration 1 with `firstResponse.Usage` (null at that point), and the background loop's multi-iteration aggregate was never logged.

## Changes

- **SubagentRunner**: read `InputTokens`/`OutputTokens`/`ModelId`/`ToolCallCount` from the existing `diagnostics`, mirroring the native user-message path's `#466` fix.
- **Text path**: move the routing-log write to terminal points where the aggregate is known — `BackgroundToolLoopAsync` now threads a `LoopDiagnostics` and logs the aggregate after the loop; the single-response branch logs `firstResponse.Usage` (the complete usage when no tools run). One entry per user message, as before.

The `TierRoutingAnalyzer` is unchanged — it already has coverage proving cost-deltas go non-null once entries carry tokens (`TierRoutingAnalyzerTests.cs:389-394`).

## Verification

- `dotnet build` + full unit suite green (incl. 226 Agent.Tests, 57 Subagent.Tests, 22 TierRoutingAnalyzer tests).
- **Live cluster (0.12.34):** triggered a user message + subagent. New entries now carry non-null tokens:
  - `subagent`: `inputTokens: 20964, outputTokens: 46, modelId: gpt-5.4-mini-...` (was `null`/`null` before)
  - `user-message`: `inputTokens: 53634, outputTokens: 62`

AC #3 (dream notes citing cost deltas) is a downstream effect that will manifest on the next scheduled tier-routing review now that the data flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)