### PR TITLE
Unlock the Blazor input immediately when Cancel is clicked

### DIFF
--- a/src/RockBot.UserProxy.Blazor/Pages/Chat.razor
+++ b/src/RockBot.UserProxy.Blazor/Pages/Chat.razor
@@ -368,6 +368,13 @@
 
     private string? _lastRenderedAgentName;
 
+    /// <summary>
+    /// Cancels the local wait for the in-flight send. The agent publishes no correlated
+    /// final reply for a cancelled turn, so without this the pending request would sit
+    /// until the reply timeout and keep the input locked.
+    /// </summary>
+    private CancellationTokenSource? _sendCts;
+
     protected override void OnInitialized()
     {
         _stateChangedHandler = () => InvokeAsync(StateHasChanged);
@@ -452,6 +459,15 @@
 
     private async Task CancelSession()
     {
+        // Release the UI immediately — the agent stops the in-flight turn and never
+        // publishes a correlated final reply for it, so there is nothing left to wait
+        // for. A new user message cancels the prior session generation anyway, so the
+        // user is free to send again right away.
+        var cts = _sendCts;
+        _sendCts = null;
+        ChatState.SetProcessing(false);
+        cts?.Cancel();
+
         try
         {
             await ProxyService.CancelSessionAsync(SessionId);
@@ -460,6 +476,8 @@
         {
             ChatState.AddError($"Could not cancel: {ex.Message}");
         }
+
+        await messageInput.FocusAsync();
     }
 
     private async Task SendMessage()
@@ -518,9 +536,14 @@
             ChatState.AppendActivityLogEntry(reply.Content);
         });
 
+        var sendCts = new CancellationTokenSource();
+        _sendCts?.Dispose();
+        _sendCts = sendCts;
+
         try
         {
-            var reply = await ProxyService.SendAsync(message, progress: progressTracker);
+            var reply = await ProxyService.SendAsync(
+                message, progress: progressTracker, cancellationToken: sendCts.Token);
 
             // Clear any background status from the thinking indicator before showing result
             ChatState.SetThinkingMessage(null);
@@ -534,14 +557,26 @@
                 ChatState.AddAgentReply(reply);
             }
         }
+        catch (OperationCanceledException)
+        {
+            // Cancel button — CancelSession already released the UI and the agent
+            // publishes its own "Cancelled." bubble. Nothing to report here.
+        }
         catch (Exception ex)
         {
             ChatState.AddError($"Error: {ex.Message}");
         }
         finally
         {
-            ChatState.SetProcessing(false);
-            await messageInput.FocusAsync();
+            // Only release the UI if this is still the current send. A cancel (which
+            // nulls _sendCts) or a newer send owns the processing state otherwise.
+            if (ReferenceEquals(_sendCts, sendCts))
+            {
+                _sendCts = null;
+                sendCts.Dispose();
+                ChatState.SetProcessing(false);
+                await messageInput.FocusAsync();
+            }
         }
     }
 
@@ -749,5 +784,7 @@
     {
         ChatState.OnStateChanged -= _stateChangedHandler;
         ProxyService.OnConnectionChanged -= _connectionChangedHandler;
+        _sendCts?.Dispose();
+        _sendCts = null;
     }
 }


### PR DESCRIPTION
@
## Problem

Clicking **Cancel** published the cancel request but left the message input disabled until the reply timeout elapsed — 3 minutes from the original send. The chain:

- `IsProcessing` was cleared only in `SendMessage`s `finally`, which requires `UserProxyService.SendAsync` to return.
- `SendAsync` blocks on a `TaskCompletionSource` keyed by the sends correlation id.
- `CancelSessionHandler` publishes `"Cancelled."` to the broadcast topic with a *fresh* correlation id, so it never resolves that TCS.
- `UserMessageHandler` excludes `OperationCanceledException` from every catch, so a cancelled turn publishes no correlated final reply.

Nothing ever completed the pending request.

## Fix

`SendMessage` now owns a `CancellationTokenSource` whose token is passed to `SendAsync`. `CancelSession` cancels it and releases the UI *before* publishing, so the input unlocks on click.

This works because `UserProxyService.SendAsync` links the callers token into its timeout CTS, and its catch filter `when (!cancellationToken.IsCancellationRequested)` deliberately lets external cancellation propagate rather than swallowing it as a timeout. The new `catch (OperationCanceledException)` in `Chat.razor` absorbs that, avoiding a spurious error bubble — the agent publishes its own `"Cancelled."` bubble. The pending entry is still removed in `SendAsync`s `finally`, so there is no leak.

The `finally` guards on `ReferenceEquals` so a stale turn cannot unlock or re-lock over a newer send.

## Testing

Built and deployed to the live cluster as `rockylhotka/rockbot-blazor:0.14.11-cancelfix` for manual verification. Clean startup: RabbitMQ connected, both response topics subscribed. Scope is a single `.razor` file with no test coverage in this project; verification is manual — cancel unlocks the input immediately, and a cancel-then-immediately-send sequence does not let the stale turn re-lock the input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@