### PR TITLE
Stop dream consolidation from destroying memories

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.14.6</Version>
+<Version>0.14.7</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.14.7</Version>
+<Version>0.14.8</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.14.8</Version>
+<Version>0.14.9</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.14.9</Version>
+<Version>0.14.10</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/deploy/helm/rockbot/templates/agent/deployment.yaml
+++ b/deploy/helm/rockbot/templates/agent/deployment.yaml
@@ -76,6 +76,13 @@ spec:
                 cp /app/agent/llm-pricing.json /data/agent/llm-pricing.json
               fi
 
+              # merge-coverage-vocabulary.json — per-deployment word list for the dream
+              # merge-coverage safeguard. Copy no-clobber so operator tuning survives upgrades.
+              if [ -f /app/agent/merge-coverage-vocabulary.json ] && [ ! -s /data/agent/merge-coverage-vocabulary.json ]; then
+                echo "  Copying default merge-coverage-vocabulary.json"
+                cp /app/agent/merge-coverage-vocabulary.json /data/agent/merge-coverage-vocabulary.json
+              fi
+
               # Per-model behavior prompt files — copy per-file so users can customise
               # individual prompts without losing others on upgrade
               for model_dir in /app/model-behaviors/*/; do

--- a/docs/dream-service.md
+++ b/docs/dream-service.md
@@ -103,7 +103,10 @@ Gating makes it roughly one decision per entry per content change.
 - Clustering comes from `IMemoryDuplicateCandidates` on the store: cosine over embeddings
   where available, Jaccard over content tokens otherwise, so BM25-only deployments still
   deduplicate. Controlled by `Dream:ConsolidationSimilarityThreshold` (default 0.88) and
-  `Dream:ConsolidationMaxClusterSize` (default 3, capping merge fan-in).
+  `Dream:ConsolidationMaxClusterSize` (default 3). The cluster cap bounds *eligibility*, not
+  merge size — the model may propose a merge over any subset of what it is shown, and in
+  practice does produce merges with more sources than this value. Large merges are constrained
+  by the coverage check below rather than by a count.
 - If the near-duplicate scan fails, the pass degrades to unreviewed-only rather than falling
   back to the whole corpus.
 

--- a/docs/dream-service.md
+++ b/docs/dream-service.md
@@ -137,6 +137,34 @@ rather than costing the fact. Every archive is logged at Information with the en
 inline, which is what makes a bad cycle reviewable without restoring a volume backup.
 `IArchivedMemoryMaintenance.RestoreAsync` puts an entry back.
 
+**Merge coverage check.** Before a merge is applied, the specifics in its sources — proper
+nouns, acronyms, and multi-digit numbers — must all appear in the merged text. If any is
+missing the merge is rejected outright: nothing is saved and the sources are left alone. This
+is what catches the characteristic failure, a plausible-reading merge that keeps the
+machine-readable half of an entry and quietly drops a name or a date.
+
+The check is deliberately biased toward rejection, because the costs are asymmetric: a false
+rejection leaves a duplicate pair alive for another cycle, while a false acceptance destroys
+the only record of how a fact was worded. Measured against a real 148-entry corpus, it rejects
+0% of merges that preserve all source content and catches 83% of merges that drop a source
+outright (the remainder being pairs where one source's specifics are a strict subset of the
+other's — genuinely redundant). Known conservative false positives include 12h→24h clock
+reformatting.
+
+**High-value pruning floor.** Entries at or above `Dream:PruningProtectionImportance`
+(default 0.80) or `Dream:PruningProtectionReinforcementCount` (default 5) can be merged, but
+are never archived as standalone ephemeral. Merging preserves content and is covered by the
+check above; ephemeral pruning discards a fact with nothing in its place, which is not
+something to do on one model's say-so to an entry the agent has re-observed dozens of times.
+This is a deterministic floor precisely because the prompt-level version did not hold —
+`dream.md` already said reinforcement signals importance, and a live corpus still lost entries
+reinforced 214, 106 and 80 times.
+
+**Provenance.** Merged entries carry `mergedFrom` (source IDs) and `mergedAt` in metadata.
+Source text is not duplicated: the sources are archived rather than deleted, so those IDs
+resolve via `GetAsync` for the retention window. Metadata is not part of the search surface,
+so this does not affect ranking. After the purge the IDs dangle by design.
+
 **Ordering — replacement first, then retirement.** Merged entries are saved *before* their
 sources are archived, and only sources belonging to a merge that actually persisted are
 retired. A `toSave` entry with blank content is skipped with a warning and its sources are

--- a/docs/dream-service.md
+++ b/docs/dream-service.md
@@ -146,6 +146,25 @@ missing the merge is rejected outright: nothing is saved and the sources are lef
 is what catches the characteristic failure, a plausible-reading merge that keeps the
 machine-readable half of an entry and quietly drops a name or a date.
 
+**Vocabulary is per-deployment.** Which capitalized words count as ordinary language rather
+than as detail is not portable between agents, so it lives in
+`merge-coverage-vocabulary.json` on the agent profile volume (next to `tier-selector.json`),
+re-read at the top of every cycle:
+
+```json
+{
+  "extraCommonWords":    ["briefing", "triage"],
+  "alwaysSpecificWords": ["May", "Will", "Rose"]
+}
+```
+
+`extraCommonWords` suppresses domain noise. `alwaysSpecificWords` reclaims words from the
+built-in generic-English baseline and takes precedence over it — this matters most for agents
+whose people or characters collide with ordinary English. The baseline contains `may`, `will`,
+`some`, `first` and `last`, so a storytelling agent with a character named **May** or **Will**
+must list them here or those names carry no coverage protection at all. A malformed file falls
+back to the baseline with a warning; coverage checking is never disabled by bad config.
+
 The check is deliberately biased toward rejection, because the costs are asymmetric: a false
 rejection leaves a duplicate pair alive for another cycle, while a false acceptance destroys
 the only record of how a fact was worded. Measured against a real 148-entry corpus, it rejects

--- a/docs/dream-service.md
+++ b/docs/dream-service.md
@@ -68,13 +68,44 @@ are not swept.)
 
 **Enabled/disabled by:** `DreamOptions.LogRetentionEnabled` (default `true`).
 
+### Pass 0b — Archive purge
+
+Hard-deletes memory entries archived longer ago than `DreamOptions.MemoryArchiveRetention`
+(default 90 days). Runs before consolidation so the retention window is measured from the
+archive event rather than from whatever the current cycle is about to archive.
+
+Requires the store to implement `IArchivedMemoryMaintenance`; with a store that does not,
+`ArchiveAsync` falls back to a hard delete and there is nothing to purge. A non-positive
+retention keeps archived entries forever.
+
 ### Pass 1 — Memory consolidation
 
-**Input:** all long-term memory entries (up to 1000) + recent feedback signals (last 7 days,
-up to 50). Each entry is rendered with its temporal context — `first=` (CreatedAt),
+**Input:** a *gated subset* of long-term memory entries + recent feedback signals (last 7
+days, up to 50). Each entry is rendered with its temporal context — `first=` (CreatedAt),
 `last=` (LastSeenAt), `reinforced=N×` (ReinforcementCount), and `subject=...` when
 subject-time metadata is present — so the LLM can reason about whether similar-sounding
 entries describe the same durable fact or distinct moments.
+
+**Candidate gating — what the LLM is allowed to see.** An entry becomes eligible only if it
+is (a) new or changed since its last review, or (b) part of a near-duplicate cluster. Anything
+else is withheld and therefore cannot be archived this cycle. Enforcement is in code, not just
+in the prompt: the source lookup used for merge arithmetic is keyed on the eligible set, so an
+ID the model invents or remembers from a previous cycle resolves to nothing.
+
+This exists because exposure compounds. Handing over the whole corpus every cycle means every
+entry is re-tried for deletion every cycle; at the default twice-daily cadence, a
+one-in-a-thousand misjudgement per entry per cycle loses roughly half the corpus in a year.
+Gating makes it roughly one decision per entry per content change.
+
+- Review state is a content fingerprint (`consolidationReviewedHash` in entry metadata), so
+  any write path — reinforcement, a tool edit, a prior merge — re-opens an entry for review,
+  while importance decay (which changes score and `UpdatedAt`, not content) does not.
+- Clustering comes from `IMemoryDuplicateCandidates` on the store: cosine over embeddings
+  where available, Jaccard over content tokens otherwise, so BM25-only deployments still
+  deduplicate. Controlled by `Dream:ConsolidationSimilarityThreshold` (default 0.88) and
+  `Dream:ConsolidationMaxClusterSize` (default 3, capping merge fan-in).
+- If the near-duplicate scan fails, the pass degrades to unreviewed-only rather than falling
+  back to the whole corpus.
 
 **What the LLM does:**
 - Merges duplicate and near-duplicate entries into single improved entries, including
@@ -83,7 +114,7 @@ entries describe the same durable fact or distinct moments.
 - Preserves topically-similar entries that describe distinct real-world moments (different
   trips, meetings, incidents) — especially when subject-time differs sharply
 - Refines categories (e.g. promotes `general` entries to more specific categories)
-- Deletes noisy, low-value, or fully superseded entries
+- Flags noisy, low-value, or fully superseded entries for removal
 - Mines `Correction` feedback for anti-patterns and writes them to `anti-patterns/{domain}`
 
 **Temporal-field arithmetic on merge (computed by the host, not the LLM):**
@@ -98,9 +129,24 @@ This division keeps the LLM focused on *what to merge* and prevents dream housek
 stamping every reprocessed entry as "just observed." See `dream.md` for the Temporal merging
 rules the LLM is given.
 
-**Exhaustive deletion contract:** The union of explicit `toDelete` IDs and all `sourceIds`
-referenced in merged entries are deleted. This prevents orphaned source entries when the LLM
-omits IDs from `toDelete` but lists them in `sourceIds`.
+**Removals are archived, never deleted.** Consolidation calls `ILongTermMemory.ArchiveAsync`,
+which hides an entry from search while keeping it on disk and retrievable by ID. The archive
+purge pass hard-deletes entries archived longer ago than `Dream:MemoryArchiveRetention`
+(default 90 days), so a wrong merge or a wrong "ephemeral" call costs recall for a while
+rather than costing the fact. Every archive is logged at Information with the entry's content
+inline, which is what makes a bad cycle reviewable without restoring a volume backup.
+`IArchivedMemoryMaintenance.RestoreAsync` puts an entry back.
+
+**Ordering — replacement first, then retirement.** Merged entries are saved *before* their
+sources are archived, and only sources belonging to a merge that actually persisted are
+retired. A `toSave` entry with blank content is skipped with a warning and its sources are
+kept. (The previous order deleted everything up front and saved afterwards, so a skipped or
+failed save destroyed the sources outright.)
+
+**Exhaustive-removal contract:** The union of explicit `toDelete` IDs and all `sourceIds`
+referenced in *persisted* merged entries is archived. This prevents orphaned source entries
+when the LLM omits IDs from `toDelete` but lists them in `sourceIds`. IDs outside the eligible
+set are ignored.
 
 **Episode reinforcement:** When a new session revisits an existing episodic memory (found by
 the episode extraction pass), the existing entry is updated with `LastSeenAt = now` and

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -424,6 +424,17 @@ This split keeps the LLM focused on *what to merge* while the host guarantees co
 temporal arithmetic and prevents the dream cycle from inadvertently stamping every
 reprocessed entry as "just seen today."
 
+**Two safeguards constrain what a pass may do:**
+
+- *Merge coverage* — every proper noun, acronym and multi-digit number in a merge's sources
+  must survive into the merged text, or the merge is rejected and the sources are kept.
+- *High-value floor* — entries at or above `Dream:PruningProtectionImportance` (0.80) or
+  `Dream:PruningProtectionReinforcementCount` (5) may be merged but never pruned outright.
+
+Both are deterministic rather than prompt guidance, because the prompt-level versions were
+already present and did not hold. Merged entries record `mergedFrom` / `mergedAt` in metadata
+(metadata is not part of the search surface). See `dream-service.md` for measured behaviour.
+
 **Removals are archived, not deleted.** Consolidation calls `ArchiveAsync`, which hides an
 entry from search but keeps it on disk and retrievable by ID; a separate purge pass
 hard-deletes archived entries after `Dream:MemoryArchiveRetention` (default 90 days), and

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -387,20 +387,27 @@ The dream service runs two memory-related passes:
 
 ### Pass 1 — Memory consolidation
 
-Reviews all long-term memory entries for duplicates, near-duplicates, and outdated content.
+Reviews a gated subset of long-term memory entries for duplicates, near-duplicates, and
+outdated content.
 
 **Inputs provided to the LLM:**
-- All memory entries (up to 1000), numbered with ID, category, tags, content, and temporal
-  context (`first=`, `last=`, `reinforced=N×`, and `subject=...` when subject-time metadata
-  is present)
+- Only *eligible* entries — those new or changed since their last review, plus those in a
+  near-duplicate cluster — numbered with ID, category, tags, content, and temporal context
+  (`first=`, `last=`, `reinforced=N×`, and `subject=...` when subject-time metadata is
+  present). Everything else is withheld and cannot be touched this cycle.
 - Recent feedback signals (last 7 days, up to 50) for quality context
 
 **What the LLM can do:**
 1. Merge duplicate or near-duplicate entries — even when widely separated in time, treating
    them as reinforcement rather than novelty
 2. Refine categories and tags
-3. Delete noisy or redundant entries
+3. Flag noisy or redundant entries for archiving
 4. Write `anti-patterns/{domain}` entries from Correction feedback
+
+**Why gating exists:** without it, the whole corpus is re-offered for deletion on every cycle,
+so per-entry survival compounds against you — at twice a day, a one-in-a-thousand misjudgement
+per entry per cycle loses about half the corpus in a year. See `dream-service.md` for the
+eligibility rules and tuning knobs.
 
 **Temporal arithmetic on merge (computed by the host, not the LLM):**
 
@@ -417,8 +424,15 @@ This split keeps the LLM focused on *what to merge* while the host guarantees co
 temporal arithmetic and prevents the dream cycle from inadvertently stamping every
 reprocessed entry as "just seen today."
 
-**Exhaustive deletion contract:** The union of explicit `toDelete` IDs and all `sourceIds` from
-merged entries are deleted — preventing orphaned source entries even if the LLM omits some IDs.
+**Removals are archived, not deleted.** Consolidation calls `ArchiveAsync`, which hides an
+entry from search but keeps it on disk and retrievable by ID; a separate purge pass
+hard-deletes archived entries after `Dream:MemoryArchiveRetention` (default 90 days), and
+`IArchivedMemoryMaintenance.RestoreAsync` brings one back. Merged entries are saved before
+their sources are archived, and only sources whose replacement actually persisted are retired.
+
+**Exhaustive-removal contract:** The union of explicit `toDelete` IDs and all `sourceIds` from
+persisted merged entries is archived — preventing orphaned source entries even if the LLM
+omits some IDs. IDs outside the eligible set are ignored.
 
 ### Pass 2 — Preference inference
 

--- a/src/RockBot.Agent/RockBot.Agent.csproj
+++ b/src/RockBot.Agent/RockBot.Agent.csproj
@@ -38,6 +38,9 @@
     <None Include="agent\llm-pricing.json" CopyToOutputDirectory="PreserveNewest">
       <Link>agent\llm-pricing.json</Link>
     </None>
+    <None Include="agent\merge-coverage-vocabulary.json" CopyToOutputDirectory="PreserveNewest">
+      <Link>agent\merge-coverage-vocabulary.json</Link>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/RockBot.Agent/agent/dream.md
+++ b/src/RockBot.Agent/agent/dream.md
@@ -4,7 +4,14 @@ You are a memory consolidation assistant performing a maintenance pass over an a
 
 ## Your task
 
-You will receive a numbered list of ALL current memory entries, each with an ID, category, tags, and content. Review them and:
+You will receive a numbered list of **some** of the agent's memory entries — each with an ID, category, tags, and content. This is a filtered working set, not the whole corpus: it contains entries that are new or changed since the last pass, plus entries that look like near-duplicates of one another. Everything else has already been reviewed, has not changed since, and is deliberately withheld.
+
+Two consequences:
+
+- **Only ever reference IDs from the list you were given.** IDs you remember from a previous pass, or infer, are rejected. A fact you cannot see is not missing — it is withheld, and it is fine.
+- **Do not try to tidy the corpus as a whole.** You are not seeing the whole corpus. Judge only what is in front of you, on its own merits.
+
+Review the listed entries and:
 
 1. **Re-evaluate importance scores** — each entry has a current importance score (0.0–1.0). Adjust scores based on:
    - How central the fact is to the agent's primary work and user's goals
@@ -79,6 +86,7 @@ whether similar entries describe the same durable fact or distinct facts.
 ## Critical rules
 
 - **Exhaustive deletion — this is the most important rule**: Every source entry you are replacing with a merged entry MUST appear in `toDelete`. If you produce one merged entry from sources A, B, and C, then A, B, and C ALL go in `toDelete`. No source survives a merge. The presence of an ID in `sourceIds` is a commitment to delete it — put it in `toDelete` too.
+- **A merged entry must carry every specific its sources carried**: names of people, places, and organisations, dates, numbers, and identifiers. Losing "Rocky also appears in travel data as Rockford Duane Lhotka" while keeping the surrounding prose is a failed merge, not a tidier one. If a merge cannot hold all the specifics at a reasonable length, do not merge — leave the sources alone.
 - **No orphaned sources**: After your pass, there must be no entry whose content is fully captured by a new entry you saved. If a fact is in your merged output, its source is deleted.
 - **Conservative on merging**: When in doubt whether two entries are truly duplicates, keep both. But when you do merge, delete ALL sources completely.
 - **Never delete without replacement**: Do not delete a unique fact that has no equivalent in your output. Ephemeral entries are the only exception.

--- a/src/RockBot.Agent/agent/merge-coverage-vocabulary.json
+++ b/src/RockBot.Agent/agent/merge-coverage-vocabulary.json
@@ -1,0 +1,26 @@
+{
+  // Merge-coverage vocabulary — tunes the safeguard that stops dream consolidation from
+  // dropping details when it merges memories.
+  //
+  // The check requires every proper noun, acronym and multi-digit number in a merge's sources
+  // to survive into the merged text. Words listed as "common" are exempt from that requirement.
+  // A built-in generic-English list is always applied; this file layers on top of it.
+  //
+  // Re-read at the top of every dream cycle — no restart needed. If this file is malformed the
+  // built-in list is used and a warning is logged; coverage checking is never disabled.
+
+  // Words to ALSO ignore. Add domain noise that keeps triggering rejections you judge to be
+  // false. Be conservative: a false rejection only costs a duplicate surviving another cycle,
+  // whereas suppressing a real name lets it be deleted silently. Do not add a word that could
+  // ever name something — "Personal", "Class" and "Benefit" look generic but carry meaning in
+  // "OneDrive Personal", "Blazor Online Class" and "MVP Azure Extended Benefit".
+  "extraCommonWords": [],
+
+  // Words to ALWAYS treat as specifics, overriding the built-in list.
+  //
+  // This matters most for agents whose people or characters collide with ordinary English.
+  // The built-in list contains "may", "will", "some", "first", "last", "new" and similar, so a
+  // storytelling agent with a character named May, Will, Rose, Grace or Hope MUST list them
+  // here — otherwise those names carry no coverage protection and a merge can drop them.
+  "alwaysSpecificWords": []
+}

--- a/src/RockBot.Host.Abstractions/DreamOptions.cs
+++ b/src/RockBot.Host.Abstractions/DreamOptions.cs
@@ -168,6 +168,32 @@ public sealed class DreamOptions
     /// </remarks>
     public int PruningProtectionReinforcementCount { get; set; } = 5;
 
+    /// <summary>
+    /// Path to the merge-coverage vocabulary file, relative to
+    /// <see cref="AgentProfileOptions.BasePath"/>. Re-read at the top of every dream cycle, so
+    /// edits take effect without a restart. When absent, a generic-English baseline is used.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Controls which capitalized words the coverage check treats as ordinary language rather
+    /// than as detail a merge must preserve. This is deployment-specific: the words an
+    /// operational assistant can safely ignore are not the words a storytelling agent can.
+    /// </para>
+    /// <para>
+    /// Shape — both fields optional:
+    /// <code>
+    /// {
+    ///   "extraCommonWords":    ["briefing", "triage"],
+    ///   "alwaysSpecificWords": ["May", "Will", "Rose"]
+    /// }
+    /// </code>
+    /// <c>alwaysSpecificWords</c> takes precedence, and matters most for agents whose characters
+    /// or people collide with ordinary English — without it, a character named May or Will is
+    /// silently stripped of coverage protection.
+    /// </para>
+    /// </remarks>
+    public string MergeCoverageVocabularyPath { get; set; } = "merge-coverage-vocabulary.json";
+
     /// <summary>Whether the memory mining pass (requires <see cref="IConversationLog"/>) is enabled.</summary>
     public bool MemoryMiningEnabled { get; set; } = true;
 

--- a/src/RockBot.Host.Abstractions/DreamOptions.cs
+++ b/src/RockBot.Host.Abstractions/DreamOptions.cs
@@ -129,12 +129,21 @@ public sealed class DreamOptions
 
     /// <summary>
     /// Ceiling on how many entries may appear in a single near-duplicate cluster. Larger
-    /// clusters are split across passes rather than dropped. Default: 3.
+    /// clusters are split into chunks rather than dropped. Default: 3.
     /// </summary>
     /// <remarks>
-    /// Caps merge fan-in. Without a cap, single-link clustering can chain a whole topic into
-    /// one group and invite the model to collapse it into a single entry — which is how a
-    /// corpus loses detail fastest.
+    /// <para>
+    /// This bounds <em>eligibility</em>, not merge size. Clusters decide which entries the
+    /// model is shown; once shown, it may propose a merge over any subset of them, so a pass
+    /// can and does produce merges with more sources than this value. Observed in production:
+    /// a 13-source merge under the default of 3.
+    /// </para>
+    /// <para>
+    /// Large merges are constrained by the coverage check instead, which is the better tool
+    /// for the job — it judges whether detail actually survived rather than guessing from a
+    /// count. The same production cycle that produced the 13-source merge had it accepted
+    /// (every specific preserved) while rejecting a 6-source merge that dropped 28.
+    /// </para>
     /// </remarks>
     public int ConsolidationMaxClusterSize { get; set; } = 3;
 

--- a/src/RockBot.Host.Abstractions/DreamOptions.cs
+++ b/src/RockBot.Host.Abstractions/DreamOptions.cs
@@ -138,6 +138,27 @@ public sealed class DreamOptions
     /// </remarks>
     public int ConsolidationMaxClusterSize { get; set; } = 3;
 
+    /// <summary>
+    /// Importance at or above which an entry may not be pruned outright by consolidation.
+    /// Merging is still permitted, since a merge preserves the content. Default: 0.80.
+    /// </summary>
+    /// <remarks>
+    /// A deterministic floor rather than prompt guidance. The directive already told the model
+    /// that reinforcement signals importance, and it deleted 0.99-scored entries anyway.
+    /// </remarks>
+    public float PruningProtectionImportance { get; set; } = 0.80f;
+
+    /// <summary>
+    /// Reinforcement count at or above which an entry may not be pruned outright by
+    /// consolidation. Merging is still permitted. Default: 5.
+    /// </summary>
+    /// <remarks>
+    /// Repeated independent observation is the strongest evidence available that a fact
+    /// matters — it is exactly the signal that should have protected the entries a live corpus
+    /// lost at 214, 106 and 80 observations.
+    /// </remarks>
+    public int PruningProtectionReinforcementCount { get; set; } = 5;
+
     /// <summary>Whether the memory mining pass (requires <see cref="IConversationLog"/>) is enabled.</summary>
     public bool MemoryMiningEnabled { get; set; } = true;
 

--- a/src/RockBot.Host.Abstractions/DreamOptions.cs
+++ b/src/RockBot.Host.Abstractions/DreamOptions.cs
@@ -100,6 +100,44 @@ public sealed class DreamOptions
     /// </remarks>
     public bool MemoryConsolidationEnabled { get; set; } = true;
 
+    /// <summary>
+    /// How long entries archived by consolidation are kept before the purge pass hard-deletes
+    /// them. Archived entries are hidden from recall but stay on disk and remain retrievable
+    /// by id, so this is the window in which a bad merge or a wrong ephemeral call can still
+    /// be undone. Set to <see cref="TimeSpan.Zero"/> or negative to keep archived entries
+    /// forever. Default: 90 days.
+    /// </summary>
+    /// <remarks>
+    /// Requires the store to implement <see cref="IArchivedMemoryMaintenance"/>; with a store
+    /// that does not, <see cref="ILongTermMemory.ArchiveAsync"/> falls back to a hard delete
+    /// and this setting has nothing to purge.
+    /// </remarks>
+    public TimeSpan MemoryArchiveRetention { get; set; } = TimeSpan.FromDays(90);
+
+    /// <summary>
+    /// Similarity (0..1) at which two memory entries are treated as possible duplicates and
+    /// become eligible for the consolidation pass. Cosine over embeddings where the store has
+    /// them, a lexical measure otherwise. Default: 0.88.
+    /// </summary>
+    /// <remarks>
+    /// This is the main dial on how much consolidation is allowed to touch. Lower values feed
+    /// it more pairs and merge more aggressively; higher values restrict it to obvious
+    /// restatements. It does not affect entries that are new or changed since the last pass —
+    /// those are always eligible regardless of similarity.
+    /// </remarks>
+    public double ConsolidationSimilarityThreshold { get; set; } = 0.88;
+
+    /// <summary>
+    /// Ceiling on how many entries may appear in a single near-duplicate cluster. Larger
+    /// clusters are split across passes rather than dropped. Default: 3.
+    /// </summary>
+    /// <remarks>
+    /// Caps merge fan-in. Without a cap, single-link clustering can chain a whole topic into
+    /// one group and invite the model to collapse it into a single entry — which is how a
+    /// corpus loses detail fastest.
+    /// </remarks>
+    public int ConsolidationMaxClusterSize { get; set; } = 3;
+
     /// <summary>Whether the memory mining pass (requires <see cref="IConversationLog"/>) is enabled.</summary>
     public bool MemoryMiningEnabled { get; set; } = true;
 

--- a/src/RockBot.Host.Abstractions/IArchivedMemoryMaintenance.cs
+++ b/src/RockBot.Host.Abstractions/IArchivedMemoryMaintenance.cs
@@ -1,0 +1,29 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Optional capability for stores that keep an archive tier — implemented alongside
+/// <see cref="ILongTermMemory.ArchiveAsync"/> to manage what has accumulated there.
+/// </summary>
+/// <remarks>
+/// Kept separate from <see cref="ILongTermMemory"/> because archiving is a retention policy,
+/// not part of the read/write contract: a store backed by something with its own versioning
+/// or soft-delete semantics can satisfy <see cref="ILongTermMemory"/> without implementing
+/// any of this. Callers probe for it (<c>memory as IArchivedMemoryMaintenance</c>) and skip
+/// the work when absent.
+/// </remarks>
+public interface IArchivedMemoryMaintenance
+{
+    /// <summary>
+    /// Returns an archived entry to normal visibility.
+    /// </summary>
+    /// <returns><c>true</c> if an archived entry was restored; <c>false</c> if it was not
+    /// found or was not archived.</returns>
+    Task<bool> RestoreAsync(string id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Hard-deletes archived entries older than <paramref name="retention"/>, measured from
+    /// <see cref="MemoryEntry.ArchivedAt"/>. Returns the number purged. A non-positive
+    /// retention disables purging so archived entries are kept indefinitely.
+    /// </summary>
+    Task<int> PurgeArchivedAsync(TimeSpan retention, CancellationToken cancellationToken = default);
+}

--- a/src/RockBot.Host.Abstractions/ILongTermMemory.cs
+++ b/src/RockBot.Host.Abstractions/ILongTermMemory.cs
@@ -24,7 +24,27 @@ public interface ILongTermMemory
     /// <summary>
     /// Deletes a memory entry by ID. No-op if not found.
     /// </summary>
+    /// <remarks>
+    /// This is a hard delete with no recovery path. Automated housekeeping should call
+    /// <see cref="ArchiveAsync"/> instead and leave hard deletion to the retention purge
+    /// and to explicit user-driven removal.
+    /// </remarks>
     Task DeleteAsync(string id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Archives a memory entry by ID — hides it from search while keeping it on disk and
+    /// retrievable by ID. No-op if not found or already archived.
+    /// </summary>
+    /// <param name="id">Entry to archive.</param>
+    /// <param name="reason">Human-readable justification recorded on the entry.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <remarks>
+    /// The default implementation falls back to <see cref="DeleteAsync"/> for stores with no
+    /// archive tier. Any store that can retain data should override it: the whole point of
+    /// this method is that a wrong automated removal stays recoverable.
+    /// </remarks>
+    Task ArchiveAsync(string id, string reason, CancellationToken cancellationToken = default)
+        => DeleteAsync(id, cancellationToken);
 
     /// <summary>
     /// Returns all distinct tags across all memory entries.

--- a/src/RockBot.Host.Abstractions/IMemoryDuplicateCandidates.cs
+++ b/src/RockBot.Host.Abstractions/IMemoryDuplicateCandidates.cs
@@ -1,0 +1,41 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Optional capability for stores that can identify which entries plausibly duplicate each
+/// other, so callers can act on a small candidate set instead of the whole corpus.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This exists to bound what dream consolidation is allowed to touch. Handing the LLM every
+/// entry each cycle means every entry is re-tried for deletion on every cycle, and survival
+/// compounds: at twice a day, a one-in-a-thousand misjudgement per entry per cycle loses
+/// roughly half the corpus in a year. Gating turns an unbounded repeated gamble into a
+/// decision made once per entry.
+/// </para>
+/// <para>
+/// Clustering lives behind the store because only the store knows whether embeddings are
+/// available. Implementations should degrade to a lexical measure rather than returning
+/// nothing when they are not — a BM25-only deployment still needs deduplication.
+/// </para>
+/// </remarks>
+public interface IMemoryDuplicateCandidates
+{
+    /// <summary>
+    /// Groups entries that plausibly describe the same fact. Only entries with at least one
+    /// sibling above <paramref name="similarityThreshold"/> appear; singletons are omitted.
+    /// </summary>
+    /// <param name="similarityThreshold">
+    /// Minimum similarity (0..1) for two entries to land in the same cluster. Interpretation
+    /// is implementation-defined — cosine over embeddings, or a lexical measure as a fallback.
+    /// </param>
+    /// <param name="maxClusterSize">
+    /// Ceiling on entries per cluster. Oversized clusters are split rather than dropped, so a
+    /// single sprawling topic cannot be collapsed into one entry in one pass.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Clusters of entry IDs, each with at least two members.</returns>
+    Task<IReadOnlyList<IReadOnlyList<string>>> FindNearDuplicateClustersAsync(
+        double similarityThreshold,
+        int maxClusterSize,
+        CancellationToken cancellationToken = default);
+}

--- a/src/RockBot.Host.Abstractions/IMemoryDuplicateCandidates.cs
+++ b/src/RockBot.Host.Abstractions/IMemoryDuplicateCandidates.cs
@@ -29,8 +29,9 @@ public interface IMemoryDuplicateCandidates
     /// is implementation-defined — cosine over embeddings, or a lexical measure as a fallback.
     /// </param>
     /// <param name="maxClusterSize">
-    /// Ceiling on entries per cluster. Oversized clusters are split rather than dropped, so a
-    /// single sprawling topic cannot be collapsed into one entry in one pass.
+    /// Ceiling on entries per cluster. Oversized clusters are split into chunks rather than
+    /// dropped, so single-link chaining cannot pull an entire topic into one group. Note this
+    /// bounds what a caller is offered, not what it subsequently does with it.
     /// </param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Clusters of entry IDs, each with at least two members.</returns>

--- a/src/RockBot.Host.Abstractions/MemoryEntry.cs
+++ b/src/RockBot.Host.Abstractions/MemoryEntry.cs
@@ -54,4 +54,28 @@ public sealed record MemoryEntry(
     /// Always <c>null</c> for live entries.
     /// </summary>
     public string? SupersededBy { get; init; }
+
+    /// <summary>
+    /// When this entry was archived — removed from recall but kept on disk. Set by
+    /// <see cref="ILongTermMemory.ArchiveAsync"/>, which the dream consolidation pass uses
+    /// instead of deleting. Archived entries are excluded from
+    /// <see cref="ILongTermMemory.SearchAsync"/> unless
+    /// <see cref="MemorySearchCriteria.IncludeArchived"/> is set, and remain retrievable by id
+    /// via <see cref="ILongTermMemory.GetAsync"/>. A retention purge hard-deletes them once
+    /// they age out. Always <c>null</c> for live entries.
+    /// </summary>
+    /// <remarks>
+    /// Consolidation merges are lossy and irreversible in a way nothing else in the pipeline
+    /// is: a merged entry is LLM-regenerated prose with no anchor back to what the sources
+    /// actually said. Archiving rather than deleting means a bad merge costs recall until
+    /// someone notices, not the fact itself.
+    /// </remarks>
+    public DateTimeOffset? ArchivedAt { get; init; }
+
+    /// <summary>
+    /// Why this entry was archived (e.g. <c>"merged into abc123"</c>, <c>"ephemeral"</c>).
+    /// Free text, written for a human reading an audit trail. Null when
+    /// <see cref="ArchivedAt"/> is null.
+    /// </summary>
+    public string? ArchiveReason { get; init; }
 }

--- a/src/RockBot.Host.Abstractions/MemorySearchCriteria.cs
+++ b/src/RockBot.Host.Abstractions/MemorySearchCriteria.cs
@@ -31,6 +31,12 @@ namespace RockBot.Host;
 /// semantics. Used by audit tooling and the dream contradiction sweep that need to inspect
 /// the full corpus.
 /// </param>
+/// <param name="IncludeArchived">
+/// When <c>true</c>, entries with <see cref="MemoryEntry.ArchivedAt"/> set are included in
+/// search results. Default <c>false</c> hides them from recall. Archived entries are not
+/// deleted — they stay on disk until the retention purge reaps them — so audit tooling and
+/// recovery flows set this to inspect or restore them.
+/// </param>
 public sealed record MemorySearchCriteria(
     string? Query = null,
     string? Category = null,
@@ -41,4 +47,5 @@ public sealed record MemorySearchCriteria(
     float[]? QueryEmbedding = null,
     MemorySearchMode Mode = MemorySearchMode.Hybrid,
     bool RegexCaseSensitive = false,
-    bool IncludeSuperseded = false);
+    bool IncludeSuperseded = false,
+    bool IncludeArchived = false);

--- a/src/RockBot.Host/DreamService.cs
+++ b/src/RockBot.Host/DreamService.cs
@@ -600,6 +600,32 @@ internal sealed class DreamService : IHostedService, IDisposable
         });
     }
 
+    /// <summary>Metadata key listing the IDs a merged entry was built from (comma-separated).</summary>
+    /// <remarks>
+    /// Those sources are archived rather than deleted, so for the retention window these IDs
+    /// resolve via <see cref="ILongTermMemory.GetAsync"/> and the merge can be audited against
+    /// what it actually replaced. After the purge they dangle, by design — provenance is a
+    /// recovery aid, not a permanent record.
+    /// </remarks>
+    internal const string MergedFromKey = "mergedFrom";
+
+    /// <summary>Metadata key holding when a merged entry was produced.</summary>
+    internal const string MergedAtKey = "mergedAt";
+
+    /// <summary>
+    /// True when an entry is valuable enough that consolidation may not discard it outright.
+    /// Merging is still allowed — that preserves the content, subject to the coverage check.
+    /// </summary>
+    /// <remarks>
+    /// Added because importance and reinforcement demonstrably conferred no protection: a
+    /// corpus lost entries scored 0.99 and reinforced 214, 106 and 80 times in a single pass,
+    /// while the directive already told the model reinforcement signals importance. Guidance
+    /// the model can ignore is not a safeguard; this is a deterministic floor it cannot.
+    /// </remarks>
+    internal static bool IsProtectedFromPruning(MemoryEntry entry, DreamOptions options) =>
+        entry.ImportanceScore >= options.PruningProtectionImportance
+        || entry.ReinforcementCount >= options.PruningProtectionReinforcementCount;
+
     /// <summary>Metadata key holding the content hash as of the last consolidation review.</summary>
     internal const string ConsolidationReviewedHashKey = "consolidationReviewedHash";
 
@@ -832,6 +858,8 @@ internal sealed class DreamService : IHostedService, IDisposable
 
         var deleted = 0;
         var saved = 0;
+        var rejectedMerges = 0;
+        var protectedFromPruning = 0;
 
         // Source lookup for merge arithmetic, keyed only on entries that were actually shown.
         // This is what enforces the gate: an ID the LLM invents, remembers from a previous
@@ -863,6 +891,22 @@ internal sealed class DreamService : IHostedService, IDisposable
                 .Select(id => byId[id])
                 .ToList();
 
+            // A merge that drops a name, a date or a number is a failed merge, not a tidier
+            // one — and once the sources are archived nobody can tell it happened. Reject it
+            // and leave the sources alone; a surviving duplicate is the cheaper mistake.
+            var missing = MergeCoverage.FindMissingSpecifics(sources, dto.Content);
+            if (missing.Count > 0)
+            {
+                rejectedMerges++;
+                _logger.LogWarning(
+                    "DreamService: rejected merge of [{Sources}] — dropped {Count} specific(s): {Missing}. Sources kept. Merged text was: {Content}",
+                    string.Join(", ", sources.Select(s => s.Id)),
+                    missing.Count,
+                    string.Join(", ", missing),
+                    dto.Content.Trim());
+                continue;
+            }
+
             // CreatedAt = earliest source (first-seen preserved); UpdatedAt = now (record rewritten)
             var firstSeen = sources.Count > 0 ? sources.Min(s => s.CreatedAt) : DateTimeOffset.UtcNow;
 
@@ -877,6 +921,21 @@ internal sealed class DreamService : IHostedService, IDisposable
                 ?? (sources.Count > 0 ? sources.Max(s => s.ImportanceScore) : 0.5f);
 
             var mergedMetadata = MergeSubjectTimeMetadata(sources);
+
+            // Provenance. The source text is not copied here — the sources are archived rather
+            // than deleted, so they stay retrievable by these IDs for the retention window and
+            // duplicating their prose would only give a later pass more to re-embellish.
+            if (sources.Count > 0)
+            {
+                var withProvenance = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                if (mergedMetadata is not null)
+                    foreach (var (key, value) in mergedMetadata)
+                        withProvenance[key] = value;
+
+                withProvenance[MergedFromKey] = string.Join(",", sources.Select(s => s.Id));
+                withProvenance[MergedAtKey] = DateTimeOffset.UtcNow.ToString("O");
+                mergedMetadata = withProvenance;
+            }
 
             var entry = new MemoryEntry(
                 Id: Guid.NewGuid().ToString("N")[..12],
@@ -904,9 +963,27 @@ internal sealed class DreamService : IHostedService, IDisposable
         }
 
         // Standalone removals (ephemeral content the LLM flagged) that no merge accounted for.
+        // Unlike a merge, this discards a fact with nothing put in its place, so the
+        // high-value floor applies: an entry the agent has re-observed many times, or scored
+        // as core, is not something to drop on one model's say-so. Such entries can still be
+        // merged — their content survives that, and the coverage check enforces it.
         foreach (var id in result.ToDelete ?? [])
-            if (byId.ContainsKey(id) && !archiveReasons.ContainsKey(id))
-                archiveReasons[id] = "flagged ephemeral by consolidation";
+        {
+            if (!byId.TryGetValue(id, out var candidate) || archiveReasons.ContainsKey(id))
+                continue;
+
+            if (IsProtectedFromPruning(candidate, _options))
+            {
+                protectedFromPruning++;
+                _logger.LogInformation(
+                    "DreamService: refused to prune {Id} ({Category}, importance={Importance:F2}, reinforced={Count}×) — above the high-value floor: {Content}",
+                    candidate.Id, candidate.Category ?? "(none)", candidate.ImportanceScore,
+                    candidate.ReinforcementCount, candidate.Content);
+                continue;
+            }
+
+            archiveReasons[id] = "flagged ephemeral by consolidation";
+        }
 
         foreach (var (id, reason) in archiveReasons)
         {
@@ -923,6 +1000,11 @@ internal sealed class DreamService : IHostedService, IDisposable
         await StampReviewedAsync(
             eligible.Select(e => e.Id).Where(id => !archiveReasons.ContainsKey(id)),
             ct);
+
+        if (rejectedMerges > 0 || protectedFromPruning > 0)
+            _logger.LogInformation(
+                "DreamService: consolidation safeguards fired — {Rejected} merge(s) rejected for dropping specifics, {Protected} entry(s) protected from pruning",
+                rejectedMerges, protectedFromPruning);
 
         return (deleted, saved);
     }

--- a/src/RockBot.Host/DreamService.cs
+++ b/src/RockBot.Host/DreamService.cs
@@ -65,6 +65,7 @@ internal sealed class DreamService : IHostedService, IDisposable
     private string? _sequenceSkillDirective;
     private string? _entityExtractionDirective;
     private string? _graphConsolidationDirective;
+    private MergeCoverageVocabulary _mergeVocabulary = MergeCoverageVocabulary.Default;
     private string? _dlqDirective;
     private string? _identityDirective;
     private string? _wispFailureDirective;
@@ -214,6 +215,27 @@ internal sealed class DreamService : IHostedService, IDisposable
         var memoryRules = File.Exists(memoryRulesPath) ? File.ReadAllText(memoryRulesPath) : string.Empty;
         if (!string.IsNullOrEmpty(memoryRules))
             _logger.LogDebug("DreamService: loaded memory-rules from {Path}", memoryRulesPath);
+
+        // Merge-coverage vocabulary. Deployment-specific by nature: an operational assistant and
+        // a storytelling agent disagree about which capitalized words are ordinary language, and
+        // getting it wrong in the storytelling direction strips coverage from character names.
+        var vocabularyPath = ResolvePath(_options.MergeCoverageVocabularyPath, _profileOptions.BasePath);
+        if (File.Exists(vocabularyPath))
+        {
+            _mergeVocabulary = MergeCoverageVocabulary.Parse(File.ReadAllText(vocabularyPath), out var vocabError);
+            if (vocabError is not null)
+                _logger.LogWarning(
+                    "DreamService: {Path} is malformed ({Error}); using the built-in vocabulary",
+                    vocabularyPath, vocabError);
+            else
+                _logger.LogDebug(
+                    "DreamService: loaded merge-coverage vocabulary from {Path} ({Common} common words, {Specific} reclaimed as specifics)",
+                    vocabularyPath, _mergeVocabulary.CommonWordCount, _mergeVocabulary.AlwaysSpecificWords.Count);
+        }
+        else
+        {
+            _mergeVocabulary = MergeCoverageVocabulary.Default;
+        }
 
         var directivePath = ResolvePath(_options.DirectivePath, _profileOptions.BasePath);
         var dreamDirective = File.Exists(directivePath)
@@ -898,7 +920,7 @@ internal sealed class DreamService : IHostedService, IDisposable
             // A merge that drops a name, a date or a number is a failed merge, not a tidier
             // one — and once the sources are archived nobody can tell it happened. Reject it
             // and leave the sources alone; a surviving duplicate is the cheaper mistake.
-            var missing = MergeCoverage.FindMissingSpecifics(sources, dto.Content);
+            var missing = MergeCoverage.FindMissingSpecifics(sources, dto.Content, _mergeVocabulary);
             if (missing.Count > 0)
             {
                 // The directive requires every sourceId to also appear in toDelete, so these

--- a/src/RockBot.Host/DreamService.cs
+++ b/src/RockBot.Host/DreamService.cs
@@ -228,9 +228,17 @@ internal sealed class DreamService : IHostedService, IDisposable
                     "DreamService: {Path} is malformed ({Error}); using the built-in vocabulary",
                     vocabularyPath, vocabError);
             else
-                _logger.LogDebug(
-                    "DreamService: loaded merge-coverage vocabulary from {Path} ({Common} common words, {Specific} reclaimed as specifics)",
-                    vocabularyPath, _mergeVocabulary.CommonWordCount, _mergeVocabulary.AlwaysSpecificWords.Count);
+                // Information, matching the per-cycle directive reload above: this file decides
+                // what a merge is allowed to drop, and an operator tuning it needs to see that
+                // their edit was picked up without raising the whole namespace to Debug.
+                _logger.LogInformation(
+                    "DreamService: merge-coverage vocabulary from {Path} — {Common} common words, {Specific} reclaimed as specifics{Reclaimed}",
+                    vocabularyPath,
+                    _mergeVocabulary.CommonWordCount,
+                    _mergeVocabulary.AlwaysSpecificWords.Count,
+                    _mergeVocabulary.AlwaysSpecificWords.Count > 0
+                        ? " (" + string.Join(", ", _mergeVocabulary.AlwaysSpecificWords) + ")"
+                        : string.Empty);
         }
         else
         {

--- a/src/RockBot.Host/DreamService.cs
+++ b/src/RockBot.Host/DreamService.cs
@@ -861,6 +861,10 @@ internal sealed class DreamService : IHostedService, IDisposable
         var rejectedMerges = 0;
         var protectedFromPruning = 0;
 
+        // Sources belonging to a merge the coverage check refused. They must survive the
+        // standalone-removal loop below.
+        var rejectedMergeSources = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
         // Source lookup for merge arithmetic, keyed only on entries that were actually shown.
         // This is what enforces the gate: an ID the LLM invents, remembers from a previous
         // cycle, or otherwise names without having been offered it is not in this map, so it
@@ -897,6 +901,13 @@ internal sealed class DreamService : IHostedService, IDisposable
             var missing = MergeCoverage.FindMissingSpecifics(sources, dto.Content);
             if (missing.Count > 0)
             {
+                // The directive requires every sourceId to also appear in toDelete, so these
+                // IDs are sitting in the standalone-removal list too. Without this the
+                // ephemeral path would archive them anyway and the rejection would achieve
+                // nothing — worse than merging, since nothing replaces them at all.
+                foreach (var srcId in sourceIds)
+                    rejectedMergeSources.Add(srcId);
+
                 rejectedMerges++;
                 _logger.LogWarning(
                     "DreamService: rejected merge of [{Sources}] — dropped {Count} specific(s): {Missing}. Sources kept. Merged text was: {Content}",
@@ -970,6 +981,9 @@ internal sealed class DreamService : IHostedService, IDisposable
         foreach (var id in result.ToDelete ?? [])
         {
             if (!byId.TryGetValue(id, out var candidate) || archiveReasons.ContainsKey(id))
+                continue;
+
+            if (rejectedMergeSources.Contains(id))
                 continue;
 
             if (IsProtectedFromPruning(candidate, _options))

--- a/src/RockBot.Host/DreamService.cs
+++ b/src/RockBot.Host/DreamService.cs
@@ -500,6 +500,11 @@ internal sealed class DreamService : IHostedService, IDisposable
             // cycles where there is nothing to consolidate.
             await RunLogRetentionPassAsync(ct);
 
+            // Reap archived memory that has outlived the recovery window. Runs before
+            // consolidation so the window is measured from the archive event, not from
+            // whatever this cycle is about to archive.
+            await RunArchivePurgePassAsync(ct);
+
             // Consolidation is one pass among many and must not gate the rest of the
             // cycle. It lives in its own method precisely so that its early exits (too
             // few entries to merge, or a failed LLM call) return from *it* rather than
@@ -573,6 +578,157 @@ internal sealed class DreamService : IHostedService, IDisposable
     }
 
     /// <summary>
+    /// Hard-deletes memory entries archived longer ago than
+    /// <see cref="DreamOptions.MemoryArchiveRetention"/>. No-op when the store has no archive
+    /// tier or retention is disabled.
+    /// </summary>
+    private async Task RunArchivePurgePassAsync(CancellationToken ct)
+    {
+        if (_memory is not IArchivedMemoryMaintenance maintenance)
+            return;
+
+        if (_options.MemoryArchiveRetention <= TimeSpan.Zero)
+            return;
+
+        await RunPassAsync("archive purge", async () =>
+        {
+            var purged = await maintenance.PurgeArchivedAsync(_options.MemoryArchiveRetention, ct);
+            if (purged > 0)
+                _logger.LogInformation(
+                    "DreamService: archive purge — {Count} entries archived over {Days:F0} days ago permanently deleted",
+                    purged, _options.MemoryArchiveRetention.TotalDays);
+        });
+    }
+
+    /// <summary>Metadata key holding the content hash as of the last consolidation review.</summary>
+    internal const string ConsolidationReviewedHashKey = "consolidationReviewedHash";
+
+    /// <summary>Metadata key holding the timestamp of the last consolidation review (human-facing).</summary>
+    internal const string ConsolidationReviewedAtKey = "consolidationReviewedAt";
+
+    /// <summary>
+    /// Stable short hash of an entry's content, used to detect whether it has changed since
+    /// its last consolidation review. Any edit by any path — reinforcement, tool update, a
+    /// previous merge — changes the hash and makes the entry eligible again.
+    /// </summary>
+    internal static string ContentFingerprint(string? content)
+    {
+        var bytes = System.Security.Cryptography.SHA256.HashData(
+            Encoding.UTF8.GetBytes(content ?? string.Empty));
+        return Convert.ToHexString(bytes.AsSpan(0, 8));
+    }
+
+    /// <summary>
+    /// True when the entry was reviewed by an earlier consolidation pass and its content has
+    /// not changed since.
+    /// </summary>
+    internal static bool IsReviewedAndUnchanged(MemoryEntry entry) =>
+        entry.Metadata is { } m
+        && m.TryGetValue(ConsolidationReviewedHashKey, out var hash)
+        && string.Equals(hash, ContentFingerprint(entry.Content), StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Chooses which entries consolidation is allowed to act on this cycle. An entry qualifies
+    /// when it is new or changed since its last review, or when it sits in a near-duplicate
+    /// cluster (a fresh entry can duplicate an old one, so the old one has to be visible for
+    /// the merge to be possible).
+    /// </summary>
+    /// <remarks>
+    /// Everything else is withheld and therefore safe. That bound is the point: exposure to a
+    /// deletion decision becomes roughly once per entry per content change, instead of once
+    /// per entry per cycle forever.
+    /// </remarks>
+    internal static async Task<List<MemoryEntry>> SelectConsolidationCandidatesAsync(
+        ILongTermMemory memory,
+        DreamOptions options,
+        ILogger logger,
+        IReadOnlyList<MemoryEntry> all,
+        CancellationToken ct)
+    {
+        var eligibleIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var e in all)
+            if (!IsReviewedAndUnchanged(e))
+                eligibleIds.Add(e.Id);
+
+        var unreviewed = eligibleIds.Count;
+
+        if (memory is IMemoryDuplicateCandidates duplicates)
+        {
+            try
+            {
+                var clusters = await duplicates.FindNearDuplicateClustersAsync(
+                    options.ConsolidationSimilarityThreshold,
+                    options.ConsolidationMaxClusterSize,
+                    ct);
+
+                foreach (var cluster in clusters)
+                    foreach (var id in cluster)
+                        eligibleIds.Add(id);
+
+                logger.LogDebug(
+                    "DreamService: {Unreviewed} unreviewed + {Clustered} in {Clusters} duplicate cluster(s)",
+                    unreviewed, eligibleIds.Count - unreviewed, clusters.Count);
+            }
+            catch (OperationCanceledException) { throw; }
+            catch (Exception ex)
+            {
+                // Degrade to unreviewed-only rather than falling back to the whole corpus.
+                // A clustering failure must not silently re-expose everything to deletion.
+                logger.LogWarning(ex,
+                    "DreamService: near-duplicate scan failed; consolidating unreviewed entries only");
+            }
+        }
+
+        // Preserve the store's ordering so the prompt stays stable between cycles.
+        return [.. all.Where(e => eligibleIds.Contains(e.Id))];
+    }
+
+    /// <summary>
+    /// Records that an entry was shown to consolidation and survived, so later cycles skip it
+    /// until its content changes.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="MemoryEntry.UpdatedAt"/> is deliberately left alone. The importance decay
+    /// pass uses it as its "time since last decay applied" anchor, so bumping it once per
+    /// cycle for bookkeeping would stall decay entirely.
+    /// </para>
+    /// <para>
+    /// Entries are re-read rather than stamped from the caller's snapshot. That snapshot is
+    /// taken before the decay pass runs, so writing it back would revert the importance and
+    /// <c>UpdatedAt</c> decay just wrote.
+    /// </para>
+    /// </remarks>
+    private async Task StampReviewedAsync(IEnumerable<string> ids, CancellationToken ct)
+    {
+        var now = DateTimeOffset.UtcNow.ToString("O");
+        var stamped = 0;
+
+        foreach (var id in ids)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var entry = await _memory.GetAsync(id, ct);
+            if (entry is null || IsReviewedAndUnchanged(entry))
+                continue;
+
+            var metadata = entry.Metadata is null
+                ? []
+                : new Dictionary<string, string>(entry.Metadata, StringComparer.OrdinalIgnoreCase);
+
+            metadata[ConsolidationReviewedHashKey] = ContentFingerprint(entry.Content);
+            metadata[ConsolidationReviewedAtKey] = now;
+
+            await _memory.SaveAsync(entry with { Metadata = metadata }, ct);
+            stamped++;
+        }
+
+        if (stamped > 0)
+            _logger.LogDebug("DreamService: stamped {Count} entries as consolidation-reviewed", stamped);
+    }
+
+    /// <summary>
     /// Merges and prunes long-term memory entries via the "memory dream" pass.
     /// Returns the number of entries deleted and saved.
     /// </summary>
@@ -606,9 +762,31 @@ internal sealed class DreamService : IHostedService, IDisposable
         // Apply importance decay to unreferenced entries before consolidation
         await RunImportanceDecayPassAsync(all);
 
+        // Gate what the LLM is allowed to see. Anything withheld here cannot be archived this
+        // cycle, which is the whole point: an entry that has already been reviewed and left
+        // alone must not be re-tried for deletion twice a day forever.
+        var eligible = await SelectConsolidationCandidatesAsync(_memory, _options, _logger, all, ct);
+        var withheld = all.Count - eligible.Count;
+
+        if (eligible.Count < 2)
+        {
+            _logger.LogInformation(
+                "DreamService: {Withheld} of {Total} entries already reviewed and unchanged with no duplicate siblings — nothing eligible to consolidate",
+                withheld, all.Count);
+            return (0, 0);
+        }
+
+        _logger.LogInformation(
+            "DreamService: consolidation reviewing {Eligible} of {Total} entries ({Withheld} withheld as reviewed-and-unchanged)",
+            eligible.Count, all.Count, withheld);
+
         // Build user message: numbered list with IDs, categories, tags, content
         var userMessage = new StringBuilder();
-        userMessage.AppendLine($"The agent currently has {all.Count} memory entries. Consolidate them:");
+        userMessage.AppendLine(
+            $"The agent has {all.Count} memory entries. {eligible.Count} of them are shown below — " +
+            "either new or changed since the last pass, or near-duplicates of each other. " +
+            $"The other {withheld} were reviewed on an earlier pass, have not changed since, and are " +
+            "deliberately withheld. Consolidate only what is shown:");
         userMessage.AppendLine();
 
         // Append recent feedback signals so the dream LLM has quality context
@@ -632,9 +810,9 @@ internal sealed class DreamService : IHostedService, IDisposable
             }
         }
 
-        for (var i = 0; i < all.Count; i++)
+        for (var i = 0; i < eligible.Count; i++)
         {
-            var e = all[i];
+            var e = eligible[i];
             var tags = e.Tags.Count > 0 ? string.Join(", ", e.Tags) : "(none)";
             var subjectTime = FormatSubjectTimeForPrompt(e.Metadata);
             userMessage.AppendLine(
@@ -655,33 +833,29 @@ internal sealed class DreamService : IHostedService, IDisposable
         var deleted = 0;
         var saved = 0;
 
-        // Union of explicit toDelete IDs and all sourceIds referenced by saved entries.
-        // This enforces the exhaustive-deletion contract even when the LLM omits some IDs
-        // from toDelete while still listing them in sourceIds.
-        var allToDelete = new HashSet<string>(
-            result.ToDelete ?? [],
-            StringComparer.OrdinalIgnoreCase);
-
-        foreach (var dto in result.ToSave ?? [])
-            foreach (var srcId in dto.SourceIds ?? [])
-                allToDelete.Add(srcId);
-
-        foreach (var id in allToDelete)
-        {
-            await _memory.DeleteAsync(id);
-            deleted++;
-            _logger.LogDebug("DreamService: deleted entry {Id}", id);
-        }
-
-        // Build source-entry lookup (case-insensitive on ID) for merge arithmetic
+        // Source lookup for merge arithmetic, keyed only on entries that were actually shown.
+        // This is what enforces the gate: an ID the LLM invents, remembers from a previous
+        // cycle, or otherwise names without having been offered it is not in this map, so it
+        // can be neither merged from nor archived.
         var byId = new Dictionary<string, MemoryEntry>(StringComparer.OrdinalIgnoreCase);
-        foreach (var e in all)
+        foreach (var e in eligible)
             byId[e.Id] = e;
+
+        // Sources are retired only after their replacement is durably saved, and only for
+        // merges that actually produced one. The previous order — delete everything first,
+        // then save — lost the sources outright whenever a toSave entry was skipped for
+        // blank content or the pass threw between the two loops.
+        var archiveReasons = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var dto in result.ToSave ?? [])
         {
             if (string.IsNullOrWhiteSpace(dto.Content))
+            {
+                _logger.LogWarning(
+                    "DreamService: dropping merge with blank content; its {Count} source(s) are kept",
+                    (dto.SourceIds ?? []).Count);
                 continue;
+            }
 
             var sourceIds = dto.SourceIds ?? [];
             var sources = sourceIds
@@ -722,7 +896,33 @@ internal sealed class DreamService : IHostedService, IDisposable
             saved++;
             _logger.LogDebug("DreamService: saved entry {Id} ({Category}, importance={Importance:F2}, reinforced={Count}×): {Content}",
                 entry.Id, entry.Category ?? "(none)", entry.ImportanceScore, entry.ReinforcementCount, entry.Content);
+
+            // Now that the replacement exists, its sources can be retired.
+            foreach (var srcId in sourceIds)
+                if (byId.ContainsKey(srcId))
+                    archiveReasons[srcId] = $"merged into {entry.Id}";
         }
+
+        // Standalone removals (ephemeral content the LLM flagged) that no merge accounted for.
+        foreach (var id in result.ToDelete ?? [])
+            if (byId.ContainsKey(id) && !archiveReasons.ContainsKey(id))
+                archiveReasons[id] = "flagged ephemeral by consolidation";
+
+        foreach (var (id, reason) in archiveReasons)
+        {
+            // Archive, never delete. Consolidation is automated judgment applied in bulk to
+            // content that has no other copy; a wrong call here should cost recall until
+            // someone notices, not the fact itself. The retention purge does the real
+            // deleting, on a delay long enough to notice.
+            await _memory.ArchiveAsync(id, reason, ct);
+            deleted++;
+        }
+
+        // Only survivors of a pass that actually ran get stamped. A failed LLM call returns
+        // earlier, so a bad cycle never marks the corpus reviewed.
+        await StampReviewedAsync(
+            eligible.Select(e => e.Id).Where(id => !archiveReasons.ContainsKey(id)),
+            ct);
 
         return (deleted, saved);
     }

--- a/src/RockBot.Host/FileMemoryStore.cs
+++ b/src/RockBot.Host/FileMemoryStore.cs
@@ -11,7 +11,7 @@ namespace RockBot.Host;
 /// File-based long-term memory store with category subdirectories and in-memory index.
 /// Thread safety via <see cref="SemaphoreSlim"/> for all file I/O.
 /// </summary>
-internal sealed partial class FileMemoryStore : ILongTermMemory
+internal sealed partial class FileMemoryStore : ILongTermMemory, IArchivedMemoryMaintenance, IMemoryDuplicateCandidates
 {
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -212,6 +212,231 @@ internal sealed partial class FileMemoryStore : ILongTermMemory
         }
     }
 
+    public async Task ArchiveAsync(string id, string reason, CancellationToken cancellationToken = default)
+    {
+        await _semaphore.WaitAsync(cancellationToken);
+        try
+        {
+            var index = await EnsureIndexAsync(cancellationToken);
+
+            if (!index.TryGetValue(id, out var entry) || entry.ArchivedAt is not null)
+                return;
+
+            var archived = entry with
+            {
+                ArchivedAt = DateTimeOffset.UtcNow,
+                ArchiveReason = reason
+            };
+
+            // Written in place: same file, same category, same embedding. Archiving changes
+            // visibility, not content, so there is nothing to re-vectorize.
+            var filePath = GetFilePath(id, entry.Category);
+            Directory.CreateDirectory(Path.GetDirectoryName(filePath)!);
+            await File.WriteAllTextAsync(filePath, JsonSerializer.Serialize(archived, JsonOptions), cancellationToken);
+
+            index[id] = archived;
+
+            // Logged at Information with the content inline: an archived entry is one an
+            // automated pass decided to stop surfacing, and the log is what makes that
+            // reviewable without restoring a volume backup.
+            _logger.LogInformation(
+                "Archived memory entry {Id} ({Category}, importance={Importance:F2}, reinforced={Count}x) — {Reason}: {Content}",
+                id, entry.Category ?? "(none)", entry.ImportanceScore, entry.ReinforcementCount, reason, entry.Content);
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+    }
+
+    /// <summary>
+    /// Restores an archived entry to normal visibility. No-op if not found or not archived.
+    /// </summary>
+    public async Task<bool> RestoreAsync(string id, CancellationToken cancellationToken = default)
+    {
+        await _semaphore.WaitAsync(cancellationToken);
+        try
+        {
+            var index = await EnsureIndexAsync(cancellationToken);
+
+            if (!index.TryGetValue(id, out var entry) || entry.ArchivedAt is null)
+                return false;
+
+            var restored = entry with { ArchivedAt = null, ArchiveReason = null };
+
+            var filePath = GetFilePath(id, entry.Category);
+            Directory.CreateDirectory(Path.GetDirectoryName(filePath)!);
+            await File.WriteAllTextAsync(filePath, JsonSerializer.Serialize(restored, JsonOptions), cancellationToken);
+
+            index[id] = restored;
+            _logger.LogInformation("Restored archived memory entry {Id}", id);
+            return true;
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+    }
+
+    /// <summary>
+    /// Hard-deletes archived entries whose <see cref="MemoryEntry.ArchivedAt"/> is older than
+    /// <paramref name="retention"/>. Returns the number purged. A non-positive retention
+    /// disables purging entirely, so archived entries are kept forever.
+    /// </summary>
+    public async Task<int> PurgeArchivedAsync(TimeSpan retention, CancellationToken cancellationToken = default)
+    {
+        if (retention <= TimeSpan.Zero)
+            return 0;
+
+        var cutoff = DateTimeOffset.UtcNow - retention;
+
+        List<string> expired;
+        await _semaphore.WaitAsync(cancellationToken);
+        try
+        {
+            var index = await EnsureIndexAsync(cancellationToken);
+            expired = index.Values
+                .Where(e => e.ArchivedAt is not null && e.ArchivedAt < cutoff)
+                .Select(e => e.Id)
+                .ToList();
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+
+        foreach (var id in expired)
+            await DeleteAsync(id, cancellationToken);
+
+        return expired.Count;
+    }
+
+    public async Task<IReadOnlyList<IReadOnlyList<string>>> FindNearDuplicateClustersAsync(
+        double similarityThreshold,
+        int maxClusterSize,
+        CancellationToken cancellationToken = default)
+    {
+        if (maxClusterSize < 2)
+            return [];
+
+        List<MemoryEntry> entries;
+        await _semaphore.WaitAsync(cancellationToken);
+        try
+        {
+            var index = await EnsureIndexAsync(cancellationToken);
+            entries = index.Values
+                .Where(e => e.ArchivedAt is null && e.SupersededBy is null)
+                .OrderBy(e => e.Id, StringComparer.Ordinal)
+                .ToList();
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+
+        if (entries.Count < 2)
+            return [];
+
+        var similarity = await BuildSimilarityFunctionAsync(entries, cancellationToken);
+
+        // Single-link agglomeration via union-find: any pair over the threshold joins the same
+        // cluster. Single-link can chain (a~b, b~c pulls in a and c), which is why callers cap
+        // cluster size — the cap splits sprawl instead of letting one cluster swallow a topic.
+        var parent = Enumerable.Range(0, entries.Count).ToArray();
+        int Find(int x)
+        {
+            while (parent[x] != x) { parent[x] = parent[parent[x]]; x = parent[x]; }
+            return x;
+        }
+
+        for (var i = 0; i < entries.Count; i++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            for (var j = i + 1; j < entries.Count; j++)
+            {
+                if (Find(i) == Find(j))
+                    continue;
+                if (similarity(i, j) >= similarityThreshold)
+                    parent[Find(i)] = Find(j);
+            }
+        }
+
+        var groups = new Dictionary<int, List<string>>();
+        for (var i = 0; i < entries.Count; i++)
+        {
+            if (!groups.TryGetValue(Find(i), out var members))
+                groups[Find(i)] = members = [];
+            members.Add(entries[i].Id);
+        }
+
+        var clusters = new List<IReadOnlyList<string>>();
+        foreach (var members in groups.Values)
+        {
+            if (members.Count < 2)
+                continue;
+
+            // Split oversized clusters into fixed-size chunks. A leftover chunk of one is
+            // dropped: a lone entry has nothing to merge with in this pass.
+            for (var offset = 0; offset < members.Count; offset += maxClusterSize)
+            {
+                var chunk = members.Skip(offset).Take(maxClusterSize).ToList();
+                if (chunk.Count >= 2)
+                    clusters.Add(chunk);
+            }
+        }
+
+        _logger.LogDebug(
+            "Near-duplicate scan: {Clusters} cluster(s) covering {Covered} of {Total} entries (threshold {Threshold:F2})",
+            clusters.Count, clusters.Sum(c => c.Count), entries.Count, similarityThreshold);
+
+        return clusters;
+    }
+
+    /// <summary>
+    /// Returns a pairwise similarity function over <paramref name="entries"/> by index —
+    /// cosine over embeddings when the store has them, Jaccard over content tokens otherwise.
+    /// </summary>
+    private async Task<Func<int, int, double>> BuildSimilarityFunctionAsync(
+        List<MemoryEntry> entries,
+        CancellationToken cancellationToken)
+    {
+        if (_embeddingCache is not null)
+        {
+            var batch = entries.Select(e => (e.Id, Text: GetDocumentText(e))).ToList();
+            var map = await _embeddingCache.GetOrCreateBatchAsync(batch, cancellationToken);
+            var vectors = entries.Select(e => map.GetValueOrDefault(e.Id)).ToArray();
+
+            // Entries whose embedding failed to generate fall through to the lexical path
+            // rather than being silently excluded from deduplication.
+            if (vectors.Any(v => v is not null))
+            {
+                var tokenSets = entries.Select(e => Tokenize(e.Content)).ToArray();
+                return (i, j) => vectors[i] is { } a && vectors[j] is { } b
+                    ? EmbeddingCache.CosineSimilarity(a, b)
+                    : Jaccard(tokenSets[i], tokenSets[j]);
+            }
+        }
+
+        var lexical = entries.Select(e => Tokenize(e.Content)).ToArray();
+        return (i, j) => Jaccard(lexical[i], lexical[j]);
+    }
+
+    private static HashSet<string> Tokenize(string? text) =>
+        text is null
+            ? []
+            : [.. Regex
+                .Matches(text.ToLowerInvariant(), @"[a-z0-9']+")
+                .Select(m => m.Value)
+                .Where(w => w.Length > 3)];
+
+    private static double Jaccard(HashSet<string> a, HashSet<string> b)
+    {
+        if (a.Count == 0 || b.Count == 0)
+            return 0;
+        var intersection = a.Count <= b.Count ? a.Count(b.Contains) : b.Count(a.Contains);
+        return (double)intersection / (a.Count + b.Count - intersection);
+    }
+
     public async Task<IReadOnlyList<string>> ListTagsAsync(CancellationToken cancellationToken = default)
     {
         await _semaphore.WaitAsync(cancellationToken);
@@ -219,6 +444,7 @@ internal sealed partial class FileMemoryStore : ILongTermMemory
         {
             var index = await EnsureIndexAsync(cancellationToken);
             return index.Values
+                .Where(e => e.ArchivedAt is null)
                 .SelectMany(e => e.Tags)
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .OrderBy(t => t, StringComparer.OrdinalIgnoreCase)
@@ -237,6 +463,7 @@ internal sealed partial class FileMemoryStore : ILongTermMemory
         {
             var index = await EnsureIndexAsync(cancellationToken);
             return index.Values
+                .Where(e => e.ArchivedAt is null)
                 .Select(e => e.Category)
                 .Where(c => c is not null)
                 .Distinct(StringComparer.OrdinalIgnoreCase)
@@ -298,6 +525,11 @@ internal sealed partial class FileMemoryStore : ILongTermMemory
         // hidden from search/recall by default but remain on disk for audit.
         // Direct GetAsync still returns them; supersession traversal needs the by-id path.
         if (entry.SupersededBy is not null && !criteria.IncludeSuperseded)
+            return false;
+
+        // Archived entries (dream consolidation merges, ephemeral pruning) are hidden from
+        // recall but kept on disk until the retention purge. Recovery tooling opts back in.
+        if (entry.ArchivedAt is not null && !criteria.IncludeArchived)
             return false;
 
         if (criteria.Category is not null)

--- a/src/RockBot.Host/MergeCoverage.cs
+++ b/src/RockBot.Host/MergeCoverage.cs
@@ -75,6 +75,12 @@ internal static partial class MergeCoverage
         "issue", "issues", "error", "errors", "warning", "warnings", "notes", "given",
         "based", "across", "within", "without", "however", "although", "though", "unless",
         "overall", "specifically", "particularly", "typically", "generally", "likely",
+        // Second live-run false positives. Kept deliberately short: several other words from
+        // the same rejections — "Personal", "Power", "Social", "Code", "Class", "Benefit",
+        // "Extended" — read as generic but are load-bearing in this corpus ("OneDrive
+        // Personal", "Blazor Online Class", "MVP Azure Extended Benefit"), and stoplisting
+        // them would blunt a correct rejection. Only add a word when it cannot carry meaning.
+        "ids", "enjoys", "downloading",
     };
 
     /// <summary>

--- a/src/RockBot.Host/MergeCoverage.cs
+++ b/src/RockBot.Host/MergeCoverage.cs
@@ -64,6 +64,17 @@ internal static partial class MergeCoverage
         "per", "via", "context", "current", "currently", "still", "already", "always", "never",
         "other", "another", "same", "different", "first", "second", "last", "next", "previous",
         "some", "most", "many", "much", "more", "less", "very", "rather", "quite",
+        // Observed as false positives on a live corpus: ordinary words that happened to open
+        // a sentence or label a clause, flagged as proper nouns and rejecting a sound merge.
+        "adding", "candidate", "candidates", "flagged", "validated", "recurring", "repeated",
+        "correct", "corrected", "short", "long", "topic", "topics", "attempts", "attempted",
+        "recommend", "recommended", "confirmed", "verified", "known", "unknown", "successful",
+        "failed", "failing", "pending", "active", "inactive", "enabled", "disabled",
+        "created", "updated", "deleted", "removed", "added", "changed", "applied",
+        "review", "reviewed", "summary", "status", "result", "results", "reason", "reasons",
+        "issue", "issues", "error", "errors", "warning", "warnings", "notes", "given",
+        "based", "across", "within", "without", "however", "although", "though", "unless",
+        "overall", "specifically", "particularly", "typically", "generally", "likely",
     };
 
     /// <summary>

--- a/src/RockBot.Host/MergeCoverage.cs
+++ b/src/RockBot.Host/MergeCoverage.cs
@@ -1,0 +1,125 @@
+using System.Text.RegularExpressions;
+
+namespace RockBot.Host;
+
+/// <summary>
+/// Checks that a consolidated memory entry still carries the specifics its sources carried.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A merge is the only place in the pipeline where stored text is regenerated rather than
+/// added or removed, and the regenerated prose has no anchor back to what the sources said.
+/// The characteristic failure is not a wrong merge, it is a plausible one: an entry recording
+/// "Rocky Lhotka also appears in travel and calendar data as Rockford Duane Lhotka, default
+/// timezone America/Chicago, accounts …" merges into something that keeps the account list —
+/// the machine-readable part — and quietly drops the name. The result reads fine. Nothing
+/// flags it. The sources are gone.
+/// </para>
+/// <para>
+/// So the check is deliberately mechanical and deliberately biased toward rejection: names,
+/// numbers and dates present in a source must appear in the merged text, or the merge does not
+/// happen and the sources are left alone. The cost of a false rejection is a duplicate pair
+/// surviving another cycle; the cost of a false acceptance is a fact nobody can recover the
+/// wording of. Those are not symmetric.
+/// </para>
+/// </remarks>
+internal static partial class MergeCoverage
+{
+    [GeneratedRegex(@"\b\p{Lu}[\p{L}']{2,}\b")]
+    private static partial Regex CapitalizedWord();
+
+    [GeneratedRegex(@"\b\p{Lu}{2,}\b")]
+    private static partial Regex Acronym();
+
+    /// <summary>
+    /// Numbers, including dates, times, versions and decimals. Two characters minimum: a bare
+    /// digit is far more often incidental ("the top 3 items") than load-bearing, and requiring
+    /// it to survive would reject merges that legitimately rephrase to "three".
+    /// </summary>
+    [GeneratedRegex(@"\d(?:[.,:/\-]?\d)+")]
+    private static partial Regex Numeric();
+
+    /// <summary>Trailing possessive, so a source's "Rocky's" is satisfied by "Rocky".</summary>
+    [GeneratedRegex(@"['’]s?$")]
+    private static partial Regex Possessive();
+
+    /// <summary>
+    /// Common words that show up capitalized purely because they start a sentence. Matching is
+    /// case-insensitive, so this also spares ordinary mid-sentence prose from being mistaken
+    /// for a proper noun.
+    /// </summary>
+    private static readonly HashSet<string> CommonWords = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "the", "this", "that", "these", "those", "there", "then", "than", "and", "but", "not",
+        "are", "was", "were", "has", "have", "had", "its", "his", "her", "their", "they", "them",
+        "also", "only", "just", "such", "each", "both", "all", "any", "one", "two", "three",
+        "new", "now", "use", "uses", "used", "using", "should", "must", "may", "can", "will",
+        "would", "could", "note", "example", "include", "includes", "including", "prefer",
+        "prefers", "avoid", "does", "did", "set", "get", "save", "send", "read", "write", "run",
+        "when", "what", "where", "while", "with", "from", "for", "into", "over", "under",
+        "about", "after", "before", "during", "between", "because", "however", "instead",
+        "since", "until", "upon", "user", "agent", "detail", "details", "task", "tasks", "item",
+        "items", "entry", "entries", "memory", "working", "long", "term", "data", "time",
+        "date", "day", "days", "week", "weeks", "month", "months", "year", "years", "ago",
+        "per", "via", "context", "current", "currently", "still", "already", "always", "never",
+        "other", "another", "same", "different", "first", "second", "last", "next", "previous",
+        "some", "most", "many", "much", "more", "less", "very", "rather", "quite",
+    };
+
+    /// <summary>
+    /// Extracts the load-bearing specifics from a piece of memory content: proper nouns,
+    /// acronyms, and numbers.
+    /// </summary>
+    internal static HashSet<string> ExtractSpecifics(string? content)
+    {
+        var specifics = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (string.IsNullOrWhiteSpace(content))
+            return specifics;
+
+        foreach (Match m in CapitalizedWord().Matches(content))
+        {
+            var word = Possessive().Replace(m.Value, string.Empty);
+            if (word.Length > 2 && !CommonWords.Contains(word))
+                specifics.Add(word);
+        }
+
+        foreach (Match m in Acronym().Matches(content))
+            if (!CommonWords.Contains(m.Value))
+                specifics.Add(m.Value);
+
+        foreach (Match m in Numeric().Matches(content))
+            specifics.Add(m.Value);
+
+        return specifics;
+    }
+
+    /// <summary>
+    /// Returns the specifics present across <paramref name="sources"/> that do not survive into
+    /// <paramref name="mergedContent"/>, sorted for stable logging. An empty result means the
+    /// merge is safe to apply.
+    /// </summary>
+    /// <remarks>
+    /// Matching is a case-insensitive substring test rather than a token test, so a merge is
+    /// credited for reformatting — "Rockford Duane Lhotka" still covers the source token
+    /// "Rockford", and "2026-09-10" covers "2026". Reformatting that genuinely discards a
+    /// component (spelling out "September" as "09") is reported as missing, which is the
+    /// conservative direction.
+    /// </remarks>
+    internal static IReadOnlyList<string> FindMissingSpecifics(
+        IEnumerable<MemoryEntry> sources,
+        string? mergedContent)
+    {
+        var merged = mergedContent ?? string.Empty;
+
+        var required = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var source in sources)
+            required.UnionWith(ExtractSpecifics(source.Content));
+
+        if (required.Count == 0)
+            return [];
+
+        return [.. required
+            .Where(s => merged.IndexOf(s, StringComparison.OrdinalIgnoreCase) < 0)
+            .OrderBy(s => s, StringComparer.OrdinalIgnoreCase)];
+    }
+}

--- a/src/RockBot.Host/MergeCoverage.cs
+++ b/src/RockBot.Host/MergeCoverage.cs
@@ -44,51 +44,20 @@ internal static partial class MergeCoverage
     private static partial Regex Possessive();
 
     /// <summary>
-    /// Common words that show up capitalized purely because they start a sentence. Matching is
-    /// case-insensitive, so this also spares ordinary mid-sentence prose from being mistaken
-    /// for a proper noun.
-    /// </summary>
-    private static readonly HashSet<string> CommonWords = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "the", "this", "that", "these", "those", "there", "then", "than", "and", "but", "not",
-        "are", "was", "were", "has", "have", "had", "its", "his", "her", "their", "they", "them",
-        "also", "only", "just", "such", "each", "both", "all", "any", "one", "two", "three",
-        "new", "now", "use", "uses", "used", "using", "should", "must", "may", "can", "will",
-        "would", "could", "note", "example", "include", "includes", "including", "prefer",
-        "prefers", "avoid", "does", "did", "set", "get", "save", "send", "read", "write", "run",
-        "when", "what", "where", "while", "with", "from", "for", "into", "over", "under",
-        "about", "after", "before", "during", "between", "because", "however", "instead",
-        "since", "until", "upon", "user", "agent", "detail", "details", "task", "tasks", "item",
-        "items", "entry", "entries", "memory", "working", "long", "term", "data", "time",
-        "date", "day", "days", "week", "weeks", "month", "months", "year", "years", "ago",
-        "per", "via", "context", "current", "currently", "still", "already", "always", "never",
-        "other", "another", "same", "different", "first", "second", "last", "next", "previous",
-        "some", "most", "many", "much", "more", "less", "very", "rather", "quite",
-        // Observed as false positives on a live corpus: ordinary words that happened to open
-        // a sentence or label a clause, flagged as proper nouns and rejecting a sound merge.
-        "adding", "candidate", "candidates", "flagged", "validated", "recurring", "repeated",
-        "correct", "corrected", "short", "long", "topic", "topics", "attempts", "attempted",
-        "recommend", "recommended", "confirmed", "verified", "known", "unknown", "successful",
-        "failed", "failing", "pending", "active", "inactive", "enabled", "disabled",
-        "created", "updated", "deleted", "removed", "added", "changed", "applied",
-        "review", "reviewed", "summary", "status", "result", "results", "reason", "reasons",
-        "issue", "issues", "error", "errors", "warning", "warnings", "notes", "given",
-        "based", "across", "within", "without", "however", "although", "though", "unless",
-        "overall", "specifically", "particularly", "typically", "generally", "likely",
-        // Second live-run false positives. Kept deliberately short: several other words from
-        // the same rejections — "Personal", "Power", "Social", "Code", "Class", "Benefit",
-        // "Extended" — read as generic but are load-bearing in this corpus ("OneDrive
-        // Personal", "Blazor Online Class", "MVP Azure Extended Benefit"), and stoplisting
-        // them would blunt a correct rejection. Only add a word when it cannot carry meaning.
-        "ids", "enjoys", "downloading",
-    };
-
-    /// <summary>
     /// Extracts the load-bearing specifics from a piece of memory content: proper nouns,
     /// acronyms, and numbers.
     /// </summary>
-    internal static HashSet<string> ExtractSpecifics(string? content)
+    /// <param name="content">Memory content to scan.</param>
+    /// <param name="vocabulary">
+    /// Which words count as ordinary language. Defaults to the generic-English baseline;
+    /// deployments override it via <c>merge-coverage-vocabulary.json</c>.
+    /// </param>
+    internal static HashSet<string> ExtractSpecifics(
+        string? content,
+        MergeCoverageVocabulary? vocabulary = null)
     {
+        var words = vocabulary ?? MergeCoverageVocabulary.Default;
+
         var specifics = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         if (string.IsNullOrWhiteSpace(content))
             return specifics;
@@ -96,12 +65,12 @@ internal static partial class MergeCoverage
         foreach (Match m in CapitalizedWord().Matches(content))
         {
             var word = Possessive().Replace(m.Value, string.Empty);
-            if (word.Length > 2 && !CommonWords.Contains(word))
+            if (word.Length > 2 && !words.IsCommon(word))
                 specifics.Add(word);
         }
 
         foreach (Match m in Acronym().Matches(content))
-            if (!CommonWords.Contains(m.Value))
+            if (!words.IsCommon(m.Value))
                 specifics.Add(m.Value);
 
         foreach (Match m in Numeric().Matches(content))
@@ -124,13 +93,14 @@ internal static partial class MergeCoverage
     /// </remarks>
     internal static IReadOnlyList<string> FindMissingSpecifics(
         IEnumerable<MemoryEntry> sources,
-        string? mergedContent)
+        string? mergedContent,
+        MergeCoverageVocabulary? vocabulary = null)
     {
         var merged = mergedContent ?? string.Empty;
 
         var required = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var source in sources)
-            required.UnionWith(ExtractSpecifics(source.Content));
+            required.UnionWith(ExtractSpecifics(source.Content, vocabulary));
 
         if (required.Count == 0)
             return [];

--- a/src/RockBot.Host/MergeCoverageVocabulary.cs
+++ b/src/RockBot.Host/MergeCoverageVocabulary.cs
@@ -1,0 +1,150 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace RockBot.Host;
+
+/// <summary>
+/// Decides which words the merge coverage check treats as ordinary language rather than as
+/// load-bearing specifics. Deployment-specific, because vocabulary is.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The built-in list is generic English — words that appear capitalized only because they open
+/// a sentence. That is a reasonable default but it is not portable, in both directions:
+/// </para>
+/// <list type="bullet">
+/// <item>
+/// An operational assistant accumulates its own noise words. Words that read as generic can
+/// also be load-bearing — "Personal", "Class", "Benefit" and "Extended" name real things in one
+/// live corpus ("OneDrive Personal", "Blazor Online Class", "MVP Azure Extended Benefit"), so
+/// suppressing them would blunt a correct rejection.
+/// </item>
+/// <item>
+/// A storytelling agent's characters collide head-on with the built-in list. A character named
+/// May, Will, Rose, Grace or Hope would be silently stripped of coverage protection, which is
+/// exactly the population that must never be lost. <see cref="AlwaysSpecificWords"/> exists for
+/// that case and takes precedence over everything else.
+/// </item>
+/// </list>
+/// <para>
+/// Loaded from <c>merge-coverage-vocabulary.json</c> on the agent profile volume, alongside
+/// <c>tier-selector.json</c> and the dream directives, and re-read at the top of every cycle so
+/// edits take effect without a restart.
+/// </para>
+/// </remarks>
+internal sealed class MergeCoverageVocabulary
+{
+    /// <summary>Generic English baseline, used when no vocabulary file is present.</summary>
+    /// <remarks>
+    /// Deferred rather than a plain initializer: static fields initialize in declaration order,
+    /// and this is declared above the word list it is built from.
+    /// </remarks>
+    public static MergeCoverageVocabulary Default => LazyDefault.Value;
+
+    private static readonly Lazy<MergeCoverageVocabulary> LazyDefault = new(() => new(null, null));
+
+    private readonly HashSet<string> _common;
+    private readonly HashSet<string> _alwaysSpecific;
+
+    public MergeCoverageVocabulary(
+        IEnumerable<string>? extraCommonWords,
+        IEnumerable<string>? alwaysSpecificWords)
+    {
+        _common = new HashSet<string>(BuiltInCommonWords, StringComparer.OrdinalIgnoreCase);
+        _alwaysSpecific = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var word in extraCommonWords ?? [])
+            if (!string.IsNullOrWhiteSpace(word))
+                _common.Add(word.Trim());
+
+        foreach (var word in alwaysSpecificWords ?? [])
+            if (!string.IsNullOrWhiteSpace(word))
+                _alwaysSpecific.Add(word.Trim());
+    }
+
+    /// <summary>
+    /// True when <paramref name="word"/> should be ignored rather than required to survive a
+    /// merge. <see cref="AlwaysSpecificWords"/> wins over the common list, so a deployment can
+    /// reclaim a built-in word it needs protected.
+    /// </summary>
+    public bool IsCommon(string word) =>
+        !_alwaysSpecific.Contains(word) && _common.Contains(word);
+
+    /// <summary>Words reclaimed as specifics regardless of the common list.</summary>
+    public IReadOnlyCollection<string> AlwaysSpecificWords => _alwaysSpecific;
+
+    /// <summary>Count of words treated as ordinary language.</summary>
+    public int CommonWordCount => _common.Count;
+
+    /// <summary>
+    /// Parses a vocabulary file. Returns <see cref="Default"/> when <paramref name="json"/> is
+    /// absent or unusable — a malformed override must not disable coverage checking.
+    /// </summary>
+    public static MergeCoverageVocabulary Parse(string? json, out string? error)
+    {
+        error = null;
+        if (string.IsNullOrWhiteSpace(json))
+            return Default;
+
+        try
+        {
+            var dto = JsonSerializer.Deserialize<VocabularyDto>(json, JsonOptions);
+            if (dto is null)
+            {
+                error = "file parsed to null";
+                return Default;
+            }
+
+            return new MergeCoverageVocabulary(dto.ExtraCommonWords, dto.AlwaysSpecificWords);
+        }
+        catch (JsonException ex)
+        {
+            error = ex.Message;
+            return Default;
+        }
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        AllowTrailingCommas = true,
+    };
+
+    private sealed record VocabularyDto(
+        [property: JsonPropertyName("extraCommonWords")] string[]? ExtraCommonWords,
+        [property: JsonPropertyName("alwaysSpecificWords")] string[]? AlwaysSpecificWords);
+
+    /// <summary>
+    /// Words that appear capitalized only by virtue of opening a sentence or labelling a
+    /// clause. Generic English plus a few observed on live corpora; anything corpus-specific
+    /// belongs in the vocabulary file, not here.
+    /// </summary>
+    private static readonly string[] BuiltInCommonWords =
+    [
+        "the", "this", "that", "these", "those", "there", "then", "than", "and", "but", "not",
+        "are", "was", "were", "has", "have", "had", "its", "his", "her", "their", "they", "them",
+        "also", "only", "just", "such", "each", "both", "all", "any", "one", "two", "three",
+        "new", "now", "use", "uses", "used", "using", "should", "must", "may", "can", "will",
+        "would", "could", "note", "example", "include", "includes", "including", "prefer",
+        "prefers", "avoid", "does", "did", "set", "get", "save", "send", "read", "write", "run",
+        "when", "what", "where", "while", "with", "from", "for", "into", "over", "under",
+        "about", "after", "before", "during", "between", "because", "however", "instead",
+        "since", "until", "upon", "user", "agent", "detail", "details", "task", "tasks", "item",
+        "items", "entry", "entries", "memory", "working", "long", "term", "data", "time",
+        "date", "day", "days", "week", "weeks", "month", "months", "year", "years", "ago",
+        "per", "via", "context", "current", "currently", "still", "already", "always", "never",
+        "other", "another", "same", "different", "first", "second", "last", "next", "previous",
+        "some", "most", "many", "much", "more", "less", "very", "rather", "quite",
+        "adding", "candidate", "candidates", "flagged", "validated", "recurring", "repeated",
+        "correct", "corrected", "short", "topic", "topics", "attempts", "attempted",
+        "recommend", "recommended", "confirmed", "verified", "known", "unknown", "successful",
+        "failed", "failing", "pending", "active", "inactive", "enabled", "disabled",
+        "created", "updated", "deleted", "removed", "added", "changed", "applied",
+        "review", "reviewed", "summary", "status", "result", "results", "reason", "reasons",
+        "issue", "issues", "error", "errors", "warning", "warnings", "notes", "given",
+        "based", "across", "within", "without", "although", "though", "unless",
+        "overall", "specifically", "particularly", "typically", "generally", "likely",
+        "ids", "enjoys", "downloading",
+    ];
+}

--- a/tests/RockBot.Host.Tests/ConsolidationCandidateGatingTests.cs
+++ b/tests/RockBot.Host.Tests/ConsolidationCandidateGatingTests.cs
@@ -1,0 +1,259 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace RockBot.Host.Tests;
+
+/// <summary>
+/// Covers the gate that decides which entries dream consolidation is allowed to touch.
+/// </summary>
+/// <remarks>
+/// Handing the LLM the whole corpus every cycle means every entry is re-tried for deletion
+/// every cycle, and survival compounds: at the default twice-daily cadence a one-in-a-thousand
+/// misjudgement per entry per cycle loses about half the corpus in a year. Gating converts an
+/// unbounded repeated gamble into a decision taken once per entry per content change, which is
+/// why "already reviewed and unchanged is withheld" is the load-bearing assertion here.
+/// </remarks>
+[TestClass]
+public class ConsolidationCandidateGatingTests
+{
+    private string _tempDir = null!;
+
+    [TestInitialize]
+    public void Init() =>
+        _tempDir = Path.Combine(Path.GetTempPath(), "rockbot-gating-" + Guid.NewGuid().ToString("N"));
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    // ── Review stamps ────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void UnstampedEntry_IsEligible()
+    {
+        Assert.IsFalse(DreamService.IsReviewedAndUnchanged(Entry("a", "Rocky has a dog named Milo")));
+    }
+
+    [TestMethod]
+    public void StampedEntry_WithUnchangedContent_IsWithheld()
+    {
+        var content = "Rocky has a dog named Milo";
+        Assert.IsTrue(DreamService.IsReviewedAndUnchanged(Reviewed(Entry("a", content), content)));
+    }
+
+    [TestMethod]
+    public void StampedEntry_BecomesEligibleAgainWhenContentChanges()
+    {
+        // Any edit path counts — reinforcement, a tool update, a previous merge. The stamp is
+        // a content fingerprint precisely so no write path can bypass it.
+        var stamped = Reviewed(Entry("a", "Rocky has a dog named Milo"), "Rocky has a dog named Milo");
+        var edited = stamped with { Content = "Rocky has a Sheltie named Milo" };
+
+        Assert.IsFalse(DreamService.IsReviewedAndUnchanged(edited));
+    }
+
+    [TestMethod]
+    public void StampWithAForeignHash_IsTreatedAsUnreviewed()
+    {
+        var entry = Entry("a", "content") with
+        {
+            Metadata = new Dictionary<string, string>
+            {
+                [DreamService.ConsolidationReviewedHashKey] = "DEADBEEFDEADBEEF",
+            },
+        };
+
+        Assert.IsFalse(DreamService.IsReviewedAndUnchanged(entry));
+    }
+
+    // ── Selection ────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task ReviewedUnchangedEntries_AreWithheldFromTheLlm()
+    {
+        // Three unrelated facts, all previously reviewed. Nothing changed, nothing is a
+        // duplicate — so consolidation gets to see none of them and can delete none of them.
+        var store = CreateStore();
+        var all = new[]
+        {
+            Reviewed(Entry("a", "Rocky lives in Minnesota"), "Rocky lives in Minnesota"),
+            Reviewed(Entry("b", "Trish Roberts is a Xebia collaborator"), "Trish Roberts is a Xebia collaborator"),
+            Reviewed(Entry("c", "The estimated tax deadline is September 10"), "The estimated tax deadline is September 10"),
+        };
+        foreach (var e in all) await store.SaveAsync(e);
+
+        var eligible = await Select(store, all);
+
+        Assert.AreEqual(0, eligible.Count);
+    }
+
+    [TestMethod]
+    public async Task NewOrChangedEntries_AreAlwaysEligible()
+    {
+        var store = CreateStore();
+        var reviewed = Reviewed(Entry("old", "Rocky lives in Minnesota"), "Rocky lives in Minnesota");
+        var fresh = Entry("new", "Rocky is speaking at VSLive Las Vegas");
+        await store.SaveAsync(reviewed);
+        await store.SaveAsync(fresh);
+
+        var eligible = await Select(store, [reviewed, fresh]);
+
+        CollectionAssert.AreEquivalent(new[] { "new" }, eligible.Select(e => e.Id).ToArray());
+    }
+
+    [TestMethod]
+    public async Task ReviewedEntry_IsPulledBackInWhenSomethingDuplicatesIt()
+    {
+        // A fresh entry restating an old reviewed one has to be mergeable, which means the
+        // old one must be visible again — otherwise duplicates could never be collapsed.
+        var store = CreateStore();
+        var reviewed = Reviewed(
+            Entry("old", "Rocky has a dog named Milo the Sheltie"),
+            "Rocky has a dog named Milo the Sheltie");
+        var fresh = Entry("new", "Rocky has a Sheltie dog named Milo");
+        await store.SaveAsync(reviewed);
+        await store.SaveAsync(fresh);
+
+        // Lexical fallback (no embedding generator in tests), so use a threshold that matches
+        // Jaccard overlap rather than a cosine-scale one.
+        var eligible = await Select(store, [reviewed, fresh], threshold: 0.5);
+
+        CollectionAssert.AreEquivalent(new[] { "old", "new" }, eligible.Select(e => e.Id).ToArray());
+    }
+
+    [TestMethod]
+    public async Task SelectionPreservesStoreOrdering()
+    {
+        var store = CreateStore();
+        var all = new[] { Entry("a", "first fact"), Entry("b", "second fact"), Entry("c", "third fact") };
+        foreach (var e in all) await store.SaveAsync(e);
+
+        var eligible = await Select(store, all);
+
+        CollectionAssert.AreEqual(new[] { "a", "b", "c" }, eligible.Select(e => e.Id).ToArray());
+    }
+
+    [TestMethod]
+    public void ReviewStamp_IsIndependentOfImportanceAndTimestamps()
+    {
+        // The stamp keys off content only. Importance decay rewrites ImportanceScore and
+        // UpdatedAt on every cycle; if either fed the stamp, decayed entries would look
+        // "changed" forever and the gate would leak the whole corpus straight back through.
+        var content = "Rocky lives in Minnesota";
+        var stamped = Reviewed(Entry("a", content), content);
+
+        var decayed = stamped with
+        {
+            ImportanceScore = 0.1f,
+            UpdatedAt = DateTimeOffset.UtcNow.AddDays(1),
+            LastSeenAt = DateTimeOffset.UtcNow.AddDays(1),
+            ReinforcementCount = 99,
+        };
+
+        Assert.IsTrue(DreamService.IsReviewedAndUnchanged(decayed));
+    }
+
+    // ── Clustering ───────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task NearDuplicates_Cluster_AndUnrelatedEntriesDoNot()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(Entry("dup1", "Rocky has a dog named Milo the Sheltie"));
+        await store.SaveAsync(Entry("dup2", "Rocky has a Sheltie dog named Milo"));
+        await store.SaveAsync(Entry("other", "Estimated quarterly taxes are due September 10"));
+
+        var clusters = await store.FindNearDuplicateClustersAsync(0.5, 3);
+
+        Assert.AreEqual(1, clusters.Count);
+        CollectionAssert.AreEquivalent(new[] { "dup1", "dup2" }, clusters[0].ToArray());
+    }
+
+    [TestMethod]
+    public async Task ThresholdControlsHowMuchIsExposed()
+    {
+        // Partial overlap: related enough to merge under a permissive threshold, not enough
+        // under a strict one. The threshold is the main dial on how much consolidation may
+        // touch, so it has to actually bite in both directions.
+        // Tokens are {rocky, lives, minnesota} vs {rocky, lives, minneapolis, minnesota},
+        // so Jaccard is 3/4 — comfortably inside 0.50 and comfortably outside 0.99.
+        var store = CreateStore();
+        await store.SaveAsync(Entry("a", "Rocky lives in Minnesota"));
+        await store.SaveAsync(Entry("b", "Rocky lives in Minneapolis Minnesota"));
+
+        Assert.AreEqual(0, (await store.FindNearDuplicateClustersAsync(0.99, 3)).Count);
+        Assert.AreEqual(1, (await store.FindNearDuplicateClustersAsync(0.50, 3)).Count);
+    }
+
+    [TestMethod]
+    public async Task ClustersAreSplitAtMaxClusterSize()
+    {
+        // Caps merge fan-in: without it, single-link chaining lets one cluster swallow a whole
+        // topic and invites the model to collapse it into a single entry.
+        var store = CreateStore();
+        for (var i = 0; i < 5; i++)
+            await store.SaveAsync(Entry($"dup{i}", "Rocky has a Sheltie dog named Milo"));
+
+        var clusters = await store.FindNearDuplicateClustersAsync(0.5, 2);
+
+        Assert.IsTrue(clusters.All(c => c.Count <= 2), "no cluster may exceed the cap");
+        Assert.AreEqual(4, clusters.Sum(c => c.Count), "the odd one out has nothing to merge with");
+    }
+
+    [TestMethod]
+    public async Task ArchivedEntries_AreNotOfferedAsDuplicateCandidates()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(Entry("live", "Rocky has a Sheltie dog named Milo"));
+        await store.SaveAsync(Entry("archived", "Rocky has a dog named Milo the Sheltie"));
+        await store.ArchiveAsync("archived", "merged earlier");
+
+        Assert.AreEqual(0, (await store.FindNearDuplicateClustersAsync(0.5, 3)).Count);
+    }
+
+    [TestMethod]
+    public async Task MaxClusterSizeBelowTwo_DisablesClustering()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(Entry("dup1", "Rocky has a Sheltie dog named Milo"));
+        await store.SaveAsync(Entry("dup2", "Rocky has a Sheltie dog named Milo"));
+
+        Assert.AreEqual(0, (await store.FindNearDuplicateClustersAsync(0.5, 1)).Count);
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static Task<List<MemoryEntry>> Select(
+        FileMemoryStore store,
+        IReadOnlyList<MemoryEntry> all,
+        double threshold = 0.88) =>
+        DreamService.SelectConsolidationCandidatesAsync(
+            store,
+            new DreamOptions { ConsolidationSimilarityThreshold = threshold },
+            NullLogger.Instance,
+            all,
+            CancellationToken.None);
+
+    private FileMemoryStore CreateStore() =>
+        new(Options.Create(new MemoryOptions { BasePath = _tempDir }),
+            Options.Create(new AgentProfileOptions()),
+            Options.Create(new EmbeddingOptions()),
+            NullLogger<FileMemoryStore>.Instance,
+            EmbeddingTextPreparer.ForTests());
+
+    private static MemoryEntry Entry(string id, string content) =>
+        new(id, content, null, [], DateTimeOffset.UtcNow);
+
+    private static MemoryEntry Reviewed(MemoryEntry entry, string contentAtReview) =>
+        entry with
+        {
+            Metadata = new Dictionary<string, string>
+            {
+                [DreamService.ConsolidationReviewedHashKey] = DreamService.ContentFingerprint(contentAtReview),
+                [DreamService.ConsolidationReviewedAtKey] = DateTimeOffset.UtcNow.ToString("O"),
+            },
+        };
+}

--- a/tests/RockBot.Host.Tests/ConsolidationCandidateGatingTests.cs
+++ b/tests/RockBot.Host.Tests/ConsolidationCandidateGatingTests.cs
@@ -191,8 +191,9 @@ public class ConsolidationCandidateGatingTests
     [TestMethod]
     public async Task ClustersAreSplitAtMaxClusterSize()
     {
-        // Caps merge fan-in: without it, single-link chaining lets one cluster swallow a whole
-        // topic and invites the model to collapse it into a single entry.
+        // Bounds eligibility, not merge size: without it, single-link chaining pulls a whole
+        // topic into one group. What the model then merges is constrained by the coverage
+        // check, not by this cap.
         var store = CreateStore();
         for (var i = 0; i < 5; i++)
             await store.SaveAsync(Entry($"dup{i}", "Rocky has a Sheltie dog named Milo"));

--- a/tests/RockBot.Host.Tests/MemoryArchiveTests.cs
+++ b/tests/RockBot.Host.Tests/MemoryArchiveTests.cs
@@ -1,0 +1,191 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace RockBot.Host.Tests;
+
+/// <summary>
+/// Covers the archive tier — the recovery path for automated removals.
+/// </summary>
+/// <remarks>
+/// Consolidation used to hard-delete, so a bad merge destroyed the only copy of a fact. A
+/// live corpus lost 26% of its entries in 3.5 days that way, including entries reinforced
+/// 214× and scored 0.99 importance. Archiving is what makes a wrong call cost recall until
+/// someone notices, rather than the fact itself.
+/// </remarks>
+[TestClass]
+public class MemoryArchiveTests
+{
+    private string _tempDir = null!;
+
+    [TestInitialize]
+    public void Setup() =>
+        _tempDir = Path.Combine(Path.GetTempPath(), "rockbot-archive-test-" + Guid.NewGuid().ToString("N"));
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    [TestMethod]
+    public async Task ArchivedEntry_IsHiddenFromSearch_ButStillRetrievableById()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(Entry("keep", "Rocky has a Sheltie named Milo"));
+        await store.SaveAsync(Entry("gone", "Trish Roberts is a collaborator at Xebia"));
+
+        await store.ArchiveAsync("gone", "merged into keep");
+
+        var visible = await store.SearchAsync(new MemorySearchCriteria(MaxResults: 50));
+        CollectionAssert.AreEquivalent(new[] { "keep" }, visible.Select(e => e.Id).ToArray());
+
+        // The whole point: still recoverable.
+        var archived = await store.GetAsync("gone");
+        Assert.IsNotNull(archived);
+        Assert.AreEqual("Trish Roberts is a collaborator at Xebia", archived.Content);
+        Assert.IsNotNull(archived.ArchivedAt);
+        Assert.AreEqual("merged into keep", archived.ArchiveReason);
+    }
+
+    [TestMethod]
+    public async Task ArchivedEntry_IsVisibleWhenExplicitlyRequested()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(Entry("gone", "Rockford Duane Lhotka appears in travel data"));
+        await store.ArchiveAsync("gone", "flagged ephemeral by consolidation");
+
+        var audited = await store.SearchAsync(new MemorySearchCriteria(MaxResults: 50, IncludeArchived: true));
+
+        Assert.AreEqual(1, audited.Count);
+        Assert.AreEqual("gone", audited[0].Id);
+    }
+
+    [TestMethod]
+    public async Task ArchivedEntry_SurvivesStoreRestart()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(Entry("gone", "PWOP Productions W-9 was completed"));
+        await store.ArchiveAsync("gone", "merged into abc123");
+
+        // Fresh index built from disk — archival must be persisted, not just in-memory state.
+        var reopened = CreateStore();
+
+        Assert.AreEqual(0, (await reopened.SearchAsync(new MemorySearchCriteria(MaxResults: 50))).Count);
+        var recovered = await reopened.GetAsync("gone");
+        Assert.IsNotNull(recovered);
+        Assert.AreEqual("merged into abc123", recovered.ArchiveReason);
+    }
+
+    [TestMethod]
+    public async Task RestoreAsync_ReturnsEntryToRecall()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(Entry("gone", "Rocky's default timezone is America/Chicago"));
+        await store.ArchiveAsync("gone", "merged into xyz");
+
+        Assert.IsTrue(await store.RestoreAsync("gone"));
+
+        var visible = await store.SearchAsync(new MemorySearchCriteria(MaxResults: 50));
+        Assert.AreEqual(1, visible.Count);
+        Assert.IsNull(visible[0].ArchivedAt);
+        Assert.IsNull(visible[0].ArchiveReason);
+    }
+
+    [TestMethod]
+    public async Task RestoreAsync_ReturnsFalseForEntryThatWasNeverArchived()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(Entry("live", "still here"));
+
+        Assert.IsFalse(await store.RestoreAsync("live"));
+        Assert.IsFalse(await store.RestoreAsync("no-such-id"));
+    }
+
+    [TestMethod]
+    public async Task ArchiveAsync_IsIdempotent_AndPreservesTheOriginalReason()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(Entry("gone", "content"));
+
+        await store.ArchiveAsync("gone", "first reason");
+        var firstStamp = (await store.GetAsync("gone"))!.ArchivedAt;
+
+        await store.ArchiveAsync("gone", "second reason");
+        var after = await store.GetAsync("gone");
+
+        Assert.AreEqual("first reason", after!.ArchiveReason);
+        Assert.AreEqual(firstStamp, after.ArchivedAt);
+    }
+
+    [TestMethod]
+    public async Task ArchiveAsync_OnMissingEntry_IsANoOp()
+    {
+        var store = CreateStore();
+        await store.ArchiveAsync("never-existed", "reason");
+        Assert.IsNull(await store.GetAsync("never-existed"));
+    }
+
+    [TestMethod]
+    public async Task PurgeArchivedAsync_DeletesOnlyEntriesPastRetention()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(Entry("old", "archived long ago"));
+        await store.SaveAsync(Entry("recent", "archived just now"));
+        await store.SaveAsync(Entry("live", "never archived"));
+
+        await store.ArchiveAsync("old", "merged");
+        await store.ArchiveAsync("recent", "merged");
+
+        // Backdate one archive stamp past the retention window.
+        var old = (await store.GetAsync("old"))!;
+        await store.SaveAsync(old with { ArchivedAt = DateTimeOffset.UtcNow.AddDays(-120) });
+
+        var purged = await store.PurgeArchivedAsync(TimeSpan.FromDays(90));
+
+        Assert.AreEqual(1, purged);
+        Assert.IsNull(await store.GetAsync("old"));
+        Assert.IsNotNull(await store.GetAsync("recent"));
+        Assert.IsNotNull(await store.GetAsync("live"));
+    }
+
+    [TestMethod]
+    public async Task PurgeArchivedAsync_WithNonPositiveRetention_KeepsEverythingForever()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(Entry("old", "archived long ago"));
+        await store.ArchiveAsync("old", "merged");
+        var old = (await store.GetAsync("old"))!;
+        await store.SaveAsync(old with { ArchivedAt = DateTimeOffset.UtcNow.AddYears(-5) });
+
+        Assert.AreEqual(0, await store.PurgeArchivedAsync(TimeSpan.Zero));
+        Assert.IsNotNull(await store.GetAsync("old"));
+    }
+
+    [TestMethod]
+    public async Task ArchivedEntries_AreExcludedFromTagAndCategoryVocabulary()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(Entry("live", "visible", category: "work/live", tags: ["kept"]));
+        await store.SaveAsync(Entry("gone", "hidden", category: "work/colleagues", tags: ["dropped"]));
+
+        await store.ArchiveAsync("gone", "merged");
+
+        CollectionAssert.AreEquivalent(new[] { "kept" }, (await store.ListTagsAsync()).ToArray());
+        CollectionAssert.AreEquivalent(new[] { "work/live" }, (await store.ListCategoriesAsync()).ToArray());
+    }
+
+    private FileMemoryStore CreateStore() =>
+        new(Options.Create(new MemoryOptions { BasePath = _tempDir }),
+            Options.Create(new AgentProfileOptions()),
+            Options.Create(new EmbeddingOptions()),
+            NullLogger<FileMemoryStore>.Instance,
+            EmbeddingTextPreparer.ForTests());
+
+    private static MemoryEntry Entry(
+        string id,
+        string content,
+        string? category = null,
+        string[]? tags = null) =>
+        new(id, content, category, tags ?? [], DateTimeOffset.UtcNow);
+}

--- a/tests/RockBot.Host.Tests/MergeCoverageTests.cs
+++ b/tests/RockBot.Host.Tests/MergeCoverageTests.cs
@@ -235,6 +235,83 @@ public class MergeCoverageTests
             "a rejected merge's sources must survive the toDelete sweep");
     }
 
+    // ── Deployment-specific vocabulary ───────────────────────────────────────
+
+    [TestMethod]
+    public void ExtraCommonWords_SuppressDeploymentNoise()
+    {
+        var vocab = new MergeCoverageVocabulary(extraCommonWords: ["briefing", "triage"], alwaysSpecificWords: null);
+
+        Assert.AreEqual(0, MergeCoverage.ExtractSpecifics("Briefing and Triage completed", vocab).Count);
+        CollectionAssert.Contains(
+            MergeCoverage.ExtractSpecifics("Briefing and Triage completed").ToArray(), "Briefing");
+    }
+
+    [TestMethod]
+    public void AlwaysSpecificWords_ReclaimBuiltInWordsThatAreActuallyNames()
+    {
+        // The failure this exists to prevent. A storytelling agent's characters collide head-on
+        // with generic English: "may", "will" and "some" are all built-in common words, so
+        // characters named May, Will or Rose would silently carry no coverage protection and a
+        // merge could drop them — the exact population that must never be lost.
+        var storytelling = new MergeCoverageVocabulary(
+            extraCommonWords: null,
+            alwaysSpecificWords: ["May", "Will", "Rose"]);
+
+        var line = "May and Will found Rose in the garden";
+
+        var unprotected = MergeCoverage.ExtractSpecifics(line);
+        Assert.IsFalse(unprotected.Contains("May"), "precondition: the built-in list swallows May");
+        Assert.IsFalse(unprotected.Contains("Will"), "precondition: the built-in list swallows Will");
+
+        var protectedSpecifics = MergeCoverage.ExtractSpecifics(line, storytelling);
+        foreach (var name in new[] { "May", "Will", "Rose" })
+            CollectionAssert.Contains(protectedSpecifics.ToArray(), name);
+    }
+
+    [TestMethod]
+    public void AlwaysSpecific_WinsOverExtraCommon()
+    {
+        var vocab = new MergeCoverageVocabulary(extraCommonWords: ["rose"], alwaysSpecificWords: ["Rose"]);
+        CollectionAssert.Contains(MergeCoverage.ExtractSpecifics("Rose arrived", vocab).ToArray(), "Rose");
+    }
+
+    [TestMethod]
+    public void VocabularyRoundTripsFromJson()
+    {
+        var vocab = MergeCoverageVocabulary.Parse(
+            """
+            {
+              // comments and trailing commas are tolerated
+              "extraCommonWords": ["briefing"],
+              "alwaysSpecificWords": ["May"],
+            }
+            """, out var error);
+
+        Assert.IsNull(error);
+        Assert.IsTrue(vocab.IsCommon("briefing"));
+        Assert.IsFalse(vocab.IsCommon("May"));
+    }
+
+    [TestMethod]
+    public void MalformedVocabulary_FallsBackWithoutDisablingTheCheck()
+    {
+        // A broken override must never silently turn coverage checking off — that would
+        // reintroduce exactly the data loss this safeguard exists to stop.
+        var vocab = MergeCoverageVocabulary.Parse("{ not json", out var error);
+
+        Assert.IsNotNull(error);
+        CollectionAssert.Contains(MergeCoverage.ExtractSpecifics("Rockford filed", vocab).ToArray(), "Rockford");
+    }
+
+    [TestMethod]
+    public void AbsentVocabulary_UsesTheBuiltInBaseline()
+    {
+        Assert.AreEqual(MergeCoverageVocabulary.Default.CommonWordCount,
+            MergeCoverageVocabulary.Parse(null, out var error).CommonWordCount);
+        Assert.IsNull(error);
+    }
+
     // ── High-value pruning floor ─────────────────────────────────────────────
 
     [TestMethod]

--- a/tests/RockBot.Host.Tests/MergeCoverageTests.cs
+++ b/tests/RockBot.Host.Tests/MergeCoverageTests.cs
@@ -85,6 +85,18 @@ public class MergeCoverageTests
     }
 
     [TestMethod]
+    public void OrdinaryWordsOpeningASentenceAreNotSpecifics()
+    {
+        // Observed live: this exact shape rejected a sound merge because "Candidate",
+        // "Adding", "Flagged" and "Validated" were read as proper nouns.
+        var specifics = MergeCoverage.ExtractSpecifics(
+            "Candidate low-signal words were reviewed. Adding them is wrong. "
+            + "Flagged entries were Validated against telemetry.");
+
+        Assert.AreEqual(0, specifics.Count, string.Join(", ", specifics));
+    }
+
+    [TestMethod]
     public void ContentWithNoSpecifics_ImposesNoRequirement()
     {
         var sources = new[] { Entry("a", "the user prefers concise replies") };
@@ -174,6 +186,32 @@ public class MergeCoverageTests
         var missing = MergeCoverage.FindMissingSpecifics(sources, "someone travelled");
 
         CollectionAssert.AreEqual(new[] { "Alpha", "Boston", "Mike", "Zulu" }, missing.ToArray());
+    }
+
+    [TestMethod]
+    public void RejectedMergeSources_MustNotBeReachableViaTheEphemeralPath()
+    {
+        // Regression for a defect the unit tests missed and a live cycle caught. dream.md
+        // requires every sourceId to also appear in toDelete, so rejecting a merge is not
+        // enough on its own — the standalone-removal loop would archive the very sources the
+        // rejection was meant to save, leaving them with no replacement at all. Strictly
+        // worse than allowing the lossy merge.
+        //
+        // Reproduces the exact shape seen in production: one dto whose sourceIds are fully
+        // duplicated into toDelete.
+        var sources = new[] { Entry("s1", "Allen Conway is a Xebia collaborator"), Entry("s2", "Allen Conway uses accountId rockyl") };
+        var mergedDroppingXebia = "Allen Conway uses accountId rockyl";
+
+        var missing = MergeCoverage.FindMissingSpecifics(sources, mergedDroppingXebia);
+        Assert.IsTrue(missing.Count > 0, "precondition: this merge must be rejected");
+
+        // The rejection has to translate into the source IDs being excluded from removal.
+        var rejectedSources = new HashSet<string>(sources.Select(s => s.Id), StringComparer.OrdinalIgnoreCase);
+        var toDelete = new[] { "s1", "s2" };
+        var actuallyRemoved = toDelete.Where(id => !rejectedSources.Contains(id)).ToArray();
+
+        Assert.AreEqual(0, actuallyRemoved.Length,
+            "a rejected merge's sources must survive the toDelete sweep");
     }
 
     // ── High-value pruning floor ─────────────────────────────────────────────

--- a/tests/RockBot.Host.Tests/MergeCoverageTests.cs
+++ b/tests/RockBot.Host.Tests/MergeCoverageTests.cs
@@ -1,0 +1,222 @@
+namespace RockBot.Host.Tests;
+
+/// <summary>
+/// Covers the safeguards that decide whether a proposed consolidation is safe to apply.
+/// </summary>
+/// <remarks>
+/// These are deterministic because the prompt-level equivalents demonstrably did not hold.
+/// <c>dream.md</c> already told the model that reinforcement signals importance, and a live
+/// corpus still lost entries reinforced 214, 106 and 80 times; it already said to keep the
+/// most specific detail, and a merge still dropped a person's legal name while keeping the
+/// account list around it.
+/// </remarks>
+[TestClass]
+public class MergeCoverageTests
+{
+    // ── Specific extraction ──────────────────────────────────────────────────
+
+    [TestMethod]
+    public void ExtractsProperNounsNumbersAndAcronyms()
+    {
+        var specifics = MergeCoverage.ExtractSpecifics(
+            "Rocky filed the PWOP Productions W-9 on 2026-08-02 with Trish Roberts.");
+
+        CollectionAssert.IsSubsetOf(
+            new[] { "Rocky", "PWOP", "Productions", "Trish", "Roberts", "2026-08-02" },
+            specifics.ToArray());
+    }
+
+    [TestMethod]
+    public void SentenceLeadingCommonWordsAreNotTreatedAsSpecifics()
+    {
+        // Otherwise every sentence start would look like a proper noun and no merge would
+        // ever pass, which would disable consolidation by accident rather than by decision.
+        var specifics = MergeCoverage.ExtractSpecifics(
+            "The user prefers email. This is a durable preference. Should always apply.");
+
+        Assert.AreEqual(0, specifics.Count, string.Join(", ", specifics));
+    }
+
+    [TestMethod]
+    public void PossessiveFormIsSatisfiedByThePlainName()
+    {
+        // "Rocky's" appears 27 times in the real corpus. Requiring the apostrophe form to
+        // survive verbatim would reject merges that simply rephrase around it.
+        var sources = new[] { Entry("a", "Rocky's Blazor Online Class launches soon") };
+
+        Assert.AreEqual(
+            0,
+            MergeCoverage.FindMissingSpecifics(sources, "The Blazor Online Class run by Rocky launches soon").Count);
+    }
+
+    [TestMethod]
+    public void BareSingleDigitsAreNotTreatedAsSpecifics()
+    {
+        // "the top 3 items" rephrased as "the top three items" is not a loss of information.
+        var sources = new[] { Entry("a", "Review the top 3 items") };
+
+        Assert.AreEqual(0, MergeCoverage.FindMissingSpecifics(sources, "Review the top three items").Count);
+    }
+
+    [TestMethod]
+    public void MultiDigitNumbersAreStillRequired()
+    {
+        var sources = new[] { Entry("a", "The deadline is the 10th, in 2026") };
+
+        var missing = MergeCoverage.FindMissingSpecifics(sources, "The deadline is soon");
+
+        CollectionAssert.Contains(missing.ToArray(), "10");
+        CollectionAssert.Contains(missing.ToArray(), "2026");
+    }
+
+    [TestMethod]
+    public void ClockReformatIsConservativelyRejected()
+    {
+        // Documents a deliberate false positive. Recognising 2:00 PM and 14:00 as the same
+        // instant would need real time parsing, and the failure modes are not symmetric: the
+        // cost here is that a duplicate pair survives another cycle, whereas accepting it
+        // blind also accepts "2:00 PM" collapsing to "2:00", which loses the meridiem.
+        var sources = new[] { Entry("a", "The recording runs 2:00 PM to 3:00 PM") };
+
+        var missing = MergeCoverage.FindMissingSpecifics(sources, "The recording runs 14:00 to 15:00");
+
+        CollectionAssert.Contains(missing.ToArray(), "2:00");
+        CollectionAssert.Contains(missing.ToArray(), "PM");
+    }
+
+    [TestMethod]
+    public void ContentWithNoSpecifics_ImposesNoRequirement()
+    {
+        var sources = new[] { Entry("a", "the user prefers concise replies") };
+        Assert.AreEqual(0, MergeCoverage.FindMissingSpecifics(sources, "user prefers brevity").Count);
+    }
+
+    // ── Coverage ─────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void MergeThatKeepsEverySpecific_IsAccepted()
+    {
+        var sources = new[]
+        {
+            Entry("a", "Rocky has a dog named Milo"),
+            Entry("b", "Rocky has a Sheltie named Milo"),
+        };
+
+        var missing = MergeCoverage.FindMissingSpecifics(
+            sources, "Rocky has a dog — a Sheltie (Shetland Sheepdog) named Milo");
+
+        Assert.AreEqual(0, missing.Count, string.Join(", ", missing));
+    }
+
+    [TestMethod]
+    public void RegressionRockfordDuane_MergeThatDropsALegalNameIsRejected()
+    {
+        // The real loss: importance 0.99, reinforced 73x. The successor kept the
+        // machine-readable account map and silently dropped the name. It read fine.
+        var sources = new[]
+        {
+            Entry("identity",
+                "Rocky Lhotka also appears in travel and calendar data as Rockford Duane Lhotka. "
+                + "Connected accounts include marimer-work, lhotka.net and xebia."),
+        };
+
+        var merged =
+            "Rocky's connected communications infrastructure includes the accounts "
+            + "marimer-work, lhotka.net and xebia.";
+
+        var missing = MergeCoverage.FindMissingSpecifics(sources, merged);
+
+        CollectionAssert.Contains(missing.ToArray(), "Rockford");
+        CollectionAssert.Contains(missing.ToArray(), "Duane");
+    }
+
+    [TestMethod]
+    public void MergeThatDropsADateIsRejected()
+    {
+        var sources = new[] { Entry("a", "Estimated taxes are due 2026-09-10") };
+
+        var missing = MergeCoverage.FindMissingSpecifics(sources, "Estimated taxes are due in the autumn");
+
+        CollectionAssert.Contains(missing.ToArray(), "2026-09-10");
+    }
+
+    [TestMethod]
+    public void ReformattingThatKeepsTheComponentsIsAccepted()
+    {
+        // Substring matching credits a merge for expanding or restructuring, so long as the
+        // component survives somewhere in the text.
+        var sources = new[] { Entry("a", "Rockford filed in 2026") };
+
+        Assert.AreEqual(
+            0,
+            MergeCoverage.FindMissingSpecifics(sources, "Rockford Duane Lhotka filed on 2026-04-15").Count);
+    }
+
+    [TestMethod]
+    public void SpecificsAreRequiredAcrossAllSources_NotJustTheLongest()
+    {
+        var sources = new[]
+        {
+            Entry("a", "Allen Conway works at Xebia"),
+            Entry("b", "Trish Roberts works at Xebia"),
+        };
+
+        var missing = MergeCoverage.FindMissingSpecifics(sources, "Allen Conway works at Xebia");
+
+        CollectionAssert.AreEquivalent(new[] { "Roberts", "Trish" }, missing.ToArray());
+    }
+
+    [TestMethod]
+    public void MissingSpecificsAreReportedInStableOrder()
+    {
+        var sources = new[] { Entry("a", "Zulu Alpha Mike went to Boston") };
+
+        var missing = MergeCoverage.FindMissingSpecifics(sources, "someone travelled");
+
+        CollectionAssert.AreEqual(new[] { "Alpha", "Boston", "Mike", "Zulu" }, missing.ToArray());
+    }
+
+    // ── High-value pruning floor ─────────────────────────────────────────────
+
+    [TestMethod]
+    public void HighImportanceEntryIsProtectedFromPruning()
+    {
+        var options = new DreamOptions();
+        Assert.IsTrue(MergeCoverage_IsProtected(Entry("a", "core fact") with { ImportanceScore = 0.99f }, options));
+    }
+
+    [TestMethod]
+    public void HeavilyReinforcedEntryIsProtectedFromPruning()
+    {
+        // The 214x self-model entry that was destroyed.
+        var options = new DreamOptions();
+        Assert.IsTrue(MergeCoverage_IsProtected(Entry("a", "self model") with { ReinforcementCount = 214 }, options));
+    }
+
+    [TestMethod]
+    public void OrdinaryEntryIsNotProtected()
+    {
+        var options = new DreamOptions();
+        var ordinary = Entry("a", "transient note") with { ImportanceScore = 0.5f, ReinforcementCount = 1 };
+        Assert.IsFalse(MergeCoverage_IsProtected(ordinary, options));
+    }
+
+    [TestMethod]
+    public void ProtectionFloorIsConfigurable()
+    {
+        var permissive = new DreamOptions
+        {
+            PruningProtectionImportance = 1.5f,
+            PruningProtectionReinforcementCount = int.MaxValue,
+        };
+
+        var valuable = Entry("a", "core") with { ImportanceScore = 0.99f, ReinforcementCount = 214 };
+        Assert.IsFalse(MergeCoverage_IsProtected(valuable, permissive));
+    }
+
+    private static bool MergeCoverage_IsProtected(MemoryEntry entry, DreamOptions options) =>
+        DreamService.IsProtectedFromPruning(entry, options);
+
+    private static MemoryEntry Entry(string id, string content) =>
+        new(id, content, null, [], DateTimeOffset.UtcNow);
+}

--- a/tests/RockBot.Host.Tests/MergeCoverageTests.cs
+++ b/tests/RockBot.Host.Tests/MergeCoverageTests.cs
@@ -97,6 +97,27 @@ public class MergeCoverageTests
     }
 
     [TestMethod]
+    public void WordsThatCannotCarryMeaning_AreNotSpecifics()
+    {
+        Assert.AreEqual(
+            0,
+            MergeCoverage.ExtractSpecifics("IDs vary by mailbox. Downloading works. Enjoys music.").Count);
+    }
+
+    [TestMethod]
+    public void GenericLookingWordsThatAreLoadBearingHere_StaySpecifics()
+    {
+        // These read as ordinary English but name real things in this corpus — "OneDrive
+        // Personal", "Blazor Online Class", "MVP Azure Extended Benefit". Stoplisting them to
+        // quieten a false positive would blunt a correct rejection.
+        var specifics = MergeCoverage.ExtractSpecifics(
+            "Personal OneDrive holds the Blazor Online Class notes and the MVP Azure Extended Benefit task.");
+
+        foreach (var expected in new[] { "Personal", "Blazor", "Online", "Class", "Azure", "Extended", "Benefit" })
+            CollectionAssert.Contains(specifics.ToArray(), expected);
+    }
+
+    [TestMethod]
     public void ContentWithNoSpecifics_ImposesNoRequirement()
     {
         var sources = new[] { Entry("a", "the user prefers concise replies") };


### PR DESCRIPTION
## The problem

Dream consolidation handed the **entire** memory corpus to the LLM every cycle with an open licence to delete, then **hard-deleted** whatever came back — `File.Delete`, no tombstone, and the only trace was a Debug log line containing the entry *ID*, not its content. So a loss was both unrecoverable and uninvestigable.

Exposure compounds. At the default twice-daily cadence each entry faces 730 deletion decisions a year:

| Per-entry, per-cycle survival | Survives 1 year |
|---|---|
| 99.99% | 93% |
| 99.9% | **48%** |
| 99.5% | 3% |

A one-in-a-thousand misjudgement loses half the corpus in a year. No directive is good enough to beat a 730×-repeated gamble.

## Measured, not theorised

Restored a Longhorn backup of a live agent's PVC and diffed it against the running store. Over **3.5 days**: 148 → 109 entries, **−26%**. Named things that vanished corpus-wide: `Duane`, `Trish`, `Roberts`, `PWOP Productions`, `Las Vegas`, `Tripit`, `BlazorBook`, `BlazorHol`.

Importance and reinforcement provided **zero** protection. Among entries whose content survived nowhere:

```
agent-knowledge/self-model          imp=0.99  reinforced=214x
anti-patterns/routing               imp=1.00  reinforced=106x
agent-knowledge/infrastructure      imp=0.99  reinforced= 80x
user-preferences/identity           imp=0.99  reinforced= 73x
project-context/blazor-online-class imp=0.97  reinforced= 41x
```

`dream.md` already told the model reinforcement signals importance. It deleted them anyway. That is why every safeguard here is deterministic rather than prompt text.

The merge failure mode is subtle: `user-preferences/identity`'s successor kept the machine-readable account map and silently dropped *"Rocky Lhotka also appears in travel and calendar data as **Rockford Duane** Lhotka."* The result reads fine. Nothing flagged it.

## Changes

**Archive instead of delete.** `MemoryEntry` gains `ArchivedAt`/`ArchiveReason`; `ILongTermMemory.ArchiveAsync` hides an entry from search while keeping it on disk and retrievable by ID. Default interface method delegating to `DeleteAsync`, so existing fakes compile untouched. Recovery/retention sit on an optional `IArchivedMemoryMaintenance`; a purge pass hard-deletes after `Dream:MemoryArchiveRetention` (90d). Archives log at Information **with content inline**.

**Candidate gating.** An entry is eligible only if new/changed since its last review, or in a near-duplicate cluster. Review state is a **content fingerprint**, not a timestamp — importance decay rewrites score and `UpdatedAt` but not content, so decayed entries don't leak back through the gate. Clustering sits behind `IMemoryDuplicateCandidates`: cosine where embeddings exist, Jaccard otherwise, so BM25-only deployments still dedupe. **Enforced in code** — merge arithmetic is keyed on the eligible set, so an ID outside it resolves to nothing. A clustering failure degrades to unreviewed-only, never back to the whole corpus.

**Merge coverage check.** Proper nouns, acronyms and multi-digit numbers in a merge's sources must appear in the merged text, or the merge is rejected and the sources are left alone. Deliberately biased toward rejection: a false rejection leaves a duplicate alive one more cycle; a false acceptance destroys the only record of how a fact was worded.

Validated against the real 148-entry corpus:
- **0** self-coverage failures
- **0/300** false rejections on content-preserving merges
- **250/300 (83%)** of detail-dropping merges caught

The 17% missed are pairs where one source's specifics are a strict subset of the other's — genuinely redundant. That empirical pass caught two false-rejection bugs the unit tests missed: possessives (`Rocky's` vs `Rocky`, 27 occurrences) and bare single digits (`top 3` → `top three`).

**High-value pruning floor.** Entries at or above `Dream:PruningProtectionImportance` (0.80) or `Dream:PruningProtectionReinforcementCount` (5) can be merged — content survives, coverage-checked — but are never archived as standalone ephemeral.

**Provenance.** `mergedFrom`/`mergedAt` on merged entries. Source text is not duplicated: sources are archived, so IDs resolve for the retention window. Metadata is outside the search surface, so ranking is unaffected.

**Latent data-loss bug fixed.** The pass deleted all sources up front, then saved. A `toSave` with blank content hit a `continue` — after its sources were already gone. Any throw between the loops did the same at scale. Merged entries are now saved **first**, and only sources whose replacement persisted are retired.

## Honest scope

Gating alone would **not** have prevented most of the observed losses — high-value entries are frequently reinforced and have near-duplicate siblings, which is exactly what keeps them eligible. For those, the coverage check and the pruning floor are the prevention, and archiving is the safety net.

**Still open** (follow-up, all pre-existing and now much less dangerous):
- `dream.md` still licenses deletion at near-zero importance
- Retrieval doesn't bump `LastSeenAt`, so a memory used weekly still decays
- No category exemptions for `user-preferences/**`
- Consolidation still caps at `MaxResults: 1000`

## Testing

`dotnet build RockBot.slnx` clean; all 19 test projects pass. 35 new tests across `MemoryArchiveTests`, `ConsolidationCandidateGatingTests` and `MergeCoverageTests` — including a regression test built from the actual `Rockford Duane` merge that lost the name.

## Deployment note

Consolidation is currently disabled on the live agent (`Dream__MemoryConsolidationEnabled=false`) to stop the bleeding. After deploying, re-enable and watch one cycle for the new Information lines: `reviewing N of M entries`, `consolidation safeguards fired`, `refused to prune`. If merge rejections run high, `ConsolidationSimilarityThreshold` is the dial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)