### PR TITLE
Ignore per-release helm values dumps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,10 @@ nupkgs/
 deploy/values.personal.yaml
 deploy/values.*.personal.yaml
 deploy/values.personal.yaml.live*
+# Per-release live-values dumps (muse, etc.) — same, secrets inside.
+# Keep values.personal.example.yaml committed; it is the only safe one.
+deploy/values.*.yaml
+!deploy/values.personal.example.yaml
 
 # Docker Compose .env files contain API keys — never commit these
 deploy/docker-compose/.env


### PR DESCRIPTION
## Problem

`helm get values <release>` dumps are the practical way to capture a live release's configuration, but the existing ignore rules only covered `values.personal.yaml` and `values.*.personal.yaml`.

A dump named for its release — e.g. `deploy/values.muse.yaml`, created while capturing the `muse` release's config — falls outside every existing pattern. That file contains the OpenRouter API key, RabbitMQ password, and Brave Search API key, so a `git add -A` would have committed live secrets.

## Fix

Broaden the rule to `deploy/values.*.yaml`, with a negation for `deploy/values.personal.example.yaml` — the only values file that is safe to commit, and which stays tracked.

## Verification

```
deploy/values.muse.yaml                    IGNORED
deploy/values.personal.yaml                IGNORED
deploy/values.personal.example.yaml        tracked/visible
```

`git ls-files 'deploy/values*'` returns only `values.personal.example.yaml`, so no already-tracked file is shadowed by the new pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
