### PR TITLE
Bump version to 0.14.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.14.0</Version>
+<Version>0.14.1</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->


### PR DESCRIPTION
Bumps `<Version>` from 0.14.0 to 0.14.1 to match the agent image tag deployed for the issue-486 `balancedFloorKeywords` rollout (#489), so the running version is observable in `kubectl describe`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)