### PR TITLE
Bump version to 0.14.4

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.14.3</Version>
+<Version>0.14.4</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->


### PR DESCRIPTION
Version bump so the injected-memory-tracker expiry fix (#498) can ship as a tagged image.

No functional change beyond `Directory.Build.props`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)