### PR TITLE
Fix docker-compose: prepare shared volume so the agent can write attachments

### DIFF
--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -63,11 +63,16 @@ services:
           done
         done
         mkdir -p /data/agent/memory /data/agent/skills /data/agent/conversations /data/agent/feedback
+        # The shared volume (attachments, script file exchange) is also root-owned;
+        # the non-root agent creates /rockbot/shared/attachments on startup, so pre-make
+        # it and open permissions here.
+        mkdir -p /rockbot/shared/attachments
         # Docker volumes are owned by root, so the non-root agent user needs access
-        chmod -R 777 /data/agent
+        chmod -R 777 /data/agent /rockbot/shared
         echo "Agent data volume ready."
     volumes:
       - ${AGENT_DATA_PATH:-agent-data}:/data/agent
+      - shared:/rockbot/shared
 
   agent:
     build:


### PR DESCRIPTION
## Problem

Running the `deploy/docker-compose/` stack, **every user message fails before the LLM is ever invoked** with:

```
System.UnauthorizedAccessException: Access to the path '/rockbot/shared/attachments' is denied.
   at RockBot.Agent.McpBridge.Attachments.AttachmentStorage..ctor(String basePath)
   ...
   at RockBot.Host.MessageTypeResolver...<CreateDispatch>  (resolving UserMessageHandler)
```

The `agent-init` service `chmod -R 777`s `/data/agent` for the non-root `rockbot` user, but it never prepares the **`shared`** volume. Once `AgentReply.Attachments` landed, `AttachmentStorage`'s constructor unconditionally does `Directory.CreateDirectory(${ROCKBOT_SHARED_PATH:-/rockbot/shared}/attachments)`. That named volume is root-owned and the agent runs as non-root, so DI of `UserMessageHandler` throws and the message is dead-lettered.

This is **provider-independent** — it affects any compose deployment. I hit it while bringing the stack up against a local Ollama (`gpt-oss:20b`) backend.

## Fix

Mount the `shared` volume into `agent-init` and `mkdir -p /rockbot/shared/attachments && chmod -R 777 /rockbot/shared`, mirroring how `/data/agent` is already prepared.

## Verification

With the fix, the same stack processes messages end-to-end: text replies, native tool-calling (`SaveMemory` persisted to `/data/agent/memory`), and multi-tier routing all work. The `shared` volume shows `drwxrwxrwx` on `/rockbot/shared` and `/rockbot/shared/attachments`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)