### PR TITLE
Re-inject recalled memories once they scroll out of context

### DIFF
--- a/src/RockBot.Agent/ClearContextHandler.cs
+++ b/src/RockBot.Agent/ClearContextHandler.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 using RockBot.Host;
+using RockBot.Memory;
 using RockBot.Messaging;
 using RockBot.UserProxy;
 
@@ -15,6 +16,7 @@ internal sealed class ClearContextHandler(
     SessionClientCapabilityStore clientCapabilityStore,
     ReplyAttachmentBuffer attachmentBuffer,
     SessionOriginStore originStore,
+    InjectedMemoryTracker injectedMemoryTracker,
     IMessagePublisher publisher,
     AgentIdentity agent,
     ILogger<ClearContextHandler> logger) : IMessageHandler<ClearContextRequest>
@@ -29,6 +31,12 @@ internal sealed class ClearContextHandler(
 
         // Clear conversation memory (ephemeral turns only — logs are preserved)
         await conversationMemory.ClearAsync(message.SessionId, ct);
+
+        // Forget which memories have been injected. Recalled memories live in context for a
+        // single turn and are never persisted into history, so leaving this set behind would
+        // start the fresh session with no history AND every previously-recalled memory
+        // suppressed — the agent would be unable to recall anything it had already seen.
+        injectedMemoryTracker.Clear(message.SessionId);
 
         // Drop the cached client capabilities so the next inbound UserMessage re-establishes
         // them from scratch — important if the user returns on a different client.

--- a/src/RockBot.Host/AgentContextBuilder.cs
+++ b/src/RockBot.Host/AgentContextBuilder.cs
@@ -345,8 +345,11 @@ public sealed class AgentContextBuilder(
 
         // Long-term memory BM25 recall
         {
+            // history.Count is the turn index; MaxLlmContextTurns is how far back the model can
+            // still see. Past that, this entry is no longer in context and must be re-injected.
             var newEntries = recalled
-                .Where(e => injectedMemoryTracker.TryMarkAsInjected(sessionId, e.Id))
+                .Where(e => injectedMemoryTracker.TryMarkAsInjected(
+                    sessionId, e.Id, history.Count, MaxLlmContextTurns))
                 .ToList();
 
             if (newEntries.Count > 0)
@@ -368,7 +371,8 @@ public sealed class AgentContextBuilder(
         // Episodic memory recall
         {
             var newEpisodes = episodes
-                .Where(e => injectedMemoryTracker.TryMarkAsInjected(sessionId, e.Id))
+                .Where(e => injectedMemoryTracker.TryMarkAsInjected(
+                    sessionId, e.Id, history.Count, MaxLlmContextTurns))
                 .ToList();
 
             if (newEpisodes.Count > 0)

--- a/src/RockBot.Host/AgentLoopRunner.cs
+++ b/src/RockBot.Host/AgentLoopRunner.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using RockBot.Llm;
+using RockBot.Memory;
 using RockBot.Tools;
 
 namespace RockBot.Host;
@@ -26,7 +27,8 @@ public sealed partial class AgentLoopRunner(
     ISkillStore skillStore,
     IEnumerable<IServiceSearchIndex> serviceSearchIndexProviders,
     IConversationMemory conversationMemory,
-    ILogger<AgentLoopRunner> logger)
+    ILogger<AgentLoopRunner> logger,
+    InjectedMemoryTracker? injectedMemoryTracker = null)
 {
     private readonly IServiceSearchIndex? _serviceSearchIndex = serviceSearchIndexProviders.FirstOrDefault();
     private const int MaxConsecutiveTimeoutIterations = 2;
@@ -2098,6 +2100,11 @@ public sealed partial class AgentLoopRunner(
             }
 
             await conversationMemory.ClearAsync(sessionId, ct);
+
+            // History just went to (at most) a single turn, so every memory injected against the
+            // discarded turns is gone from context. Drop the injection record too, or those
+            // memories stay suppressed for the rest of the process and can never be recalled.
+            injectedMemoryTracker?.Clear(sessionId);
 
             if (lastUserTurn is not null)
             {

--- a/src/RockBot.Memory/InjectedMemoryTracker.cs
+++ b/src/RockBot.Memory/InjectedMemoryTracker.cs
@@ -6,33 +6,75 @@ namespace RockBot.Memory;
 /// Tracks which long-term memory entry IDs have already been injected into each session's
 /// LLM context, enabling delta injection: only entries the LLM has not yet seen are surfaced
 /// on each turn. When the conversational topic drifts, newly relevant entries surface naturally
-/// because they haven't been injected yet; already-seen entries are never re-injected.
+/// because they haven't been injected yet.
+///
+/// Injections expire. A recalled memory is appended as a system message for a single LLM call
+/// and is never written into conversation history, so the only durable trace it leaves is
+/// whatever the assistant's reply happened to carry forward. Once the turn it was injected on
+/// scrolls out of the history window the model can still see, the memory is absent from context
+/// entirely — suppressing re-injection past that point would make it permanently unrecallable
+/// even while it keeps ranking top of every search. Callers pass the current turn index and the
+/// size of the visible history window; entries injected longer ago than that window become
+/// eligible for re-injection.
 ///
 /// Registered as a singleton. State is in-process and resets on restart (intentional — the
 /// LLM's context window resets too, so re-injection on the next process start is correct).
+/// Callers that wipe a session's conversation history must also <see cref="Clear"/> it, or the
+/// session resumes with no history and its memories still suppressed.
 /// </summary>
 public sealed class InjectedMemoryTracker
 {
-    // sessionId -> set of already-injected memory IDs
-    // ConcurrentDictionary<string, byte> is the standard concurrent hash-set pattern.
-    private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, byte>> _sessions = new();
+    // sessionId -> (memoryId -> turn index at which it was last injected)
+    private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, int>> _sessions = new();
 
     /// <summary>
     /// Attempts to mark <paramref name="memoryId"/> as injected for <paramref name="sessionId"/>.
-    /// Returns <c>true</c> if this is the first injection of this ID (caller should inject it);
-    /// returns <c>false</c> if it was already injected (caller should skip it).
+    /// Returns <c>true</c> if the caller should inject it — either because it has never been
+    /// injected, or because the turn that carried it has scrolled out of the visible window.
+    /// Returns <c>false</c> if it is still present in context and should be skipped.
     /// Thread-safe.
     /// </summary>
-    public bool TryMarkAsInjected(string sessionId, string memoryId)
+    /// <param name="sessionId">Session whose context is being built.</param>
+    /// <param name="memoryId">ID of the memory entry being considered for injection.</param>
+    /// <param name="currentTurn">
+    /// Index of the turn being built — the count of turns in conversation memory. Only meaningful
+    /// alongside <paramref name="visibleHistoryTurns"/>.
+    /// </param>
+    /// <param name="visibleHistoryTurns">
+    /// How many of the most recent turns the model can still see. An entry injected more than this
+    /// many turns ago is treated as no longer present in context and becomes injectable again.
+    /// <c>null</c> disables expiry, injecting an entry at most once per session.
+    /// </param>
+    public bool TryMarkAsInjected(
+        string sessionId,
+        string memoryId,
+        int currentTurn = 0,
+        int? visibleHistoryTurns = null)
     {
         var set = _sessions.GetOrAdd(sessionId,
-            _ => new ConcurrentDictionary<string, byte>(StringComparer.Ordinal));
-        return set.TryAdd(memoryId, 0);
+            _ => new ConcurrentDictionary<string, int>(StringComparer.Ordinal));
+
+        while (true)
+        {
+            if (set.TryAdd(memoryId, currentTurn))
+                return true;
+
+            if (!set.TryGetValue(memoryId, out var injectedAtTurn))
+                continue; // Removed concurrently — retry the add.
+
+            if (visibleHistoryTurns is not int window || currentTurn - injectedAtTurn < window)
+                return false;
+
+            // The turn carrying this memory has scrolled out of the window the model can see;
+            // re-injecting is the only way it can observe this entry again.
+            // A lost race means another thread just re-injected it for this same turn.
+            return set.TryUpdate(memoryId, currentTurn, injectedAtTurn);
+        }
     }
 
     /// <summary>
     /// Clears tracked state for a session, allowing all entries to be re-injected.
-    /// Call this if the session is explicitly reset.
+    /// Call this whenever the session's conversation history is reset or wiped.
     /// </summary>
     public void Clear(string sessionId) => _sessions.TryRemove(sessionId, out _);
 }

--- a/tests/RockBot.Agent.Tests/ClearContextHandlerTests.cs
+++ b/tests/RockBot.Agent.Tests/ClearContextHandlerTests.cs
@@ -1,0 +1,75 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using RockBot.Agent;
+using RockBot.Host;
+using RockBot.Memory;
+using RockBot.Messaging;
+using RockBot.UserProxy;
+// StubSessionTracker lives with the A2A test helpers; StubConversationMemory and
+// TrackingPublisher resolve from this namespace, which takes precedence over the import.
+using RockBot.Agent.A2A.Tests;
+
+namespace RockBot.Agent.Tests;
+
+[TestClass]
+public class ClearContextHandlerTests
+{
+    private const string SessionId = "test-session";
+    private const string AgentName = "TestBot";
+
+    [TestMethod]
+    public async Task HandleAsync_ClearsInjectedMemoryTracker()
+    {
+        var tracker = new InjectedMemoryTracker();
+        var handler = BuildHandler(tracker);
+
+        // A memory injected before the clear would otherwise stay suppressed for the life of
+        // the process, leaving the fresh session unable to recall anything it had already seen.
+        tracker.TryMarkAsInjected(SessionId, "mem-abc");
+        Assert.IsFalse(tracker.TryMarkAsInjected(SessionId, "mem-abc"),
+            "Precondition: the entry is suppressed before the context is cleared");
+
+        await handler.HandleAsync(
+            new ClearContextRequest { SessionId = SessionId }, BuildContext());
+
+        Assert.IsTrue(tracker.TryMarkAsInjected(SessionId, "mem-abc"),
+            "After clearing context the entry must be injectable again");
+    }
+
+    [TestMethod]
+    public async Task HandleAsync_OnlyClearsTheTargetSession()
+    {
+        var tracker = new InjectedMemoryTracker();
+        var handler = BuildHandler(tracker);
+
+        tracker.TryMarkAsInjected(SessionId, "mem-abc");
+        tracker.TryMarkAsInjected("other-session", "mem-abc");
+
+        await handler.HandleAsync(
+            new ClearContextRequest { SessionId = SessionId }, BuildContext());
+
+        Assert.IsTrue(tracker.TryMarkAsInjected(SessionId, "mem-abc"));
+        Assert.IsFalse(tracker.TryMarkAsInjected("other-session", "mem-abc"),
+            "An unrelated session's injection state must survive");
+    }
+
+    private static ClearContextHandler BuildHandler(InjectedMemoryTracker tracker) =>
+        new(
+            new StubConversationMemory(),
+            new StubSessionTracker(),
+            new SessionClientCapabilityStore(),
+            new ReplyAttachmentBuffer(),
+            new SessionOriginStore(),
+            tracker,
+            new TrackingPublisher(),
+            new AgentIdentity(AgentName),
+            NullLogger<ClearContextHandler>.Instance);
+
+    private static MessageHandlerContext BuildContext() => new()
+    {
+        Envelope = new ClearContextRequest { SessionId = SessionId }
+            .ToEnvelope<ClearContextRequest>(source: "UserProxy"),
+        Agent = new AgentIdentity(AgentName),
+        Services = null!,
+        CancellationToken = CancellationToken.None
+    };
+}

--- a/tests/RockBot.Agent.Tests/InjectedMemoryTrackerTests.cs
+++ b/tests/RockBot.Agent.Tests/InjectedMemoryTrackerTests.cs
@@ -48,6 +48,71 @@ public class InjectedMemoryTrackerTests
     }
 
     [TestMethod]
+    public void TryMarkAsInjected_WithinVisibleWindow_StaysSuppressed()
+    {
+        var tracker = new InjectedMemoryTracker();
+        tracker.TryMarkAsInjected("session-1", "mem-abc", currentTurn: 5, visibleHistoryTurns: 20);
+
+        // Turn 24 is still within 20 turns of the injection at turn 5, so the entry remains
+        // visible in context and must not be injected a second time.
+        Assert.IsFalse(tracker.TryMarkAsInjected(
+            "session-1", "mem-abc", currentTurn: 24, visibleHistoryTurns: 20));
+    }
+
+    [TestMethod]
+    public void TryMarkAsInjected_AfterScrollingOutOfWindow_IsReInjected()
+    {
+        var tracker = new InjectedMemoryTracker();
+        tracker.TryMarkAsInjected("session-1", "mem-abc", currentTurn: 5, visibleHistoryTurns: 20);
+
+        // At turn 25 the injecting turn has fallen out of the visible window, so the entry is
+        // no longer in context and has to be re-injected for the model to see it.
+        Assert.IsTrue(tracker.TryMarkAsInjected(
+            "session-1", "mem-abc", currentTurn: 25, visibleHistoryTurns: 20));
+    }
+
+    [TestMethod]
+    public void TryMarkAsInjected_ReInjectionResetsTheWindow()
+    {
+        var tracker = new InjectedMemoryTracker();
+        tracker.TryMarkAsInjected("session-1", "mem-abc", currentTurn: 0, visibleHistoryTurns: 10);
+        // Expires and is re-injected at turn 10, which restarts the window from there.
+        tracker.TryMarkAsInjected("session-1", "mem-abc", currentTurn: 10, visibleHistoryTurns: 10);
+
+        Assert.IsFalse(tracker.TryMarkAsInjected(
+            "session-1", "mem-abc", currentTurn: 15, visibleHistoryTurns: 10),
+            "Turn 15 is within 10 turns of the re-injection at turn 10");
+        Assert.IsTrue(tracker.TryMarkAsInjected(
+            "session-1", "mem-abc", currentTurn: 20, visibleHistoryTurns: 10),
+            "Turn 20 is a full window past the re-injection at turn 10");
+    }
+
+    [TestMethod]
+    public void TryMarkAsInjected_WithoutVisibleWindow_NeverExpires()
+    {
+        var tracker = new InjectedMemoryTracker();
+        tracker.TryMarkAsInjected("session-1", "mem-abc", currentTurn: 0);
+
+        // No window supplied → expiry disabled, preserving inject-at-most-once behaviour.
+        Assert.IsFalse(tracker.TryMarkAsInjected("session-1", "mem-abc", currentTurn: 10_000));
+    }
+
+    [TestMethod]
+    public void TryMarkAsInjected_ExpiryIsPerMemoryId()
+    {
+        var tracker = new InjectedMemoryTracker();
+        tracker.TryMarkAsInjected("session-1", "mem-old", currentTurn: 0, visibleHistoryTurns: 20);
+        tracker.TryMarkAsInjected("session-1", "mem-new", currentTurn: 21, visibleHistoryTurns: 20);
+
+        Assert.IsTrue(tracker.TryMarkAsInjected(
+            "session-1", "mem-old", currentTurn: 25, visibleHistoryTurns: 20),
+            "mem-old was injected at turn 0 and has scrolled out");
+        Assert.IsFalse(tracker.TryMarkAsInjected(
+            "session-1", "mem-new", currentTurn: 25, visibleHistoryTurns: 20),
+            "mem-new was injected at turn 21 and is still visible");
+    }
+
+    [TestMethod]
     public void Clear_NonexistentSession_NoOp()
     {
         var tracker = new InjectedMemoryTracker();


### PR DESCRIPTION
## Problem

Recalled long-term and episodic memories are appended as system messages for a single LLM call and are never persisted into conversation history — the only durable trace one leaves is whatever the assistant's reply happened to carry forward.

`InjectedMemoryTracker` nonetheless suppressed a memory for the entire process lifetime after its first injection. Its docstring justified this by assuming tracker lifetime matches the model's context window. That assumption only holds at process start: history is trimmed to the last 20 turns (`AgentContextBuilder.MaxLlmContextTurns`), so an entry injected early scrolls out of context and can then never be surfaced again, however highly it ranks in every subsequent search.

The effect is a session that quietly loses access to its own memories as it grows, while retrieval keeps reporting hits. A process restart "fixes" it by resetting the tracker, which makes the underlying cause easy to misattribute.

Two paths made it worse by wiping a session's conversation history without clearing the tracker, producing the worst combination — no history, and every previously recalled memory still suppressed:

- `ClearContextHandler`, which resets a session on request
- `AgentLoopRunner`'s content-filter recovery, which discards all but the last user turn

## Change

- `TryMarkAsInjected` takes the current turn index and the size of the visible history window, and treats an entry injected further back than that window as absent from context and eligible for re-injection. Omitting the window keeps the previous inject-at-most-once behaviour, so existing callers are unaffected.
- `AgentContextBuilder` passes `history.Count` and `MaxLlmContextTurns` at both the long-term and episodic injection sites.
- `ClearContextHandler` and `AgentLoopRunner`'s content-filter recovery clear the tracker for the session.

## Tests

Five new cases covering expiry: suppression within the window, re-injection past it, the window restarting on re-injection, expiry being per-memory-id, and no-window preserving the old behaviour. Two new cases covering `ClearContextHandler` clearing the tracker and leaving unrelated sessions alone.

Full suite green (`dotnet test RockBot.slnx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)