### PR TITLE
Resolve NuGet security advisories + upgrade ModelContextProtocol to 1.4.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.13.1</Version>
+<Version>0.14.0</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/McpServer.Introspection/McpServer.Introspection.csproj
+++ b/src/McpServer.Introspection/McpServer.Introspection.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.8.0-preview.1" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/McpServer.OpenRouter/McpServer.OpenRouter.csproj
+++ b/src/McpServer.OpenRouter/McpServer.OpenRouter.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.8.0-preview.1" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.4.0" />
   </ItemGroup>
 
 </Project>

--- a/src/McpServer.TodoApp/McpServer.TodoApp.csproj
+++ b/src/McpServer.TodoApp/McpServer.TodoApp.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.8.0-preview.1" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.4.0" />
   </ItemGroup>
 
 </Project>

--- a/src/RockBot.Agent/RockBot.Agent.csproj
+++ b/src/RockBot.Agent/RockBot.Agent.csproj
@@ -19,10 +19,10 @@
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.3.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.*" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.*" />
-    <PackageReference Include="ModelContextProtocol" Version="0.8.0-preview.1" />
-    <!-- Transitive pins: override ModelContextProtocol's vulnerable MessagePack/Nerdbank.MessagePack
-         (GHSA-hv8m-jj95-wg3x, GHSA-2cwq-pwfr-wcw3, GHSA-92vj-hp7m-gwcj, GHSA-qjvr-435c-5fjh).
-         Stay in-major to remain API-compatible with MCP. -->
+    <PackageReference Include="ModelContextProtocol" Version="1.4.0" />
+    <!-- Transitive pins: override the vulnerable MessagePack/Nerdbank.MessagePack pulled in via
+         RockBot.Llm.Copilot -> GitHub.Copilot.SDK -> StreamJsonRpc
+         (GHSA-hv8m-jj95-wg3x, GHSA-2cwq-pwfr-wcw3, GHSA-92vj-hp7m-gwcj, GHSA-qjvr-435c-5fjh). -->
     <PackageReference Include="MessagePack" Version="2.5.302" />
     <PackageReference Include="Nerdbank.MessagePack" Version="1.2.4" />
   </ItemGroup>

--- a/src/RockBot.Agent/RockBot.Agent.csproj
+++ b/src/RockBot.Agent/RockBot.Agent.csproj
@@ -20,6 +20,11 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.*" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.*" />
     <PackageReference Include="ModelContextProtocol" Version="0.8.0-preview.1" />
+    <!-- Transitive pins: override ModelContextProtocol's vulnerable MessagePack/Nerdbank.MessagePack
+         (GHSA-hv8m-jj95-wg3x, GHSA-2cwq-pwfr-wcw3, GHSA-92vj-hp7m-gwcj, GHSA-qjvr-435c-5fjh).
+         Stay in-major to remain API-compatible with MCP. -->
+    <PackageReference Include="MessagePack" Version="2.5.302" />
+    <PackageReference Include="Nerdbank.MessagePack" Version="1.2.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/RockBot.Llm.Copilot/RockBot.Llm.Copilot.csproj
+++ b/src/RockBot.Llm.Copilot/RockBot.Llm.Copilot.csproj
@@ -17,6 +17,10 @@
     <PackageReference Include="GitHub.Copilot.SDK" Version="0.2.0" />
     <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.*" />
+    <!-- Transitive pins: override GitHub.Copilot.SDK/StreamJsonRpc's vulnerable MessagePack/Nerdbank.MessagePack
+         (GHSA-hv8m-jj95-wg3x, GHSA-2cwq-pwfr-wcw3, GHSA-92vj-hp7m-gwcj, GHSA-qjvr-435c-5fjh). -->
+    <PackageReference Include="MessagePack" Version="2.5.302" />
+    <PackageReference Include="Nerdbank.MessagePack" Version="1.2.4" />
   </ItemGroup>
 
 </Project>

--- a/src/RockBot.Scripts.Container/RockBot.Scripts.Container.csproj
+++ b/src/RockBot.Scripts.Container/RockBot.Scripts.Container.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="KubernetesClient" Version="16.*" />
+    <PackageReference Include="KubernetesClient" Version="17.*" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.*" />
   </ItemGroup>

--- a/src/RockBot.Tools.Mcp/McpToolExecutor.cs
+++ b/src/RockBot.Tools.Mcp/McpToolExecutor.cs
@@ -78,8 +78,8 @@ internal sealed class McpToolExecutor(CallToolDelegate callTool) : IToolExecutor
             blocks.Add(block switch
             {
                 TextContentBlock text => new ToolContentBlock { Type = "text", Text = text.Text },
-                ImageContentBlock img => new ToolContentBlock { Type = "image", Data = img.Data, MimeType = img.MimeType },
-                AudioContentBlock audio => new ToolContentBlock { Type = "audio", Data = audio.Data, MimeType = audio.MimeType },
+                ImageContentBlock img => new ToolContentBlock { Type = "image", Data = Convert.ToBase64String(img.Data.Span), MimeType = img.MimeType },
+                AudioContentBlock audio => new ToolContentBlock { Type = "audio", Data = Convert.ToBase64String(audio.Data.Span), MimeType = audio.MimeType },
                 _ => new ToolContentBlock { Type = block.Type ?? "unknown", Text = $"[{block.Type ?? "unknown"} content block]" }
             });
         }

