### PR TITLE
Make the LLM context turn window configurable

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.14.5</Version>
+<Version>0.14.6</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.Agent/Program.cs
+++ b/src/RockBot.Agent/Program.cs
@@ -300,6 +300,7 @@ builder.Services.AddRockBotHost(agent =>
     agent.WithProfile();
     agent.WithRules();
     agent.WithMemory();
+    agent.WithConversationMemory(opts => builder.Configuration.GetSection("ConversationMemory").Bind(opts));
     agent.WithConversationLog();
     agent.WithFeedback(opts => builder.Configuration.GetSection("Feedback").Bind(opts));
     agent.WithSkills();

--- a/src/RockBot.Host/AgentContextBuilder.cs
+++ b/src/RockBot.Host/AgentContextBuilder.cs
@@ -36,10 +36,12 @@ public sealed class AgentContextBuilder(
     IToolCallLog? toolCallLog = null,
     IOptions<AgentHostOptions>? agentHostOptions = null)
 {
-    private const int MaxLlmContextTurns = 20;
-
     /// <summary>Host options, defaulted when not supplied so existing callers and tests are unaffected.</summary>
     private readonly AgentHostOptions _hostOptions = agentHostOptions?.Value ?? new AgentHostOptions();
+
+    /// <summary>How many recent turns are replayed into the LLM context; see
+    /// <see cref="AgentHostOptions.MaxLlmContextTurns"/>.</summary>
+    private int MaxLlmContextTurns => _hostOptions.MaxLlmContextTurns;
 
     private readonly IServiceSearchIndex? _serviceSearchIndex = serviceSearchIndexProviders.FirstOrDefault();
     private readonly IKnowledgeGraph? _knowledgeGraph = knowledgeGraphProviders.FirstOrDefault();

--- a/src/RockBot.Host/AgentHostOptions.cs
+++ b/src/RockBot.Host/AgentHostOptions.cs
@@ -146,6 +146,19 @@ public sealed class AgentHostOptions
     public bool PersistErrorTurns { get; set; } = true;
 
     /// <summary>
+    /// Number of the most recent conversation turns replayed into the LLM context on each
+    /// call. Defaults to 20.
+    /// <para>
+    /// Raise this for agents on large-context models where continuity matters more than
+    /// prompt cost — a creative or long-running conversational agent loses the thread when
+    /// the window is short. Values above
+    /// <see cref="ConversationMemoryOptions.MaxTurnsPerSession"/> have no effect, because
+    /// retention caps how many turns exist to replay.
+    /// </para>
+    /// </summary>
+    public int MaxLlmContextTurns { get; set; } = 20;
+
+    /// <summary>
     /// Maximum number of times the completion evaluator can re-prompt the agent when it
     /// determines the task is incomplete. Set to 0 to disable completion evaluation entirely.
     /// Individual models may override this via <c>ModelBehavior.MaxCompletionRepromptsOverride</c>.

--- a/tests/RockBot.Host.Tests/AgentContextBuilderContextTurnsTests.cs
+++ b/tests/RockBot.Host.Tests/AgentContextBuilderContextTurnsTests.cs
@@ -1,0 +1,199 @@
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using RockBot.Llm;
+using RockBot.Memory;
+using RockBot.Skills;
+
+namespace RockBot.Host.Tests;
+
+/// <summary>
+/// Covers <see cref="AgentHostOptions.MaxLlmContextTurns"/>, which controls how many of the
+/// most recent conversation turns <see cref="AgentContextBuilder"/> replays into the LLM
+/// context. It was a hard-coded 20 before; large-context conversational agents need to raise
+/// it without a rebuild.
+/// </summary>
+[TestClass]
+public class AgentContextBuilderContextTurnsTests
+{
+    [TestMethod]
+    public void DefaultIs20()
+    {
+        Assert.AreEqual(20, new AgentHostOptions().MaxLlmContextTurns,
+            "Default must stay 20 so existing deployments are unaffected.");
+    }
+
+    [TestMethod]
+    public async Task DefaultOptions_ReplaysAtMost20Turns()
+    {
+        var builder = BuildBuilder(new FixedHistoryConversationMemory(turnCount: 60));
+
+        var messages = await builder.BuildAsync("session-default", "current message", CancellationToken.None);
+
+        Assert.AreEqual(20, CountHistoryTurns(messages),
+            "With default options only the last 20 turns should reach the model.");
+    }
+
+    [TestMethod]
+    public async Task RaisedOption_ReplaysThatManyTurns()
+    {
+        var builder = BuildBuilder(
+            new FixedHistoryConversationMemory(turnCount: 60),
+            new AgentHostOptions { MaxLlmContextTurns = 50 });
+
+        var messages = await builder.BuildAsync("session-50", "current message", CancellationToken.None);
+
+        Assert.AreEqual(50, CountHistoryTurns(messages),
+            "MaxLlmContextTurns=50 should replay the last 50 turns.");
+    }
+
+    [TestMethod]
+    public async Task RaisedOption_KeepsTheMostRecentTurns()
+    {
+        var builder = BuildBuilder(
+            new FixedHistoryConversationMemory(turnCount: 60),
+            new AgentHostOptions { MaxLlmContextTurns = 50 });
+
+        var messages = await builder.BuildAsync("session-recency", "current message", CancellationToken.None);
+        var replayed = HistoryTurns(messages).ToList();
+
+        // Turns are numbered 0..59; the last 50 are 10..59.
+        Assert.AreEqual("turn-10", replayed[0], "Oldest replayed turn should be turn-10.");
+        Assert.AreEqual("turn-59", replayed[^1], "Newest replayed turn should be turn-59.");
+    }
+
+    [TestMethod]
+    public async Task HistoryShorterThanWindow_ReplaysEverything()
+    {
+        var builder = BuildBuilder(
+            new FixedHistoryConversationMemory(turnCount: 7),
+            new AgentHostOptions { MaxLlmContextTurns = 50 });
+
+        var messages = await builder.BuildAsync("session-short", "current message", CancellationToken.None);
+
+        Assert.AreEqual(7, CountHistoryTurns(messages),
+            "A window larger than the available history must not pad or throw.");
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    /// <summary>Synthetic history turns are the only messages whose text starts with "turn-".</summary>
+    private static IEnumerable<string> HistoryTurns(IReadOnlyList<ChatMessage> messages) =>
+        messages.Select(m => m.Text).Where(t => t.StartsWith("turn-", StringComparison.Ordinal));
+
+    private static int CountHistoryTurns(IReadOnlyList<ChatMessage> messages) => HistoryTurns(messages).Count();
+
+    private static AgentContextBuilder BuildBuilder(
+        IConversationMemory conversationMemory,
+        AgentHostOptions? hostOptions = null)
+    {
+        var profileHolder = new ProfileHolder();
+        var doc = new AgentProfileDocument("soul", null, [], "I am a test agent.");
+        profileHolder.Update(new AgentProfile(doc, doc));
+        var nameHolder = new AgentNameHolder();
+
+        var agentProfileOptions = Options.Create(new AgentProfileOptions
+        {
+            BasePath = Path.Combine(Path.GetTempPath(), "rockbot-ctxturns-test-" + Guid.NewGuid().ToString("N"))
+        });
+        Directory.CreateDirectory(agentProfileOptions.Value.BasePath);
+
+        var clock = new AgentClock(
+            new ConfigurationBuilder().Build(),
+            agentProfileOptions,
+            NullLoggerFactory.Instance.CreateLogger<AgentClock>());
+
+        return new AgentContextBuilder(
+            profileHolder: profileHolder,
+            agent: new AgentIdentity("TestBot"),
+            promptBuilder: new DefaultSystemPromptBuilder(profileHolder, nameHolder, Options.Create(new AgentProfileOptions())),
+            rulesStore: new StubRulesStore(),
+            modelBehavior: ModelBehavior.Default,
+            conversationMemory: conversationMemory,
+            longTermMemory: new StubLongTermMemory(),
+            injectedMemoryTracker: new InjectedMemoryTracker(),
+            workingMemory: new StubWorkingMemory(),
+            skillStore: new StubSkillStore(),
+            skillIndexTracker: new SkillIndexTracker(),
+            skillRecallTracker: new SkillRecallTracker(),
+            clock: clock,
+            serviceSearchIndexProviders: [],
+            knowledgeGraphProviders: [],
+            knowledgeGraphOptions: Options.Create(new KnowledgeGraphOptions()),
+            embeddingGenerators: [],
+            logger: NullLogger<AgentContextBuilder>.Instance,
+            agentHostOptions: hostOptions is null ? null : Options.Create(hostOptions));
+    }
+
+    // ── Stubs ────────────────────────────────────────────────────────────────
+
+    /// <summary>Returns <paramref name="turnCount"/> alternating turns named <c>turn-{i}</c>.</summary>
+    private sealed class FixedHistoryConversationMemory(int turnCount) : IConversationMemory
+    {
+        private readonly IReadOnlyList<ConversationTurn> _turns =
+            [.. Enumerable.Range(0, turnCount).Select(i =>
+                new ConversationTurn(i % 2 == 0 ? "user" : "assistant", $"turn-{i}", DateTimeOffset.UtcNow))];
+
+        public Task AddTurnAsync(string sessionId, ConversationTurn turn, CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
+
+        public Task<IReadOnlyList<ConversationTurn>> GetTurnsAsync(string sessionId, CancellationToken cancellationToken = default) =>
+            Task.FromResult(_turns);
+
+        public Task ClearAsync(string sessionId, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task<IReadOnlyList<string>> ListSessionsAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<string>>([]);
+    }
+
+    private sealed class StubLongTermMemory : ILongTermMemory
+    {
+        public Task SaveAsync(MemoryEntry entry, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task<IReadOnlyList<MemoryEntry>> SearchAsync(MemorySearchCriteria criteria, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<MemoryEntry>>([]);
+
+        public Task<MemoryEntry?> GetAsync(string id, CancellationToken cancellationToken = default) =>
+            Task.FromResult<MemoryEntry?>(null);
+
+        public Task DeleteAsync(string id, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task<IReadOnlyList<string>> ListTagsAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<string>>([]);
+
+        public Task<IReadOnlyList<string>> ListCategoriesAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<string>>([]);
+    }
+
+    private sealed class StubWorkingMemory : IWorkingMemory
+    {
+        public Task SetAsync(string key, string value, TimeSpan? ttl = null, string? category = null, IReadOnlyList<string>? tags = null) => Task.CompletedTask;
+        public Task<string?> GetAsync(string key) => Task.FromResult<string?>(null);
+        public Task<IReadOnlyList<WorkingMemoryEntry>> ListAsync(string? prefix = null) =>
+            Task.FromResult<IReadOnlyList<WorkingMemoryEntry>>([]);
+        public Task DeleteAsync(string key) => Task.CompletedTask;
+        public Task ClearAsync(string? prefix = null) => Task.CompletedTask;
+        public Task<IReadOnlyList<WorkingMemoryEntry>> SearchAsync(MemorySearchCriteria criteria, string? prefix = null) =>
+            Task.FromResult<IReadOnlyList<WorkingMemoryEntry>>([]);
+    }
+
+    private sealed class StubSkillStore : ISkillStore
+    {
+        public Task SaveAsync(Skill skill) => Task.CompletedTask;
+        public Task<Skill?> GetAsync(string name) => Task.FromResult<Skill?>(null);
+        public Task<IReadOnlyList<Skill>> ListAsync() => Task.FromResult<IReadOnlyList<Skill>>([]);
+        public Task DeleteAsync(string name) => Task.CompletedTask;
+        public Task<IReadOnlyList<Skill>> SearchAsync(string query, int maxResults, CancellationToken cancellationToken = default, float[]? queryEmbedding = null) =>
+            Task.FromResult<IReadOnlyList<Skill>>([]);
+    }
+
+    private sealed class StubRulesStore : IRulesStore
+    {
+        public IReadOnlyList<string> Rules => [];
+        public Task<IReadOnlyList<string>> ListAsync() => Task.FromResult<IReadOnlyList<string>>([]);
+        public Task AddAsync(string rule) => Task.CompletedTask;
+        public Task RemoveAsync(string rule) => Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Problem

`AgentContextBuilder` replayed a hard-coded 20 most-recent conversation turns into every LLM call:

```csharp
private const int MaxLlmContextTurns = 20;
```

Agents running on large-context models — where continuity matters far more than prompt cost — had no way to raise that without a rebuild.

## Change

- **`AgentHostOptions.MaxLlmContextTurns`**, default `20`, so every existing deployment behaves exactly as before. `AgentContextBuilder` reads it instead of the const.
- The injected-memory re-injection tracker (PR #498) already keyed off the same number, so it picks the option up automatically and the re-injection horizon stays consistent with the actual window.
- **Bind the `ConversationMemory` config section** in the agent host. `ConversationMemoryOptions.MaxTurnsPerSession` (retention, default 50) was never bound to configuration, so it could only be changed in code. Retention caps how many turns exist to replay, so the two knobs have to be settable together — a 50-turn window is pointless against 20-turn retention.
- Version bump to 0.14.6.

## Configuration

```
AgentHost__MaxLlmContextTurns=50
ConversationMemory__MaxTurnsPerSession=80
```

## Tests

New `AgentContextBuilderContextTurnsTests` (5 tests): default stays 20; a raised option replays that many turns; the turns replayed are the most recent ones; and a window larger than the available history neither pads nor throws.

Full suite green (2,568 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)