### PR TITLE
Add optional Tailscale layer-7 Ingress for the Blazor UI

### DIFF
--- a/deploy/helm/rockbot/Chart.yaml
+++ b/deploy/helm/rockbot/Chart.yaml
@@ -4,8 +4,8 @@ description: >
   RockBot — an event-driven autonomous agent framework built on .NET.
   Deploys the RockBot agent and the Blazor Server web UI.
 type: application
-version: 0.10.16
-appVersion: "0.10.16"
+version: 0.10.17
+appVersion: "0.10.17"
 home: https://github.com/rockylhotka/rockbot
 keywords:
   - ai

--- a/deploy/helm/rockbot/templates/NOTES.txt
+++ b/deploy/helm/rockbot/templates/NOTES.txt
@@ -44,6 +44,17 @@ NEXT STEPS
 
    The Blazor UI is exposed on your Tailscale network via the
    Tailscale Kubernetes Operator at:
+{{- if .Values.blazor.tailscale.ingress.enabled }}
+
+     https://{{ .Values.blazor.tailscale.hostname }}.<your-tailnet>.ts.net
+
+   The exact name appears in the ADDRESS field once the certificate is
+   issued (Let's Encrypt, provisioned by the operator — allow a minute):
+
+     kubectl -n {{ .Values.namespace }} get ingress {{ include "rockbot.fullname" . }}-blazor
+
+   Still private to your tailnet — Funnel is not enabled.
+{{- else }}
 
      http://{{ .Values.blazor.tailscale.hostname }}
 
@@ -51,6 +62,10 @@ NEXT STEPS
    device to register. Check operator status with:
 
      kubectl -n {{ .Values.namespace }} describe svc {{ include "rockbot.fullname" . }}-blazor
+
+   For HTTPS, set blazor.tailscale.ingress.enabled=true — read the
+   switchover note in values.yaml first, the device is replaced.
+{{- end }}
 
 
 4. LOGS IN GRAFANA / LOKI

--- a/deploy/helm/rockbot/templates/blazor/ingress.yaml
+++ b/deploy/helm/rockbot/templates/blazor/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.blazor.tailscale.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "rockbot.fullname" . }}-blazor
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "rockbot.labels" . | nindent 4 }}
+    app.kubernetes.io/component: blazor
+  {{- if .Values.blazor.tailscale.ingress.proxyGroup }}
+  annotations:
+    tailscale.com/proxy-group: {{ .Values.blazor.tailscale.ingress.proxyGroup | quote }}
+  {{- end }}
+  # Deliberately absent: tailscale.com/funnel. That annotation — and only that
+  # annotation — would publish this endpoint to the public internet. Without it the
+  # Ingress is served by Tailscale Serve and stays private to the tailnet.
+spec:
+  ingressClassName: tailscale
+  tls:
+    # tls.hosts[0] sets the MagicDNS name; the operator resolves it to
+    # <hostname>.<your-tailnet>.ts.net and issues the certificate for that.
+    # The FQDN shows up in the Ingress ADDRESS field once provisioning completes.
+    - hosts:
+        - {{ .Values.blazor.tailscale.hostname | quote }}
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "rockbot.fullname" . }}-blazor
+                port:
+                  number: 80
+{{- end }}

--- a/deploy/helm/rockbot/templates/blazor/service.yaml
+++ b/deploy/helm/rockbot/templates/blazor/service.yaml
@@ -6,14 +6,24 @@ metadata:
   labels:
     {{- include "rockbot.labels" . | nindent 4 }}
     app.kubernetes.io/component: blazor
+{{- if not .Values.blazor.tailscale.ingress.enabled }}
   annotations:
     # Tailscale Kubernetes Operator — exposes this service on your tailnet
     # at <hostname> (no Funnel, private to tailnet only).
     # Requires: https://tailscale.com/kb/1236/kubernetes-operator
     tailscale.com/hostname: {{ .Values.blazor.tailscale.hostname | quote }}
+{{- end }}
 spec:
+{{- if .Values.blazor.tailscale.ingress.enabled }}
+  # Layer-7 mode: the Ingress owns the Tailscale device and terminates TLS, so this
+  # Service is a plain in-cluster backend. It must NOT also be a tailscale
+  # LoadBalancer — two devices competing for <hostname> means the loser is renamed
+  # <hostname>-1 and the certificate follows the wrong name.
+  type: ClusterIP
+{{- else }}
   type: LoadBalancer
   loadBalancerClass: tailscale
