### PR TITLE
A2A late-reply fold-back to primary session (#424)

### DIFF
--- a/src/RockBot.A2A/A2ACallerServiceCollectionExtensions.cs
+++ b/src/RockBot.A2A/A2ACallerServiceCollectionExtensions.cs
@@ -72,17 +72,23 @@ public static class A2ACallerServiceCollectionExtensions
         // InputRequired handler for multi-turn follow-up (trust-gated LLM response generation)
         builder.Services.AddSingleton<InputRequiredHandler>();
 
-        // Message handlers for result/error/status
+        // Late-reply fold-back: recovers a terminated subagent's primary session so an A2A
+        // reply that arrives after the subagent exits is surfaced rather than dropped.
+        builder.Services.AddSingleton<A2ALateReplyFolder>();
+
+        // Message handlers for result/error/status + late-reply fold-back
         builder.HandleMessage<AgentTaskResult, A2ATaskResultHandler>();
         builder.HandleMessage<AgentTaskError, A2ATaskErrorHandler>();
         builder.HandleMessage<AgentTaskStatusUpdate, A2ATaskStatusHandler>();
+        builder.HandleMessage<LateA2ANotificationMessage, LateA2ANotificationHandler>();
 
-        // Subscribe to the per-agent result topic (agent.response.{agentName})
-        // and the shared status topic
+        // Subscribe to the per-agent result topic (agent.response.{agentName}), the shared
+        // status topic, and the per-agent late-notification topic
         var agentName = builder.Identity.Name;
         var resultTopic = $"{options.CallerResultTopic}.{agentName}";
         builder.SubscribeTo(resultTopic);
         builder.SubscribeTo(options.StatusTopic);
+        builder.SubscribeTo($"{options.LateNotificationTopic}.{agentName}");
 
         // Tool registration hosted service
         builder.Services.AddHostedService<A2ACallerToolRegistrar>();

--- a/src/RockBot.A2A/A2ALateReplyFolder.cs
+++ b/src/RockBot.A2A/A2ALateReplyFolder.cs
@@ -1,0 +1,105 @@
+using Microsoft.Extensions.Logging;
+using RockBot.Host;
+using RockBot.Messaging;
+
+namespace RockBot.A2A;
+
+/// <summary>
+/// Safety net for A2A replies that arrive after the subagent that issued the invocation has
+/// already exited. Such replies are not user-facing on the subagent's own session, so the
+/// receive-side handlers normally stash them to working memory and return — but if the
+/// subagent is gone, nobody consumes that entry and the reply is silently lost.
+///
+/// This folder recovers the subagent's owning primary (user) session via
+/// <see cref="ISubagentSessionResolver"/>, stashes the payload under the primary's
+/// <c>notifications/</c> namespace, and publishes a <see cref="LateA2ANotificationMessage"/>
+/// so <see cref="LateA2ANotificationHandler"/> can surface it in a fresh primary turn.
+/// </summary>
+internal sealed class A2ALateReplyFolder(
+    IMessagePublisher publisher,
+    IWorkingMemory workingMemory,
+    AgentIdentity agent,
+    A2AOptions options,
+    ILogger<A2ALateReplyFolder> logger,
+    ISubagentSessionResolver? resolver = null)
+{
+    /// <summary>
+    /// Attempts to fold a late reply back to the originating subagent's primary session.
+    /// No-ops (returning false) when the origin is not a recoverable subagent session or the
+    /// subagent is still active — in those cases the caller's existing behavior (return /
+    /// let the awaiter deliver) is correct.
+    /// </summary>
+    public async Task<bool> TryFoldBackAsync(
+        PendingA2ATask pending, string a2aTaskId, NotificationKind kind, string payloadText, CancellationToken ct)
+    {
+        var origin = pending.PrimarySessionId;
+
+        if (resolver is null || !resolver.IsSubagentSession(origin))
+            return false;
+
+        // Still running: the existing a2aAwaiter path (subagent blocks on outstanding A2A
+        // before publishing) handles delivery. Don't double-surface.
+        if (resolver.IsActive(origin))
+            return false;
+
+        var primary = resolver.ResolvePrimarySession(origin);
+        if (primary is null || !IsUserSession(primary))
+        {
+            logger.LogWarning(
+                "Late A2A {Kind} for task {TaskId} from subagent session {Origin} cannot be folded back " +
+                "(primary unresolved or non-user: {Primary}) — dropping", kind, a2aTaskId, origin, primary);
+            return false;
+        }
+
+        var subagentTaskId = ExtractSubagentTaskId(origin);
+        var kindSlug = kind.ToString().ToLowerInvariant();
+        var wmKey = $"{primary}/notifications/a2a/{subagentTaskId}/{kindSlug}";
+
+        await workingMemory.SetAsync(
+            wmKey, payloadText,
+            ttl: TimeSpan.FromMinutes(60),
+            category: "a2a-late-notification",
+            tags: [pending.TargetAgent, a2aTaskId, kindSlug]);
+
+        // Append to the primary's notifications index so list_working_memory surfaces it
+        // and the directive-driven per-turn check can find pending notifications.
+        var indexKey = $"{primary}/notifications/index";
+        var existing = await workingMemory.GetAsync(indexKey) ?? string.Empty;
+        var line = $"{kindSlug} from '{pending.TargetAgent}' (subagent {subagentTaskId}) -> {wmKey}";
+        await workingMemory.SetAsync(
+            indexKey, existing.Length == 0 ? line + "\n" : existing + line + "\n",
+            ttl: TimeSpan.FromMinutes(60),
+            category: "notifications-index");
+
+        var message = new LateA2ANotificationMessage(
+            PrimarySessionId: primary,
+            SubagentTaskId: subagentTaskId,
+            SubagentName: $"subagent-{subagentTaskId}",
+            PeerAgent: pending.TargetAgent,
+            Kind: kind,
+            WorkingMemoryKey: wmKey);
+
+        var envelope = message.ToEnvelope<LateA2ANotificationMessage>(source: agent.Name);
+        await publisher.PublishAsync($"{options.LateNotificationTopic}.{agent.Name}", envelope, ct);
+
+        logger.LogInformation(
+            "Folded late A2A {Kind} for task {TaskId} from terminated subagent {SubagentTaskId} back to " +
+            "primary session {Primary} (wm key {Key})", kind, a2aTaskId, subagentTaskId, primary, wmKey);
+        return true;
+    }
+
+    // Mirrors the IsUserSession guard used by the A2A receive-side handlers.
+    private static bool IsUserSession(string sessionId) =>
+        sessionId.StartsWith("session/", StringComparison.OrdinalIgnoreCase) &&
+        !sessionId.StartsWith("session/subagent-", StringComparison.OrdinalIgnoreCase);
+
+    private static string ExtractSubagentTaskId(string origin)
+    {
+        foreach (var prefix in new[] { "subagent/", "session/subagent-", "subagent-" })
+        {
+            if (origin.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                return origin[prefix.Length..];
+        }
+        return origin;
+    }
+}

--- a/src/RockBot.A2A/A2AOptions.cs
+++ b/src/RockBot.A2A/A2AOptions.cs
@@ -16,6 +16,11 @@ public sealed class A2AOptions
     /// The full per-agent topic is "{CallerResultTopic}.{agentName}".</summary>
     public string CallerResultTopic { get; set; } = "agent.response";
 
+    /// <summary>Topic prefix where this agent receives late-A2A-reply fold-back
+    /// notifications (replies that arrived after the owning subagent exited).
+    /// The full per-agent topic is "{LateNotificationTopic}.{agentName}".</summary>
+    public string LateNotificationTopic { get; set; } = "agent.late-notification";
+
     /// <summary>
     /// Path to the file where the agent directory is persisted across restarts.
     /// Relative paths are resolved from <see cref="AppContext.BaseDirectory"/>.

--- a/src/RockBot.A2A/A2ATaskErrorHandler.cs
+++ b/src/RockBot.A2A/A2ATaskErrorHandler.cs
@@ -104,7 +104,8 @@ internal sealed class A2ATaskErrorHandler(
         var sessionWorkingMemoryTools = new WorkingMemoryTools(workingMemory, sessionNamespace, logger);
         var sessionSkillTools = new SkillTools(skillStore, llmClient, logger, rawSessionId);
         var batchId = Guid.NewGuid().ToString("N")[..12];
-        var registryTools = toolRegistry.BuildAgentToolFunctions(sessionNamespace, batchId);
+        var registryTools = toolRegistry.BuildAgentToolFunctions(
+            sessionNamespace, batchId, ToolProfiles.A2ASynthesis, logger: logger);
 
         var chatOptions = new ChatOptions
         {

--- a/src/RockBot.A2A/A2ATaskErrorHandler.cs
+++ b/src/RockBot.A2A/A2ATaskErrorHandler.cs
@@ -30,6 +30,7 @@ internal sealed class A2ATaskErrorHandler(
     A2ATaskTracker tracker,
     AgentNameHolder agentNameHolder,
     SessionClientCapabilityStore clientCapabilityStore,
+    A2ALateReplyFolder lateReplyFolder,
     ILogger<A2ATaskErrorHandler> logger) : IMessageHandler<AgentTaskError>
 {
     private string DisplayName => agentNameHolder.DisplayName ?? agent.Name;
@@ -74,6 +75,11 @@ internal sealed class A2ATaskErrorHandler(
         // agent and show transport-layer noise to the user.
         if (!IsUserSession(pending.PrimarySessionId))
         {
+            // Fold back to the primary if the originating subagent has already exited;
+            // otherwise the calling loop surfaces the failure in its own output.
+            var errorText = $"A2A peer '{pending.TargetAgent}' failed task {error.TaskId}: " +
+                            $"[{error.Code}] {error.Message}";
+            await lateReplyFolder.TryFoldBackAsync(pending, error.TaskId, NotificationKind.Error, errorText, ct);
             logger.LogInformation(
                 "A2A task error for {TaskId} originated from non-user session {SessionId} — " +
                 "skipping synthesis and bubble publish (caller will surface the error)",

--- a/src/RockBot.A2A/A2ATaskResultHandler.cs
+++ b/src/RockBot.A2A/A2ATaskResultHandler.cs
@@ -316,11 +316,9 @@ internal sealed class A2ATaskResultHandler(
         var sessionSkillTools = new SkillTools(skillStore, llmClient, logger, rawSessionId);
         // Exclude A2A caller tools (invoke_agent, register_agent, etc.) from the result
         // synthesis — the LLM should present the result, not start new agent interactions.
-        var a2aToolNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-            { "invoke_agent", "register_agent", "unregister_agent", "list_known_agents", "get_agent_details" };
         var batchId = Guid.NewGuid().ToString("N")[..12];
         var registryTools = toolRegistry.BuildAgentToolFunctions(
-            sessionNamespace, batchId, r => !a2aToolNames.Contains(r.Name));
+            sessionNamespace, batchId, ToolProfiles.A2ASynthesis, logger: logger);
 
         var chatOptions = new ChatOptions
         {

--- a/src/RockBot.A2A/A2ATaskResultHandler.cs
+++ b/src/RockBot.A2A/A2ATaskResultHandler.cs
@@ -40,6 +40,7 @@ internal sealed class A2ATaskResultHandler(
     InputRequiredHandler inputRequiredHandler,
     A2AOptions a2aOptions,
     SessionClientCapabilityStore clientCapabilityStore,
+    A2ALateReplyFolder lateReplyFolder,
     ILogger<A2ATaskResultHandler> logger) : IMessageHandler<AgentTaskResult>
 {
     private string DisplayName => agentNameHolder.DisplayName ?? agent.Name;
@@ -279,6 +280,10 @@ internal sealed class A2ATaskResultHandler(
         // synthesis + publish entirely for those callers.
         if (!IsUserSession(pending.PrimarySessionId))
         {
+            // Normally the calling loop (still-running subagent) pulls the working-memory
+            // result. If the owning subagent has already exited, fold the result back to its
+            // primary session instead of dropping it silently.
+            await lateReplyFolder.TryFoldBackAsync(pending, result.TaskId, NotificationKind.Result, resultText, ct);
             logger.LogInformation(
                 "A2A task {TaskId} originated from non-user session {SessionId} — skipping " +
                 "synthesis and bubble publish (caller will consume the working-memory result)",
@@ -370,6 +375,9 @@ internal sealed class A2ATaskResultHandler(
         // rather than emitting our own bubble.
         if (!IsUserSession(pending.PrimarySessionId))
         {
+            // Fold back to the primary if the originating subagent has already exited;
+            // otherwise the caller surfaces the error in its own output.
+            await lateReplyFolder.TryFoldBackAsync(pending, taskId, NotificationKind.Error, errorMessage, ct);
             logger.LogInformation(
                 "Suppressing A2A error bubble for task {TaskId} — invocation came from non-user " +
                 "session {SessionId}; caller will surface the error in its own output",

--- a/src/RockBot.A2A/A2ATaskStatusHandler.cs
+++ b/src/RockBot.A2A/A2ATaskStatusHandler.cs
@@ -100,7 +100,8 @@ internal sealed class A2ATaskStatusHandler(
         var sessionWorkingMemoryTools = new WorkingMemoryTools(workingMemory, sessionNamespace, logger);
         var sessionSkillTools = new SkillTools(skillStore, llmClient, logger, rawSessionId);
         var batchId = Guid.NewGuid().ToString("N")[..12];
-        var registryTools = toolRegistry.BuildAgentToolFunctions(sessionNamespace, batchId);
+        var registryTools = toolRegistry.BuildAgentToolFunctions(
+            sessionNamespace, batchId, ToolProfiles.A2ASynthesis, logger: logger);
 
         var chatOptions = new ChatOptions
         {

--- a/src/RockBot.A2A/InputRequiredHandler.cs
+++ b/src/RockBot.A2A/InputRequiredHandler.cs
@@ -91,7 +91,8 @@ internal sealed class InputRequiredHandler(
         var sessionWorkingMemoryTools = new WorkingMemoryTools(workingMemory, sessionNamespace, logger);
         var sessionSkillTools = new SkillTools(skillStore, llmClient, logger, rawSessionId);
         var batchId = Guid.NewGuid().ToString("N")[..12];
-        var registryTools = toolRegistry.BuildAgentToolFunctions(sessionNamespace, batchId);
+        var registryTools = toolRegistry.BuildAgentToolFunctions(
+            sessionNamespace, batchId, ToolProfiles.A2ASynthesis, logger: logger);
 
         var chatOptions = new ChatOptions
         {

--- a/src/RockBot.A2A/LateA2ANotificationHandler.cs
+++ b/src/RockBot.A2A/LateA2ANotificationHandler.cs
@@ -1,0 +1,115 @@
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using RockBot.Host;
+using RockBot.Llm;
+using RockBot.Memory;
+using RockBot.Messaging;
+using RockBot.Skills;
+using RockBot.Tools;
+using RockBot.UserProxy;
+
+namespace RockBot.A2A;
+
+/// <summary>
+/// Folds a late A2A reply (one that arrived after its owning subagent exited) into a fresh
+/// primary-agent turn. The payload was stashed to working memory by
+/// <see cref="A2ALateReplyFolder"/>; this handler prompts the primary to read it, decide
+/// whether to act, and surface it to the user with the late-arrival context made explicit.
+/// </summary>
+internal sealed class LateA2ANotificationHandler(
+    AgentLoopRunner agentLoopRunner,
+    AgentContextBuilder agentContextBuilder,
+    ILlmClient llmClient,
+    IMessagePublisher publisher,
+    AgentIdentity agent,
+    IWorkingMemory workingMemory,
+    MemoryTools memoryTools,
+    ISkillStore skillStore,
+    IToolRegistry toolRegistry,
+    RulesTools rulesTools,
+    ToolGuideTools toolGuideTools,
+    IConversationMemory conversationMemory,
+    AgentNameHolder agentNameHolder,
+    SessionClientCapabilityStore clientCapabilityStore,
+    ILogger<LateA2ANotificationHandler> logger) : IMessageHandler<LateA2ANotificationMessage>
+{
+    private string DisplayName => agentNameHolder.DisplayName ?? agent.Name;
+
+    public async Task HandleAsync(LateA2ANotificationMessage message, MessageHandlerContext context)
+    {
+        var ct = context.CancellationToken;
+
+        var sessionNamespace = message.PrimarySessionId;
+        const string SessionPrefix = "session/";
+        var rawSessionId = sessionNamespace.StartsWith(SessionPrefix, StringComparison.OrdinalIgnoreCase)
+            ? sessionNamespace[SessionPrefix.Length..]
+            : sessionNamespace;
+
+        var kindSlug = message.Kind.ToString().ToLowerInvariant();
+        var syntheticUserTurn =
+            $"A late {kindSlug} arrived from A2A peer '{message.PeerAgent}' for your completed subagent " +
+            $"'{message.SubagentName}'. The payload is in working memory at '{message.WorkingMemoryKey}'. " +
+            $"Call get_from_working_memory with that key to read it, decide whether to act on it, and inform " +
+            $"the user if it is relevant. Make clear this is a late result from earlier background work so the " +
+            $"context is not opaque.";
+
+        logger.LogInformation(
+            "Folding late A2A {Kind} from peer '{Peer}' (subagent {SubagentTaskId}) into primary session {Session}",
+            message.Kind, message.PeerAgent, message.SubagentTaskId, rawSessionId);
+
+        await conversationMemory.AddTurnAsync(
+            rawSessionId,
+            new ConversationTurn("user", syntheticUserTurn, DateTimeOffset.UtcNow) { AgentName = message.PeerAgent },
+            ct);
+
+        var chatMessages = await agentContextBuilder.BuildAsync(
+            rawSessionId, syntheticUserTurn, ct,
+            clientCapabilities: clientCapabilityStore.Get(rawSessionId));
+
+        var sessionWorkingMemoryTools = new WorkingMemoryTools(workingMemory, sessionNamespace, logger);
+        var sessionSkillTools = new SkillTools(skillStore, llmClient, logger, rawSessionId);
+        var batchId = Guid.NewGuid().ToString("N")[..12];
+        var registryTools = toolRegistry.BuildAgentToolFunctions(
+            sessionNamespace, batchId, ToolProfiles.A2ASynthesis, logger: logger);
+
+        var chatOptions = new ChatOptions
+        {
+            Tools = [..memoryTools.Tools, ..sessionWorkingMemoryTools.Tools, ..sessionSkillTools.Tools,
+                     ..rulesTools.Tools, ..toolGuideTools.Tools, ..registryTools]
+        };
+
+        try
+        {
+            using var progressCtx = ToolProgressNotifier.SetContext(new ToolProgressContext
+            {
+                SessionId = rawSessionId,
+                AgentName = DisplayName,
+                ReplyTo = $"{UserProxyTopics.UserResponse}.{agent.Name}"
+            });
+
+            var finalContent = await agentLoopRunner.RunAsync(
+                chatMessages, chatOptions, rawSessionId,
+                enableFollowUp: false, cancellationToken: ct);
+
+            await conversationMemory.AddTurnAsync(
+                rawSessionId,
+                new ConversationTurn("assistant", finalContent, DateTimeOffset.UtcNow) { AgentName = DisplayName },
+                ct);
+
+            var reply = new AgentReply
+            {
+                Content = finalContent,
+                SessionId = rawSessionId,
+                AgentName = DisplayName,
+                IsFinal = true
+            };
+            var envelope = reply.ToEnvelope<AgentReply>(source: agent.Name);
+            await publisher.PublishAsync($"{UserProxyTopics.UserResponse}.{agent.Name}", envelope, ct);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            logger.LogError(ex,
+                "Failed to fold late A2A notification for subagent {SubagentTaskId}", message.SubagentTaskId);
+        }
+    }
+}

--- a/src/RockBot.A2A/LateA2ANotificationMessage.cs
+++ b/src/RockBot.A2A/LateA2ANotificationMessage.cs
@@ -1,0 +1,29 @@
+namespace RockBot.A2A;
+
+/// <summary>The kind of A2A reply that arrived late and is being folded back.</summary>
+public enum NotificationKind
+{
+    Result,
+    Status,
+    Error,
+    InputRequired
+}
+
+/// <summary>
+/// Published when an A2A reply arrives for a subagent that has already exited. Rather than
+/// dropping the reply, the receive-side handler stashes its payload to the primary session's
+/// working memory and emits this message so the <c>LateA2ANotificationHandler</c> can fold it
+/// into a fresh primary-agent turn.
+/// </summary>
+/// <remarks>
+/// Going through the bus (rather than synthesizing inline in the A2A handler) lets multiple
+/// late arrivals serialize into separate primary turns without colliding with an in-progress
+/// turn, and lets the original A2A handler return promptly.
+/// </remarks>
+public sealed record LateA2ANotificationMessage(
+    string PrimarySessionId,
+    string SubagentTaskId,
+    string SubagentName,
+    string PeerAgent,
+    NotificationKind Kind,
+    string WorkingMemoryKey);

--- a/src/RockBot.Agent/ScheduledTaskHandler.cs
+++ b/src/RockBot.Agent/ScheduledTaskHandler.cs
@@ -89,12 +89,13 @@ internal sealed class ScheduledTaskHandler(
         var batchId = Guid.NewGuid().ToString("N")[..12];
         var spawnedSubagent = false;
         var registryTools = toolRegistry.BuildAgentToolFunctions(
-            sessionId, batchId,
+            sessionId, batchId, ToolProfiles.Scheduled,
             onInvoke: name =>
             {
                 if (string.Equals(name, "spawn_subagent", StringComparison.OrdinalIgnoreCase))
                     spawnedSubagent = true;
-            });
+            },
+            logger: logger);
 
         var allTools = memoryTools.Tools
             .Concat(sessionWorkingMemoryTools.Tools)

--- a/src/RockBot.Agent/UserFeedbackHandler.cs
+++ b/src/RockBot.Agent/UserFeedbackHandler.cs
@@ -132,7 +132,8 @@ internal sealed class UserFeedbackHandler(
                 var sessionWorkingMemoryTools = new WorkingMemoryTools(workingMemory, sessionNamespace, logger);
                 var sessionSkillTools = new SkillTools(skillStore, llmClient, logger, message.SessionId);
                 var batchId = Guid.NewGuid().ToString("N")[..12];
-                var registryTools = toolRegistry.BuildAgentToolFunctions(sessionNamespace, batchId);
+                var registryTools = toolRegistry.BuildAgentToolFunctions(
+                    sessionNamespace, batchId, ToolProfiles.Main, logger: logger);
 
                 var chatOptions = new ChatOptions
                 {

--- a/src/RockBot.Agent/UserMessageHandler.cs
+++ b/src/RockBot.Agent/UserMessageHandler.cs
@@ -174,7 +174,8 @@ internal sealed class UserMessageHandler(
             var sessionSkillTools = new SkillTools(skillStore, llmClient, logger, message.SessionId, skillUsageStore);
 
             var batchId = Guid.NewGuid().ToString("N")[..12];
-            var registryTools = toolRegistry.BuildAgentToolFunctions(sessionNamespace, batchId);
+            var registryTools = toolRegistry.BuildAgentToolFunctions(
+                sessionNamespace, batchId, ToolProfiles.Main, logger: logger);
 
             var allTools = memoryTools.Tools
                 .Concat(sessionWorkingMemoryTools.Tools)

--- a/src/RockBot.Agent/agent/directives.md
+++ b/src/RockBot.Agent/agent/directives.md
@@ -220,6 +220,18 @@ To act on patrol findings:
 4. The entries expire automatically when their TTL lapses — typically at the
    next patrol run.
 
+## Late Background Notifications
+
+When a subagent dispatched work to another agent (A2A) and the reply arrived
+after the subagent had already finished, the framework folds that late reply
+back to you and stashes it under `notifications/a2a/{id}/{kind}` in working
+memory, with a one-line entry appended to `notifications/index`. You will
+usually be prompted directly with the working-memory key — read it with
+`get_from_working_memory`, decide whether it still matters, and tell the user,
+making clear it is a late result from earlier background work. As a backstop,
+glance at `notifications/index` when you have unfinished background work in
+flight; delete entries you have surfaced so they don't linger.
+
 ## Invalidate Stale Shared/Patrol Memory After Completion
 
 Completion is not just "do the thing." It also includes scrubbing the

--- a/src/RockBot.Host.Abstractions/ISubagentSessionResolver.cs
+++ b/src/RockBot.Host.Abstractions/ISubagentSessionResolver.cs
@@ -1,0 +1,31 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Read-only seam letting lower-level code (e.g. <c>RockBot.A2A</c>, which does not
+/// reference <c>RockBot.Subagent</c>) ask about the liveness and ownership of a subagent
+/// session without taking a dependency on the subagent manager itself. Mirrors the
+/// <see cref="ISessionA2AAwaiter"/> pattern.
+/// </summary>
+/// <remarks>
+/// A subagent's A2A invocations carry its working-memory namespace as the session id
+/// (e.g. <c>subagent/{taskId}</c>). When an A2A reply folds back after the owning subagent
+/// has exited, the receive-side handler uses this seam to (a) confirm the session is a
+/// subagent session, (b) check whether it is still active (if so, the existing awaiter path
+/// handles delivery), and (c) recover the real user-facing primary session to fold into.
+/// Resolution must survive the subagent's removal from the active set, so implementations
+/// keep a short-lived tombstone of recently-completed subagents.
+/// </remarks>
+public interface ISubagentSessionResolver
+{
+    /// <summary>True if <paramref name="sessionId"/> names a subagent session.</summary>
+    bool IsSubagentSession(string sessionId);
+
+    /// <summary>True if the named subagent session is still running.</summary>
+    bool IsActive(string sessionId);
+
+    /// <summary>
+    /// Returns the primary (user-facing) session that spawned the named subagent, or null
+    /// if it cannot be resolved (unknown id, or tombstone expired).
+    /// </summary>
+    string? ResolvePrimarySession(string sessionId);
+}

--- a/src/RockBot.Subagent/SubagentManager.cs
+++ b/src/RockBot.Subagent/SubagentManager.cs
@@ -15,9 +15,16 @@ public sealed class SubagentManager(
     IOptions<SubagentOptions> options,
     IMessagePublisher publisher,
     AgentIdentity agent,
-    ILogger<SubagentManager> logger) : ISubagentManager
+    ILogger<SubagentManager> logger) : ISubagentManager, ISubagentSessionResolver
 {
     private readonly ConcurrentDictionary<string, SubagentEntry> _active = new();
+
+    // Short-lived record of recently-removed subagents (taskId -> owning primary session).
+    // A late A2A reply can arrive after a subagent has exited and been pulled from _active;
+    // the tombstone lets ISubagentSessionResolver still recover the primary to fold into.
+    // Retention comfortably exceeds the A2A invocation timeout so late replies resolve.
+    private static readonly TimeSpan TombstoneRetention = TimeSpan.FromHours(2);
+    private readonly ConcurrentDictionary<string, (string PrimarySessionId, DateTimeOffset RemovedAt)> _tombstones = new();
 
     public async Task<string> SpawnAsync(
         string description,
@@ -33,7 +40,7 @@ public sealed class SubagentManager(
         foreach (var key in _active.Keys.ToList())
         {
             if (_active.TryGetValue(key, out var entry) && entry.Task.IsCompleted)
-                _active.TryRemove(key, out _);
+                RemoveActive(key);
         }
 
         var opts = options.Value;
@@ -89,7 +96,7 @@ public sealed class SubagentManager(
 
         await entry.CancellationTokenSource.CancelAsync();
         try { await entry.Task.WaitAsync(TimeSpan.FromSeconds(5)); } catch { /* ignore */ }
-        _active.TryRemove(taskId, out _);
+        RemoveActive(taskId);
         logger.LogInformation("Cancelled subagent {TaskId}", taskId);
         return true;
     }
@@ -100,7 +107,7 @@ public sealed class SubagentManager(
         foreach (var key in _active.Keys.ToList())
         {
             if (_active.TryGetValue(key, out var e) && e.Task.IsCompleted)
-                _active.TryRemove(key, out _);
+                RemoveActive(key);
         }
         return _active.Values.ToList();
     }
@@ -158,7 +165,68 @@ public sealed class SubagentManager(
         finally
         {
             SubagentDiagnostics.Active.Add(-1);
-            _active.TryRemove(taskId, out _);
+            RemoveActive(taskId);
         }
+    }
+
+    /// <summary>
+    /// Removes a subagent from the active set and records a tombstone of its owning primary
+    /// session so a late A2A reply can still be folded back after the subagent has exited.
+    /// </summary>
+    private void RemoveActive(string taskId)
+    {
+        if (_active.TryRemove(taskId, out var entry))
+            _tombstones[taskId] = (entry.PrimarySessionId, DateTimeOffset.UtcNow);
+        PruneTombstones();
+    }
+
+    private void PruneTombstones()
+    {
+        var cutoff = DateTimeOffset.UtcNow - TombstoneRetention;
+        foreach (var (key, value) in _tombstones)
+        {
+            if (value.RemovedAt < cutoff)
+                _tombstones.TryRemove(key, out _);
+        }
+    }
+
+    // ── ISubagentSessionResolver ──────────────────────────────────────────────
+    // A subagent's A2A session id is its working-memory namespace, "subagent/{taskId}"
+    // (see SubagentRunner). Defensively also accept "session/subagent-{taskId}" and the
+    // bare "subagent-{taskId}" form used elsewhere. _active is keyed by the raw taskId.
+
+    public bool IsSubagentSession(string sessionId) => TryExtractTaskId(sessionId, out _);
+
+    public bool IsActive(string sessionId) =>
+        TryExtractTaskId(sessionId, out var taskId)
+        && _active.TryGetValue(taskId, out var e)
+        && !e.Task.IsCompleted;
+
+    public string? ResolvePrimarySession(string sessionId)
+    {
+        if (!TryExtractTaskId(sessionId, out var taskId))
+            return null;
+        if (_active.TryGetValue(taskId, out var entry))
+            return entry.PrimarySessionId;
+        if (_tombstones.TryGetValue(taskId, out var tomb))
+            return tomb.PrimarySessionId;
+        return null;
+    }
+
+    private static bool TryExtractTaskId(string sessionId, out string taskId)
+    {
+        taskId = string.Empty;
+        if (string.IsNullOrEmpty(sessionId))
+            return false;
+
+        foreach (var prefix in new[] { "subagent/", "session/subagent-", "subagent-" })
+        {
+            if (sessionId.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                taskId = sessionId[prefix.Length..];
+                return taskId.Length > 0;
+            }
+        }
+        return false;
     }
 }

--- a/src/RockBot.Subagent/SubagentRunner.cs
+++ b/src/RockBot.Subagent/SubagentRunner.cs
@@ -146,12 +146,12 @@ internal sealed class SubagentRunner(
         // Allowed from source "mcp:management":
         //   mcp_invoke_tool, mcp_list_services, mcp_get_service_details — subagents need
         //   these to call MCP servers (calendar, email, openrouter, etc.)
+        // ToolProfiles.Subagent encodes the deny rules described in the comment above
+        // (no nested subagents, no scheduling, no async A2A, no MCP bridge reconfig).
+        // The inline .Select with SubagentRegistryToolFunction is preserved — only the
+        // predicate moves to the shared profile so the surface is drift-tested.
         var registryTools = toolRegistry.GetTools()
-            .Where(r => r.Source != "subagent"
-                     && r.Source != "scheduling"
-                     && r.Source != "a2a"
-                     && r.Name != "mcp_register_server"
-                     && r.Name != "mcp_unregister_server")
+            .Where(ToolProfiles.Subagent.Matches)
             .Select(r => (AIFunction)new SubagentRegistryToolFunction(
                 r, toolRegistry.GetExecutor(r.Name)!, subagentNamespace))
             .ToArray();

--- a/src/RockBot.Subagent/SubagentServiceCollectionExtensions.cs
+++ b/src/RockBot.Subagent/SubagentServiceCollectionExtensions.cs
@@ -29,6 +29,10 @@ public static class SubagentServiceCollectionExtensions
 
         // Core infrastructure
         builder.Services.AddSingleton<ISubagentManager, SubagentManager>();
+        // Expose the same singleton as the A2A fold-back resolver seam (RockBot.A2A
+        // cannot reference RockBot.Subagent directly).
+        builder.Services.AddSingleton<ISubagentSessionResolver>(
+            sp => (SubagentManager)sp.GetRequiredService<ISubagentManager>());
         builder.Services.AddSingleton<SubagentResultGate>();
         builder.Services.AddTransient<SubagentRunner>();
 

--- a/src/RockBot.Tools/ToolProfile.cs
+++ b/src/RockBot.Tools/ToolProfile.cs
@@ -1,0 +1,120 @@
+using System.Collections.Immutable;
+
+namespace RockBot.Tools;
+
+/// <summary>
+/// A named, in-code allow/deny policy over the tool registry, used to scope the tool
+/// surface advertised to the LLM for a particular in-process role (main turn, subagent,
+/// scheduled task, A2A result synthesis).
+/// </summary>
+/// <remarks>
+/// Profiles are intentionally <b>not</b> hot-reloadable. They are a safety boundary —
+/// subagents must not register MCP servers, the A2A synthesis loop must not dispatch a
+/// fresh <c>invoke_agent</c> while folding in the current result. A bad PVC edit silently
+/// opening that boundary is a worse failure mode than a redeploy.
+///
+/// Matching fails <i>closed</i>: a registration is included only when it is not denied
+/// AND it is explicitly allowed (by name, by source, or by the <c>"*"</c> source wildcard).
+/// New tool sources therefore do not leak into a restricted profile automatically — they
+/// must be added consciously (the snapshot drift test enforces this).
+/// </remarks>
+public sealed record ToolProfile(
+    string Name,
+    ImmutableHashSet<string> AllowedSources,
+    ImmutableHashSet<string> DeniedSources,
+    ImmutableHashSet<string> AllowedToolNames,
+    ImmutableHashSet<string> DeniedToolNames)
+{
+    /// <summary>Returns true if the given registration is permitted by this profile.</summary>
+    public bool Matches(ToolRegistration r) =>
+        !DeniedToolNames.Contains(r.Name)
+        && !DeniedSources.Contains(r.Source)
+        && (AllowedToolNames.Contains(r.Name)
+            || AllowedSources.Contains("*")
+            || AllowedSources.Contains(r.Source));
+
+    /// <summary>A profile matching every registered tool. The basis for composition.</summary>
+    public static ToolProfile All { get; } = new(
+        Name: "All",
+        AllowedSources: ["*"],
+        DeniedSources: [],
+        AllowedToolNames: [],
+        DeniedToolNames: []);
+
+    /// <summary>Returns a copy with a different display name.</summary>
+    public ToolProfile Named(string name) => this with { Name = name };
+
+    /// <summary>Returns a copy that additionally denies the given tool <paramref name="sources"/>.</summary>
+    public ToolProfile DenyingSources(params string[] sources) =>
+        this with { DeniedSources = DeniedSources.Union(sources) };
+
+    /// <summary>Returns a copy that additionally denies the given tool <paramref name="names"/>.</summary>
+    public ToolProfile DenyingToolNames(params string[] names) =>
+        this with { DeniedToolNames = DeniedToolNames.Union(names) };
+
+    /// <summary>
+    /// Returns a copy whose allowed surface is restricted to exactly the given
+    /// <paramref name="sources"/> (replaces the <c>"*"</c> wildcard).
+    /// </summary>
+    public ToolProfile AllowingOnlySources(params string[] sources) =>
+        this with { AllowedSources = [..sources] };
+
+    /// <summary>Returns a copy that additionally allow-lists the given tool <paramref name="names"/>.</summary>
+    public ToolProfile AllowingToolNames(params string[] names) =>
+        this with { AllowedToolNames = AllowedToolNames.Union(names) };
+}
+
+/// <summary>
+/// The named tool profiles applied across the in-process roles that share the main agent's
+/// DI container. Each restricted profile preserves the behavior of the ad-hoc inline filter
+/// it replaced.
+/// </summary>
+public static class ToolProfiles
+{
+    /// <summary>
+    /// Everything. The default for the primary user-facing turn — preserves the
+    /// historical unfiltered surface. Named explicitly at call sites so that future
+    /// tool additions land here visibly rather than leaking into a restricted profile.
+    /// </summary>
+    public static ToolProfile Main { get; } = ToolProfile.All.Named("Main");
+
+    /// <summary>
+    /// Subagent surface. Mirrors the long-standing <c>SubagentRunner</c> predicate:
+    /// <list type="bullet">
+    ///   <item><c>subagent</c> — no spawning nested subagents.</item>
+    ///   <item><c>scheduling</c> — no creating new scheduled tasks.</item>
+    ///   <item><c>a2a</c> — <c>invoke_agent</c> is async and its result folds into the
+    ///   primary session, not the subagent's, so it is silently useless here.</item>
+    ///   <item><c>mcp_register_server</c> / <c>mcp_unregister_server</c> — infrastructure-only;
+    ///   subagents must not reconfigure the MCP bridge.</item>
+    /// </list>
+    /// Everything else (including <c>mcp:management</c> invoke/list/details) is allowed.
+    /// </summary>
+    public static ToolProfile Subagent { get; } = ToolProfile.All
+        .Named("Subagent")
+        .DenyingSources("subagent", "scheduling", "a2a")
+        .DenyingToolNames("mcp_register_server", "mcp_unregister_server");
+
+    /// <summary>
+    /// Scheduled-task surface. Denies only MCP bridge reconfiguration — scheduled tasks
+    /// (e.g. the heartbeat patrol) legitimately spawn subagents, so source <c>subagent</c>
+    /// is intentionally <b>not</b> denied here despite the originating issue's table:
+    /// <c>ScheduledTaskHandler</c> tracks <c>spawn_subagent</c> invocations and denying the
+    /// source would silently disable that path.
+    /// </summary>
+    public static ToolProfile Scheduled { get; } = ToolProfile.All
+        .Named("Scheduled")
+        .DenyingToolNames("mcp_register_server", "mcp_unregister_server");
+
+    /// <summary>
+    /// A2A result-synthesis surface. Denies the A2A caller tools so the synthesis LLM
+    /// presents the current result instead of dispatching a fresh agent interaction.
+    /// Mirrors the inline HashSet previously used only in <c>A2ATaskResultHandler</c>;
+    /// now applied to all A2A receive-side handlers and the late-reply fold-back handler.
+    /// </summary>
+    public static ToolProfile A2ASynthesis { get; } = ToolProfile.All
+        .Named("A2ASynthesis")
+        .DenyingToolNames(
+            "invoke_agent", "register_agent", "unregister_agent",
+            "list_known_agents", "get_agent_details");
+}

--- a/src/RockBot.Tools/ToolRegistryExtensions.cs
+++ b/src/RockBot.Tools/ToolRegistryExtensions.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
 
 namespace RockBot.Tools;
 
@@ -32,5 +33,34 @@ public static class ToolRegistryExtensions
             .Select(r => (AIFunction)new RegistryToolFunction(
                 r, registry.GetExecutor(r.Name)!, sessionId, batchId, onInvoke))
             .ToArray();
+    }
+
+    /// <summary>
+    /// Materializes the registry tools permitted by <paramref name="profile"/> as
+    /// <see cref="AIFunction"/> instances. Delegates to the predicate overload via
+    /// <see cref="ToolProfile.Matches"/>; logs the profile and allowed/denied counts at
+    /// Information so the scoped surface is observable in logs. See
+    /// <see cref="BuildAgentToolFunctions(IToolRegistry, string?, string?, Func{ToolRegistration, bool}?, Action{string}?)"/>
+    /// for the meaning of <paramref name="batchId"/>.
+    /// </summary>
+    public static AIFunction[] BuildAgentToolFunctions(
+        this IToolRegistry registry,
+        string? sessionId,
+        string? batchId,
+        ToolProfile profile,
+        Action<string>? onInvoke = null,
+        ILogger? logger = null)
+    {
+        ArgumentNullException.ThrowIfNull(registry);
+        ArgumentNullException.ThrowIfNull(profile);
+
+        var total = registry.GetTools().Count;
+        var functions = registry.BuildAgentToolFunctions(sessionId, batchId, profile.Matches, onInvoke);
+
+        logger?.LogInformation(
+            "Tool profile '{Profile}': {Allowed}/{Total} tools allowed ({Denied} denied)",
+            profile.Name, functions.Length, total, total - functions.Length);
+
+        return functions;
     }
 }

--- a/tests/RockBot.A2A.Tests/A2ALateReplyFolderTests.cs
+++ b/tests/RockBot.A2A.Tests/A2ALateReplyFolderTests.cs
@@ -1,0 +1,128 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using RockBot.Host;
+using RockBot.Messaging;
+
+namespace RockBot.A2A.Tests;
+
+[TestClass]
+public class A2ALateReplyFolderTests
+{
+    private readonly InMemoryWorkingMemory _memory = new();
+    private readonly TrackingPublisher _publisher = new();
+    private readonly AgentIdentity _agent = new("primary-agent");
+    private readonly A2AOptions _options = new();
+
+    private A2ALateReplyFolder CreateFolder(ISubagentSessionResolver? resolver) =>
+        new(_publisher, _memory, _agent, _options,
+            NullLogger<A2ALateReplyFolder>.Instance, resolver);
+
+    private static PendingA2ATask Pending(string originSession) => new()
+    {
+        TaskId = "a2a-task-1",
+        TargetAgent = "AdvisorCouncil",
+        Skill = "deliberate",
+        PrimarySessionId = originSession,
+        StartedAt = DateTimeOffset.UtcNow,
+        Cts = new CancellationTokenSource()
+    };
+
+    private sealed class FakeResolver : ISubagentSessionResolver
+    {
+        public bool Subagent { get; init; } = true;
+        public bool Active { get; init; }
+        public string? Primary { get; init; } = "session/blazor-session";
+
+        public bool IsSubagentSession(string sessionId) => Subagent;
+        public bool IsActive(string sessionId) => Active;
+        public string? ResolvePrimarySession(string sessionId) => Primary;
+    }
+
+    [TestMethod]
+    public async Task TerminatedSubagent_WithUserPrimary_FoldsBack()
+    {
+        var folder = CreateFolder(new FakeResolver { Active = false, Primary = "session/blazor-session" });
+
+        var folded = await folder.TryFoldBackAsync(
+            Pending("subagent/abc123"), "a2a-task-1", NotificationKind.Result, "the result text", CancellationToken.None);
+
+        Assert.IsTrue(folded);
+
+        // Payload stashed under the primary's notifications namespace + index appended.
+        Assert.IsTrue(_memory.Writes.Any(w =>
+            w.Key == "session/blazor-session/notifications/a2a/abc123/result" && w.Value == "the result text"));
+        Assert.IsTrue(_memory.Writes.Any(w => w.Key == "session/blazor-session/notifications/index"));
+
+        // LateA2ANotificationMessage published to the per-agent late-notification topic.
+        Assert.AreEqual(1, _publisher.Published.Count);
+        var (topic, envelope) = _publisher.Published[0];
+        Assert.AreEqual("agent.late-notification.primary-agent", topic);
+        var msg = envelope.GetPayload<LateA2ANotificationMessage>();
+        Assert.AreEqual("session/blazor-session", msg!.PrimarySessionId);
+        Assert.AreEqual("abc123", msg.SubagentTaskId);
+        Assert.AreEqual("AdvisorCouncil", msg.PeerAgent);
+        Assert.AreEqual(NotificationKind.Result, msg.Kind);
+        Assert.AreEqual("session/blazor-session/notifications/a2a/abc123/result", msg.WorkingMemoryKey);
+    }
+
+    [TestMethod]
+    public async Task ActiveSubagent_DoesNotFold()
+    {
+        var folder = CreateFolder(new FakeResolver { Active = true });
+
+        var folded = await folder.TryFoldBackAsync(
+            Pending("subagent/abc123"), "a2a-task-1", NotificationKind.Result, "x", CancellationToken.None);
+
+        Assert.IsFalse(folded);
+        Assert.AreEqual(0, _publisher.Published.Count);
+        Assert.AreEqual(0, _memory.Writes.Count);
+    }
+
+    [TestMethod]
+    public async Task NoResolver_DoesNotFold()
+    {
+        var folder = CreateFolder(resolver: null);
+
+        var folded = await folder.TryFoldBackAsync(
+            Pending("subagent/abc123"), "a2a-task-1", NotificationKind.Error, "x", CancellationToken.None);
+
+        Assert.IsFalse(folded);
+        Assert.AreEqual(0, _publisher.Published.Count);
+    }
+
+    [TestMethod]
+    public async Task UnresolvablePrimary_DoesNotFold()
+    {
+        var folder = CreateFolder(new FakeResolver { Active = false, Primary = null });
+
+        var folded = await folder.TryFoldBackAsync(
+            Pending("subagent/abc123"), "a2a-task-1", NotificationKind.Result, "x", CancellationToken.None);
+
+        Assert.IsFalse(folded);
+        Assert.AreEqual(0, _publisher.Published.Count);
+    }
+
+    [TestMethod]
+    public async Task NonUserPrimary_DoesNotFold()
+    {
+        // A primary that resolves to another non-user session must not produce a user bubble.
+        var folder = CreateFolder(new FakeResolver { Active = false, Primary = "wisp-xyz" });
+
+        var folded = await folder.TryFoldBackAsync(
+            Pending("subagent/abc123"), "a2a-task-1", NotificationKind.Result, "x", CancellationToken.None);
+
+        Assert.IsFalse(folded);
+        Assert.AreEqual(0, _publisher.Published.Count);
+    }
+
+    [TestMethod]
+    public async Task NonSubagentOrigin_DoesNotFold()
+    {
+        var folder = CreateFolder(new FakeResolver { Subagent = false });
+
+        var folded = await folder.TryFoldBackAsync(
+            Pending("wisp-xyz"), "a2a-task-1", NotificationKind.Result, "x", CancellationToken.None);
+
+        Assert.IsFalse(folded);
+        Assert.AreEqual(0, _publisher.Published.Count);
+    }
+}

--- a/tests/RockBot.A2A.Tests/A2ATaskResultHandlerTests.cs
+++ b/tests/RockBot.A2A.Tests/A2ATaskResultHandlerTests.cs
@@ -47,6 +47,9 @@ public class A2ATaskResultHandlerTests
             inputRequiredHandler: null!,
             a2aOptions: _options,
             clientCapabilityStore: new SessionClientCapabilityStore(),
+            lateReplyFolder: new A2ALateReplyFolder(
+                _publisher, _memory, _agent, _options,
+                NullLogger<A2ALateReplyFolder>.Instance, resolver: null),
             logger: NullLogger<A2ATaskResultHandler>.Instance);
 
     private void TrackPending() =>

--- a/tests/RockBot.Subagent.Tests/SubagentManagerTests.cs
+++ b/tests/RockBot.Subagent.Tests/SubagentManagerTests.cs
@@ -237,6 +237,63 @@ public class SubagentManagerTests
         Assert.AreEqual(0, active.Count);
     }
 
+    // ── ISubagentSessionResolver ────────────────────────────────────────────────
+
+    [TestMethod]
+    public void Resolver_RecognizesSubagentSessionForms()
+    {
+        var manager = CreateManager();
+
+        Assert.IsTrue(manager.IsSubagentSession("subagent/abc123"));
+        Assert.IsTrue(manager.IsSubagentSession("session/subagent-abc123"));
+        Assert.IsTrue(manager.IsSubagentSession("subagent-abc123"));
+        Assert.IsFalse(manager.IsSubagentSession("session/blazor-session"));
+        Assert.IsFalse(manager.IsSubagentSession("wisp-xyz"));
+        Assert.IsFalse(manager.IsSubagentSession(""));
+    }
+
+    [TestMethod]
+    public async Task Resolver_ActiveSubagent_IsActiveAndResolvesPrimary()
+    {
+        var (manager, release) = CreateBlockingManager();
+        var taskId = await manager.SpawnAsync(
+            "Blocking task", context: null, timeoutMinutes: 10,
+            primarySessionId: "session/blazor-session", ct: CancellationToken.None);
+        await Task.Delay(100);
+
+        var sessionId = $"subagent/{taskId}";
+        Assert.IsTrue(manager.IsActive(sessionId));
+        Assert.AreEqual("session/blazor-session", manager.ResolvePrimarySession(sessionId));
+
+        release.SetResult(true);
+        await manager.CancelAsync(taskId);
+    }
+
+    [TestMethod]
+    public async Task Resolver_TerminatedSubagent_ResolvesPrimaryFromTombstone()
+    {
+        var (manager, release) = CreateBlockingManager();
+        var taskId = await manager.SpawnAsync(
+            "Blocking task", context: null, timeoutMinutes: 10,
+            primarySessionId: "session/blazor-session", ct: CancellationToken.None);
+        await Task.Delay(100);
+
+        await manager.CancelAsync(taskId); // removes from active, records tombstone
+
+        var sessionId = $"subagent/{taskId}";
+        Assert.IsFalse(manager.IsActive(sessionId));
+        // Tombstone still resolves the owning primary so a late A2A reply can fold back.
+        Assert.AreEqual("session/blazor-session", manager.ResolvePrimarySession(sessionId));
+    }
+
+    [TestMethod]
+    public void Resolver_UnknownSubagent_ResolvesNull()
+    {
+        var manager = CreateManager();
+        Assert.IsNull(manager.ResolvePrimarySession("subagent/never-existed"));
+        Assert.IsFalse(manager.IsActive("subagent/never-existed"));
+    }
+
     // ── Test doubles ───────────────────────────────────────────────────────────
 
     /// <summary>LLM client that immediately returns an empty response.</summary>

--- a/tests/RockBot.Tools.Tests/ToolProfileSnapshotTests.cs
+++ b/tests/RockBot.Tools.Tests/ToolProfileSnapshotTests.cs
@@ -1,0 +1,111 @@
+using RockBot.Tools;
+
+namespace RockBot.Tools.Tests;
+
+/// <summary>
+/// Snapshots the tool surface each named profile admits over a canonical registry that
+/// covers every known tool <c>Source</c> plus the specific tool names the profiles key on.
+/// Acts as a drift detector: landing a new tool source (a new <c>ToolRegistrar</c>) means
+/// adding it to <see cref="Canonical"/> here, which shifts the snapshots and forces a
+/// conscious decision about whether each restricted profile should admit it.
+/// </summary>
+[TestClass]
+public class ToolProfileSnapshotTests
+{
+    // One representative registration per known Source, plus the individually-named tools
+    // that profiles allow/deny by name. Keep this list in sync with the live ToolRegistrars.
+    private static readonly ToolRegistration[] Canonical =
+    [
+        // a2a (RockBot.A2A / A2ACallerToolRegistrar)
+        R("invoke_agent", "a2a"),
+        R("register_agent", "a2a"),
+        R("unregister_agent", "a2a"),
+        R("list_known_agents", "a2a"),
+        R("get_agent_details", "a2a"),
+        // mcp:management (McpServersIndexedHandler)
+        R("mcp_invoke_tool", "mcp:management"),
+        R("mcp_list_services", "mcp:management"),
+        R("mcp_get_service_details", "mcp:management"),
+        R("mcp_register_server", "mcp:management"),
+        R("mcp_unregister_server", "mcp:management"),
+        // mcp:{server} (McpToolRegistrar — per-server source)
+        R("calendar__list_events", "mcp:calendar"),
+        // scheduling (SchedulingToolRegistrar)
+        R("create_scheduled_task", "scheduling"),
+        R("cancel_scheduled_task", "scheduling"),
+        // subagent (SubagentToolRegistrar)
+        R("spawn_subagent", "subagent"),
+        R("cancel_subagent", "subagent"),
+        R("list_subagents", "subagent"),
+        // web (WebToolRegistrar)
+        R("web_search", "web"),
+        R("browse_url", "web"),
+        // script (ScriptToolRegistrar)
+        R("run_script", "script"),
+        // service-search (ServiceSearchToolRegistrar)
+        R("service_search", "service-search"),
+        // filesystem (FileSystemToolRegistrar)
+        R("read_file", "filesystem"),
+        // worker (WorkerToolRegistrar)
+        R("spawn_worker", "worker"),
+        // wisp (WispToolRegistrar)
+        R("wisp_execute", "wisp"),
+    ];
+
+    private static ToolRegistration R(string name, string source) =>
+        new() { Name = name, Description = name, Source = source };
+
+    private static string[] Allowed(ToolProfile profile) =>
+        Canonical.Where(profile.Matches).Select(r => r.Name).OrderBy(n => n, StringComparer.Ordinal).ToArray();
+
+    [TestMethod]
+    public void Main_AdmitsEverything()
+    {
+        Assert.AreEqual(Canonical.Length, Allowed(ToolProfiles.Main).Length);
+    }
+
+    [TestMethod]
+    public void Subagent_Snapshot()
+    {
+        // Denies sources subagent/scheduling/a2a and the two MCP-bridge reconfig tools.
+        string[] expected =
+        [
+            "browse_url",
+            "calendar__list_events",
+            "mcp_get_service_details",
+            "mcp_invoke_tool",
+            "mcp_list_services",
+            "read_file",
+            "run_script",
+            "service_search",
+            "spawn_worker",
+            "web_search",
+            "wisp_execute",
+        ];
+        CollectionAssert.AreEqual(expected, Allowed(ToolProfiles.Subagent));
+    }
+
+    [TestMethod]
+    public void Scheduled_Snapshot()
+    {
+        // Denies only the two MCP-bridge reconfig tools; subagent spawning stays available.
+        var expected = Canonical
+            .Select(r => r.Name)
+            .Where(n => n is not ("mcp_register_server" or "mcp_unregister_server"))
+            .OrderBy(n => n, StringComparer.Ordinal)
+            .ToArray();
+        CollectionAssert.AreEqual(expected, Allowed(ToolProfiles.Scheduled));
+        Assert.IsTrue(Allowed(ToolProfiles.Scheduled).Contains("spawn_subagent"));
+    }
+
+    [TestMethod]
+    public void A2ASynthesis_Snapshot()
+    {
+        // Denies the five A2A caller tools so synthesis cannot dispatch a fresh interaction.
+        var allowed = Allowed(ToolProfiles.A2ASynthesis);
+        foreach (var blocked in new[]
+                 { "invoke_agent", "register_agent", "unregister_agent", "list_known_agents", "get_agent_details" })
+            Assert.IsFalse(allowed.Contains(blocked), $"{blocked} should be denied");
+        Assert.AreEqual(Canonical.Length - 5, allowed.Length);
+    }
+}

--- a/tests/RockBot.Tools.Tests/ToolProfileTests.cs
+++ b/tests/RockBot.Tools.Tests/ToolProfileTests.cs
@@ -1,0 +1,90 @@
+using RockBot.Tools;
+
+namespace RockBot.Tools.Tests;
+
+[TestClass]
+public class ToolProfileTests
+{
+    private static ToolRegistration Reg(string name, string source) =>
+        new() { Name = name, Description = name, Source = source };
+
+    [TestMethod]
+    public void All_MatchesEverything()
+    {
+        Assert.IsTrue(ToolProfile.All.Matches(Reg("anything", "any-source")));
+        Assert.IsTrue(ToolProfile.All.Matches(Reg("spawn_subagent", "subagent")));
+    }
+
+    [TestMethod]
+    public void DeniedToolName_OverridesWildcardAllow()
+    {
+        var profile = ToolProfile.All.DenyingToolNames("blocked_tool");
+
+        Assert.IsFalse(profile.Matches(Reg("blocked_tool", "web")));
+        Assert.IsTrue(profile.Matches(Reg("other_tool", "web")));
+    }
+
+    [TestMethod]
+    public void DeniedSource_OverridesWildcardAllow()
+    {
+        var profile = ToolProfile.All.DenyingSources("a2a");
+
+        Assert.IsFalse(profile.Matches(Reg("invoke_agent", "a2a")));
+        Assert.IsTrue(profile.Matches(Reg("web_search", "web")));
+    }
+
+    [TestMethod]
+    public void DeniedToolName_BeatsExplicitAllowName()
+    {
+        // Deny takes precedence over an explicit allow of the same name.
+        var profile = ToolProfile.All
+            .AllowingOnlySources("web")
+            .AllowingToolNames("special")
+            .DenyingToolNames("special");
+
+        Assert.IsFalse(profile.Matches(Reg("special", "a2a")));
+    }
+
+    [TestMethod]
+    public void FailsClosed_WhenNoAllowMatches()
+    {
+        // Restricted to source "web" only — a tool from another source with no
+        // explicit name allow is excluded even though nothing denies it.
+        var profile = ToolProfile.All.AllowingOnlySources("web");
+
+        Assert.IsTrue(profile.Matches(Reg("web_search", "web")));
+        Assert.IsFalse(profile.Matches(Reg("read_file", "filesystem")));
+    }
+
+    [TestMethod]
+    public void AllowingToolNames_AdmitsToolFromOtherwiseDeniedSource()
+    {
+        var profile = ToolProfile.All
+            .AllowingOnlySources("web")
+            .AllowingToolNames("read_file");
+
+        Assert.IsTrue(profile.Matches(Reg("read_file", "filesystem")));
+        Assert.IsFalse(profile.Matches(Reg("delete_file", "filesystem")));
+    }
+
+    [TestMethod]
+    public void CompositionHelpers_DoNotMutateSource()
+    {
+        var derived = ToolProfile.All.DenyingSources("a2a").DenyingToolNames("x");
+
+        // ToolProfile.All is the shared basis — composition must return new records.
+        Assert.AreEqual(0, ToolProfile.All.DeniedSources.Count);
+        Assert.AreEqual(0, ToolProfile.All.DeniedToolNames.Count);
+        Assert.AreEqual(1, derived.DeniedSources.Count);
+        Assert.AreEqual(1, derived.DeniedToolNames.Count);
+    }
+
+    [TestMethod]
+    public void Named_SetsDisplayNameWithoutChangingRules()
+    {
+        var profile = ToolProfile.All.Named("Custom");
+
+        Assert.AreEqual("Custom", profile.Name);
+        Assert.IsTrue(profile.Matches(Reg("anything", "any")));
+    }
+}


### PR DESCRIPTION
Closes #424. Supersedes #476 (auto-closed when its base branch `feat/425-tool-profiles` was deleted on merge of #475). Code is unchanged; now targets `main` since #475 has merged.

When a subagent dispatches A2A work and the reply arrives after the subagent has exited, the receive-side handlers stash the payload to working memory and return — assuming the (now-gone) subagent will consume it. The reply was thus silently lost. This adds a safety net that folds such late replies back to the subagent's owning primary (user) session.

## Changes
- `ISubagentSessionResolver` (Host.Abstractions): read-only seam mirroring `ISessionA2AAwaiter` so `RockBot.A2A` can query subagent liveness/ownership without referencing `RockBot.Subagent`.
- `SubagentManager` implements it (`IsSubagentSession`/`IsActive`/`ResolvePrimarySession`), backed by a short-lived tombstone of recently-removed subagents so resolution survives the subagent leaving the active set.
- `LateA2ANotificationMessage` + `A2ALateReplyFolder` (stash + index + publish) + `LateA2ANotificationHandler` (folds into a fresh primary turn using the `A2ASynthesis` profile).
- Wired into the `!IsUserSession` branches of `A2ATaskResultHandler` (terminal + InputRequired-error) and `A2ATaskErrorHandler`. Still-active subagents keep the existing awaiter path; wisp/unresolvable origins drop cleanly.
- `directives.md`: per-turn `notifications/` check as defense-in-depth.
- 13 unit tests + a handler→folder→publish integration test.

⚠️ Because `ToolProfiles.Subagent` (#425) currently denies `a2a`, this fold-back is dormant for direct subagent A2A until that's re-enabled — forward-looking safety net. Follow-up #478 builds on this for consume-and-refine subagent A2A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)