### PR TITLE
helm: add agent.extraEnv escape hatch for raw config keys

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.14.2</Version>
+<Version>0.14.3</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/deploy/helm/rockbot/templates/configmap.yaml
+++ b/deploy/helm/rockbot/templates/configmap.yaml
@@ -90,3 +90,13 @@ data:
   Telemetry__OtlpEndpoint: {{ required "telemetry.otlpEndpoint is required when telemetry.enabled=true" .Values.telemetry.otlpEndpoint | quote }}
   Telemetry__ServiceName: {{ .Values.telemetry.serviceName | quote }}
   {{- end }}
+
+  {{- with .Values.agent.extraEnv }}
+  # ── Operator-supplied raw config keys (agent.extraEnv) ─────────────────────
+  # Escape hatch for .NET configuration keys that have no dedicated value above.
+  # Rendered last, but ConfigMap data is a map — a key repeated here would collide
+  # with the templated one rather than override it, so use distinct keys only.
+  {{- range $key, $value := . }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}

--- a/deploy/helm/rockbot/values.yaml
+++ b/deploy/helm/rockbot/values.yaml
@@ -9,6 +9,19 @@ agent:
   image:
     repository: rockylhotka/rockbot-agent
     tag: latest
+  # Escape hatch for raw .NET configuration keys that have no dedicated value in
+  # this file — e.g. AgentHost__*, Dream__*, ModelBehaviors__Models__<prefix>__*.
+  # Rendered verbatim into the agent ConfigMap, so use the environment-variable
+  # form with "__" as the section separator. Values are quoted for you.
+  #
+  #   extraEnv:
+  #     AgentHost__Temperature: "0.9"
+  #     Dream__MemoryConsolidationEnabled: "false"
+  #     ModelBehaviors__Models__somevendor__UseTextBasedToolCalling: "true"
+  #
+  # Non-secret keys only — anything sensitive belongs under `secrets` instead.
+  # This mirrors the optional agent.extra.env file in the docker-compose stack.
+  extraEnv: {}
   # Always Recreate — only one agent may run at a time (stateful)
   replicaCount: 1
   # IANA timezone ID injected into every LLM prompt as current date/time context.


### PR DESCRIPTION
## Summary

The agent receives its configuration solely through `envFrom` on a chart-managed ConfigMap, and that ConfigMap contains only keys the chart explicitly templates. Any .NET configuration key without a dedicated value in `values.yaml` is therefore unreachable.

That is a real gap in practice: the chart templates four `Dream__*` keys and one `ModelBehaviors__*` key, but the framework exposes many more — `AgentHost__*` in its entirety, the rest of `Dream__*`, and per-model `ModelBehaviors__Models__<prefix>__*` entries. Setting any of them meant editing the chart or patching the Deployment by hand, and the latter is silently reverted by the next `helm upgrade`.

`agent.extraEnv` is a string map rendered verbatim into the agent ConfigMap:

```yaml
agent:
  extraEnv:
    AgentHost__Temperature: "0.9"
    AgentHost__EnableReasoningScaffolding: "false"
    Dream__MemoryConsolidationEnabled: "false"
    ModelBehaviors__Models__somevendor__UseTextBasedToolCalling: "true"
```

This mirrors the optional `agent.extra.env` env_file the docker-compose stack already supports, so both deployment paths now have the same escape hatch.

## Compatibility

Defaults to `{}` and renders nothing when unset, so existing releases produce a **byte-identical** ConfigMap. Verified by rendering the chart with and without the value.

## Notes

- **Non-secret keys only.** Documented in `values.yaml`. Anything sensitive belongs under `secrets`, which renders into a Secret rather than a ConfigMap.
- **Not override semantics.** The keys render after the templated ones, but ConfigMap `data` is a YAML map, so a duplicated key collides rather than overriding. Called out in the template comment so nobody reaches for this expecting to override a chart-managed key.
- Also bumps the version to **0.14.3**, since 0.14.2 is already published and deployed.

## Testing

- `helm lint` clean.
- Rendered with `--set agent.extraEnv.AgentHost__Temperature=0.95 --set agent.extraEnv.Dream__MemoryConsolidationEnabled=false`; both appear correctly quoted in the ConfigMap.
- Rendered with the value unset; no output block, no diff against current behaviour.
- Deployed a release using it end to end: 54 config keys reached the agent container's environment and were honoured at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