--- a/src/RockBot.Tools.Mcp/RockBot.Tools.Mcp.csproj
+++ b/src/RockBot.Tools.Mcp/RockBot.Tools.Mcp.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.*" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.*" />
-    <PackageReference Include="ModelContextProtocol" Version="0.8.0-preview.1" />
+    <PackageReference Include="ModelContextProtocol" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/RockBot.Scripts.Tests/RockBot.Scripts.Tests.csproj
+++ b/tests/RockBot.Scripts.Tests/RockBot.Scripts.Tests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.*" />
     <PackageReference Include="Docker.DotNet" Version="3.*" />
-    <PackageReference Include="KubernetesClient" Version="16.*" />
+    <PackageReference Include="KubernetesClient" Version="17.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/RockBot.Tools.Tests/McpToolExecutorTests.cs
+++ b/tests/RockBot.Tools.Tests/McpToolExecutorTests.cs
@@ -240,12 +240,13 @@ public class McpToolExecutorTests
     [TestMethod]
     public void MapContentBlocks_PreservesImageContent()
     {
+        var imageBytes = new byte[] { 0xDE, 0xAD, 0xBE, 0xEF };
         var result = new CallToolResult
         {
             Content =
             [
                 new TextContentBlock { Text = "Here is an image:" },
-                new ImageContentBlock { Data = "abc123", MimeType = "image/png" }
+                new ImageContentBlock { Data = imageBytes, MimeType = "image/png" }
             ]
         };
         var blocks = McpToolExecutor.MapContentBlocks(result);
@@ -253,7 +254,7 @@ public class McpToolExecutorTests
         Assert.AreEqual(2, blocks.Count);
         Assert.AreEqual("text", blocks[0].Type);
         Assert.AreEqual("image", blocks[1].Type);
-        Assert.AreEqual("abc123", blocks[1].Data);
+        Assert.AreEqual(Convert.ToBase64String(imageBytes), blocks[1].Data);
         Assert.AreEqual("image/png", blocks[1].MimeType);
         // TextFromBlocks only returns text parts
         Assert.AreEqual("Here is an image:", McpToolExecutor.TextFromBlocks(blocks));


### PR DESCRIPTION
Two related dependency-hygiene changes. Originally scoped to the security advisories; the MCP SDK upgrade was folded in afterward.

## 1. NuGet security advisories
Clears all outstanding advisory warnings (NU1903/NU1902) surfaced during build.

| Package | Was | Now | Advisory |
|---|---|---|---|
| `MessagePack` | 2.5.198 | **2.5.302** | GHSA-hv8m-jj95-wg3x (high) |
| `Nerdbank.MessagePack` | 1.0.2 | **1.2.4** | GHSA-2cwq-pwfr-wcw3 (high), GHSA-92vj-hp7m-gwcj, GHSA-qjvr-435c-5fjh (moderate) |
| `KubernetesClient` | 16.0.7 | **17.0.14** | GHSA-w7r3-mgwf-4mqq (moderate) |

- **KubernetesClient** is a direct reference — bumped `16.*` → `17.*` in `RockBot.Scripts.Container` and `RockBot.Scripts.Tests`.
- **MessagePack / Nerdbank.MessagePack** are transitive (via `RockBot.Llm.Copilot` → `GitHub.Copilot.SDK` → `StreamJsonRpc`). Resolved with **transitive pins** in `RockBot.Agent` and `RockBot.Llm.Copilot`, which propagate to their test projects via project reference.

## 2. ModelContextProtocol 0.8.0-preview.1 → 1.4.0
Brings both MCP SDK surfaces to the current stable release:
- `ModelContextProtocol` 1.4.0 in `RockBot.Agent` and `RockBot.Tools.Mcp`
- `ModelContextProtocol.AspNetCore` 1.4.0 in the three `McpServer.*` projects

The 0.8→1.4 range carries **one** breaking change that touches this code: `ImageContentBlock.Data` / `AudioContentBlock.Data` changed from `string` to `ReadOnlyMemory<byte>` (0.9.0-preview.1). `McpToolExecutor.MapContentBlocks` now base64-encodes the bytes into the (string) `ToolContentBlock.Data`; the corresponding test was updated to construct byte data and assert the base64 output. The major API reshaping (`McpClient.CreateAsync`, `ContentBlock`/`CallToolResult`, the `.Protocol` namespace) predates 0.8, so the rest of the consumed surface is unchanged. No TFM/runtime bump.

Note these two changes are independent: the MessagePack chain enters via Copilot/StreamJsonRpc, **not** via ModelContextProtocol, so the pins remain necessary regardless of the MCP upgrade.

## Verification
- Clean rebuild: **0 errors, 0 advisory warnings** (was 40 total; the only remaining 2 are pre-existing Windows-only `CA1416` platform notes, unrelated).
- Resolved versions confirmed patched via `dotnet list package`.
- **Full test suite green** — no failures, including every project whose dependency graph changed.

## Deploy-time follow-up (not covered by tests)
Legacy SSE endpoints became opt-in at MCP 1.2.0. The agent connects to the internal MCP servers at root with `TransportMode=AutoDetect` (negotiates Streamable HTTP), so this should be transparent — **verify agent↔server connectivity after deploy**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)