### PR TITLE
Bump chart to 0.10.18

### DIFF
--- a/deploy/helm/rockbot/Chart.yaml
+++ b/deploy/helm/rockbot/Chart.yaml
@@ -4,8 +4,8 @@ description: >
   RockBot — an event-driven autonomous agent framework built on .NET.
   Deploys the RockBot agent and the Blazor Server web UI.
 type: application
-version: 0.10.17
-appVersion: "0.10.17"
+version: 0.10.18
+appVersion: "0.10.18"
 home: https://github.com/rockylhotka/rockbot
 keywords:
   - ai


### PR DESCRIPTION
Follow-up to #504.

## Why

#504 changed three chart files — the `rockbot-shared-cleanup` CronJob command, the `protectedPaths` helper in `_helpers.tpl`, and the `shared.protectedPaths` default in `values.yaml` — but left `Chart.yaml` at `0.10.17`. Two materially different charts therefore shared a version: one that honours `protectedPaths` and one that sweeps straight through them.

That distinction is worth being able to name. The sweep deletes on `mtime`, so the failure mode of running the older chart against a volume holding durable content is silent data loss, and "which chart version is this cluster on" is the first question you'd ask.

## What

`version` and `appVersion` bumped in lockstep, `0.10.17` → `0.10.18`, matching the convention in #503, #400, and #320.

## Verification

- `helm lint` — 0 failed (only the pre-existing "icon is recommended" info)
- Dry-run against the live release renders 28 `helm.sh/chart: rockbot-0.10.18` labels and 0 remaining `rockbot-0.10.17` references

## Note

This does not touch `Directory.Build.props`, which stays at `0.14.11` — the app version already matches the images built and pushed for #504, and no code changed here, so bumping it would name a version no pushed image corresponds to.

The live release is on chart `0.10.17` with the #504 templates already applied (revision 275). It will pick up the new chart version on the next `helm upgrade`; nothing needs redeploying for this alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)