### PR TITLE
Workers: always retain the MCP gateway regardless of tools_allow

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.14.1</Version>
+<Version>0.14.2</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.Subagent/Worker/WorkerRunner.cs
+++ b/src/RockBot.Subagent/Worker/WorkerRunner.cs
@@ -70,6 +70,25 @@ internal sealed class WorkerRunner(
         "invoke_agent",
     };
 
+    /// <summary>
+    /// MCP gateway data tools workers ALWAYS retain, regardless of a definition's
+    /// <c>tools_allow</c> allowlist. Every external MCP call routes through this
+    /// single gateway (there are no per-server tools in the registry), so a
+    /// server-scoped allowlist like <c>["calendar-mcp.*"]</c> matches none of these
+    /// literal names and would silently strip all MCP access — which is exactly the
+    /// job most workers are spawned to do. The allowlist still narrows non-MCP
+    /// registry tools (web_search, execute_python_script, spawn_wisps, …); the admin
+    /// gateway tools (mcp_register_server / mcp_unregister_server) stay blocked via
+    /// <see cref="ExcludedNames"/>.
+    /// </summary>
+    private static readonly HashSet<string> AlwaysAllowedGatewayTools = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "mcp_list_services",
+        "mcp_get_service_details",
+        "mcp_invoke_tool",
+        "mcp_get_prompt",
+    };
+
     public async Task<WorkerResult> RunAsync(
         string taskId,
         WorkerDefinition definition,
@@ -267,7 +286,10 @@ internal sealed class WorkerRunner(
         var allowedRegistrations = toolRegistry.GetTools()
             .Where(r => !ExcludedSources.Contains(r.Source ?? string.Empty))
             .Where(r => !ExcludedNames.Contains(r.Name))
-            .Where(r => MatchesAllowlist(r.Name, toolsAllow))
+            // The MCP gateway is always available — the allowlist only narrows
+            // everything else. See AlwaysAllowedGatewayTools.
+            .Where(r => AlwaysAllowedGatewayTools.Contains(r.Name)
+                        || MatchesAllowlist(r.Name, toolsAllow))
             .ToList();
 
         var tools = new List<AIFunction>(allowedRegistrations.Count);
@@ -279,6 +301,14 @@ internal sealed class WorkerRunner(
         }
         return tools;
     }
+
+    /// <summary>
+    /// True when <paramref name="toolName"/> is an MCP gateway data tool that
+    /// workers always keep, bypassing the <c>tools_allow</c> allowlist. See
+    /// <see cref="AlwaysAllowedGatewayTools"/>.
+    /// </summary>
+    internal static bool IsAlwaysAllowedGatewayTool(string toolName) =>
+        AlwaysAllowedGatewayTools.Contains(toolName);
 
     internal static bool MatchesAllowlist(string toolName, IReadOnlyList<string>? toolsAllow)
     {

--- a/src/RockBot.Subagent/Worker/WorkerRunner.cs
+++ b/src/RockBot.Subagent/Worker/WorkerRunner.cs
@@ -71,23 +71,23 @@ internal sealed class WorkerRunner(
     };
 
     /// <summary>
-    /// MCP gateway data tools workers ALWAYS retain, regardless of a definition's
-    /// <c>tools_allow</c> allowlist. Every external MCP call routes through this
-    /// single gateway (there are no per-server tools in the registry), so a
-    /// server-scoped allowlist like <c>["calendar-mcp.*"]</c> matches none of these
-    /// literal names and would silently strip all MCP access — which is exactly the
-    /// job most workers are spawned to do. The allowlist still narrows non-MCP
-    /// registry tools (web_search, execute_python_script, spawn_wisps, …); the admin
-    /// gateway tools (mcp_register_server / mcp_unregister_server) stay blocked via
-    /// <see cref="ExcludedNames"/>.
+    /// Registry <see cref="ToolRegistration.Source"/> of the MCP gateway tools
+    /// (<c>mcp_list_services</c>, <c>mcp_get_service_details</c>,
+    /// <c>mcp_invoke_tool</c>, <c>mcp_get_prompt</c>, plus the two admin tools).
+    /// Workers ALWAYS retain gateway tools regardless of a definition's
+    /// <c>tools_allow</c> allowlist. Every external MCP call routes through the
+    /// single <c>mcp_invoke_tool</c> gateway (there are no per-server tools in the
+    /// registry), so a server-scoped allowlist like <c>["calendar-mcp.*"]</c> matches
+    /// none of the gateway's literal names and would silently strip all MCP access —
+    /// which is exactly the job most workers are spawned for. Keying off the source
+    /// (rather than a hard-coded name list) means any future gateway tool is covered
+    /// automatically, matching how the primary/subagent <c>ToolProfile</c> paths
+    /// treat the gateway. The allowlist still narrows non-MCP registry tools
+    /// (web_search, execute_python_script, spawn_wisps, …); the admin gateway tools
+    /// (mcp_register_server / mcp_unregister_server) stay blocked via
+    /// <see cref="ExcludedNames"/>, which is applied before this exemption.
     /// </summary>
-    private static readonly HashSet<string> AlwaysAllowedGatewayTools = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "mcp_list_services",
-        "mcp_get_service_details",
-        "mcp_invoke_tool",
-        "mcp_get_prompt",
-    };
+    private const string McpGatewaySource = "mcp:management";
 
     public async Task<WorkerResult> RunAsync(
         string taskId,
@@ -287,8 +287,9 @@ internal sealed class WorkerRunner(
             .Where(r => !ExcludedSources.Contains(r.Source ?? string.Empty))
             .Where(r => !ExcludedNames.Contains(r.Name))
             // The MCP gateway is always available — the allowlist only narrows
-            // everything else. See AlwaysAllowedGatewayTools.
-            .Where(r => AlwaysAllowedGatewayTools.Contains(r.Name)
+            // everything else. See McpGatewaySource. (ExcludedNames above has
+            // already dropped the two admin gateway tools.)
+            .Where(r => IsMcpGatewayTool(r.Source)
                         || MatchesAllowlist(r.Name, toolsAllow))
             .ToList();
 
@@ -303,12 +304,13 @@ internal sealed class WorkerRunner(
     }
 
     /// <summary>
-    /// True when <paramref name="toolName"/> is an MCP gateway data tool that
-    /// workers always keep, bypassing the <c>tools_allow</c> allowlist. See
-    /// <see cref="AlwaysAllowedGatewayTools"/>.
+    /// True when a tool registered under <paramref name="source"/> is an MCP gateway
+    /// tool that workers always keep, bypassing the <c>tools_allow</c> allowlist. See
+    /// <see cref="McpGatewaySource"/>. Admin gateway tools share this source but are
+    /// dropped earlier by <see cref="ExcludedNames"/>.
     /// </summary>
-    internal static bool IsAlwaysAllowedGatewayTool(string toolName) =>
-        AlwaysAllowedGatewayTools.Contains(toolName);
+    internal static bool IsMcpGatewayTool(string? source) =>
+        string.Equals(source, McpGatewaySource, StringComparison.OrdinalIgnoreCase);
 
     internal static bool MatchesAllowlist(string toolName, IReadOnlyList<string>? toolsAllow)
     {

--- a/src/RockBot.Subagent/Worker/WorkerToolRegistrar.cs
+++ b/src/RockBot.Subagent/Worker/WorkerToolRegistrar.cs
@@ -42,7 +42,7 @@ internal sealed class WorkerToolRegistrar(
                   "tools_allow": {
                     "type": "array",
                     "items": { "type": "string" },
-                    "description": "Optional allowlist of tool names (exact match) or name prefixes (trailing asterisk, e.g. calendar-mcp.*) the worker may invoke."
+                    "description": "Optional allowlist that narrows the NON-MCP registry tools (web_search, execute_python_script, spawn_wisps, etc.) the worker may invoke — exact tool names or name prefixes (trailing asterisk). The MCP gateway (mcp_list_services / mcp_get_service_details / mcp_invoke_tool / mcp_get_prompt) is ALWAYS available and is not gated by this list; a value like calendar-mcp.* has no effect on MCP access since all MCP calls go through the gateway."
                   }
                 },
                 "required": ["description"]

--- a/src/RockBot.Subagent/Worker/WorkerToolSkillProvider.cs
+++ b/src/RockBot.Subagent/Worker/WorkerToolSkillProvider.cs
@@ -38,9 +38,14 @@ public sealed class WorkerToolSkillProvider : IToolSkillProvider
           working-memory key. Use this when you want the worker to overwrite a known
           shared key directly (e.g. `shared/patrol/calendar-latest`).
         - `timeout_minutes` (optional) — soft wall-clock cap. Default 5.
-        - `tools_allow` (optional) — explicit allowlist of tool names or prefixes
-          (`calendar-mcp.*`) the worker may invoke. Use to bound the schema-injection
-          cost when you know the scope ahead of time.
+        - `tools_allow` (optional) — allowlist that narrows the **non-MCP** registry
+          tools (`web_search`, `execute_python_script`, `spawn_wisps`, …) the worker
+          may invoke — exact names or prefixes. Use it to bound schema-injection cost
+          when you know the scope ahead of time. The **MCP gateway is always
+          available** (`mcp_list_services`, `mcp_get_service_details`,
+          `mcp_invoke_tool`, `mcp_get_prompt`) and is never gated by this list — every
+          external MCP call routes through the gateway, so a value like `calendar-mcp.*`
+          does not restrict (or grant) MCP access.
 
         ## Consuming a worker batch
 

--- a/tests/RockBot.Subagent.Tests/Worker/WorkerRunnerHelpersTests.cs
+++ b/tests/RockBot.Subagent.Tests/Worker/WorkerRunnerHelpersTests.cs
@@ -56,6 +56,51 @@ public class WorkerRunnerHelpersTests
         Assert.IsTrue(WorkerRunner.MatchesAllowlist("anything", ["*"]));
     }
 
+    // ── IsAlwaysAllowedGatewayTool ───────────────────────────────────────────
+
+    [TestMethod]
+    [DataRow("mcp_invoke_tool")]
+    [DataRow("mcp_list_services")]
+    [DataRow("mcp_get_service_details")]
+    [DataRow("mcp_get_prompt")]
+    public void IsAlwaysAllowedGatewayTool_GatewayTools_AreAlwaysAllowed(string toolName)
+    {
+        Assert.IsTrue(WorkerRunner.IsAlwaysAllowedGatewayTool(toolName));
+    }
+
+    [TestMethod]
+    public void IsAlwaysAllowedGatewayTool_IsCaseInsensitive()
+    {
+        Assert.IsTrue(WorkerRunner.IsAlwaysAllowedGatewayTool("MCP_Invoke_Tool"));
+    }
+
+    [TestMethod]
+    [DataRow("mcp_register_server")]   // admin gateway tool — blocked via ExcludedNames
+    [DataRow("mcp_unregister_server")]
+    [DataRow("web_search")]
+    [DataRow("save_memory")]
+    public void IsAlwaysAllowedGatewayTool_NonGatewayOrAdminTools_AreNot(string toolName)
+    {
+        Assert.IsFalse(WorkerRunner.IsAlwaysAllowedGatewayTool(toolName));
+    }
+
+    [TestMethod]
+    public void GatewayTool_SurvivesServerScopedAllowlist_ThatMatchesNothing()
+    {
+        // Regression for the #431 bug: a server-scoped allowlist like
+        // ["calendar-mcp.*"] matches none of the gateway's literal tool names, so
+        // MatchesAllowlist alone would strip mcp_invoke_tool and leave the worker
+        // with no way to reach any MCP server. The gateway exemption must win.
+        string[] allowlist = ["calendar-mcp.*"];
+
+        Assert.IsFalse(WorkerRunner.MatchesAllowlist("mcp_invoke_tool", allowlist),
+            "precondition: the allowlist does not literally match the gateway name");
+        Assert.IsTrue(
+            WorkerRunner.IsAlwaysAllowedGatewayTool("mcp_invoke_tool")
+            || WorkerRunner.MatchesAllowlist("mcp_invoke_tool", allowlist),
+            "gateway must survive a server-scoped allowlist that matches nothing");
+    }
+
     // ── ParseWorkerSelfReport ────────────────────────────────────────────────
 
     [TestMethod]

--- a/tests/RockBot.Subagent.Tests/Worker/WorkerRunnerHelpersTests.cs
+++ b/tests/RockBot.Subagent.Tests/Worker/WorkerRunnerHelpersTests.cs
@@ -56,32 +56,32 @@ public class WorkerRunnerHelpersTests
         Assert.IsTrue(WorkerRunner.MatchesAllowlist("anything", ["*"]));
     }
 
-    // ── IsAlwaysAllowedGatewayTool ───────────────────────────────────────────
+    // ── IsMcpGatewayTool ─────────────────────────────────────────────────────
+
+    // The gateway is keyed off the registry Source ("mcp:management"), so any
+    // future gateway tool is covered automatically — no per-name maintenance.
 
     [TestMethod]
-    [DataRow("mcp_invoke_tool")]
-    [DataRow("mcp_list_services")]
-    [DataRow("mcp_get_service_details")]
-    [DataRow("mcp_get_prompt")]
-    public void IsAlwaysAllowedGatewayTool_GatewayTools_AreAlwaysAllowed(string toolName)
+    public void IsMcpGatewayTool_ManagementSource_IsGateway()
     {
-        Assert.IsTrue(WorkerRunner.IsAlwaysAllowedGatewayTool(toolName));
+        Assert.IsTrue(WorkerRunner.IsMcpGatewayTool("mcp:management"));
     }
 
     [TestMethod]
-    public void IsAlwaysAllowedGatewayTool_IsCaseInsensitive()
+    public void IsMcpGatewayTool_IsCaseInsensitive()
     {
-        Assert.IsTrue(WorkerRunner.IsAlwaysAllowedGatewayTool("MCP_Invoke_Tool"));
+        Assert.IsTrue(WorkerRunner.IsMcpGatewayTool("MCP:Management"));
     }
 
     [TestMethod]
-    [DataRow("mcp_register_server")]   // admin gateway tool — blocked via ExcludedNames
-    [DataRow("mcp_unregister_server")]
-    [DataRow("web_search")]
-    [DataRow("save_memory")]
-    public void IsAlwaysAllowedGatewayTool_NonGatewayOrAdminTools_AreNot(string toolName)
+    [DataRow("mcp")]        // bridged per-server tools, not the management gateway
+    [DataRow("worker")]
+    [DataRow("memory")]
+    [DataRow("")]
+    [DataRow(null)]
+    public void IsMcpGatewayTool_OtherSources_AreNot(string? source)
     {
-        Assert.IsFalse(WorkerRunner.IsAlwaysAllowedGatewayTool(toolName));
+        Assert.IsFalse(WorkerRunner.IsMcpGatewayTool(source));
     }
 
     [TestMethod]
@@ -90,13 +90,13 @@ public class WorkerRunnerHelpersTests
         // Regression for the #431 bug: a server-scoped allowlist like
         // ["calendar-mcp.*"] matches none of the gateway's literal tool names, so
         // MatchesAllowlist alone would strip mcp_invoke_tool and leave the worker
-        // with no way to reach any MCP server. The gateway exemption must win.
+        // with no way to reach any MCP server. The source-keyed exemption must win.
         string[] allowlist = ["calendar-mcp.*"];
 
         Assert.IsFalse(WorkerRunner.MatchesAllowlist("mcp_invoke_tool", allowlist),
             "precondition: the allowlist does not literally match the gateway name");
         Assert.IsTrue(
-            WorkerRunner.IsAlwaysAllowedGatewayTool("mcp_invoke_tool")
+            WorkerRunner.IsMcpGatewayTool("mcp:management")
             || WorkerRunner.MatchesAllowlist("mcp_invoke_tool", allowlist),
             "gateway must survive a server-scoped allowlist that matches nothing");
     }


### PR DESCRIPTION
## Problem

A user asked the live agent to *"add a todo for Friday"*. Instead of a single `add_task` call, the agent spawned a 6-worker calendar sweep (one per account) that ran ~4 minutes and mostly failed — every worker reported *"No calendar fetch tool was available in the provided tool surface; only working-memory tools were available."* One worker hit the 240s timeout.

Root cause of the worker failures: `spawn_workers`' `tools_allow` allowlist is applied to **every** registry tool, including the MCP gateway. Every external MCP call routes through the single `mcp_invoke_tool` gateway — there are **no** per-server tools in the registry — so the natural, model-generated allowlist `["calendar-mcp.*"]` matched none of the gateway's literal tool names (`mcp_invoke_tool`, `mcp_list_services`, `mcp_get_service_details`, `mcp_get_prompt`) and silently stripped **all** MCP access, leaving workers unable to do the gather work they were spawned for.

**Regression introduced in #431 (0.12.0)** — the allowlist + `MatchesAllowlist` filtering shipped with no gateway exemption, and has been latent ever since.

## Fix

Workers always retain the MCP gateway, bypassing the `tools_allow` narrowing. The exemption is keyed off the registry **source** `mcp:management` (not a hard-coded tool-name list), so any future gateway tool is covered automatically — the same way the primary/subagent `ToolProfile` paths treat the gateway.

- The allowlist continues to scope non-MCP registry tools (`web_search`, `execute_python_script`, `spawn_wisps`, …).
- The admin gateway tools (`mcp_register_server` / `mcp_unregister_server`) share the source but remain blocked via `ExcludedNames`, which is applied before the exemption.

Also updated the `spawn_workers` parameter schema and the worker tool guide so the model understands `tools_allow` does not gate MCP (and that a value like `calendar-mcp.*` neither grants nor restricts MCP access).

## Verified: all four agent types always have the gateway

Audited every tool-surface build path:

| Agent type | Path | Gateway guaranteed? |
|---|---|---|
| Primary | `ToolProfiles.Main` (allow-all) | ✅ always |
| Subagent | `ToolProfiles.Subagent` (denies only admin names + unrelated sources) | ✅ always |
| Worker | inline sets + `tools_allow` | ✅ **after this PR** |
| Wisp | direct `IToolRegistry.GetExecutor`, no allowlist | ✅ always |

The worker was the only broken path. Primary/subagent filter by `ToolProfile` (source-based); wisps apply no access filter at all and hard-map MCP steps to `mcp_invoke_tool`. Keying the worker exemption off the same `mcp:management` source brings all four into structural agreement.

## Tests

`WorkerRunnerHelpersTests` covers `IsMcpGatewayTool` (source match, case-insensitivity, non-gateway/null sources) plus a regression test that a server-scoped allowlist matching nothing still leaves the gateway available. Worker helper suite: 21 passing.

## Out of scope

- Does **not** implement per-server scoping of the gateway (making `calendar-mcp.*` actually restrict *which* MCP servers a worker may invoke) — that would be a separate enforcement feature.
- The separate skill-over-recall issue that caused the agent to launch the sweep at all is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)