+{{- end }}
   selector:
     app: rockbot-blazor
     {{- include "rockbot.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/rockbot/values.yaml
+++ b/deploy/helm/rockbot/values.yaml
@@ -81,6 +81,37 @@ blazor:
     # Requires the Tailscale Kubernetes Operator to be installed.
     hostname: rockbot
 
+    ingress:
+      # false (default) — expose over a layer-3 LoadBalancer Service. Plain HTTP
+      #   at http://<hostname>. No TLS certificate is issued.
+      # true — expose over a layer-7 Ingress instead. The operator provisions a
+      #   Let's Encrypt certificate and the UI is served at
+      #   https://<hostname>.<your-tailnet>.ts.net. The Service drops to ClusterIP
+      #   so only one Tailscale device ever claims <hostname>.
+      #
+      # Either way the endpoint stays PRIVATE to your tailnet — it resolves to a
+      # CGNAT 100.x address that is not routable from the internet. Public exposure
+      # would require Tailscale Funnel, which this chart never enables.
+      #
+      # Prerequisites (Tailscale admin console → DNS): MagicDNS enabled AND the
+      # "HTTPS Certificates" toggle enabled.
+      #
+      # NOTE: issuing a certificate publishes <hostname>.<tailnet>.ts.net to the
+      # public Certificate Transparency log, permanently. The service stays private;
+      # the name does not. Do not enable this for a host whose name is sensitive.
+      #
+      # NOTE: switching an existing deployment from LoadBalancer to Ingress replaces
+      # the Tailscale device. Apply with this false first so the old device is
+      # released, then flip it to true — otherwise the new device is named
+      # <hostname>-1 and the certificate is issued for that instead. Let's Encrypt
+      # allows only 5 certificates per week for the same name, so a retry loop can
+      # lock you out of the name for days.
+      enabled: false
+
+      # Optional ProxyGroup for HA ingress (see the tailscale.com/proxy-group
+      # annotation). Empty means a single standalone proxy Pod.
+      proxyGroup: ""
+
 # ── RabbitMQ ──────────────────────────────────────────────────────────────────
 rabbitmq:
   hostName: ""      # REQUIRED — hostname or k8s service name of your RabbitMQ instance

--- a/docs/blazor-ui.md
+++ b/docs/blazor-ui.md
@@ -152,13 +152,48 @@ Docker image (`rockylhotka/rockbot-blazor`). It requires only:
 
 It does **not** need access to the agent data PVC or any agent-internal configuration.
 
-The UI is exposed on the Tailscale network via the Tailscale Kubernetes Operator:
+The UI is exposed on the Tailscale network via the Tailscale Kubernetes Operator, in one
+of two modes.
+
+**Layer 3 (default)** — a `LoadBalancer` Service with `loadBalancerClass: tailscale`.
+Plain HTTP, no certificate:
 
 ```yaml
 blazor:
   tailscale:
     hostname: "rockbot"   # accessible at http://rockbot on your tailnet
 ```
+
+**Layer 7 (HTTPS)** — an `Ingress` with `ingressClassName: tailscale`. The operator
+provisions a Let's Encrypt certificate and the Service drops to `ClusterIP`:
+
+```yaml
+blazor:
+  tailscale:
+    hostname: "rockbot"
+    ingress:
+      enabled: true       # https://rockbot.<your-tailnet>.ts.net
+      proxyGroup: ""      # optional ProxyGroup name for HA ingress
+```
+
+Requires MagicDNS **and** the *HTTPS Certificates* toggle in the Tailscale admin console's
+DNS settings. Certificates are only ever issued for `<hostname>.<tailnet>.ts.net` — never
+for a bare hostname, and never for a custom domain.
+
+Both modes stay **private to your tailnet**: the name resolves to a CGNAT `100.x` address
+that is not routable from the internet. Publishing to the public internet would require the
+`tailscale.com/funnel` annotation, which this chart never emits.
+
+Two things to know before switching an existing deployment:
+
+- **The Tailscale device is replaced.** Deploy once with `ingress.enabled: false` so the
+  layer-3 device releases `<hostname>`, then flip it to `true`. Otherwise the new device is
+  named `<hostname>-1` and the certificate is issued for that name instead.
+- **Get it right on the first apply.** Let's Encrypt allows 5 certificates per week for the
+  same name, so a create/delete retry loop can lock you out of the name for days.
+
+Issuing a certificate publishes `<hostname>.<tailnet>.ts.net` to the public Certificate
+Transparency log permanently. The service stays private; the name does not.
 
 ---
 


### PR DESCRIPTION
Adds an opt-in Tailscale layer-7 Ingress for the Blazor UI so it can be served over HTTPS.

## Why

The chart only ever exposed Blazor over a **layer-3** `LoadBalancer` Service (`loadBalancerClass: tailscale`). The Tailscale operator does not provision TLS on that path — it's raw TCP forwarding — which is why the UI has always been plain `http://<hostname>`. Certificates only come from the **layer-7** Ingress path, where the operator provisions a Let's Encrypt cert and fronts the app with Tailscale Serve.

## What changed

New `blazor.tailscale.ingress.enabled`, **default `false`**, so existing deployments render byte-identically until opted in.

| | `false` (default) | `true` |
|---|---|---|
| Service | `LoadBalancer`, `loadBalancerClass: tailscale` | `ClusterIP` |
| Ingress | not rendered | `ingressClassName: tailscale` |
| URL | `http://<hostname>` | `https://<hostname>.<tailnet>.ts.net` |
| TLS | none | Let's Encrypt, operator-provisioned |

The Service **must** drop to `ClusterIP` in layer-7 mode. If both the Service and the Ingress claim `<hostname>`, two Tailscale devices compete for the name, the loser is renamed `<hostname>-1`, and the certificate is issued for the wrong name.

`blazor.tailscale.hostname` is reused across both modes — the `tailscale.com/hostname` annotation in layer 3, `tls.hosts[0]` in layer 7, which is what the operator reads to set the MagicDNS name.

Optional `ingress.proxyGroup` emits `tailscale.com/proxy-group` for HA ingress; empty means a single standalone proxy Pod.

## Both modes stay private

The endpoint resolves to a CGNAT `100.x` address that is not routable from the internet, in either mode. Adding a certificate changes how your own devices connect, not who can reach it.

Public exposure requires the `tailscale.com/funnel` annotation, which **this chart never emits**. The Ingress template carries an explicit comment recording that as a deliberate omission, so it doesn't get "helpfully" added later.

What *does* become public is the **name**: issuing a certificate publishes `<hostname>.<tailnet>.ts.net` to the Certificate Transparency log, permanently and irrevocably. The service stays private; the name does not. Called out in `values.yaml`, the docs, and the commit message, because it's the one consequence that can't be undone by flipping the flag back.

## Switchover hazards (documented in values.yaml + docs)

- **The Tailscale device is replaced.** Deploy once with `enabled: false` so the layer-3 device releases `<hostname>`, *then* flip to `true`. Otherwise you get `<hostname>-1`.
- **Get it right on the first apply.** Let's Encrypt allows 5 certificates per week for the same name — a create/delete retry loop can lock you out of the name for days.

## Prerequisites

Tailscale admin console → DNS: MagicDNS enabled **and** the *HTTPS Certificates* toggle enabled. Certificates are only ever issued for `<hostname>.<tailnet>.ts.net` — never a bare hostname, never a custom domain.

## Verification

`helm lint` clean. Rendering checked on both real values files in this cluster:

- **Default path** — Service unchanged: `LoadBalancer` + `loadBalancerClass: tailscale` + `tailscale.com/hostname`. Zero `kind: Ingress` in the full render.
- **Enabled path** — Service is `ClusterIP` with no Tailscale annotation; Ingress renders with `ingressClassName: tailscale` and `tls.hosts: ["rockbot"]`.
- **No active Funnel annotation** in the enabled render — the only `funnel` match in the entire output is the explanatory comment.
- **muse is unaffected.** Its values file doesn't set the new key, so it falls back to the chart default: renders `LoadBalancer` + `tailscale.com/hostname: "muse"`, zero Ingress — identical to what's deployed today.

Chart version 0.10.16 → 0.10.17.

Not enabled on any live release in this PR; the rockbot cutover is a separate deliberate step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
