### PR TITLE
Origin anchor on unsolicited replies (#426)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.12.34</Version>
+<Version>0.12.35</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.A2A/A2ATaskErrorHandler.cs
+++ b/src/RockBot.A2A/A2ATaskErrorHandler.cs
@@ -30,6 +30,7 @@ internal sealed class A2ATaskErrorHandler(
     A2ATaskTracker tracker,
     AgentNameHolder agentNameHolder,
     SessionClientCapabilityStore clientCapabilityStore,
+    SessionOriginStore originStore,
     A2ALateReplyFolder lateReplyFolder,
     ILogger<A2ATaskErrorHandler> logger) : IMessageHandler<AgentTaskError>
 {
@@ -143,7 +144,8 @@ internal sealed class A2ATaskErrorHandler(
                 Content = finalContent,
                 SessionId = rawSessionId,
                 AgentName = DisplayName,
-                IsFinal = true
+                IsFinal = true,
+                Origin = originStore.Get(rawSessionId)
             };
             var envelope = reply.ToEnvelope<AgentReply>(source: agent.Name);
             await publisher.PublishAsync($"{UserProxyTopics.UserResponse}.{agent.Name}", envelope, ct);

--- a/src/RockBot.A2A/A2ATaskResultHandler.cs
+++ b/src/RockBot.A2A/A2ATaskResultHandler.cs
@@ -40,6 +40,7 @@ internal sealed class A2ATaskResultHandler(
     InputRequiredHandler inputRequiredHandler,
     A2AOptions a2aOptions,
     SessionClientCapabilityStore clientCapabilityStore,
+    SessionOriginStore originStore,
     A2ALateReplyFolder lateReplyFolder,
     ILogger<A2ATaskResultHandler> logger) : IMessageHandler<AgentTaskResult>
 {
@@ -355,7 +356,8 @@ internal sealed class A2ATaskResultHandler(
                 Content = finalContent,
                 SessionId = rawSessionId,
                 AgentName = DisplayName,
-                IsFinal = true
+                IsFinal = true,
+                Origin = originStore.Get(rawSessionId)
             };
             var envelope = reply.ToEnvelope<AgentReply>(source: agent.Name);
             await publisher.PublishAsync($"{UserProxyTopics.UserResponse}.{agent.Name}", envelope, ct);
@@ -398,7 +400,8 @@ internal sealed class A2ATaskResultHandler(
                 Content = errorMessage,
                 SessionId = rawSessionId,
                 AgentName = DisplayName,
-                IsFinal = true
+                IsFinal = true,
+                Origin = originStore.Get(rawSessionId)
             };
             var envelope = reply.ToEnvelope<AgentReply>(source: agent.Name);
             await publisher.PublishAsync($"{UserProxyTopics.UserResponse}.{agent.Name}", envelope, ct);

--- a/src/RockBot.A2A/A2ATaskStatusHandler.cs
+++ b/src/RockBot.A2A/A2ATaskStatusHandler.cs
@@ -31,6 +31,7 @@ internal sealed class A2ATaskStatusHandler(
     A2ATaskTracker tracker,
     AgentNameHolder agentNameHolder,
     SessionClientCapabilityStore clientCapabilityStore,
+    SessionOriginStore originStore,
     ILogger<A2ATaskStatusHandler> logger) : IMessageHandler<AgentTaskStatusUpdate>
 {
     private string DisplayName => agentNameHolder.DisplayName ?? agent.Name;
@@ -65,7 +66,8 @@ internal sealed class A2ATaskStatusHandler(
                     Content = statusText,
                     SessionId = pending.PrimarySessionId,
                     AgentName = pending.TargetAgent,
-                    IsFinal = false
+                    IsFinal = false,
+                    Origin = originStore.Get(StripSessionPrefix(pending.PrimarySessionId))
                 };
                 var progressEnvelope = progressReply.ToEnvelope<AgentReply>(source: agent.Name);
                 await publisher.PublishAsync($"{UserProxyTopics.UserResponse}.{agent.Name}", progressEnvelope, ct);
@@ -133,7 +135,8 @@ internal sealed class A2ATaskStatusHandler(
                 Content = finalContent,
                 SessionId = rawSessionId,
                 AgentName = DisplayName,
-                IsFinal = false
+                IsFinal = false,
+                Origin = originStore.Get(rawSessionId)
             };
             var envelope = reply.ToEnvelope<AgentReply>(source: agent.Name);
             await publisher.PublishAsync($"{UserProxyTopics.UserResponse}.{agent.Name}", envelope, ct);
@@ -142,5 +145,13 @@ internal sealed class A2ATaskStatusHandler(
         {
             logger.LogError(ex, "Failed to handle A2A status update for task {TaskId}", update.TaskId);
         }
+    }
+
+    private static string StripSessionPrefix(string sessionId)
+    {
+        const string SessionPrefix = "session/";
+        return sessionId.StartsWith(SessionPrefix, StringComparison.OrdinalIgnoreCase)
+            ? sessionId[SessionPrefix.Length..]
+            : sessionId;
     }
 }

--- a/src/RockBot.A2A/LateA2ANotificationHandler.cs
+++ b/src/RockBot.A2A/LateA2ANotificationHandler.cs
@@ -31,6 +31,7 @@ internal sealed class LateA2ANotificationHandler(
     IConversationMemory conversationMemory,
     AgentNameHolder agentNameHolder,
     SessionClientCapabilityStore clientCapabilityStore,
+    SessionOriginStore originStore,
     ILogger<LateA2ANotificationHandler> logger) : IMessageHandler<LateA2ANotificationMessage>
 {
     private string DisplayName => agentNameHolder.DisplayName ?? agent.Name;
@@ -101,7 +102,8 @@ internal sealed class LateA2ANotificationHandler(
                 Content = finalContent,
                 SessionId = rawSessionId,
                 AgentName = DisplayName,
-                IsFinal = true
+                IsFinal = true,
+                Origin = originStore.Get(rawSessionId)
             };
             var envelope = reply.ToEnvelope<AgentReply>(source: agent.Name);
             await publisher.PublishAsync($"{UserProxyTopics.UserResponse}.{agent.Name}", envelope, ct);

--- a/src/RockBot.Agent/ClearContextHandler.cs
+++ b/src/RockBot.Agent/ClearContextHandler.cs
@@ -13,6 +13,7 @@ internal sealed class ClearContextHandler(
     IConversationMemory conversationMemory,
     ISessionTracker sessionTracker,
     SessionClientCapabilityStore clientCapabilityStore,
+    SessionOriginStore originStore,
     IMessagePublisher publisher,
     AgentIdentity agent,
     ILogger<ClearContextHandler> logger) : IMessageHandler<ClearContextRequest>
@@ -31,6 +32,9 @@ internal sealed class ClearContextHandler(
         // Drop the cached client capabilities so the next inbound UserMessage re-establishes
         // them from scratch — important if the user returns on a different client.
         clientCapabilityStore.Clear(message.SessionId);
+
+        // Drop the cached origin so the next turn re-anchors fresh background work.
+        originStore.Clear(message.SessionId);
 
         logger.LogInformation("Cleared conversation context for session {SessionId}", message.SessionId);
 

--- a/src/RockBot.Agent/ScheduledTaskHandler.cs
+++ b/src/RockBot.Agent/ScheduledTaskHandler.cs
@@ -180,7 +180,13 @@ internal sealed class ScheduledTaskHandler(
             Content = finalText,
             SessionId = replySessionId,
             AgentName = agent.Name,
-            IsFinal = true
+            IsFinal = true,
+            // Synthetic origin — scheduled tasks have no originating user session.
+            Origin = new ReplyOrigin(
+                Channel: "scheduled",
+                PromptSummary: message.TaskName,
+                StartedAt: DateTimeOffset.UtcNow,
+                SessionId: replySessionId)
         };
 
         var envelope = reply.ToEnvelope<AgentReply>(source: agent.Name);

--- a/src/RockBot.Agent/UserMessageHandler.cs
+++ b/src/RockBot.Agent/UserMessageHandler.cs
@@ -49,6 +49,7 @@ internal sealed class UserMessageHandler(
     ISessionTracker sessionTracker,
     SessionStartTracker sessionStartTracker,
     SessionClientCapabilityStore clientCapabilityStore,
+    SessionOriginStore originStore,
     IOptions<AgentProfileOptions> profileOptions,
     IWipTracker wipTracker,
     AgentNameHolder agentNameHolder,
@@ -86,6 +87,19 @@ internal sealed class UserMessageHandler(
         // them without the originating UserMessage in scope. Last-writer-wins handles
         // a user switching clients mid-conversation.
         clientCapabilityStore.Set(message.SessionId, message.ClientCapabilities);
+
+        // Record the session origin (channel + first-prompt summary + start time) once, so
+        // unsolicited replies produced later for this session (subagent/A2A/scheduled
+        // completions) can anchor themselves to the request that started the work. First
+        // writer wins — set inside the store — so follow-up turns keep the original anchor.
+        var channel = !string.IsNullOrWhiteSpace(message.ChannelName)
+            ? message.ChannelName!
+            : ChannelFromSource(context.Envelope.Source);
+        originStore.Set(message.SessionId, new ReplyOrigin(
+            Channel: channel,
+            PromptSummary: SummarizePrompt(message.Content),
+            StartedAt: DateTimeOffset.UtcNow,
+            SessionId: message.SessionId));
 
         // Cancel any background loop still running for this session from a prior message.
         // This prevents stale tool calls (e.g. sending an email from a previous topic)
@@ -715,4 +729,23 @@ internal sealed class UserMessageHandler(
 
         return (false, text);
     }
+
+    /// <summary>
+    /// Truncates the user's prompt to a short single-line summary for the origin anchor.
+    /// Cheap and synchronous so it adds no latency at the message entry point.
+    /// </summary>
+    private static string SummarizePrompt(string content)
+    {
+        const int MaxLength = 80;
+        var trimmed = content.Trim().ReplaceLineEndings(" ");
+        return trimmed.Length <= MaxLength ? trimmed : trimmed[..MaxLength].TrimEnd() + "…";
+    }
+
+    /// <summary>
+    /// Derives a channel name from the envelope source (proxy id), used only when the inbound
+    /// message did not carry an explicit <see cref="UserMessage.ChannelName"/>. A proxy id like
+    /// "cli-rocky-abc123" yields "cli".
+    /// </summary>
+    private static string ChannelFromSource(string? source) =>
+        string.IsNullOrWhiteSpace(source) ? "unknown" : source.Split('-', 2)[0];
 }

--- a/src/RockBot.Host/InboundNotificationService.cs
+++ b/src/RockBot.Host/InboundNotificationService.cs
@@ -93,12 +93,25 @@ internal sealed class InboundNotificationService : IHostedService, IDisposable
 
             var content = FormatNotifications(notifications);
 
+            // Synthetic origin describing the calling agent(s)/skill and the earliest arrival.
+            var first = notifications[0];
+            var callers = notifications.Select(n => n.CallerName).Distinct().ToList();
+            var summary = callers.Count == 1
+                ? (first.SkillId is { Length: > 0 } skill ? $"{first.CallerName} · {skill}" : first.CallerName)
+                : $"{callers.Count} agents";
+            var startedAt = notifications.Min(n => n.ReceivedAt);
+
             var reply = new AgentReply
             {
                 Content = content,
                 SessionId = A2AInboundSessionId,
                 AgentName = A2AInboundAgentName,
-                IsFinal = true
+                IsFinal = true,
+                Origin = new ReplyOrigin(
+                    Channel: "a2a-inbound",
+                    PromptSummary: summary,
+                    StartedAt: startedAt,
+                    SessionId: A2AInboundSessionId)
             };
 
             var envelope = reply.ToEnvelope<AgentReply>(source: _agent.Name);

--- a/src/RockBot.Host/ServiceCollectionExtensions.cs
+++ b/src/RockBot.Host/ServiceCollectionExtensions.cs
@@ -42,6 +42,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<AgentContextBuilder>();
         services.AddSingleton<SessionStartTracker>();
         services.AddSingleton<SessionClientCapabilityStore>();
+        services.AddSingleton<SessionOriginStore>();
         services.AddSingleton<IUserActivityMonitor, UserActivityMonitor>();
         services.AddSingleton<ISessionTracker, SessionBackgroundTaskTracker>();
         services.AddSingleton<IAgentWorkSerializer, AgentWorkSerializer>();

--- a/src/RockBot.Host/SessionOriginStore.cs
+++ b/src/RockBot.Host/SessionOriginStore.cs
@@ -1,0 +1,48 @@
+using RockBot.UserProxy;
+
+namespace RockBot.Host;
+
+/// <summary>
+/// In-memory cache of each user session's origin (channel + first-prompt summary + start
+/// time), written on every inbound <see cref="UserMessage"/> arrival. Read by entry points
+/// that emit <b>unsolicited</b> replies for a session but don't have the originating
+/// <see cref="UserMessage"/> in scope — subagent result/progress handlers and A2A
+/// receive-side handlers — so they can stamp <see cref="AgentReply.Origin"/> and let
+/// frontends anchor the message to the request that started it.
+/// <para>
+/// Parallels <see cref="SessionClientCapabilityStore"/> in lifetime and intent: a singleton
+/// spanning the agent process, persisting across loops (a subagent/A2A callback may fire long
+/// after the user's loop completes), cleared on session reset. First-writer-wins per session
+/// so follow-up turns don't overwrite the anchor of in-flight background work.
+/// </para>
+/// </summary>
+public sealed class SessionOriginStore
+{
+    private readonly Dictionary<string, ReplyOrigin> _byId = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Lock _lock = new();
+
+    /// <summary>
+    /// Records the origin for <paramref name="sessionId"/> if none is cached yet. The first
+    /// turn of a session establishes the anchor; later turns within the same session do not
+    /// overwrite it, so background work started early still reports its true beginning.
+    /// </summary>
+    public void Set(string sessionId, ReplyOrigin origin)
+    {
+        lock (_lock)
+            _byId.TryAdd(sessionId, origin);
+    }
+
+    /// <summary>Returns the cached origin for <paramref name="sessionId"/>, or null.</summary>
+    public ReplyOrigin? Get(string sessionId)
+    {
+        lock (_lock)
+            return _byId.GetValueOrDefault(sessionId);
+    }
+
+    /// <summary>Removes any cached entry. Called when the user resets the conversation.</summary>
+    public void Clear(string sessionId)
+    {
+        lock (_lock)
+            _byId.Remove(sessionId);
+    }
+}

--- a/src/RockBot.Subagent/SubagentProgressHandler.cs
+++ b/src/RockBot.Subagent/SubagentProgressHandler.cs
@@ -24,6 +24,7 @@ internal sealed class SubagentProgressHandler(
     IToolRegistry toolRegistry,
     ToolGuideTools toolGuideTools,
     IConversationMemory conversationMemory,
+    SessionOriginStore originStore,
     ILogger<SubagentProgressHandler> logger) : IMessageHandler<SubagentProgressMessage>
 {
     public async Task HandleAsync(SubagentProgressMessage message, MessageHandlerContext context)
@@ -42,12 +43,17 @@ internal sealed class SubagentProgressHandler(
         // A2A Working status updates do.
         try
         {
+            const string SessionPrefix = "session/";
+            var rawSessionId = message.PrimarySessionId.StartsWith(SessionPrefix, StringComparison.OrdinalIgnoreCase)
+                ? message.PrimarySessionId[SessionPrefix.Length..]
+                : message.PrimarySessionId;
             var progressReply = new AgentReply
             {
                 Content = message.Message,
                 SessionId = message.PrimarySessionId,
                 AgentName = $"subagent-{message.TaskId}",
-                IsFinal = false
+                IsFinal = false,
+                Origin = originStore.Get(rawSessionId)
             };
             var envelope = progressReply.ToEnvelope<AgentReply>(source: agent.Name);
             await publisher.PublishAsync($"{UserProxyTopics.UserResponse}.{agent.Name}", envelope, ct);

--- a/src/RockBot.Subagent/SubagentResultHandler.cs
+++ b/src/RockBot.Subagent/SubagentResultHandler.cs
@@ -31,6 +31,7 @@ internal sealed class SubagentResultHandler(
     SubagentResultGate gate,
     ISubagentManager subagentManager,
     ISessionTracker sessionTracker,
+    SessionOriginStore originStore,
     ILogger<SubagentResultHandler> logger) : IMessageHandler<SubagentResultMessage>
 {
     public async Task HandleAsync(SubagentResultMessage message, MessageHandlerContext context)
@@ -74,7 +75,8 @@ internal sealed class SubagentResultHandler(
                 SessionId = rawSessionId,
                 AgentName = $"subagent-{message.TaskId}",
                 IsFinal = false,
-                IsCompletion = true
+                IsCompletion = true,
+                Origin = originStore.Get(rawSessionId)
             };
             var completionEnvelope = completionReply.ToEnvelope<AgentReply>(
                 source: $"subagent-{message.TaskId}");
@@ -240,7 +242,8 @@ internal sealed class SubagentResultHandler(
                 Content = finalContent,
                 SessionId = rawSessionId,
                 AgentName = agent.Name,
-                IsFinal = true
+                IsFinal = true,
+                Origin = originStore.Get(rawSessionId)
             };
             var envelope = reply.ToEnvelope<AgentReply>(source: agent.Name);
             await publisher.PublishAsync($"{UserProxyTopics.UserResponse}.{agent.Name}", envelope, ct);
@@ -284,7 +287,8 @@ internal sealed class SubagentResultHandler(
                 Content = content,
                 SessionId = rawSessionId,
                 AgentName = agent.Name,
-                IsFinal = true
+                IsFinal = true,
+                Origin = originStore.Get(rawSessionId)
             };
             var envelope = reply.ToEnvelope<AgentReply>(source: agent.Name);
             await publisher.PublishAsync($"{UserProxyTopics.UserResponse}.{agent.Name}", envelope, ct);

--- a/src/RockBot.UserProxy.Abstractions/AgentReply.cs
+++ b/src/RockBot.UserProxy.Abstractions/AgentReply.cs
@@ -19,4 +19,13 @@ public sealed record AgentReply
 
     public string? StructuredData { get; init; }
     public string? ContentType { get; init; }
+
+    /// <summary>
+    /// Provenance for an unsolicited reply (subagent completion, scheduled task, A2A
+    /// result, idle inbox batch). Null for replies that are a direct response to the
+    /// user's current turn. Frontends render a short anchor preamble from this so the
+    /// user can re-ground a message that finished after the originating session is gone
+    /// or arrived in a different client.
+    /// </summary>
+    public ReplyOrigin? Origin { get; init; }
 }

--- a/src/RockBot.UserProxy.Abstractions/ReplyOrigin.cs
+++ b/src/RockBot.UserProxy.Abstractions/ReplyOrigin.cs
@@ -1,0 +1,17 @@
+namespace RockBot.UserProxy;
+
+/// <summary>
+/// Provenance for an <b>unsolicited</b> agent reply — one produced without an immediately
+/// preceding user turn in the receiving client (a subagent completion, scheduled task,
+/// A2A result, idle inbox batch). Lets a frontend render a short anchor preamble so the
+/// user can see what the message is about, when the work started, and where it came from.
+/// </summary>
+/// <param name="Channel">Originating channel, e.g. "cli", "blazor", "discord", "scheduled", "a2a-inbound".</param>
+/// <param name="PromptSummary">Truncated (or summarized) first user turn that started the work.</param>
+/// <param name="StartedAt">When the originating request started.</param>
+/// <param name="SessionId">Original session id, for deep-linking / dedupe / anchor suppression.</param>
+public sealed record ReplyOrigin(
+    string Channel,
+    string PromptSummary,
+    DateTimeOffset StartedAt,
+    string? SessionId);

--- a/src/RockBot.UserProxy.Abstractions/ReplyOriginFormatter.cs
+++ b/src/RockBot.UserProxy.Abstractions/ReplyOriginFormatter.cs
@@ -1,0 +1,55 @@
+namespace RockBot.UserProxy;
+
+/// <summary>
+/// Shared rendering of the <see cref="ReplyOrigin"/> anchor preamble and its relative-time
+/// formatting, so every frontend produces a consistent anchor and the (fiddly) "2h 14m ago"
+/// logic lives in one tested place.
+/// </summary>
+public static class ReplyOriginFormatter
+{
+    /// <summary>
+    /// Renders the anchor preamble for <paramref name="origin"/>, or null when there is no
+    /// origin or it should be suppressed (the reply originated in the channel + session the
+    /// user is currently viewing, so the anchor would just be noise).
+    /// </summary>
+    public static string? RenderAnchor(
+        ReplyOrigin? origin, string? currentChannel, string? currentSessionId, DateTimeOffset now)
+    {
+        if (origin is null)
+            return null;
+
+        if (currentChannel is not null
+            && string.Equals(origin.Channel, currentChannel, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(origin.SessionId, currentSessionId, StringComparison.Ordinal))
+            return null;
+
+        var localTime = origin.StartedAt.ToLocalTime().ToString("HH:mm");
+        var ago = RelativeTime(origin.StartedAt, now);
+        var summary = string.IsNullOrWhiteSpace(origin.PromptSummary) ? "(no prompt)" : origin.PromptSummary;
+        return $"↳ Re: \"{summary}\"\n   started {localTime} from {origin.Channel} · {ago}";
+    }
+
+    /// <summary>Formats the gap between <paramref name="then"/> and <paramref name="now"/> as a coarse "ago" string.</summary>
+    public static string RelativeTime(DateTimeOffset then, DateTimeOffset now)
+    {
+        var span = now - then;
+        if (span < TimeSpan.Zero)
+            span = TimeSpan.Zero;
+
+        if (span.TotalSeconds < 60)
+            return "just now";
+        if (span.TotalMinutes < 60)
+            return $"{(int)span.TotalMinutes}m ago";
+        if (span.TotalHours < 24)
+        {
+            var h = (int)span.TotalHours;
+            var m = span.Minutes;
+            return m > 0 ? $"{h}h {m}m ago" : $"{h}h ago";
+        }
+        if (span.TotalDays < 2)
+            return "yesterday";
+        if (span.TotalDays < 7)
+            return $"{(int)span.TotalDays}d ago";
+        return then.ToLocalTime().ToString("MMM d");
+    }
+}

--- a/src/RockBot.UserProxy.Abstractions/UserMessage.cs
+++ b/src/RockBot.UserProxy.Abstractions/UserMessage.cs
@@ -20,4 +20,12 @@ public sealed record UserMessage
     /// working unchanged.
     /// </summary>
     public ClientCapabilities ClientCapabilities { get; init; } = ClientCapabilities.None;
+
+    /// <summary>
+    /// Human-friendly channel name of the originating client ("cli", "blazor", "discord", …).
+    /// Cached per-session so unsolicited replies (subagent/A2A/scheduled) can show the user
+    /// where the originating request came from. Null for older proxies that don't set it —
+    /// the agent falls back to deriving the channel from the envelope source.
+    /// </summary>
+    public string? ChannelName { get; init; }
 }

--- a/src/RockBot.UserProxy.Blazor/Pages/Chat.razor
+++ b/src/RockBot.UserProxy.Blazor/Pages/Chat.razor
@@ -507,7 +507,8 @@
             Content = effectiveContent,
             SessionId = SessionId,
             UserId = UserId,
-            ClientCapabilities = ClientCapabilityPresets.Blazor
+            ClientCapabilities = ClientCapabilityPresets.Blazor,
+            ChannelName = "blazor"
         };
 
         var progressTracker = new Progress<AgentReply>(reply =>

--- a/src/RockBot.UserProxy.Blazor/Services/BlazorUserFrontend.cs
+++ b/src/RockBot.UserProxy.Blazor/Services/BlazorUserFrontend.cs
@@ -20,9 +20,22 @@ public sealed class BlazorUserFrontend(ChatStateService chatState) : IUserFronte
 
         var category = CategorizeReply(reply);
 
+        // Prepend an origin anchor (as a markdown blockquote) for unsolicited replies whose
+        // work started elsewhere, so the user can re-ground a message that arrived in this
+        // client after the originating session is gone. Suppressed for replies delivered on
+        // their own blazor session (origin channel + session match).
+        var displayReply = reply;
+        var anchor = ReplyOriginFormatter.RenderAnchor(
+            reply.Origin, currentChannel: "blazor", currentSessionId: reply.SessionId, DateTimeOffset.UtcNow);
+        if (anchor is not null)
+        {
+            var quoted = string.Join("\n", anchor.Split('\n').Select(l => "> " + l.TrimStart()));
+            displayReply = reply with { Content = quoted + "\n\n" + reply.Content };
+        }
+
         // Final result — add as a permanent chat bubble and clear the progress indicator
         chatState.SetThinkingMessage(null);
-        chatState.AddAgentReply(reply, category);
+        chatState.AddAgentReply(displayReply, category);
         return Task.CompletedTask;
     }
 

--- a/src/RockBot.UserProxy.Cli/ChatCommand.cs
+++ b/src/RockBot.UserProxy.Cli/ChatCommand.cs
@@ -59,7 +59,8 @@ internal sealed class ChatCommand : AsyncCommand<ChatCommand.Settings>
             SessionId = settings.SessionId ?? "cli-session",
             UserId = settings.UserId ?? "cli-user",
             TargetAgent = settings.TargetAgent,
-            ClientCapabilities = ClientCapabilityPresets.Cli
+            ClientCapabilities = ClientCapabilityPresets.Cli,
+            ChannelName = "cli"
         };
 
         // Mirror intermediate progress to stderr so callers piping stdout get
@@ -123,7 +124,8 @@ internal sealed class ChatCommand : AsyncCommand<ChatCommand.Settings>
                 SessionId = sessionId,
                 UserId = userId,
                 TargetAgent = settings.TargetAgent,
-                ClientCapabilities = ClientCapabilityPresets.Cli
+                ClientCapabilities = ClientCapabilityPresets.Cli,
+                ChannelName = "cli"
             };
 
             string? progressText = null;

--- a/src/RockBot.UserProxy.Cli/PlainConsoleFrontend.cs
+++ b/src/RockBot.UserProxy.Cli/PlainConsoleFrontend.cs
@@ -12,6 +12,10 @@ internal sealed class PlainConsoleFrontend : IUserFrontend
 {
     public Task DisplayReplyAsync(AgentReply reply, CancellationToken cancellationToken = default)
     {
+        var anchor = ReplyOriginFormatter.RenderAnchor(
+            reply.Origin, currentChannel: "cli", currentSessionId: reply.SessionId, DateTimeOffset.UtcNow);
+        if (anchor is not null)
+            Console.Out.WriteLine(anchor);
         Console.Out.WriteLine(HtmlPlainTextRenderer.StripHtml(reply.Content));
         return Task.CompletedTask;
     }

--- a/src/RockBot.UserProxy.Cli/SpectreConsoleFrontend.cs
+++ b/src/RockBot.UserProxy.Cli/SpectreConsoleFrontend.cs
@@ -10,6 +10,11 @@ internal sealed class SpectreConsoleFrontend : IUserFrontend
 {
     public Task DisplayReplyAsync(AgentReply reply, CancellationToken cancellationToken = default)
     {
+        var anchor = ReplyOriginFormatter.RenderAnchor(
+            reply.Origin, currentChannel: "cli", currentSessionId: reply.SessionId, DateTimeOffset.UtcNow);
+        if (anchor is not null)
+            AnsiConsole.MarkupLine($"[dim]{Markup.Escape(anchor)}[/]");
+
         var panel = new Panel(SpectreMarkupConverter.ToSpectreMarkup(reply.Content))
         {
             Header = new PanelHeader(Markup.Escape(reply.AgentName)),

--- a/src/RockBot.UserProxy/UserProxyOptions.cs
+++ b/src/RockBot.UserProxy/UserProxyOptions.cs
@@ -8,6 +8,21 @@ public sealed class UserProxyOptions
     public string ProxyId { get; set; } = "user-proxy";
 
     /// <summary>
+    /// Human-friendly channel name for this proxy ("cli", "blazor", "discord", …), stamped
+    /// onto outgoing <see cref="UserMessage.ChannelName"/> so unsolicited replies can show
+    /// the user which client originated the work. Defaults to the portion of
+    /// <see cref="ProxyId"/> before the first '-' (e.g. "cli-rocky-abc" → "cli").
+    /// </summary>
+    public string? ChannelName { get; set; }
+
+    /// <summary>Resolves the effective channel name: explicit <see cref="ChannelName"/> if set,
+    /// otherwise the prefix of <see cref="ProxyId"/> before the first '-'.</summary>
+    public string ResolveChannelName() =>
+        !string.IsNullOrWhiteSpace(ChannelName)
+            ? ChannelName
+            : (ProxyId.Split('-', 2)[0] is { Length: > 0 } prefix ? prefix : ProxyId);
+
+    /// <summary>
     /// Name of the agent this proxy communicates with.
     /// Used to scope message bus topics so multiple agent instances can share the same broker.
     /// </summary>

--- a/tests/RockBot.A2A.Tests/A2AFoldbackIntegrationTests.cs
+++ b/tests/RockBot.A2A.Tests/A2AFoldbackIntegrationTests.cs
@@ -1,0 +1,150 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using RockBot.Host;
+using RockBot.Messaging;
+
+namespace RockBot.A2A.Tests;
+
+/// <summary>
+/// End-to-end coverage of the #424 fold-back path through the real
+/// <see cref="A2ATaskResultHandler"/> + <see cref="A2ALateReplyFolder"/>: a terminal A2A
+/// result for a subagent-issued task, arriving after the subagent has exited, must be
+/// folded back to the subagent's owning primary session (a published
+/// <see cref="LateA2ANotificationMessage"/>) rather than silently dropped.
+///
+/// The subagent-resolution itself (tombstone) is unit-tested in
+/// <c>SubagentManagerTests</c>; here it is represented by a fake resolver so the test
+/// focuses on the handler → folder → publish integration. Heavy LLM dependencies stay
+/// <c>null!</c> because the non-user-session branch returns before touching them.
+/// </summary>
+[TestClass]
+public class A2AFoldbackIntegrationTests
+{
+    private const string TargetAgent = "AdvisorCouncil";
+    private const string TaskId = "a2a-task-77";
+    // A subagent-issued A2A carries the subagent's working-memory namespace as the session.
+    private const string SubagentSession = "subagent/sub-1";
+    private const string PrimarySession = "session/blazor-session";
+
+    private readonly InMemoryWorkingMemory _memory = new();
+    private readonly A2ATaskTracker _tracker = new();
+    private readonly TrackingPublisher _publisher = new();
+    private readonly A2AOptions _options = new();
+    private readonly AgentIdentity _agent = new("primary-agent");
+    private readonly AgentNameHolder _nameHolder = new();
+
+    /// <summary>Fake resolver standing in for SubagentManager's tombstone lookup.</summary>
+    private sealed class FakeResolver(bool active) : ISubagentSessionResolver
+    {
+        public bool IsSubagentSession(string sessionId) => sessionId.StartsWith("subagent/", StringComparison.Ordinal);
+        public bool IsActive(string sessionId) => active;
+        public string? ResolvePrimarySession(string sessionId) => PrimarySession;
+    }
+
+    private A2ATaskResultHandler CreateHandler(bool subagentActive)
+    {
+        var folder = new A2ALateReplyFolder(
+            _publisher, _memory, _agent, _options,
+            NullLogger<A2ALateReplyFolder>.Instance, new FakeResolver(subagentActive));
+
+        return new A2ATaskResultHandler(
+            agentLoopRunner: null!,
+            agentContextBuilder: null!,
+            llmClient: null!,
+            publisher: _publisher,
+            agent: _agent,
+            workingMemory: _memory,
+            memoryTools: null!,
+            skillStore: null!,
+            toolRegistry: null!,
+            rulesTools: null!,
+            toolGuideTools: null!,
+            conversationMemory: null!,
+            tracker: _tracker,
+            modelBehavior: null!,
+            agentNameHolder: _nameHolder,
+            inputRequiredHandler: null!,
+            a2aOptions: _options,
+            clientCapabilityStore: new SessionClientCapabilityStore(),
+            originStore: new SessionOriginStore(),
+            lateReplyFolder: folder,
+            logger: NullLogger<A2ATaskResultHandler>.Instance);
+    }
+
+    private void TrackPending() =>
+        _tracker.Track(new PendingA2ATask
+        {
+            TaskId = TaskId,
+            TargetAgent = TargetAgent,
+            Skill = "deliberate",
+            PrimarySessionId = SubagentSession,
+            StartedAt = DateTimeOffset.UtcNow,
+            Cts = new CancellationTokenSource()
+        });
+
+    private static AgentTaskResult Result() => new()
+    {
+        TaskId = TaskId,
+        State = AgentTaskState.Completed,
+        Message = new AgentMessage
+        {
+            Role = "agent",
+            Parts = [new AgentMessagePart { Kind = "text", Text = "The council recommends option B." }]
+        }
+    };
+
+    private MessageHandlerContext Context(MessageEnvelope envelope) => new()
+    {
+        Envelope = envelope,
+        Agent = _agent,
+        Services = null!,
+        CancellationToken = default
+    };
+
+    [TestMethod]
+    public async Task TerminatedSubagent_LateResult_FoldsBackToPrimary()
+    {
+        TrackPending();
+        var result = Result();
+        var envelope = TestEnvelopeHelper.CreateEnvelope(result, correlationId: TaskId);
+
+        await CreateHandler(subagentActive: false).HandleAsync(result, Context(envelope));
+
+        // A LateA2ANotificationMessage was published to the primary agent's late-notification topic.
+        var published = _publisher.Published
+            .Where(p => p.Topic == "agent.late-notification.primary-agent")
+            .ToList();
+        Assert.AreEqual(1, published.Count, "expected exactly one fold-back notification");
+
+        var msg = published[0].Envelope.GetPayload<LateA2ANotificationMessage>();
+        Assert.IsNotNull(msg);
+        Assert.AreEqual(PrimarySession, msg!.PrimarySessionId);
+        Assert.AreEqual("sub-1", msg.SubagentTaskId);
+        Assert.AreEqual(TargetAgent, msg.PeerAgent);
+        Assert.AreEqual(NotificationKind.Result, msg.Kind);
+
+        // Payload stashed under the primary's notifications namespace, with index appended.
+        Assert.IsTrue(_memory.Writes.Any(w =>
+                w.Key == $"{PrimarySession}/notifications/a2a/sub-1/result"
+                && w.Value == "The council recommends option B."),
+            "expected the result payload under the primary's notifications namespace");
+        Assert.IsTrue(_memory.Writes.Any(w => w.Key == $"{PrimarySession}/notifications/index"),
+            "expected a notifications index entry");
+    }
+
+    [TestMethod]
+    public async Task ActiveSubagent_LateResult_DoesNotFold()
+    {
+        // The subagent is still running: the existing awaiter path delivers the result, so
+        // the handler must NOT fold back (no notification, no primary-namespace writes).
+        TrackPending();
+        var result = Result();
+        var envelope = TestEnvelopeHelper.CreateEnvelope(result, correlationId: TaskId);
+
+        await CreateHandler(subagentActive: true).HandleAsync(result, Context(envelope));
+
+        Assert.IsFalse(_publisher.Published.Any(p => p.Topic == "agent.late-notification.primary-agent"),
+            "must not fold back while the subagent is still active");
+        Assert.IsFalse(_memory.Writes.Any(w => w.Key.Contains("/notifications/")),
+            "must not write notifications while the subagent is still active");
+    }
+}

--- a/tests/RockBot.A2A.Tests/A2ATaskResultHandlerTests.cs
+++ b/tests/RockBot.A2A.Tests/A2ATaskResultHandlerTests.cs
@@ -47,6 +47,7 @@ public class A2ATaskResultHandlerTests
             inputRequiredHandler: null!,
             a2aOptions: _options,
             clientCapabilityStore: new SessionClientCapabilityStore(),
+            originStore: new SessionOriginStore(),
             lateReplyFolder: new A2ALateReplyFolder(
                 _publisher, _memory, _agent, _options,
                 NullLogger<A2ALateReplyFolder>.Instance, resolver: null),

--- a/tests/RockBot.UserProxy.Tests/ReplyOriginFormatterTests.cs
+++ b/tests/RockBot.UserProxy.Tests/ReplyOriginFormatterTests.cs
@@ -1,0 +1,72 @@
+namespace RockBot.UserProxy.Tests;
+
+[TestClass]
+public sealed class ReplyOriginFormatterTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 6, 15, 12, 0, 0, TimeSpan.Zero);
+
+    private static ReplyOrigin Origin(string channel = "cli", string? session = "s1", DateTimeOffset? at = null) =>
+        new(channel, "deep research 8 topics", at ?? Now.AddMinutes(-134), session);
+
+    [TestMethod]
+    public void RelativeTime_Buckets()
+    {
+        Assert.AreEqual("just now", ReplyOriginFormatter.RelativeTime(Now.AddSeconds(-5), Now));
+        Assert.AreEqual("3m ago", ReplyOriginFormatter.RelativeTime(Now.AddMinutes(-3), Now));
+        Assert.AreEqual("2h 14m ago", ReplyOriginFormatter.RelativeTime(Now.AddMinutes(-134), Now));
+        Assert.AreEqual("5h ago", ReplyOriginFormatter.RelativeTime(Now.AddHours(-5), Now));
+        Assert.AreEqual("yesterday", ReplyOriginFormatter.RelativeTime(Now.AddHours(-30), Now));
+        Assert.AreEqual("3d ago", ReplyOriginFormatter.RelativeTime(Now.AddDays(-3), Now));
+    }
+
+    [TestMethod]
+    public void RelativeTime_FutureClampsToJustNow()
+    {
+        Assert.AreEqual("just now", ReplyOriginFormatter.RelativeTime(Now.AddMinutes(5), Now));
+    }
+
+    [TestMethod]
+    public void RenderAnchor_NullOrigin_ReturnsNull()
+    {
+        Assert.IsNull(ReplyOriginFormatter.RenderAnchor(null, "cli", "s1", Now));
+    }
+
+    [TestMethod]
+    public void RenderAnchor_SameChannelAndSession_Suppressed()
+    {
+        var anchor = ReplyOriginFormatter.RenderAnchor(Origin("blazor", "s1"), "blazor", "s1", Now);
+        Assert.IsNull(anchor);
+    }
+
+    [TestMethod]
+    public void RenderAnchor_DifferentChannel_Shows()
+    {
+        var anchor = ReplyOriginFormatter.RenderAnchor(Origin("cli", "s1"), "blazor", "s1", Now);
+        Assert.IsNotNull(anchor);
+        StringAssert.Contains(anchor, "deep research 8 topics");
+        StringAssert.Contains(anchor, "from cli");
+        StringAssert.Contains(anchor, "2h 14m ago");
+    }
+
+    [TestMethod]
+    public void RenderAnchor_SameChannelDifferentSession_Shows()
+    {
+        var anchor = ReplyOriginFormatter.RenderAnchor(Origin("blazor", "other"), "blazor", "s1", Now);
+        Assert.IsNotNull(anchor);
+    }
+
+    [TestMethod]
+    public void RenderAnchor_NoCurrentContext_Shows()
+    {
+        var anchor = ReplyOriginFormatter.RenderAnchor(Origin("scheduled", "sched-1"), null, null, Now);
+        Assert.IsNotNull(anchor);
+    }
+
+    [TestMethod]
+    public void ResolveChannelName_PrefersExplicit_ThenProxyIdPrefix()
+    {
+        Assert.AreEqual("discord", new UserProxyOptions { ChannelName = "discord", ProxyId = "x-y" }.ResolveChannelName());
+        Assert.AreEqual("cli", new UserProxyOptions { ProxyId = "cli-rocky-abc" }.ResolveChannelName());
+        Assert.AreEqual("blazor", new UserProxyOptions { ProxyId = "blazor" }.ResolveChannelName());
+    }
+}


### PR DESCRIPTION
Closes #426. **Stacked on #476 (#424) → #475 (#425)** — merge those first; this branch's diff is against `feat/424-a2a-foldback`.

Unsolicited replies (subagent completions, scheduled tasks, A2A results, idle inbox batches) fan out on the broadcast topic and can land in a client long after — or somewhere other than — where the work was requested, with no cue as to what/when/where. This adds provenance the user can see.

## Changes
- `ReplyOrigin` (channel, prompt summary, start time, session) + `AgentReply.Origin`.
- `SessionOriginStore` (RockBot.Host): per-session origin cache parallel to `SessionClientCapabilityStore`; first-writer-wins; cleared on session reset.
- `UserMessageHandler` captures the origin once per session (truncated first-prompt summary; channel from `UserMessage.ChannelName`, else derived from envelope source).
- `UserMessage.ChannelName` + `UserProxyOptions.ChannelName` (+ `ResolveChannelName`); CLI and Blazor stamp their channel on outgoing messages.
- Origin stamped at the broadcast publish sites: subagent result (×3) + progress, A2A status/result/error + the late-reply fold-back handler (read from the store); scheduled tasks and a2a-inbound batches synthesize their origin in place.
- `ReplyOriginFormatter`: shared relative-time + anchor rendering with suppression when origin channel+session match the current view. Wired into Blazor (markdown blockquote) and both CLI frontends.
- 8 new tests (formatter buckets/suppression + `ResolveChannelName`).

## Decisions (per discussion)
- Truncated first-prompt summary (no entry-point latency) over LLM summarization.
- Explicit `ChannelName` field over ProxyId parsing.

## Known limitation
Suppression keys on `reply.SessionId` rather than a per-frontend "currently-viewed session," so a second same-channel session viewing a broadcast bubble could over-suppress. Noted for a follow-up if it matters in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)