### PR TITLE
Add partial-edit tools for every memory surface

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.14.11</Version>
+<Version>0.14.12</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.Host.Abstractions/ContentEditResult.cs
+++ b/src/RockBot.Host.Abstractions/ContentEditResult.cs
@@ -1,0 +1,40 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Outcome of a partial, exact-match edit applied inside a store — long-term memory,
+/// working memory, a skill body, a scheduled-task directive, or a rule.
+/// </summary>
+/// <param name="IsSuccess">Whether the edit was applied and persisted.</param>
+/// <param name="Error">
+/// Human-readable failure description, suitable for returning to the model verbatim;
+/// <c>null</c> on success.
+/// </param>
+/// <param name="ReplacementCount">Number of occurrences replaced. Zero unless successful.</param>
+/// <param name="OldLength">Character length of the content before the edit.</param>
+/// <param name="NewLength">Character length of the content after the edit.</param>
+/// <remarks>
+/// Deliberately not a second copy of the primitive's status enum: a store that refuses an
+/// edit passes the primitive's own <c>Error</c> straight through, so there is exactly one
+/// place in the codebase that decides how a refusal is worded.
+/// </remarks>
+public readonly record struct ContentEditResult(
+    bool IsSuccess,
+    string? Error,
+    int ReplacementCount,
+    int OldLength,
+    int NewLength)
+{
+    /// <summary>A refusal carrying <paramref name="error"/> as its explanation.</summary>
+    public static ContentEditResult Failed(string error) => new(false, error, 0, 0, 0);
+
+    /// <summary>An applied edit.</summary>
+    public static ContentEditResult Applied(int replacementCount, int oldLength, int newLength) =>
+        new(true, null, replacementCount, oldLength, newLength);
+
+    /// <summary>
+    /// The refusal every interface's default implementation returns — stores that have
+    /// not opted into partial edits (in-memory test doubles, null-object stores).
+    /// </summary>
+    public static ContentEditResult NotSupported { get; } =
+        Failed("This store does not support partial edits.");
+}

--- a/src/RockBot.Host.Abstractions/ILongTermMemory.cs
+++ b/src/RockBot.Host.Abstractions/ILongTermMemory.cs
@@ -12,6 +12,35 @@ public interface ILongTermMemory
     Task SaveAsync(MemoryEntry entry, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Replaces an exact piece of text inside an existing entry's content, leaving every
+    /// other field — including <see cref="MemoryEntry.CreatedAt"/>,
+    /// <see cref="MemoryEntry.LastSeenAt"/>, and
+    /// <see cref="MemoryEntry.ReinforcementCount"/> — untouched.
+    /// </summary>
+    /// <param name="id">Entry to edit.</param>
+    /// <param name="oldText">Exact text to find. Must be non-empty.</param>
+    /// <param name="newText">Replacement text. May be empty to delete the match.</param>
+    /// <param name="replaceAll">
+    /// When <c>true</c>, replaces every occurrence. When <c>false</c>, more than one
+    /// occurrence is refused rather than guessed at.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <remarks>
+    /// The correction path that <see cref="DeleteAsync"/> plus <see cref="SaveAsync"/> cannot
+    /// be: that pair mints a new id and resets the entry's provenance, so fixing one word in a
+    /// fact reinforced two hundred times leaves a fact seen once. Implementations must apply
+    /// the whole read-modify-write cycle under whatever lock guards their other writes, so a
+    /// concurrent save cannot be silently discarded.
+    /// </remarks>
+    Task<ContentEditResult> EditAsync(
+        string id,
+        string oldText,
+        string newText,
+        bool replaceAll = false,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult(ContentEditResult.NotSupported);
+
+    /// <summary>
     /// Searches memory entries matching the given criteria.
     /// </summary>
     Task<IReadOnlyList<MemoryEntry>> SearchAsync(MemorySearchCriteria criteria, CancellationToken cancellationToken = default);

--- a/src/RockBot.Host.Abstractions/IRulesStore.cs
+++ b/src/RockBot.Host.Abstractions/IRulesStore.cs
@@ -18,4 +18,21 @@ public interface IRulesStore
 
     /// <summary>Removes a rule by exact text (case-insensitive). No-ops if not found.</summary>
     Task RemoveAsync(string rule);
+
+    /// <summary>
+    /// Replaces an exact piece of text inside the active rules, leaving every other rule —
+    /// and any surrounding document structure — untouched.
+    /// </summary>
+    /// <param name="oldText">Exact text to find within a rule. Must be non-empty.</param>
+    /// <param name="newText">Replacement text. May be empty to delete the match.</param>
+    /// <param name="replaceAll">
+    /// When <c>true</c>, replaces every occurrence across every rule. When <c>false</c>, more
+    /// than one occurrence anywhere in the rule set is refused rather than guessed at.
+    /// </param>
+    /// <remarks>
+    /// The alternative — <see cref="RemoveAsync"/> then <see cref="AddAsync"/> — moves the
+    /// rule to the end of the list and requires restating it in full to change one word of it.
+    /// </remarks>
+    Task<ContentEditResult> EditAsync(string oldText, string newText, bool replaceAll = false)
+        => Task.FromResult(ContentEditResult.NotSupported);
 }

--- a/src/RockBot.Host.Abstractions/IScheduledTaskStore.cs
+++ b/src/RockBot.Host.Abstractions/IScheduledTaskStore.cs
@@ -26,4 +26,26 @@ public interface IScheduledTaskStore
     /// system/runOnce flags) are left unchanged.
     /// </summary>
     Task UpdateDirectiveAsync(string name, string directive);
+
+    /// <summary>
+    /// Replaces an exact piece of text inside an existing task's
+    /// <see cref="ScheduledTask.Directive"/>, leaving the rest of it and every other field
+    /// untouched.
+    /// </summary>
+    /// <param name="name">Task whose directive to edit.</param>
+    /// <param name="oldText">Exact text to find. Must be non-empty.</param>
+    /// <param name="newText">Replacement text. May be empty to delete the match.</param>
+    /// <param name="replaceAll">
+    /// When <c>true</c>, replaces every occurrence. When <c>false</c>, more than one
+    /// occurrence is refused rather than guessed at.
+    /// </param>
+    /// <remarks>
+    /// A directive is a checklist a recurring task accumulates over many fires, and
+    /// <see cref="UpdateDirectiveAsync"/> replaces it wholesale — so a task that wants to add
+    /// one line has to restate every line it wants to keep. Unlike that method, an unknown
+    /// task name is reported rather than silently ignored: the caller asked to change specific
+    /// text and needs to know it did not happen.
+    /// </remarks>
+    Task<ContentEditResult> EditDirectiveAsync(string name, string oldText, string newText, bool replaceAll = false)
+        => Task.FromResult(ContentEditResult.NotSupported);
 }

--- a/src/RockBot.Host.Abstractions/ISkillStore.cs
+++ b/src/RockBot.Host.Abstractions/ISkillStore.cs
@@ -21,6 +21,28 @@ public interface ISkillStore
     /// <summary>Returns the skill by name, or <c>null</c> if not found.</summary>
     Task<Skill?> GetAsync(string name);
 
+    /// <summary>
+    /// Replaces an exact piece of text inside an existing skill's markdown body, leaving the
+    /// rest of the document and every other field untouched.
+    /// </summary>
+    /// <param name="name">Skill to edit.</param>
+    /// <param name="oldText">Exact text to find. Must be non-empty.</param>
+    /// <param name="newText">Replacement text. May be empty to delete the match.</param>
+    /// <param name="replaceAll">
+    /// When <c>true</c>, replaces every occurrence. When <c>false</c>, more than one
+    /// occurrence is refused rather than guessed at.
+    /// </param>
+    /// <remarks>
+    /// Distinct from <see cref="SaveAsync(Skill)"/> in more than granularity: the save path
+    /// clears the summary and regenerates it with a background LLM call, so adding one pitfall
+    /// note to a long procedure costs a model round-trip and leaves the skill index blank
+    /// until it returns. An edit keeps the summary, the manifest, and
+    /// <see cref="Skill.CreatedAt"/>, and moves only the body and
+    /// <see cref="Skill.UpdatedAt"/>.
+    /// </remarks>
+    Task<ContentEditResult> EditContentAsync(string name, string oldText, string newText, bool replaceAll = false)
+        => Task.FromResult(ContentEditResult.NotSupported);
+
     /// <summary>Returns all skills ordered by name.</summary>
     Task<IReadOnlyList<Skill>> ListAsync();
 

--- a/src/RockBot.Host.Abstractions/IWorkingMemory.cs
+++ b/src/RockBot.Host.Abstractions/IWorkingMemory.cs
@@ -17,6 +17,27 @@ public interface IWorkingMemory
     Task<string?> GetAsync(string key);
 
     /// <summary>
+    /// Replaces an exact piece of text inside an existing entry's value, leaving the rest of
+    /// it untouched. The entry keeps its category and tags, and its TTL restarts from now
+    /// using the same window it was originally stored with.
+    /// </summary>
+    /// <param name="key">Full-path key of the entry to edit.</param>
+    /// <param name="oldText">Exact text to find. Must be non-empty.</param>
+    /// <param name="newText">Replacement text. May be empty to delete the match.</param>
+    /// <param name="replaceAll">
+    /// When <c>true</c>, replaces every occurrence. When <c>false</c>, more than one
+    /// occurrence is refused rather than guessed at.
+    /// </param>
+    /// <remarks>
+    /// Refreshing the TTL is the deliberate choice: an entry someone is actively amending is
+    /// an entry still in use, and expiring it on the original clock would drop it moments
+    /// after a correction. The window is reused rather than reset to the default so a
+    /// deliberately long-lived handoff entry does not silently become a five-minute one.
+    /// </remarks>
+    Task<ContentEditResult> EditAsync(string key, string oldText, string newText, bool replaceAll = false)
+        => Task.FromResult(ContentEditResult.NotSupported);
+
+    /// <summary>
     /// Lists all live entries whose key starts with <paramref name="prefix"/> (expired entries
     /// are pruned). Pass <c>null</c> or empty string to list everything.
     /// </summary>

--- a/src/RockBot.Host/AtomicFile.cs
+++ b/src/RockBot.Host/AtomicFile.cs
@@ -1,0 +1,81 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Crash-safe UTF-8 text writes for store-owned files.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="File.WriteAllTextAsync(string, string?, CancellationToken)"/> truncates the
+/// target before the replacement content is durable, so a cancelled or interrupted write —
+/// a pod eviction, a shutdown mid-save — leaves a memory entry or skill as an empty file.
+/// Writing to a sibling temporary file and renaming makes the replacement a single
+/// directory operation: the file is either the old content or the new one, never neither.
+/// </para>
+/// <para>
+/// This is the encoding-agnostic sibling of the file-tool path's writer. These are files the
+/// store itself creates and owns, always UTF-8 JSON or markdown, so there is no original
+/// encoding to detect and preserve.
+/// </para>
+/// </remarks>
+internal static class AtomicFile
+{
+    /// <summary>
+    /// Writes <paramref name="content"/> to <paramref name="path"/> as UTF-8 (no BOM),
+    /// replacing any existing file atomically. Parent directories are created.
+    /// </summary>
+    internal static async Task WriteAllTextAsync(
+        string path,
+        string content,
+        CancellationToken cancellationToken = default)
+    {
+        var directory = Path.GetDirectoryName(path);
+        if (string.IsNullOrEmpty(directory))
+            directory = ".";
+        else
+            Directory.CreateDirectory(directory);
+
+        var tempPath = Path.Combine(directory, $".{Path.GetFileName(path)}.{Guid.NewGuid():N}.tmp");
+
+        try
+        {
+            await File.WriteAllTextAsync(tempPath, content, cancellationToken);
+            CopyUnixFileMode(path, tempPath);
+            File.Move(tempPath, path, overwrite: true);
+        }
+        catch
+        {
+            TryDelete(tempPath);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Gives the replacement the mode of the file it replaces, so rewriting a file does not
+    /// change its permissions. Best-effort: no-ops when the target does not exist yet or the
+    /// platform has no Unix modes.
+    /// </summary>
+    private static void CopyUnixFileMode(string source, string destination)
+    {
+        try
+        {
+            if (File.Exists(source))
+                File.SetUnixFileMode(destination, File.GetUnixFileMode(source));
+        }
+        catch
+        {
+            // Non-Unix platforms and filesystems without mode support.
+        }
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch
+        {
+            // The temp file is already the failure path; nothing useful to add.
+        }
+    }
+}

--- a/src/RockBot.Host/FileMemoryStore.cs
+++ b/src/RockBot.Host/FileMemoryStore.cs
@@ -58,24 +58,7 @@ internal sealed partial class FileMemoryStore : ILongTermMemory, IArchivedMemory
         try
         {
             var index = await EnsureIndexAsync(cancellationToken);
-            var filePath = GetFilePath(entry.Id, entry.Category);
-
-            Directory.CreateDirectory(Path.GetDirectoryName(filePath)!);
-
-            var json = JsonSerializer.Serialize(entry, JsonOptions);
-            await File.WriteAllTextAsync(filePath, json, cancellationToken);
-
-            // If overwriting, remove old file if category changed
-            if (index.TryGetValue(entry.Id, out var existing) && existing.Category != entry.Category)
-            {
-                var oldPath = GetFilePath(existing.Id, existing.Category);
-                if (File.Exists(oldPath))
-                    File.Delete(oldPath);
-            }
-
-            index[entry.Id] = entry;
-
-            _logger.LogDebug("Saved memory entry {Id} in category {Category}", entry.Id, entry.Category ?? "(none)");
+            await WriteEntryAsync(index, entry, cancellationToken);
         }
         finally
         {
@@ -85,6 +68,110 @@ internal sealed partial class FileMemoryStore : ILongTermMemory, IArchivedMemory
         // Generate embedding in the background — agent flow should not block on vectorization.
         if (_embeddingCache is not null)
             _ = _embeddingCache.UpdateAsync(entry.Id, GetDocumentText(entry), cancellationToken);
+    }
+
+    public async Task<ContentEditResult> EditAsync(
+        string id,
+        string oldText,
+        string newText,
+        bool replaceAll = false,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(oldText);
+        ArgumentNullException.ThrowIfNull(newText);
+
+        ContentEditResult result;
+        MemoryEntry updated;
+
+        // The whole read-modify-write cycle runs under the store's own lock. Doing the read
+        // in the caller and the write through SaveAsync would let a concurrent save land
+        // between the two and be erased by the edit, with both reporting success.
+        await _semaphore.WaitAsync(cancellationToken);
+        try
+        {
+            var index = await EnsureIndexAsync(cancellationToken);
+
+            if (!index.TryGetValue(id, out var existing))
+            {
+                return ContentEditResult.Failed(
+                    $"No memory entry found with id '{id}'. Search memory to find the id — it appears " +
+                    "in brackets in search results, e.g. [abc123].");
+            }
+
+            var edit = TextEdit.Apply(existing.Content, oldText, newText, replaceAll);
+            if (!edit.IsSuccess)
+                return ContentEditResult.Failed(edit.Error!);
+
+            // Only Content and UpdatedAt move. CreatedAt, LastSeenAt, ReinforcementCount,
+            // ImportanceScore, Metadata, SupersededBy, ArchivedAt, Category, and Tags all
+            // carry through — that provenance is the entire reason this path exists.
+            updated = existing with
+            {
+                Content = edit.Content!,
+                UpdatedAt = DateTimeOffset.UtcNow
+            };
+
+            await WriteEntryAsync(index, updated, cancellationToken);
+
+            result = ContentEditResult.Applied(
+                edit.ReplacementCount, existing.Content.Length, edit.Content!.Length);
+
+            _logger.LogInformation(
+                "Edited memory entry {Id} ({Category}, reinforced={Count}x) — {Replacements} replacement(s), {Old}→{New} chars",
+                id, existing.Category ?? "(none)", existing.ReinforcementCount,
+                edit.ReplacementCount, existing.Content.Length, edit.Content.Length);
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+
+        // Content is part of the BM25/vector document text, so the edit genuinely invalidates
+        // the entry's vector. Refreshed off the hot path, exactly as a save would.
+        if (_embeddingCache is not null)
+            _ = _embeddingCache.UpdateAsync(updated.Id, GetDocumentText(updated), cancellationToken);
+
+        return result;
+    }
+
+    /// <summary>
+    /// Persists <paramref name="entry"/> and updates <paramref name="index"/>. Callers must
+    /// already hold <see cref="_semaphore"/> — it is not reentrant, so this is the shared body
+    /// of every in-lock write rather than a call back into <see cref="SaveAsync"/>.
+    /// </summary>
+    private async Task WriteEntryAsync(
+        Dictionary<string, MemoryEntry> index,
+        MemoryEntry entry,
+        CancellationToken cancellationToken)
+    {
+        index.TryGetValue(entry.Id, out var existing);
+
+        // A write whose UpdatedAt predates what is on disk is a read-modify-write cycle that
+        // started before someone else's write finished — the dream passes do exactly this,
+        // with no compare-and-swap. The write still proceeds (refusing would strand those
+        // passes); the log is what makes the loss visible instead of silent.
+        if (existing?.UpdatedAt is { } stored && entry.UpdatedAt is { } incoming && incoming < stored)
+        {
+            _logger.LogWarning(
+                "Memory entry {Id} written with UpdatedAt {Incoming:o}, older than the stored {Stored:o} — " +
+                "a concurrent read-modify-write may have discarded an edit",
+                entry.Id, incoming, stored);
+        }
+
+        var filePath = GetFilePath(entry.Id, entry.Category);
+        await AtomicFile.WriteAllTextAsync(filePath, JsonSerializer.Serialize(entry, JsonOptions), cancellationToken);
+
+        // If overwriting, remove old file if category changed
+        if (existing is not null && existing.Category != entry.Category)
+        {
+            var oldPath = GetFilePath(existing.Id, existing.Category);
+            if (File.Exists(oldPath))
+                File.Delete(oldPath);
+        }
+
+        index[entry.Id] = entry;
+
+        _logger.LogDebug("Saved memory entry {Id} in category {Category}", entry.Id, entry.Category ?? "(none)");
     }
 
     public async Task<IReadOnlyList<MemoryEntry>> SearchAsync(MemorySearchCriteria criteria, CancellationToken cancellationToken = default)

--- a/src/RockBot.Host/FileRulesStore.cs
+++ b/src/RockBot.Host/FileRulesStore.cs
@@ -1,20 +1,40 @@
+using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace RockBot.Host;
 
 /// <summary>
-/// File-backed implementation of <see cref="IRulesStore"/>.
-/// Loads rules from <c>rules.md</c> in the agent profile directory at startup
-/// and persists changes immediately after each add or remove.
+/// File-backed implementation of <see cref="IRulesStore"/>, storing rules as markdown
+/// bullets in <c>rules.md</c> in the agent profile directory.
 /// Thread-safe via an async semaphore.
 /// </summary>
-internal sealed class FileRulesStore : IRulesStore
+/// <remarks>
+/// <para>
+/// The file is treated as a document, not as a serialised list. Every line that is not a
+/// bullet — headings, prose, blank lines, a note explaining why a rule exists — is preserved
+/// verbatim in place, and a bullet keeps its original marker and indentation. Reading rules
+/// out and regenerating the file from them destroyed anything a human had written there on
+/// the next <c>add_rule</c>, which is exactly the kind of loss that goes unnoticed.
+/// </para>
+/// <para>
+/// Every mutation re-reads the file first. There is no watcher on <c>rules.md</c>, so a copy
+/// pushed to a running pod would otherwise be overwritten by the next write from a list
+/// loaded at startup. The file is a handful of lines; re-reading it costs nothing.
+/// </para>
+/// </remarks>
+internal sealed partial class FileRulesStore : IRulesStore
 {
     private readonly string _filePath;
     private readonly ILogger<FileRulesStore> _logger;
     private readonly SemaphoreSlim _lock = new(1, 1);
-    private List<string> _rules;
+
+    /// <summary>
+    /// Cache of the rule texts, refreshed from disk on every read-through and every write.
+    /// <see cref="Rules"/> is consumed synchronously while building each system prompt, so it
+    /// serves this snapshot rather than touching the filesystem per turn.
+    /// </summary>
+    private IReadOnlyList<string> _rules;
 
     public FileRulesStore(IOptions<AgentProfileOptions> options, ILogger<FileRulesStore> logger)
     {
@@ -26,7 +46,7 @@ internal sealed class FileRulesStore : IRulesStore
             : Path.Combine(AppContext.BaseDirectory, opts.BasePath);
 
         _filePath = Path.Combine(baseDir, "rules.md");
-        _rules = Load();
+        _rules = ExtractRules(ReadLines());
 
         _logger.LogInformation("Rules store initialised — {Count} rule(s) loaded from {Path}",
             _rules.Count, _filePath);
@@ -36,8 +56,22 @@ internal sealed class FileRulesStore : IRulesStore
     public IReadOnlyList<string> Rules => _rules;
 
     /// <inheritdoc />
-    public Task<IReadOnlyList<string>> ListAsync() =>
-        Task.FromResult<IReadOnlyList<string>>(_rules);
+    public async Task<IReadOnlyList<string>> ListAsync()
+    {
+        await _lock.WaitAsync();
+        try
+        {
+            // Read-through rather than serving the cache: this is the surface behind
+            // list_rules, and answering it from a startup snapshot would hide any rule
+            // added to the file since.
+            _rules = ExtractRules(ReadLines());
+            return _rules;
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
 
     /// <inheritdoc />
     public async Task AddAsync(string rule)
@@ -45,14 +79,32 @@ internal sealed class FileRulesStore : IRulesStore
         await _lock.WaitAsync();
         try
         {
-            if (_rules.Any(r => r.Equals(rule, StringComparison.OrdinalIgnoreCase)))
+            var lines = ReadLines();
+            var bullets = FindBullets(lines);
+
+            if (bullets.Any(b => b.Text.Equals(rule, StringComparison.OrdinalIgnoreCase)))
             {
+                _rules = bullets.Select(b => b.Text).ToList();
                 _logger.LogDebug("AddRule: rule already exists, skipping — {Rule}", rule);
                 return;
             }
 
-            _rules.Add(rule);
-            await PersistAsync();
+            if (bullets.Count > 0)
+            {
+                // Straight after the last existing rule, so the block stays contiguous and
+                // anything written below it (notes, other sections) stays below it.
+                lines.Insert(bullets[^1].Index + 1, $"- {rule}");
+            }
+            else if (lines.Count == 0)
+            {
+                lines.AddRange(["# Active Rules", string.Empty, $"- {rule}"]);
+            }
+            else
+            {
+                lines.Add($"- {rule}");
+            }
+
+            await PersistAsync(lines);
             _logger.LogInformation("Added rule: {Rule}", rule);
         }
         finally
@@ -67,16 +119,24 @@ internal sealed class FileRulesStore : IRulesStore
         await _lock.WaitAsync();
         try
         {
-            var removed = _rules.RemoveAll(r => r.Equals(rule, StringComparison.OrdinalIgnoreCase));
-            if (removed > 0)
+            var lines = ReadLines();
+            var matches = FindBullets(lines)
+                .Where(b => b.Text.Equals(rule, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            if (matches.Count == 0)
             {
-                await PersistAsync();
-                _logger.LogInformation("Removed rule: {Rule}", rule);
-            }
-            else
-            {
+                _rules = ExtractRules(lines);
                 _logger.LogDebug("RemoveRule: rule not found — {Rule}", rule);
+                return;
             }
+
+            // Descending so earlier indices stay valid as lines are removed.
+            foreach (var match in matches.OrderByDescending(m => m.Index))
+                lines.RemoveAt(match.Index);
+
+            await PersistAsync(lines);
+            _logger.LogInformation("Removed rule: {Rule}", rule);
         }
         finally
         {
@@ -84,25 +144,119 @@ internal sealed class FileRulesStore : IRulesStore
         }
     }
 
-    private List<string> Load()
+    /// <inheritdoc />
+    public async Task<ContentEditResult> EditAsync(string oldText, string newText, bool replaceAll = false)
     {
-        if (!File.Exists(_filePath))
-            return [];
+        ArgumentNullException.ThrowIfNull(oldText);
+        ArgumentNullException.ThrowIfNull(newText);
 
-        return File.ReadAllLines(_filePath)
-            .Select(l => l.TrimStart('-', '*', ' ').Trim())
-            .Where(l => !string.IsNullOrWhiteSpace(l) && !l.StartsWith('#'))
-            .ToList();
+        // An empty or unchanged oldText is rejected before any content is inspected, and the
+        // wording comes from the shared primitive rather than being restated here.
+        if (oldText.Length == 0 || string.Equals(oldText, newText, StringComparison.Ordinal))
+            return ContentEditResult.Failed(TextEdit.Apply(string.Empty, oldText, newText, replaceAll).Error!);
+
+        await _lock.WaitAsync();
+        try
+        {
+            var lines = ReadLines();
+            var matches = FindBullets(lines)
+                .Select(b => (b.Index, b.Prefix, b.Text, Count: TextEdit.CountOccurrences(b.Text, oldText)))
+                .Where(b => b.Count > 0)
+                .ToList();
+
+            var total = matches.Sum(m => m.Count);
+
+            if (total == 0)
+            {
+                _rules = ExtractRules(lines);
+                return ContentEditResult.Failed(
+                    "oldText was not found in any active rule. It must match the rule text exactly — " +
+                    "list the rules and copy it verbatim.");
+            }
+
+            if (total > 1 && !replaceAll)
+            {
+                _rules = ExtractRules(lines);
+                return ContentEditResult.Failed(
+                    $"oldText occurs {total} times across the active rules — the edit target is ambiguous. " +
+                    "Either include more of the rule so the match is unique, or set replaceAll to change " +
+                    "every occurrence.");
+            }
+
+            var oldLength = 0;
+            var newLength = 0;
+            var replacements = 0;
+
+            foreach (var match in matches)
+            {
+                var edit = TextEdit.Apply(match.Text, oldText, newText, replaceAll);
+                if (!edit.IsSuccess)
+                    return ContentEditResult.Failed(edit.Error!);
+
+                lines[match.Index] = match.Prefix + edit.Content;
+                oldLength += match.Text.Length;
+                newLength += edit.Content!.Length;
+                replacements += edit.ReplacementCount;
+            }
+
+            await PersistAsync(lines);
+
+            _logger.LogInformation(
+                "Edited rules — {Replacements} replacement(s) across {Rules} rule(s)",
+                replacements, matches.Count);
+
+            return ContentEditResult.Applied(replacements, oldLength, newLength);
+        }
+        finally
+        {
+            _lock.Release();
+        }
     }
 
-    private async Task PersistAsync()
+    // ── Internals ─────────────────────────────────────────────────────────────
+
+    /// <summary>A bullet line: where it is, the marker and indentation, and the rule text.</summary>
+    private readonly record struct Bullet(int Index, string Prefix, string Text);
+
+    private List<string> ReadLines() =>
+        File.Exists(_filePath) ? [.. File.ReadAllLines(_filePath)] : [];
+
+    /// <summary>
+    /// Returns the bullet lines in <paramref name="lines"/>, in document order. A bullet is a
+    /// line beginning (after optional indentation) with <c>-</c> or <c>*</c> and a space;
+    /// everything else — headings, prose, blanks — is not a rule and is left alone.
+    /// </summary>
+    private static List<Bullet> FindBullets(List<string> lines)
     {
-        var dir = Path.GetDirectoryName(_filePath)!;
-        Directory.CreateDirectory(dir);
+        var bullets = new List<Bullet>();
 
-        var lines = new List<string> { "# Active Rules", string.Empty };
-        lines.AddRange(_rules.Select(r => $"- {r}"));
+        for (var i = 0; i < lines.Count; i++)
+        {
+            var match = BulletPattern().Match(lines[i]);
+            if (!match.Success)
+                continue;
 
-        await File.WriteAllLinesAsync(_filePath, lines);
+            var prefix = match.Value;
+            var text = lines[i][prefix.Length..].TrimEnd();
+            if (text.Length > 0)
+                bullets.Add(new Bullet(i, prefix, text));
+        }
+
+        return bullets;
     }
+
+    private static IReadOnlyList<string> ExtractRules(List<string> lines) =>
+        FindBullets(lines).Select(b => b.Text).ToList();
+
+    private async Task PersistAsync(List<string> lines)
+    {
+        await AtomicFile.WriteAllTextAsync(
+            _filePath,
+            lines.Count == 0 ? string.Empty : string.Join(Environment.NewLine, lines) + Environment.NewLine);
+
+        _rules = ExtractRules(lines);
+    }
+
+    [GeneratedRegex(@"^\s*[-*]\s+")]
+    private static partial Regex BulletPattern();
 }

--- a/src/RockBot.Host/FileScheduledTaskStore.cs
+++ b/src/RockBot.Host/FileScheduledTaskStore.cs
@@ -147,6 +147,49 @@ internal sealed class FileScheduledTaskStore : IScheduledTaskStore
         }
     }
 
+    public async Task<ContentEditResult> EditDirectiveAsync(
+        string name,
+        string oldText,
+        string newText,
+        bool replaceAll = false)
+    {
+        ArgumentNullException.ThrowIfNull(oldText);
+        ArgumentNullException.ThrowIfNull(newText);
+
+        await _lock.WaitAsync();
+        try
+        {
+            var tasks = await ReadAllAsync();
+            if (!tasks.TryGetValue(name, out var existing))
+                return ContentEditResult.Failed($"No scheduled task named '{name}'.");
+
+            var current = existing.Directive ?? string.Empty;
+            if (current.Length == 0)
+            {
+                return ContentEditResult.Failed(
+                    $"Scheduled task '{name}' has no directive yet, so there is nothing to edit. " +
+                    "Write the first version with update_task_directive.");
+            }
+
+            var edit = TextEdit.Apply(current, oldText, newText, replaceAll);
+            if (!edit.IsSuccess)
+                return ContentEditResult.Failed(edit.Error!);
+
+            tasks[name] = existing with { Directive = edit.Content };
+            await WriteAllAsync(tasks);
+
+            _logger.LogInformation(
+                "Edited directive for scheduled task '{Name}' — {Replacements} replacement(s), {Old}→{New} chars",
+                name, edit.ReplacementCount, current.Length, edit.Content!.Length);
+
+            return ContentEditResult.Applied(edit.ReplacementCount, current.Length, edit.Content.Length);
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
     // ── Internal ─────────────────────────────────────────────────────────────
 
     private async Task<Dictionary<string, ScheduledTask>> ReadAllAsync()
@@ -173,6 +216,6 @@ internal sealed class FileScheduledTaskStore : IScheduledTaskStore
             .OrderBy(t => t.Name, StringComparer.OrdinalIgnoreCase)
             .ToList();
         var json = JsonSerializer.Serialize(list, JsonOptions);
-        await File.WriteAllTextAsync(_filePath, json);
+        await AtomicFile.WriteAllTextAsync(_filePath, json);
     }
 }

--- a/src/RockBot.Host/FileSkillStore.cs
+++ b/src/RockBot.Host/FileSkillStore.cs
@@ -73,12 +73,8 @@ internal sealed partial class FileSkillStore : ISkillStore
                 ? skill with { Manifest = existing.Manifest }
                 : skill;
 
-            var filePath = GetFilePath(skill.Name);
-
-            Directory.CreateDirectory(Path.GetDirectoryName(filePath)!);
-
             var json = JsonSerializer.Serialize(skillToSave, JsonOptions);
-            await File.WriteAllTextAsync(filePath, json);
+            await AtomicFile.WriteAllTextAsync(GetFilePath(skill.Name), json);
 
             index[skill.Name] = skillToSave;
 
@@ -158,7 +154,7 @@ internal sealed partial class FileSkillStore : ISkillStore
             // Save skill JSON with updated manifest
             var skillWithManifest = skill with { Manifest = manifest };
             var json = JsonSerializer.Serialize(skillWithManifest, JsonOptions);
-            await File.WriteAllTextAsync(filePath, json);
+            await AtomicFile.WriteAllTextAsync(filePath, json);
 
             index[skill.Name] = skillWithManifest;
 
@@ -186,6 +182,67 @@ internal sealed partial class FileSkillStore : ISkillStore
         {
             _semaphore.Release();
         }
+    }
+
+    public async Task<ContentEditResult> EditContentAsync(
+        string name,
+        string oldText,
+        string newText,
+        bool replaceAll = false)
+    {
+        ArgumentNullException.ThrowIfNull(oldText);
+        ArgumentNullException.ThrowIfNull(newText);
+        ValidateName(name);
+
+        ContentEditResult result;
+        Skill saved;
+
+        await _semaphore.WaitAsync();
+        try
+        {
+            var index = await EnsureIndexAsync();
+
+            if (!index.TryGetValue(name, out var existing))
+            {
+                return ContentEditResult.Failed(
+                    $"Skill '{name}' not found. List skills to see what exists.");
+            }
+
+            var edit = TextEdit.Apply(existing.Content, oldText, newText, replaceAll);
+            if (!edit.IsSuccess)
+                return ContentEditResult.Failed(edit.Error!);
+
+            // Summary, Manifest, CreatedAt, LastUsedAt and SeeAlso all carry through — a body
+            // edit is not a reason to blank the index entry and pay for a regenerated summary.
+            saved = existing with
+            {
+                Content = edit.Content!,
+                UpdatedAt = DateTimeOffset.UtcNow
+            };
+
+            var json = JsonSerializer.Serialize(saved, JsonOptions);
+            await AtomicFile.WriteAllTextAsync(GetFilePath(name), json);
+            index[name] = saved;
+
+            result = ContentEditResult.Applied(
+                edit.ReplacementCount, existing.Content.Length, edit.Content!.Length);
+
+            _logger.LogInformation(
+                "Edited skill '{Name}' — {Replacements} replacement(s), {Old}→{New} chars",
+                name, edit.ReplacementCount, existing.Content.Length, edit.Content.Length);
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+
+        // The skill vector is built from name + summary, neither of which an edit touches, so
+        // this refresh is a no-op in substance. Kept for symmetry with the other write paths —
+        // the day the document text includes the body, forgetting it here would be a silent bug.
+        if (_embeddingCache is not null)
+            _ = _embeddingCache.UpdateAsync(saved.Name, GetDocumentText(saved));
+
+        return result;
     }
 
     public async Task<bool> AttachResourceAsync(
@@ -242,7 +299,7 @@ internal sealed partial class FileSkillStore : ISkillStore
 
             saved = existing with { Manifest = newManifest, UpdatedAt = DateTimeOffset.UtcNow };
             var json = JsonSerializer.Serialize(saved, JsonOptions);
-            await File.WriteAllTextAsync(GetFilePath(skillName), json);
+            await AtomicFile.WriteAllTextAsync(GetFilePath(skillName), json);
             index[skillName] = saved;
 
             _logger.LogDebug(
@@ -293,7 +350,7 @@ internal sealed partial class FileSkillStore : ISkillStore
                 UpdatedAt = DateTimeOffset.UtcNow
             };
             var json = JsonSerializer.Serialize(saved, JsonOptions);
-            await File.WriteAllTextAsync(GetFilePath(skillName), json);
+            await AtomicFile.WriteAllTextAsync(GetFilePath(skillName), json);
             index[skillName] = saved;
 
             _logger.LogDebug("Removed resource '{File}' from skill '{Name}'", filename, skillName);
@@ -343,7 +400,7 @@ internal sealed partial class FileSkillStore : ISkillStore
 
             saved = existing with { Manifest = newManifest, UpdatedAt = DateTimeOffset.UtcNow };
             var json = JsonSerializer.Serialize(saved, JsonOptions);
-            await File.WriteAllTextAsync(GetFilePath(skillName), json);
+            await AtomicFile.WriteAllTextAsync(GetFilePath(skillName), json);
             index[skillName] = saved;
         }
         finally

--- a/src/RockBot.Host/FileWorkingMemory.cs
+++ b/src/RockBot.Host/FileWorkingMemory.cs
@@ -151,6 +151,16 @@ internal sealed class FileWorkingMemory : IWorkingMemory, IHostedService
     public Task<string?> GetAsync(string key)
         => _inner.GetAsync(key);
 
+    public async Task<ContentEditResult> EditAsync(string key, string oldText, string newText, bool replaceAll = false)
+    {
+        // The inner store applies the edit through its own SetAsync, which does not know about
+        // persistence — so the group file is rewritten here, and only when something changed.
+        var result = await _inner.EditAsync(key, oldText, newText, replaceAll);
+        if (result.IsSuccess)
+            await PersistGroupAsync(GetGroup(key));
+        return result;
+    }
+
     public Task<IReadOnlyList<WorkingMemoryEntry>> ListAsync(string? prefix = null)
         => _inner.ListAsync(prefix);
 

--- a/src/RockBot.Host/HybridCacheWorkingMemory.cs
+++ b/src/RockBot.Host/HybridCacheWorkingMemory.cs
@@ -26,6 +26,13 @@ internal sealed class HybridCacheWorkingMemory : IWorkingMemory
     // fullKey -> float[] (in-memory only, evicted with the entry)
     private readonly ConcurrentDictionary<string, float[]> _embeddings = new(StringComparer.OrdinalIgnoreCase);
 
+    /// <summary>
+    /// One lock per key, held across an <see cref="EditAsync"/> read-modify-write so two
+    /// concurrent edits to the same entry cannot both start from the pre-edit value. Entries
+    /// are never evicted — one small object per distinct key edited in the process lifetime.
+    /// </summary>
+    private readonly ConcurrentDictionary<string, SemaphoreSlim> _editLocks = new(StringComparer.OrdinalIgnoreCase);
+
     private sealed record EntryMeta(
         DateTimeOffset StoredAt,
         DateTimeOffset ExpiresAt,
@@ -145,6 +152,57 @@ internal sealed class HybridCacheWorkingMemory : IWorkingMemory
 
         _cache.TryGetValue<string>(CacheKey(key), out var value);
         return Task.FromResult(value);
+    }
+
+    public async Task<ContentEditResult> EditAsync(string key, string oldText, string newText, bool replaceAll = false)
+    {
+        ArgumentNullException.ThrowIfNull(oldText);
+        ArgumentNullException.ThrowIfNull(newText);
+
+        // Serializes edits to this key against each other. A concurrent full SetAsync still
+        // wins — working memory has no versioning to compare against — but two models
+        // amending the same cached payload no longer silently overwrite one another.
+        var gate = _editLocks.GetOrAdd(key, _ => new SemaphoreSlim(1, 1));
+        await gate.WaitAsync();
+        try
+        {
+            if (!_index.TryGetValue(key, out var meta) || meta.ExpiresAt <= DateTimeOffset.UtcNow)
+            {
+                return ContentEditResult.Failed(
+                    $"Working memory entry '{key}' was not found or has expired, so there is nothing to edit.");
+            }
+
+            if (!_cache.TryGetValue<string>(CacheKey(key), out var current) || current is null)
+            {
+                return ContentEditResult.Failed(
+                    $"Working memory entry '{key}' is no longer cached — it was evicted under memory pressure. " +
+                    "Re-save the value rather than editing it.");
+            }
+
+            var edit = TextEdit.Apply(current, oldText, newText, replaceAll);
+            if (!edit.IsSuccess)
+                return ContentEditResult.Failed(edit.Error!);
+
+            // Reuse the window the entry was stored with, restarting it from now. Going back
+            // through SetAsync is what re-arms the cache expiry and re-embeds the new value.
+            var window = meta.ExpiresAt - meta.StoredAt;
+            await SetAsync(
+                key,
+                edit.Content!,
+                window > TimeSpan.Zero ? window : null,
+                meta.Category,
+                meta.Tags);
+
+            _logger.LogDebug(
+                "Working memory edit: key={Key} replacements={Count} {Old}->{New} chars",
+                key, edit.ReplacementCount, current.Length, edit.Content!.Length);
+
+            return ContentEditResult.Applied(edit.ReplacementCount, current.Length, edit.Content.Length);
+        }
+        finally
+        {
+            gate.Release();
+        }
     }
 
     public Task<IReadOnlyList<WorkingMemoryEntry>> ListAsync(string? prefix = null)

--- a/src/RockBot.Host/RulesTools.cs
+++ b/src/RockBot.Host/RulesTools.cs
@@ -26,6 +26,7 @@ public sealed class RulesTools
         _tools =
         [
             AIFunctionFactory.Create(AddRule),
+            AIFunctionFactory.Create(EditRule),
             AIFunctionFactory.Create(RemoveRule),
             AIFunctionFactory.Create(ListRules),
             AIFunctionFactory.Create(SetTimezone)
@@ -49,16 +50,47 @@ public sealed class RulesTools
         return $"Rule added: \"{rule}\"";
     }
 
-    [Description("Remove an active behavioral rule. Call list_rules first to see the exact text of " +
-                 "current rules — the rule argument must match exactly.")]
+    [Description("Change part of an existing behavioral rule, leaving the rest of it as it is. " +
+                 "Use this to narrow, widen, or correct a rule the user already has — removing and " +
+                 "re-adding means restating the whole rule and moves it to the end of the list. " +
+                 "Call list_rules first and copy old_string verbatim; if it appears in more than one rule " +
+                 "the edit is refused, so include more of the rule text or set replace_all.")]
+    public async Task<string> EditRule(
+        [Description("Exact text to find within an active rule — copy it verbatim from list_rules")] string old_string,
+        [Description("Replacement text. Pass an empty string to delete the matched text.")] string new_string,
+        [Description("Replace every occurrence across all rules instead of refusing an ambiguous match. Default false.")] bool replace_all = false)
+    {
+        _logger.LogInformation("Tool call: EditRule(replaceAll={ReplaceAll})", replace_all);
+
+        var result = await _rulesStore.EditAsync(
+            old_string ?? string.Empty, new_string ?? string.Empty, replace_all);
+
+        if (!result.IsSuccess)
+            return $"Rule edit failed: {result.Error}";
+
+        var plural = result.ReplacementCount == 1 ? "occurrence" : "occurrences";
+        var rules = await _rulesStore.ListAsync();
+        var sb = new StringBuilder();
+        sb.AppendLine($"Rule edited — replaced {result.ReplacementCount} {plural}.");
+        sb.AppendLine($"Active rules ({rules.Count}):");
+        foreach (var r in rules)
+            sb.AppendLine($"- {r}");
+        return sb.ToString().TrimEnd();
+    }
+
+    [Description("Remove an active behavioral rule entirely. Call list_rules first to see the exact text of " +
+                 "current rules — the rule argument must match exactly. " +
+                 "To change part of a rule rather than drop it, use edit_rule.")]
     public async Task<string> RemoveRule(
         [Description("The exact text of the rule to remove (use list_rules to find it)")] string rule)
     {
         _logger.LogInformation("Tool call: RemoveRule({Rule})", rule);
 
-        var countBefore = _rulesStore.Rules.Count;
+        // Counted from the store's read-through listing on both sides: the in-memory snapshot
+        // can predate a rules.md edited outside the agent, which would misreport the outcome.
+        var countBefore = (await _rulesStore.ListAsync()).Count;
         await _rulesStore.RemoveAsync(rule);
-        var countAfter = _rulesStore.Rules.Count;
+        var countAfter = (await _rulesStore.ListAsync()).Count;
 
         return countBefore == countAfter
             ? $"No rule found matching \"{rule}\". Use list_rules to see current rules."

--- a/src/RockBot.Host/TaskDirectiveTools.cs
+++ b/src/RockBot.Host/TaskDirectiveTools.cs
@@ -27,7 +27,8 @@ public sealed class TaskDirectiveTools
 
         Tools =
         [
-            AIFunctionFactory.Create(UpdateTaskDirective)
+            AIFunctionFactory.Create(UpdateTaskDirective),
+            AIFunctionFactory.Create(EditTaskDirective)
         ];
     }
 
@@ -37,7 +38,9 @@ public sealed class TaskDirectiveTools
         "Replace the entire body of the current scheduled task's evolving directive — the running " +
         "checklist or notes the agent maintains across runs of this task. The new content " +
         "becomes part of the system prompt on the next fire of this task. " +
-        "Use this to record what to look for, what was just learned, or what to watch next time. " +
+        "Use this to write the first version of a directive, or to deliberately start over. " +
+        "To change part of an existing directive, use edit_task_directive instead — this tool " +
+        "discards everything you do not restate. " +
         "This tool is only available inside a scheduled-task execution and only edits the " +
         "directive of the task that is currently running.")]
     public async Task<string> UpdateTaskDirective(
@@ -49,6 +52,34 @@ public sealed class TaskDirectiveTools
 
         await _store.UpdateDirectiveAsync(_taskName, content ?? string.Empty);
         return $"Directive for task '{_taskName}' updated ({(content ?? string.Empty).Length} chars). " +
+               "It will be part of the system prompt on the next fire.";
+    }
+
+    [Description(
+        "Change part of the current scheduled task's directive, leaving the rest of it exactly as it is. " +
+        "This is how a recurring task adds a checklist item, corrects a note, or records what to watch " +
+        "next time without restating the whole directive — which is what update_task_directive requires, " +
+        "and what quietly loses the lines you forget. " +
+        "The directive is shown to you in the system prompt on each fire; copy old_string from there " +
+        "verbatim. If it appears more than once the edit is refused — include more surrounding text or " +
+        "set replace_all.")]
+    public async Task<string> EditTaskDirective(
+        [Description("Exact text to find in the current directive — copy it verbatim")] string old_string,
+        [Description("Replacement text. Pass an empty string to delete the matched text.")] string new_string,
+        [Description("Replace every occurrence instead of refusing an ambiguous match. Default false.")] bool replace_all = false)
+    {
+        _logger.LogInformation(
+            "Tool call: EditTaskDirective(task={Task}, replaceAll={ReplaceAll})", _taskName, replace_all);
+
+        var result = await _store.EditDirectiveAsync(
+            _taskName, old_string ?? string.Empty, new_string ?? string.Empty, replace_all);
+
+        if (!result.IsSuccess)
+            return $"Edit failed on the directive for task '{_taskName}': {result.Error}";
+
+        var plural = result.ReplacementCount == 1 ? "occurrence" : "occurrences";
+        return $"Directive for task '{_taskName}' edited — replaced {result.ReplacementCount} {plural} " +
+               $"({result.OldLength} → {result.NewLength} chars). " +
                "It will be part of the system prompt on the next fire.";
     }
 }

--- a/src/RockBot.Host/TextEdit.cs
+++ b/src/RockBot.Host/TextEdit.cs
@@ -192,9 +192,10 @@ public static class TextEdit
     }
 
     /// <summary>
-    /// Counts non-overlapping ordinal occurrences of <paramref name="needle"/>.
+    /// Counts non-overlapping ordinal occurrences of <paramref name="needle"/>, which must
+    /// be non-empty.
     /// </summary>
-    private static int CountOccurrences(string haystack, string needle)
+    internal static int CountOccurrences(string haystack, string needle)
     {
         var count = 0;
         var index = 0;

--- a/src/RockBot.Memory/MemoryToolSkillProvider.cs
+++ b/src/RockBot.Memory/MemoryToolSkillProvider.cs
@@ -104,11 +104,57 @@ public sealed class MemoryToolSkillProvider : IToolSkillProvider
         - IDs appear in brackets in results: `[abc123]` — you need the ID to delete an entry
 
 
+        ### Editing existing content: edit, don't rewrite
+
+        `save_memory` creates new entries; it never amends one. `save_to_working_memory`
+        replaces the entire cached value. Anything you do not reproduce in full is gone —
+        and on a long entry you will not reliably reproduce it in full.
+
+        So when the content already exists and you are changing part of it, use `edit_memory`
+        or `edit_working_memory`. Reserve the save tools for new content and for deliberately
+        replacing a whole short payload.
+
+        For long-term memory this matters beyond the text. Every entry carries how long the
+        fact has been known and how many times it has been reinforced, and search ranks and
+        renders entries with it (`seen 12× from 2025-11 to today`). Delete-then-save throws all
+        of that away and leaves a fact that has been seen once — so the fix for a wrong detail
+        costs the agent everything it knew about how well-established the fact was.
+
+        ### edit_memory
+
+        Replaces an exact piece of text inside an existing entry's content, leaving the rest
+        of the entry — and its id, age, and reinforcement count — untouched.
+
+        **Parameters**
+        - `id` (string, required) — the ID from search results (e.g. `abc123`)
+        - `old_string` (string, required) — exact text to find in the entry's content
+        - `new_string` (string, required) — replacement text; empty string deletes the match
+        - `replace_all` (boolean, optional, default false) — change every occurrence
+
+        ```
+        edit_memory(
+          id: "abc123",
+          old_string: "prefers meetings in the morning",
+          new_string: "prefers meetings after 13:00"
+        )
+        ```
+
+        Rules:
+        - `old_string` must match the stored content **exactly**. Search first and copy the
+          text verbatim rather than reconstructing it.
+        - `old_string` must match **exactly once**, or the edit is refused — include more
+          surrounding text, or pass `replace_all: true`.
+        - A refused edit is information, not an obstacle. "Not found" means your `old_string`
+          does not match; re-read the entry rather than retrying the same text. Do not fall
+          back to delete + save to work around a refusal — that is the loss this tool avoids.
+
+
         ### delete_memory
 
-        Deletes a memory entry by its ID. Use this to remove entries that are wrong,
-        outdated, or superseded. To correct a fact: delete the old entry, then save the
-        corrected version.
+        Deletes a memory entry by its ID. Use this when the entry is wrong or obsolete *as a
+        whole* — a fact that turned out to be false, a duplicate, something the user asked you
+        to forget. When the entry is mostly right and one detail changed, use `edit_memory`
+        instead.
 
         **Parameters**
         - `id` (string, required) — the ID from search results (e.g. `abc123`)
@@ -229,6 +275,32 @@ public sealed class MemoryToolSkillProvider : IToolSkillProvider
         call. See the wisp guide for full pipeline mechanics.
 
 
+        ### edit_working_memory
+
+        Replaces an exact piece of text inside a cached entry, leaving the rest of the value
+        untouched. Use it to amend a running draft, checklist, or handoff note in place instead
+        of re-sending the whole payload through `save_to_working_memory`.
+
+        **Parameters**
+        - `key` (string, required) — plain key for your own namespace, or a full path
+        - `old_string` (string, required) — exact text to find in the cached value
+        - `new_string` (string, required) — replacement text; empty string deletes the match
+        - `replace_all` (boolean, optional, default false) — change every occurrence
+
+        ```
+        edit_working_memory(
+          key: "shared/drafts/tina-vslive",
+          old_string: "Session length: 60 minutes",
+          new_string: "Session length: 75 minutes"
+        )
+        ```
+
+        The entry keeps its category and tags, and its TTL restarts from now using the same
+        window it was stored with — an entry you are still amending is one still in use. Same
+        exact-match rules as `edit_memory`: verbatim `old_string`, one match unless
+        `replace_all`.
+
+
         ### search_working_memory
 
         Searches *and* lists cached entries. Defaults to your own namespace; pass `namespace`
@@ -272,8 +344,9 @@ public sealed class MemoryToolSkillProvider : IToolSkillProvider
           research sessions; keep it short to avoid stale data
         - **Use consistent category conventions** — `user-preferences/*`, `project/*`,
           `domain/*` for long-term; `email`, `calendar`, `research` for working memory
-        - **Delete wrong facts promptly** — stale or incorrect long-term memories
-          can silently degrade future responses
+        - **Correct wrong facts promptly** — stale or incorrect long-term memories can
+          silently degrade future responses. Fix the detail with `edit_memory`; reserve
+          `delete_memory` for entries that are wrong as a whole
 
 
         ## Common Pitfalls

--- a/src/RockBot.Memory/MemoryTools.cs
+++ b/src/RockBot.Memory/MemoryTools.cs
@@ -91,6 +91,7 @@ public sealed class MemoryTools
         [
             AIFunctionFactory.Create(SaveMemory),
             AIFunctionFactory.Create(SearchMemory),
+            AIFunctionFactory.Create(EditMemory),
             AIFunctionFactory.Create(DeleteMemory),
             AIFunctionFactory.Create(UpdateMemoryImportance)
         ];
@@ -348,9 +349,40 @@ public sealed class MemoryTools
         return string.Empty;
     }
 
+    [Description("Correct part of an existing memory entry in place, leaving the rest of it and all of its " +
+                 "history untouched. Find the ID first by calling SearchMemory — IDs appear in brackets, " +
+                 "e.g. [abc123]. Use this rather than delete_memory + save_memory whenever a fact is mostly " +
+                 "right: deleting and re-saving mints a new entry that has been seen once, discarding how long " +
+                 "the fact has been known and how many times it was reinforced. " +
+                 "old_string must match the entry's content exactly; if it appears more than once the edit is " +
+                 "refused, so include more surrounding text or set replace_all.")]
+    public async Task<string> EditMemory(
+        [Description("The ID of the memory entry to edit (from SearchMemory results, shown in brackets)")] string id,
+        [Description("Exact text to find inside the entry's content — copy it verbatim from the search result")] string old_string,
+        [Description("Replacement text. Pass an empty string to delete the matched text.")] string new_string,
+        [Description("Replace every occurrence instead of refusing an ambiguous match. Default false.")] bool replace_all = false)
+    {
+        _logger.LogInformation("Tool call: EditMemory(id={Id}, replaceAll={ReplaceAll})", id, replace_all);
+
+        var result = await _memory.EditAsync(id, old_string ?? string.Empty, new_string ?? string.Empty, replace_all);
+
+        if (!result.IsSuccess)
+        {
+            _logger.LogInformation("EditMemory refused for {Id}: {Error}", id, result.Error);
+            return $"Edit failed on memory entry '{id}': {result.Error}";
+        }
+
+        var plural = result.ReplacementCount == 1 ? "occurrence" : "occurrences";
+        return $"Edited memory entry '{id}' — replaced {result.ReplacementCount} {plural} " +
+               $"({result.OldLength} → {result.NewLength} characters). " +
+               "Its id, age, and reinforcement history are unchanged.";
+    }
+
     [Description("Delete a memory entry by its ID. Use this to remove facts that are wrong, outdated, or " +
-                 "superseded. Find the ID first by calling SearchMemory — IDs appear in brackets, e.g. [abc123]. " +
-                 "To correct a wrong fact: delete the old entry, then save the corrected version with SaveMemory.")]
+                 "superseded in full. Find the ID first by calling SearchMemory — IDs appear in brackets, " +
+                 "e.g. [abc123]. " +
+                 "To correct part of a fact, use EditMemory instead — deleting and re-saving destroys the " +
+                 "entry's age and reinforcement history.")]
     public async Task<string> DeleteMemory(
         [Description("The ID of the memory entry to delete (from SearchMemory results)")] string id)
     {

--- a/src/RockBot.Memory/WorkingMemoryTools.cs
+++ b/src/RockBot.Memory/WorkingMemoryTools.cs
@@ -30,6 +30,7 @@ public sealed class WorkingMemoryTools
         [
             AIFunctionFactory.Create(SaveToWorkingMemory),
             AIFunctionFactory.Create(GetFromWorkingMemory),
+            AIFunctionFactory.Create(EditWorkingMemory),
             AIFunctionFactory.Create(DeleteFromWorkingMemory),
             AIFunctionFactory.Create(SearchWorkingMemory)
         ];
@@ -82,6 +83,33 @@ public sealed class WorkingMemoryTools
         if (value is null)
             return $"Working memory entry '{fullKey}' not found or has expired.";
         return value;
+    }
+
+    [Description("Change part of a cached working memory entry without re-sending the whole payload. " +
+                 "Use this to amend a running draft, checklist, or handoff note in place — re-saving it with " +
+                 "save_to_working_memory means reproducing every character you want to keep, and anything you " +
+                 "do not reproduce is gone. " +
+                 "old_string must match the cached value exactly; if it appears more than once the edit is " +
+                 "refused, so include more surrounding text or set replace_all. " +
+                 "The entry keeps its category and tags, and its TTL restarts from now.")]
+    public async Task<string> EditWorkingMemory(
+        [Description("Key to edit — plain key for own namespace, full path for cross-namespace (e.g. 'shared/drafts/report')")] string key,
+        [Description("Exact text to find inside the cached value — copy it verbatim")] string old_string,
+        [Description("Replacement text. Pass an empty string to delete the matched text.")] string new_string,
+        [Description("Replace every occurrence instead of refusing an ambiguous match. Default false.")] bool replace_all = false)
+    {
+        var fullKey = key.Contains('/') ? key : $"{_namespace}/{key}";
+        _logger.LogInformation("Tool call: EditWorkingMemory(key={Key}, replaceAll={ReplaceAll})", fullKey, replace_all);
+
+        var result = await _workingMemory.EditAsync(
+            fullKey, old_string ?? string.Empty, new_string ?? string.Empty, replace_all);
+
+        if (!result.IsSuccess)
+            return $"Edit failed on working memory entry '{fullKey}': {result.Error}";
+
+        var plural = result.ReplacementCount == 1 ? "occurrence" : "occurrences";
+        return $"Edited working memory entry '{fullKey}' — replaced {result.ReplacementCount} {plural} " +
+               $"({result.OldLength} → {result.NewLength} characters). TTL restarted.";
     }
 
     [Description("Delete an entry from working memory by key. " +

--- a/src/RockBot.Skills/SkillToolSkillProvider.cs
+++ b/src/RockBot.Skills/SkillToolSkillProvider.cs
@@ -146,11 +146,42 @@ public sealed class SkillToolSkillProvider : IToolSkillProvider
         - Keep it focused on one task type; create separate skills for related but distinct tasks
         - Move scripts, schemas, and other structured artifacts into `resources` instead of embedding them in markdown
 
-        **Updating an existing skill:**
-        - Load the current skill with `get_skill` first
-        - Add new steps, examples, or pitfall notes discovered during use
-        - If updating only the markdown, omit `resources` — existing resource files are preserved
-        - Save with the same name to overwrite
+        **Updating an existing skill:** use `edit_skill`, not `save_skill` — see below.
+        Reserve `save_skill` for creating a skill, replacing a short one outright, or changing
+        the `resources` bundle.
+
+
+        ### edit_skill
+
+        Replaces an exact piece of text in an existing skill's markdown, leaving the rest of
+        the document byte-for-byte untouched. This is the normal way to improve a skill:
+        adding the pitfall you just hit, correcting a step, updating an example.
+
+        **Parameters**
+        - `name` (string, required) — the skill to edit
+        - `old_string` (string, required) — exact text to find in the skill's markdown
+        - `new_string` (string, required) — replacement text; empty string deletes the match
+        - `replace_all` (boolean, optional, default false) — change every occurrence
+
+        ```
+        edit_skill(
+          name: "plan-meeting",
+          old_string: "3. Send the invite.",
+          new_string: "3. Send the invite.\n4. Check the room booking — it is not automatic."
+        )
+        ```
+
+        Why this rather than `save_skill`:
+        - `save_skill` replaces the **entire** body. Anything you do not reproduce verbatim is
+          gone, and on a long procedure you will not reproduce it verbatim.
+        - `save_skill` also clears the summary and regenerates it with a background LLM call,
+          so the skill index reads "(summary pending)" until it returns. An edit keeps it.
+
+        Rules:
+        - Call `get_skill` first and copy `old_string` from what it returns.
+        - `old_string` must match **exactly once**, or the edit is refused — add surrounding
+          text or pass `replace_all: true`. Do not switch to `save_skill` to work around a
+          refusal.
 
 
         ### delete_skill
@@ -206,6 +237,29 @@ public sealed class SkillToolSkillProvider : IToolSkillProvider
         - Confirm with the user before adding rules they haven't explicitly requested
 
 
+        ### edit_rule
+
+        Changes part of an existing rule in place — narrowing it, widening it, or correcting a
+        detail — without restating the whole rule.
+
+        **Parameters**
+        - `old_string` (string, required) — exact text to find within an active rule
+        - `new_string` (string, required) — replacement text; empty string deletes the match
+        - `replace_all` (boolean, optional, default false) — change every occurrence across all rules
+
+        ```
+        edit_rule(
+          old_string: "never use bullet points",
+          new_string: "never use bullet points in email drafts"
+        )
+        ```
+
+        Call `list_rules` first and copy `old_string` verbatim. If it appears in more than one
+        rule the edit is refused — include more of the rule text, or pass `replace_all: true`.
+        Prefer this to `remove_rule` + `add_rule`, which requires restating the rule in full and
+        moves it to the end of the list.
+
+
         ### list_rules
 
         Lists all currently active rules.
@@ -235,7 +289,8 @@ public sealed class SkillToolSkillProvider : IToolSkillProvider
         - **Check the skill index before starting a multi-step task** — if a relevant
           skill exists, load it immediately with `get_skill` rather than improvising
         - **Update skills after every real use** — add the pitfalls and examples you
-          discover; the skill document should get better each time you use it
+          discover with `edit_skill`; the skill document should get better each time you use
+          it, and an edit cannot drop the parts you were not thinking about
         - **Prefer updating over creating** — before saving a new skill, check whether
           an existing one covers the same ground and could be extended instead
         - **Use resources for structured artifacts** — move Python scripts, JSON schemas,

--- a/src/RockBot.Skills/SkillTools.cs
+++ b/src/RockBot.Skills/SkillTools.cs
@@ -54,6 +54,7 @@ public sealed class SkillTools
             AIFunctionFactory.Create(GetSkillResource),
             AIFunctionFactory.Create(ListSkills),
             AIFunctionFactory.Create(SaveSkill),
+            AIFunctionFactory.Create(EditSkill),
             AIFunctionFactory.Create(DeleteSkill),
         };
 
@@ -192,6 +193,32 @@ public sealed class SkillTools
 
         var index = await _skillStore.ListAsync();
         return $"Skill '{name}' saved. Summary is being generated.\n\n{FormatIndex(index)}";
+    }
+
+    [Description("Change part of an existing skill's markdown without rewriting the whole document. " +
+                 "This is the right tool for the usual case — adding a pitfall you just hit, correcting a step, " +
+                 "updating an example. save_skill replaces the entire body, so anything you do not reproduce " +
+                 "verbatim is lost, and on a long procedure you will not reproduce it verbatim. " +
+                 "Editing also keeps the existing summary instead of regenerating it. " +
+                 "Call get_skill first and copy old_string from what it returns; it must match exactly, and if " +
+                 "it appears more than once the edit is refused — include more surrounding text or set replace_all.")]
+    public async Task<string> EditSkill(
+        [Description("The skill name to edit (e.g. 'plan-meeting')")] string name,
+        [Description("Exact text to find in the skill's markdown — copy it verbatim from get_skill")] string old_string,
+        [Description("Replacement text. Pass an empty string to delete the matched text.")] string new_string,
+        [Description("Replace every occurrence instead of refusing an ambiguous match. Default false.")] bool replace_all = false)
+    {
+        _logger.LogInformation("Tool call: EditSkill(name={Name}, replaceAll={ReplaceAll})", name, replace_all);
+
+        var result = await _skillStore.EditContentAsync(
+            name, old_string ?? string.Empty, new_string ?? string.Empty, replace_all);
+
+        if (!result.IsSuccess)
+            return $"Edit failed on skill '{name}': {result.Error}";
+
+        var plural = result.ReplacementCount == 1 ? "occurrence" : "occurrences";
+        return $"Skill '{name}' edited — replaced {result.ReplacementCount} {plural} " +
+               $"({result.OldLength} → {result.NewLength} characters). Summary and resources unchanged.";
     }
 
     [Description("Save a working asset (wisp definition, script, schema) you just verified " +

--- a/src/RockBot.Subagent/Worker/WorkerRunner.cs
+++ b/src/RockBot.Subagent/Worker/WorkerRunner.cs
@@ -64,9 +64,12 @@ internal sealed class WorkerRunner(
         "mcp_register_server",
         "mcp_unregister_server",
         "save_memory",
+        "edit_memory",
         "save_skill",
+        "edit_skill",
         "promote_skill_asset",
         "update_task_directive",
+        "edit_task_directive",
         "invoke_agent",
     };
 

--- a/tests/RockBot.Agent.Tests/MemoryToolsTests.cs
+++ b/tests/RockBot.Agent.Tests/MemoryToolsTests.cs
@@ -98,6 +98,74 @@ public class MemoryToolsTests
     }
 
     // -------------------------------------------------------------------------
+    // EditMemory
+    // -------------------------------------------------------------------------
+
+    [TestMethod]
+    public void Tools_ExposeEditMemory()
+    {
+        var tools = MakeTools(new StubLongTermMemory());
+
+        var names = tools.Tools.OfType<AIFunction>().Select(f => f.Name).ToList();
+
+        CollectionAssert.Contains(names, "EditMemory");
+    }
+
+    [TestMethod]
+    public async Task EditMemory_AppliesTheEdit_AndReportsTheCount()
+    {
+        var memory = new StubLongTermMemory();
+        memory.Add(Entry("abc123", "User lives in Chicago", DateTimeOffset.UtcNow));
+        var tools = MakeTools(memory);
+
+        var result = await tools.EditMemory("abc123", "Chicago", "Minneapolis");
+
+        StringAssert.Contains(result, "abc123");
+        StringAssert.Contains(result, "replaced 1 occurrence");
+        Assert.AreEqual("User lives in Minneapolis", (await memory.GetAsync("abc123"))!.Content);
+    }
+
+    [TestMethod]
+    public async Task EditMemory_Refusal_ReachesTheModelVerbatim()
+    {
+        // The store's wording is the only explanation the model gets; paraphrasing it here
+        // would strip the part that says how to fix the call.
+        const string refusal = "oldText occurs 3 times — the edit target is ambiguous.";
+        var memory = new StubLongTermMemory { EditResult = ContentEditResult.Failed(refusal) };
+        var tools = MakeTools(memory);
+
+        var result = await tools.EditMemory("abc123", "dogs", "cats");
+
+        StringAssert.Contains(result, refusal);
+    }
+
+    [TestMethod]
+    public async Task EditMemory_PassesReplaceAllThrough()
+    {
+        var memory = new StubLongTermMemory();
+        memory.Add(Entry("abc123", "dog dog", DateTimeOffset.UtcNow));
+        var tools = MakeTools(memory);
+
+        var result = await tools.EditMemory("abc123", "dog", "cat", replace_all: true);
+
+        StringAssert.Contains(result, "replaced 2 occurrences");
+        Assert.AreEqual("cat cat", (await memory.GetAsync("abc123"))!.Content);
+    }
+
+    [TestMethod]
+    public async Task EditMemory_WithoutReplaceAll_AmbiguousMatchIsRefused()
+    {
+        var memory = new StubLongTermMemory();
+        memory.Add(Entry("abc123", "dog dog", DateTimeOffset.UtcNow));
+        var tools = MakeTools(memory);
+
+        var result = await tools.EditMemory("abc123", "dog", "cat");
+
+        StringAssert.Contains(result, "ambiguous");
+        Assert.AreEqual("dog dog", (await memory.GetAsync("abc123"))!.Content);
+    }
+
+    // -------------------------------------------------------------------------
     // DeleteMemory
     // -------------------------------------------------------------------------
 
@@ -649,6 +717,33 @@ internal sealed class StubLongTermMemory : ILongTermMemory
 
     public Task<MemoryEntry?> GetAsync(string id, CancellationToken cancellationToken = default) =>
         Task.FromResult(_entries.FirstOrDefault(e => e.Id == id));
+
+    /// <summary>When set, <see cref="EditAsync"/> returns this instead of applying the edit.</summary>
+    public ContentEditResult? EditResult { get; set; }
+
+    public Task<ContentEditResult> EditAsync(
+        string id, string oldText, string newText, bool replaceAll = false,
+        CancellationToken cancellationToken = default)
+    {
+        if (EditResult is { } canned)
+            return Task.FromResult(canned);
+
+        lock (_entries)
+        {
+            var index = _entries.FindIndex(e => e.Id == id);
+            if (index < 0)
+                return Task.FromResult(ContentEditResult.Failed($"No memory entry found with id '{id}'."));
+
+            var existing = _entries[index];
+            var edit = TextEdit.Apply(existing.Content, oldText, newText, replaceAll);
+            if (!edit.IsSuccess)
+                return Task.FromResult(ContentEditResult.Failed(edit.Error!));
+
+            _entries[index] = existing with { Content = edit.Content!, UpdatedAt = DateTimeOffset.UtcNow };
+            return Task.FromResult(ContentEditResult.Applied(
+                edit.ReplacementCount, existing.Content.Length, edit.Content!.Length));
+        }
+    }
 
     public Task DeleteAsync(string id, CancellationToken cancellationToken = default)
     {

--- a/tests/RockBot.Agent.Tests/SkillToolsTests.cs
+++ b/tests/RockBot.Agent.Tests/SkillToolsTests.cs
@@ -103,6 +103,56 @@ public class SkillToolsTests
         Assert.IsTrue(result.Contains("not found"));
     }
 
+    // ── EditSkill ─────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void Tools_ExposeEditSkill()
+    {
+        var tools = new SkillTools(new StubSkillStore(), new StubChatClient(), NullLogger<SkillTools>.Instance);
+
+        var names = tools.Tools.OfType<AIFunction>().Select(f => f.Name).ToList();
+
+        CollectionAssert.Contains(names, "EditSkill");
+    }
+
+    [TestMethod]
+    public async Task EditSkill_AppliesTheEdit_AndKeepsTheSummary()
+    {
+        var store = new StubSkillStore();
+        store.Add(new Skill("plan-meeting", "Plans meetings", "1. Book the room.", DateTimeOffset.UtcNow));
+        var tools = new SkillTools(store, new StubChatClient(), NullLogger<SkillTools>.Instance);
+
+        var result = await tools.EditSkill("plan-meeting", "1. Book the room.", "1. Book the room.\n2. Send the invite.");
+
+        StringAssert.Contains(result, "replaced 1 occurrence");
+        var skill = await store.GetAsync("plan-meeting");
+        StringAssert.Contains(skill!.Content, "2. Send the invite.");
+        Assert.AreEqual("Plans meetings", skill.Summary,
+            "A body edit must not blank the summary the way save_skill does.");
+    }
+
+    [TestMethod]
+    public async Task EditSkill_Refusal_ReachesTheModelVerbatim()
+    {
+        const string refusal = "oldText was not found. It must match the content exactly.";
+        var store = new StubSkillStore { EditResult = ContentEditResult.Failed(refusal) };
+        var tools = new SkillTools(store, new StubChatClient(), NullLogger<SkillTools>.Instance);
+
+        var result = await tools.EditSkill("plan-meeting", "missing", "replacement");
+
+        StringAssert.Contains(result, refusal);
+    }
+
+    [TestMethod]
+    public async Task EditSkill_UnknownSkill_ReturnsNotFound()
+    {
+        var tools = new SkillTools(new StubSkillStore(), new StubChatClient(), NullLogger<SkillTools>.Instance);
+
+        var result = await tools.EditSkill("nonexistent", "a", "b");
+
+        StringAssert.Contains(result, "not found");
+    }
+
     // ── GetSkillResource ──────────────────────────────────────────────────────
 
     [TestMethod]
@@ -500,6 +550,26 @@ public class SkillToolsTests
             return Task.CompletedTask;
         }
         public Task<Skill?> GetAsync(string name) => Task.FromResult(_skills.GetValueOrDefault(name));
+
+        /// <summary>When set, <see cref="EditContentAsync"/> returns this instead of editing.</summary>
+        public ContentEditResult? EditResult { get; set; }
+
+        public Task<ContentEditResult> EditContentAsync(string name, string oldText, string newText, bool replaceAll = false)
+        {
+            if (EditResult is { } canned)
+                return Task.FromResult(canned);
+
+            if (!_skills.TryGetValue(name, out var existing))
+                return Task.FromResult(ContentEditResult.Failed($"Skill '{name}' not found."));
+
+            var edit = TextEdit.Apply(existing.Content, oldText, newText, replaceAll);
+            if (!edit.IsSuccess)
+                return Task.FromResult(ContentEditResult.Failed(edit.Error!));
+
+            _skills[name] = existing with { Content = edit.Content!, UpdatedAt = DateTimeOffset.UtcNow };
+            return Task.FromResult(ContentEditResult.Applied(
+                edit.ReplacementCount, existing.Content.Length, edit.Content!.Length));
+        }
         public Task<IReadOnlyList<Skill>> ListAsync() =>
             Task.FromResult<IReadOnlyList<Skill>>(_skills.Values.OrderBy(s => s.Name).ToList());
         public Task DeleteAsync(string name) { _skills.Remove(name); return Task.CompletedTask; }

--- a/tests/RockBot.Agent.Tests/WorkingMemoryToolsTests.cs
+++ b/tests/RockBot.Agent.Tests/WorkingMemoryToolsTests.cs
@@ -40,6 +40,59 @@ public class WorkingMemoryToolsTests
             "Namespace must not be prepended twice");
     }
 
+    // ── EditWorkingMemory ─────────────────────────────────────────────────
+
+    [TestMethod]
+    public void Tools_ExposeEditWorkingMemory()
+    {
+        var names = _tools.Tools.OfType<AIFunction>().Select(f => f.Name).ToList();
+
+        CollectionAssert.Contains(names, "EditWorkingMemory");
+    }
+
+    [TestMethod]
+    public async Task EditWorkingMemory_PlainKey_PrependsNamespace()
+    {
+        _memory.Store["subagent/abc123/draft"] = "before";
+
+        await _tools.EditWorkingMemory("draft", "before", "after");
+
+        Assert.AreEqual("subagent/abc123/draft", _memory.LastEditKey);
+        Assert.AreEqual("after", _memory.Store["subagent/abc123/draft"]);
+    }
+
+    [TestMethod]
+    public async Task EditWorkingMemory_AbsoluteKey_UsesAsIs()
+    {
+        _memory.Store["shared/drafts/report"] = "before";
+
+        await _tools.EditWorkingMemory("shared/drafts/report", "before", "after");
+
+        Assert.AreEqual("shared/drafts/report", _memory.LastEditKey);
+    }
+
+    [TestMethod]
+    public async Task EditWorkingMemory_Success_ReportsReplacementCount()
+    {
+        _memory.Store["subagent/abc123/draft"] = "todo todo";
+
+        var result = await _tools.EditWorkingMemory("draft", "todo", "done", replace_all: true);
+
+        StringAssert.Contains(result, "replaced 2 occurrences");
+        Assert.AreEqual("done done", _memory.Store["subagent/abc123/draft"]);
+    }
+
+    [TestMethod]
+    public async Task EditWorkingMemory_Refusal_ReachesTheModelVerbatim()
+    {
+        const string refusal = "Working memory entry 'x' was not found or has expired.";
+        _memory.EditResult = ContentEditResult.Failed(refusal);
+
+        var result = await _tools.EditWorkingMemory("draft", "a", "b");
+
+        StringAssert.Contains(result, refusal);
+    }
+
     // ── GetFromWorkingMemory ──────────────────────────────────────────────
 
     [TestMethod]
@@ -227,6 +280,30 @@ public class WorkingMemoryToolsTests
 
         public Task<string?> GetAsync(string key) =>
             Task.FromResult(Store.TryGetValue(key, out var v) ? v : null);
+
+        /// <summary>When set, <see cref="EditAsync"/> returns this instead of applying the edit.</summary>
+        public ContentEditResult? EditResult { get; set; }
+
+        public string? LastEditKey { get; private set; }
+
+        public Task<ContentEditResult> EditAsync(string key, string oldText, string newText, bool replaceAll = false)
+        {
+            LastEditKey = key;
+
+            if (EditResult is { } canned)
+                return Task.FromResult(canned);
+
+            if (!Store.TryGetValue(key, out var current))
+                return Task.FromResult(ContentEditResult.Failed($"Working memory entry '{key}' was not found."));
+
+            var edit = TextEdit.Apply(current, oldText, newText, replaceAll);
+            if (!edit.IsSuccess)
+                return Task.FromResult(ContentEditResult.Failed(edit.Error!));
+
+            Store[key] = edit.Content!;
+            return Task.FromResult(ContentEditResult.Applied(
+                edit.ReplacementCount, current.Length, edit.Content!.Length));
+        }
 
         public Task<IReadOnlyList<WorkingMemoryEntry>> ListAsync(string? prefix = null) =>
             Task.FromResult<IReadOnlyList<WorkingMemoryEntry>>([]);

--- a/tests/RockBot.Host.Tests/FileMemoryStoreEditTests.cs
+++ b/tests/RockBot.Host.Tests/FileMemoryStoreEditTests.cs
@@ -1,0 +1,291 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace RockBot.Host.Tests;
+
+/// <summary>
+/// Covers <see cref="FileMemoryStore.EditAsync"/> — the partial-edit path that exists so a
+/// correction does not cost an entry its identity and history.
+/// </summary>
+[TestClass]
+public sealed class FileMemoryStoreEditTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true
+    };
+
+    private string _tempDir = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "rockbot-memory-edit-test-" + Guid.NewGuid().ToString("N"));
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    // ── Success ───────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task EditAsync_ReplacesMatchedText()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(Entry("m1", "User prefers meetings in the morning"));
+
+        var result = await store.EditAsync("m1", "in the morning", "after 13:00");
+
+        Assert.IsTrue(result.IsSuccess, result.Error);
+        Assert.AreEqual(1, result.ReplacementCount);
+        var updated = await store.GetAsync("m1");
+        Assert.AreEqual("User prefers meetings after 13:00", updated!.Content);
+    }
+
+    [TestMethod]
+    public async Task EditAsync_ReportsLengthsOfTheWholeContent()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(Entry("m1", "abcdef"));
+
+        var result = await store.EditAsync("m1", "cd", "CDCD");
+
+        Assert.AreEqual(6, result.OldLength);
+        Assert.AreEqual(8, result.NewLength);
+    }
+
+    [TestMethod]
+    public async Task EditAsync_EmptyNewText_DeletesTheMatch()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(Entry("m1", "A fact, with an aside, worth keeping"));
+
+        var result = await store.EditAsync("m1", ", with an aside,", "");
+
+        Assert.IsTrue(result.IsSuccess, result.Error);
+        Assert.AreEqual("A fact worth keeping", (await store.GetAsync("m1"))!.Content);
+    }
+
+    [TestMethod]
+    public async Task EditAsync_ReplaceAll_ReplacesEveryOccurrence()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(Entry("m1", "chicago and chicago and chicago"));
+
+        var result = await store.EditAsync("m1", "chicago", "denver", replaceAll: true);
+
+        Assert.IsTrue(result.IsSuccess, result.Error);
+        Assert.AreEqual(3, result.ReplacementCount);
+        Assert.AreEqual("denver and denver and denver", (await store.GetAsync("m1"))!.Content);
+    }
+
+    [TestMethod]
+    public async Task EditAsync_PersistsToDisk()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(Entry("m1", "Old wording", category: "user-preferences"));
+
+        await store.EditAsync("m1", "Old", "New");
+
+        var json = await File.ReadAllTextAsync(Path.Combine(_tempDir, "user-preferences", "m1.json"));
+        var onDisk = JsonSerializer.Deserialize<MemoryEntry>(json, JsonOptions);
+        Assert.AreEqual("New wording", onDisk!.Content);
+    }
+
+    [TestMethod]
+    public async Task EditAsync_LeavesNoTemporaryFilesBehind()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(Entry("m1", "Old wording"));
+
+        await store.EditAsync("m1", "Old", "New");
+
+        var strays = Directory.EnumerateFiles(_tempDir, "*.tmp", SearchOption.AllDirectories).ToList();
+        Assert.AreEqual(0, strays.Count, "The atomic write must not leave its temp file behind.");
+    }
+
+    // ── Provenance ────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task EditAsync_PreservesEveryFieldExceptContentAndUpdatedAt()
+    {
+        var store = CreateStore();
+        var created = DateTimeOffset.UtcNow.AddDays(-400);
+        var lastSeen = DateTimeOffset.UtcNow.AddDays(-3);
+        var original = new MemoryEntry(
+            "m1",
+            "User lives in Chicago and works remotely",
+            Category: "user-preferences/location",
+            Tags: ["location", "chicago"],
+            CreatedAt: created,
+            UpdatedAt: created.AddDays(1),
+            Metadata: new Dictionary<string, string> { ["subjectTime"] = "2019" },
+            ImportanceScore: 0.87f)
+        {
+            LastSeenAt = lastSeen,
+            ReinforcementCount = 214,
+            SupersededBy = "other-entry",
+            ArchivedAt = created.AddDays(2),
+            ArchiveReason = "merged into other-entry"
+        };
+        await store.SaveAsync(original);
+
+        var before = DateTimeOffset.UtcNow;
+        var result = await store.EditAsync("m1", "Chicago", "Minneapolis");
+
+        Assert.IsTrue(result.IsSuccess, result.Error);
+        var edited = await store.GetAsync("m1");
+        Assert.IsNotNull(edited);
+
+        Assert.AreEqual("User lives in Minneapolis and works remotely", edited.Content);
+        Assert.IsTrue(edited.UpdatedAt >= before, "UpdatedAt should move to now.");
+
+        Assert.AreEqual("m1", edited.Id, "The id must survive — it is how the entry is referenced.");
+        Assert.AreEqual(created, edited.CreatedAt);
+        Assert.AreEqual(lastSeen, edited.LastSeenAt, "An edit is not a reinforcement.");
+        Assert.AreEqual(214, edited.ReinforcementCount);
+        Assert.AreEqual(0.87f, edited.ImportanceScore);
+        Assert.AreEqual("user-preferences/location", edited.Category);
+        CollectionAssert.AreEqual(new[] { "location", "chicago" }, edited.Tags.ToArray());
+        Assert.AreEqual("2019", edited.Metadata!["subjectTime"]);
+        Assert.AreEqual("other-entry", edited.SupersededBy);
+        Assert.AreEqual(created.AddDays(2), edited.ArchivedAt);
+        Assert.AreEqual("merged into other-entry", edited.ArchiveReason);
+    }
+
+    [TestMethod]
+    public async Task EditAsync_KeepsTheEntryInItsExistingCategoryFile()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(Entry("m1", "Old wording", category: "project-context/rockbot"));
+
+        await store.EditAsync("m1", "Old", "New");
+
+        Assert.IsTrue(File.Exists(Path.Combine(_tempDir, "project-context", "rockbot", "m1.json")));
+        Assert.IsFalse(File.Exists(Path.Combine(_tempDir, "m1.json")));
+    }
+
+    // ── Refusals ──────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task EditAsync_UnknownId_RefusesWithAnActionableMessage()
+    {
+        var store = CreateStore();
+
+        var result = await store.EditAsync("nope", "a", "b");
+
+        Assert.IsFalse(result.IsSuccess);
+        StringAssert.Contains(result.Error, "nope");
+        StringAssert.Contains(result.Error, "Search memory");
+    }
+
+    [TestMethod]
+    public async Task EditAsync_TextNotFound_Refuses_AndLeavesContentUntouched()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(Entry("m1", "User prefers concise answers"));
+
+        var result = await store.EditAsync("m1", "verbose", "concise");
+
+        Assert.IsFalse(result.IsSuccess);
+        StringAssert.Contains(result.Error, "not found");
+        Assert.AreEqual("User prefers concise answers", (await store.GetAsync("m1"))!.Content);
+    }
+
+    [TestMethod]
+    public async Task EditAsync_AmbiguousMatch_Refuses_AndWritesNothing()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(Entry("m1", "dogs and more dogs"));
+        var stampBefore = (await store.GetAsync("m1"))!.UpdatedAt;
+
+        var result = await store.EditAsync("m1", "dogs", "cats");
+
+        Assert.IsFalse(result.IsSuccess);
+        StringAssert.Contains(result.Error, "occurs 2 times");
+        var after = await store.GetAsync("m1");
+        Assert.AreEqual("dogs and more dogs", after!.Content);
+        Assert.AreEqual(stampBefore, after.UpdatedAt, "A refused edit must not bump UpdatedAt.");
+    }
+
+    [TestMethod]
+    public async Task EditAsync_IdenticalOldAndNew_Refuses()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(Entry("m1", "unchanged"));
+
+        var result = await store.EditAsync("m1", "unchanged", "unchanged");
+
+        Assert.IsFalse(result.IsSuccess);
+        StringAssert.Contains(result.Error, "identical");
+    }
+
+    [TestMethod]
+    public async Task EditAsync_EmptyOldText_Refuses()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(Entry("m1", "some content"));
+
+        var result = await store.EditAsync("m1", "", "something");
+
+        Assert.IsFalse(result.IsSuccess);
+        StringAssert.Contains(result.Error, "must not be empty");
+    }
+
+    // ── Concurrency ───────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task EditAsync_ConcurrentEdits_AllLand()
+    {
+        // Each edit targets a distinct marker, so a lost read-modify-write cycle shows up as
+        // a marker that is still present after every call reported success.
+        // Markers are zero-padded so none is a prefix of another — otherwise "M1" would match
+        // inside "M10" and the edit would be refused as ambiguous rather than tested.
+        const int markers = 12;
+        var store = CreateStore();
+        await store.SaveAsync(Entry("m1", string.Join(" ", Enumerable.Range(0, markers).Select(i => $"M{i:D2}"))));
+
+        var results = await Task.WhenAll(
+            Enumerable.Range(0, markers).Select(i => store.EditAsync("m1", $"M{i:D2}", $"X{i:D2}")));
+
+        Assert.IsTrue(
+            results.All(r => r.IsSuccess),
+            "Every concurrent edit should apply: " + string.Join("; ", results.Where(r => !r.IsSuccess).Select(r => r.Error)));
+        var content = (await store.GetAsync("m1"))!.Content;
+        for (var i = 0; i < markers; i++)
+            StringAssert.Contains(content, $"X{i:D2}", $"Edit of M{i:D2} was overwritten by a concurrent edit.");
+    }
+
+    [TestMethod]
+    public async Task EditAsync_ConcurrentWithSave_DoesNotCorruptTheEntry()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(Entry("m1", "alpha bravo"));
+
+        var edit = store.EditAsync("m1", "alpha", "ALPHA");
+        var save = store.SaveAsync(Entry("m2", "unrelated"));
+        await Task.WhenAll(edit, save);
+
+        Assert.IsTrue(edit.Result.IsSuccess, edit.Result.Error);
+        Assert.AreEqual("ALPHA bravo", (await store.GetAsync("m1"))!.Content);
+        Assert.AreEqual("unrelated", (await store.GetAsync("m2"))!.Content);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private FileMemoryStore CreateStore() =>
+        new(Options.Create(new MemoryOptions { BasePath = _tempDir }),
+            Options.Create(new AgentProfileOptions()),
+            Options.Create(new EmbeddingOptions()),
+            NullLogger<FileMemoryStore>.Instance,
+            EmbeddingTextPreparer.ForTests());
+
+    private static MemoryEntry Entry(string id, string content, string? category = null) =>
+        new(id, content, category, [], DateTimeOffset.UtcNow);
+}

--- a/tests/RockBot.Host.Tests/FileRulesStoreTests.cs
+++ b/tests/RockBot.Host.Tests/FileRulesStoreTests.cs
@@ -1,0 +1,355 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace RockBot.Host.Tests;
+
+/// <summary>
+/// Covers <see cref="FileRulesStore"/> — in particular that <c>rules.md</c> is treated as a
+/// document whose non-rule content survives a mutation, and that a file edited outside the
+/// agent is not clobbered by the next write.
+/// </summary>
+[TestClass]
+public sealed class FileRulesStoreTests
+{
+    private string _tempDir = null!;
+    private string _rulesPath = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "rockbot-rules-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+        _rulesPath = Path.Combine(_tempDir, "rules.md");
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    // ── Basic behaviour ───────────────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task AddAsync_OnAFreshStore_CreatesTheFileWithAHeading()
+    {
+        var store = CreateStore();
+
+        await store.AddAsync("Always respond in British English");
+
+        var lines = await File.ReadAllLinesAsync(_rulesPath);
+        Assert.AreEqual("# Active Rules", lines[0]);
+        CollectionAssert.Contains(lines, "- Always respond in British English");
+        CollectionAssert.AreEqual(new[] { "Always respond in British English" }, store.Rules.ToArray());
+    }
+
+    [TestMethod]
+    public async Task AddAsync_DuplicateRule_IsIgnored()
+    {
+        var store = CreateStore();
+        await store.AddAsync("Never use bullet points");
+
+        await store.AddAsync("never use BULLET points");
+
+        Assert.AreEqual(1, (await store.ListAsync()).Count);
+    }
+
+    [TestMethod]
+    public async Task RemoveAsync_DropsOnlyThatRule()
+    {
+        var store = CreateStore();
+        await store.AddAsync("Rule one");
+        await store.AddAsync("Rule two");
+
+        await store.RemoveAsync("rule one");
+
+        CollectionAssert.AreEqual(new[] { "Rule two" }, (await store.ListAsync()).ToArray());
+    }
+
+    [TestMethod]
+    public async Task RemoveAsync_UnknownRule_LeavesTheFileAlone()
+    {
+        var store = CreateStore();
+        await store.AddAsync("Rule one");
+        var before = await File.ReadAllTextAsync(_rulesPath);
+
+        await store.RemoveAsync("no such rule");
+
+        Assert.AreEqual(before, await File.ReadAllTextAsync(_rulesPath));
+    }
+
+    // ── Document round-trip ───────────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task AddAsync_PreservesHandAuthoredStructure()
+    {
+        // A rules.md someone wrote by hand: headings, prose, blank lines, a trailing note.
+        // Regenerating the file from an extracted rule list destroyed all of it.
+        await WriteRulesFileAsync(
+            "# Active Rules",
+            "",
+            "These are enforced on every turn. Keep the list short.",
+            "",
+            "## Style",
+            "",
+            "- Always respond in British English",
+            "- Never use bullet points in email drafts",
+            "",
+            "## Notes",
+            "",
+            "The style rules came from the 2026-03 review; ask before changing them.");
+
+        var store = CreateStore();
+        await store.AddAsync("Prefer prose to tables");
+
+        var lines = await File.ReadAllLinesAsync(_rulesPath);
+        CollectionAssert.AreEqual(
+            new[]
+            {
+                "# Active Rules",
+                "",
+                "These are enforced on every turn. Keep the list short.",
+                "",
+                "## Style",
+                "",
+                "- Always respond in British English",
+                "- Never use bullet points in email drafts",
+                "- Prefer prose to tables",
+                "",
+                "## Notes",
+                "",
+                "The style rules came from the 2026-03 review; ask before changing them."
+            },
+            lines);
+    }
+
+    [TestMethod]
+    public async Task RemoveAsync_PreservesHandAuthoredStructure()
+    {
+        await WriteRulesFileAsync(
+            "# Active Rules",
+            "",
+            "Context for the reader.",
+            "",
+            "- Rule one",
+            "- Rule two",
+            "",
+            "Trailing note.");
+
+        var store = CreateStore();
+        await store.RemoveAsync("Rule one");
+
+        CollectionAssert.AreEqual(
+            new[]
+            {
+                "# Active Rules",
+                "",
+                "Context for the reader.",
+                "",
+                "- Rule two",
+                "",
+                "Trailing note."
+            },
+            await File.ReadAllLinesAsync(_rulesPath));
+    }
+
+    [TestMethod]
+    public async Task Load_IgnoresNonBulletLines()
+    {
+        await WriteRulesFileAsync(
+            "# Active Rules",
+            "",
+            "Some prose that is not a rule.",
+            "- An actual rule");
+
+        var store = CreateStore();
+
+        CollectionAssert.AreEqual(new[] { "An actual rule" }, store.Rules.ToArray());
+    }
+
+    [TestMethod]
+    public async Task AddAsync_PreservesAsteriskBulletsAlreadyInTheFile()
+    {
+        await WriteRulesFileAsync("* Written with an asterisk");
+
+        var store = CreateStore();
+        await store.AddAsync("Added by the agent");
+
+        var lines = await File.ReadAllLinesAsync(_rulesPath);
+        CollectionAssert.AreEqual(
+            new[] { "* Written with an asterisk", "- Added by the agent" },
+            lines);
+    }
+
+    // ── Re-read on mutation ───────────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task AddAsync_DoesNotClobberRulesAddedToTheFileSinceStartup()
+    {
+        // The store has no watcher, so a rules.md pushed to a running pod would previously be
+        // overwritten by the next add from the startup-loaded list.
+        var store = CreateStore();
+        await store.AddAsync("Agent rule");
+
+        await File.AppendAllLinesAsync(_rulesPath, ["- Rule added out of band"]);
+
+        await store.AddAsync("Another agent rule");
+
+        var rules = await store.ListAsync();
+        CollectionAssert.AreEquivalent(
+            new[] { "Agent rule", "Rule added out of band", "Another agent rule" },
+            rules.ToArray());
+    }
+
+    [TestMethod]
+    public async Task ListAsync_ReflectsAnOutOfBandEdit()
+    {
+        var store = CreateStore();
+        await store.AddAsync("Agent rule");
+
+        await File.AppendAllLinesAsync(_rulesPath, ["- Rule added out of band"]);
+
+        CollectionAssert.Contains((await store.ListAsync()).ToArray(), "Rule added out of band");
+    }
+
+    // ── EditAsync ─────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task EditAsync_ChangesTheRuleInPlace()
+    {
+        await WriteRulesFileAsync(
+            "# Active Rules",
+            "",
+            "- Never use bullet points",
+            "- Always sign off with a name");
+
+        var store = CreateStore();
+        var result = await store.EditAsync("Never use bullet points", "Never use bullet points in email drafts");
+
+        Assert.IsTrue(result.IsSuccess, result.Error);
+        Assert.AreEqual(1, result.ReplacementCount);
+        CollectionAssert.AreEqual(
+            new[]
+            {
+                "# Active Rules",
+                "",
+                "- Never use bullet points in email drafts",
+                "- Always sign off with a name"
+            },
+            await File.ReadAllLinesAsync(_rulesPath));
+    }
+
+    [TestMethod]
+    public async Task EditAsync_KeepsTheRuleInItsOriginalPosition()
+    {
+        await WriteRulesFileAsync("- First", "- Second", "- Third");
+
+        var store = CreateStore();
+        await store.EditAsync("Second", "Middle");
+
+        CollectionAssert.AreEqual(
+            new[] { "First", "Middle", "Third" },
+            (await store.ListAsync()).ToArray());
+    }
+
+    [TestMethod]
+    public async Task EditAsync_TextNotFound_Refuses()
+    {
+        await WriteRulesFileAsync("- Never use bullet points");
+        var store = CreateStore();
+
+        var result = await store.EditAsync("tables", "charts");
+
+        Assert.IsFalse(result.IsSuccess);
+        StringAssert.Contains(result.Error, "not found");
+    }
+
+    [TestMethod]
+    public async Task EditAsync_AmbiguousAcrossRules_Refuses_AndWritesNothing()
+    {
+        await WriteRulesFileAsync("- Prefer prose", "- Prefer prose over tables");
+        var store = CreateStore();
+        var before = await File.ReadAllTextAsync(_rulesPath);
+
+        var result = await store.EditAsync("Prefer prose", "Prefer bullets");
+
+        Assert.IsFalse(result.IsSuccess);
+        StringAssert.Contains(result.Error, "occurs 2 times");
+        Assert.AreEqual(before, await File.ReadAllTextAsync(_rulesPath));
+    }
+
+    [TestMethod]
+    public async Task EditAsync_ReplaceAll_ChangesEveryMatchingRule()
+    {
+        await WriteRulesFileAsync("- Prefer prose", "- Prefer prose over tables");
+        var store = CreateStore();
+
+        var result = await store.EditAsync("Prefer prose", "Prefer bullets", replaceAll: true);
+
+        Assert.IsTrue(result.IsSuccess, result.Error);
+        Assert.AreEqual(2, result.ReplacementCount);
+        CollectionAssert.AreEqual(
+            new[] { "Prefer bullets", "Prefer bullets over tables" },
+            (await store.ListAsync()).ToArray());
+    }
+
+    [TestMethod]
+    public async Task EditAsync_DoesNotMatchAgainstNonRuleLines()
+    {
+        await WriteRulesFileAsync(
+            "# Active Rules",
+            "",
+            "The word chicago appears in this note.",
+            "- An unrelated rule");
+
+        var store = CreateStore();
+        var result = await store.EditAsync("chicago", "denver");
+
+        Assert.IsFalse(result.IsSuccess, "Prose is not a rule and must not be edited by edit_rule.");
+    }
+
+    [TestMethod]
+    public async Task EditAsync_EmptyOldText_Refuses()
+    {
+        await WriteRulesFileAsync("- A rule");
+        var store = CreateStore();
+
+        var result = await store.EditAsync("", "something");
+
+        Assert.IsFalse(result.IsSuccess);
+        StringAssert.Contains(result.Error, "must not be empty");
+    }
+
+    [TestMethod]
+    public async Task EditAsync_IdenticalOldAndNew_Refuses()
+    {
+        await WriteRulesFileAsync("- A rule");
+        var store = CreateStore();
+
+        var result = await store.EditAsync("A rule", "A rule");
+
+        Assert.IsFalse(result.IsSuccess);
+        StringAssert.Contains(result.Error, "identical");
+    }
+
+    [TestMethod]
+    public async Task EditAsync_RefreshesTheSynchronousRulesSnapshot()
+    {
+        await WriteRulesFileAsync("- Never use bullet points");
+        var store = CreateStore();
+
+        await store.EditAsync("bullet points", "tables");
+
+        CollectionAssert.AreEqual(new[] { "Never use tables" }, store.Rules.ToArray());
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private FileRulesStore CreateStore() =>
+        new(Options.Create(new AgentProfileOptions { BasePath = _tempDir }),
+            NullLogger<FileRulesStore>.Instance);
+
+    private Task WriteRulesFileAsync(params string[] lines) =>
+        File.WriteAllLinesAsync(_rulesPath, lines);
+}

--- a/tests/RockBot.Host.Tests/FileScheduledTaskStoreTests.cs
+++ b/tests/RockBot.Host.Tests/FileScheduledTaskStoreTests.cs
@@ -249,6 +249,92 @@ public sealed class FileScheduledTaskStoreTests
         Assert.IsNull(await store.GetAsync("nonexistent"));
     }
 
+    // ── EditDirectiveAsync ────────────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task EditDirectiveAsync_ChangesOnlyTheMatchedText()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(MakeTask("patrol"));
+        await store.UpdateDirectiveAsync("patrol", "## Checklist\n- check plans\n- check todos");
+
+        var result = await store.EditDirectiveAsync("patrol", "- check todos", "- check todos\n- check email");
+
+        Assert.IsTrue(result.IsSuccess, result.Error);
+        Assert.AreEqual(1, result.ReplacementCount);
+        var retrieved = await store.GetAsync("patrol");
+        Assert.AreEqual("## Checklist\n- check plans\n- check todos\n- check email", retrieved!.Directive);
+    }
+
+    [TestMethod]
+    public async Task EditDirectiveAsync_PreservesOtherFields()
+    {
+        var store = CreateStore();
+        var firedAt = new DateTimeOffset(2026, 2, 19, 8, 0, 0, TimeSpan.Zero);
+        await store.SaveAsync(MakeTask("patrol", cron: "0 8 * * *", description: "Patrol"));
+        await store.UpdateLastFiredAsync("patrol", firedAt);
+        await store.UpdateDirectiveAsync("patrol", "watch the queue");
+
+        await store.EditDirectiveAsync("patrol", "queue", "backlog");
+
+        var retrieved = await store.GetAsync("patrol");
+        Assert.AreEqual("watch the backlog", retrieved!.Directive);
+        Assert.AreEqual("0 8 * * *", retrieved.CronExpression);
+        Assert.AreEqual("Patrol", retrieved.Description);
+        Assert.AreEqual(firedAt, retrieved.LastFiredAt);
+    }
+
+    [TestMethod]
+    public async Task EditDirectiveAsync_UnknownTask_Refuses()
+    {
+        var store = CreateStore();
+
+        var result = await store.EditDirectiveAsync("nonexistent", "a", "b");
+
+        Assert.IsFalse(result.IsSuccess, "Unlike UpdateDirectiveAsync, an edit must report a missing task.");
+        StringAssert.Contains(result.Error, "nonexistent");
+    }
+
+    [TestMethod]
+    public async Task EditDirectiveAsync_TaskWithNoDirective_Refuses()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(MakeTask("patrol"));
+
+        var result = await store.EditDirectiveAsync("patrol", "a", "b");
+
+        Assert.IsFalse(result.IsSuccess);
+        StringAssert.Contains(result.Error, "no directive yet");
+    }
+
+    [TestMethod]
+    public async Task EditDirectiveAsync_AmbiguousMatch_Refuses_AndWritesNothing()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(MakeTask("patrol"));
+        await store.UpdateDirectiveAsync("patrol", "check\ncheck");
+
+        var result = await store.EditDirectiveAsync("patrol", "check", "verify");
+
+        Assert.IsFalse(result.IsSuccess);
+        StringAssert.Contains(result.Error, "occurs 2 times");
+        Assert.AreEqual("check\ncheck", (await store.GetAsync("patrol"))!.Directive);
+    }
+
+    [TestMethod]
+    public async Task EditDirectiveAsync_ReplaceAll_ReplacesEveryOccurrence()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(MakeTask("patrol"));
+        await store.UpdateDirectiveAsync("patrol", "check\ncheck");
+
+        var result = await store.EditDirectiveAsync("patrol", "check", "verify", replaceAll: true);
+
+        Assert.IsTrue(result.IsSuccess, result.Error);
+        Assert.AreEqual(2, result.ReplacementCount);
+        Assert.AreEqual("verify\nverify", (await store.GetAsync("patrol"))!.Directive);
+    }
+
     // ── Persistence ───────────────────────────────────────────────────────────
 
     [TestMethod]

--- a/tests/RockBot.Host.Tests/FileSkillStoreTests.cs
+++ b/tests/RockBot.Host.Tests/FileSkillStoreTests.cs
@@ -832,6 +832,98 @@ public class FileSkillStoreTests
         Assert.IsNotNull(entry.CreatedAt);
     }
 
+    // ── EditContentAsync ──────────────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task EditContentAsync_ReplacesTextInTheBody()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(MakeSkill("plan-meeting", "Plans a meeting", "# Plan\n\n1. Book the room.\n2. Send the invite."));
+
+        var result = await store.EditContentAsync("plan-meeting", "2. Send the invite.", "2. Send the invite.\n3. Confirm attendance.");
+
+        Assert.IsTrue(result.IsSuccess, result.Error);
+        Assert.AreEqual(1, result.ReplacementCount);
+        var skill = await store.GetAsync("plan-meeting");
+        StringAssert.Contains(skill!.Content, "3. Confirm attendance.");
+        StringAssert.Contains(skill.Content, "1. Book the room.");
+    }
+
+    [TestMethod]
+    public async Task EditContentAsync_PreservesSummaryManifestAndCreatedAt()
+    {
+        // save_skill clears the summary and regenerates it with a background LLM call; a body
+        // edit must not pay that cost or leave the skill index blank in the meantime.
+        var store = CreateStore();
+        var created = DateTimeOffset.UtcNow.AddDays(-90);
+        var lastUsed = DateTimeOffset.UtcNow.AddDays(-2);
+        await store.SaveAsync(
+            new Skill("calendar/scan", "Scans the calendar for conflicts", "# Scan\n\nStep one.", created,
+                UpdatedAt: created, LastUsedAt: lastUsed, SeeAlso: ["plan-meeting"]),
+            [new SkillResourceInput("scan.json", SkillResourceType.Wisp, "Fan-out", "{\"v\":1}")]);
+
+        var before = DateTimeOffset.UtcNow;
+        var result = await store.EditContentAsync("calendar/scan", "Step one.", "Step one, then step two.");
+
+        Assert.IsTrue(result.IsSuccess, result.Error);
+        var skill = await store.GetAsync("calendar/scan");
+        Assert.AreEqual("Scans the calendar for conflicts", skill!.Summary);
+        Assert.AreEqual(created, skill.CreatedAt);
+        Assert.AreEqual(lastUsed, skill.LastUsedAt);
+        CollectionAssert.AreEqual(new[] { "plan-meeting" }, skill.SeeAlso!.ToArray());
+        Assert.AreEqual("scan.json", skill.Manifest!.Single().Filename);
+        Assert.IsTrue(skill.UpdatedAt >= before, "UpdatedAt should move to now.");
+    }
+
+    [TestMethod]
+    public async Task EditContentAsync_UnknownSkill_Refuses()
+    {
+        var store = CreateStore();
+
+        var result = await store.EditContentAsync("no-such-skill", "a", "b");
+
+        Assert.IsFalse(result.IsSuccess);
+        StringAssert.Contains(result.Error, "no-such-skill");
+    }
+
+    [TestMethod]
+    public async Task EditContentAsync_AmbiguousMatch_Refuses_AndWritesNothing()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(MakeSkill("s", "sum", "step\nstep"));
+
+        var result = await store.EditContentAsync("s", "step", "stage");
+
+        Assert.IsFalse(result.IsSuccess);
+        StringAssert.Contains(result.Error, "occurs 2 times");
+        Assert.AreEqual("step\nstep", (await store.GetAsync("s"))!.Content);
+    }
+
+    [TestMethod]
+    public async Task EditContentAsync_ReplaceAll_ReplacesEveryOccurrence()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(MakeSkill("s", "sum", "step\nstep"));
+
+        var result = await store.EditContentAsync("s", "step", "stage", replaceAll: true);
+
+        Assert.IsTrue(result.IsSuccess, result.Error);
+        Assert.AreEqual(2, result.ReplacementCount);
+        Assert.AreEqual("stage\nstage", (await store.GetAsync("s"))!.Content);
+    }
+
+    [TestMethod]
+    public async Task EditContentAsync_PersistsToDisk()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(MakeSkill("s", "sum", "before"));
+
+        await store.EditContentAsync("s", "before", "after");
+
+        var json = await File.ReadAllTextAsync(Path.Combine(_tempDir, "s.json"));
+        StringAssert.Contains(json, "after");
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     private FileSkillStore CreateStore() =>

--- a/tests/RockBot.Host.Tests/HybridCacheWorkingMemoryTests.cs
+++ b/tests/RockBot.Host.Tests/HybridCacheWorkingMemoryTests.cs
@@ -75,6 +75,118 @@ public class HybridCacheWorkingMemoryTests
         Assert.AreEqual("session/s1/live", entries[0].Key);
     }
 
+    // ── Edit ───────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task EditAsync_ReplacesTextInPlace()
+    {
+        await _memory.SetAsync("session/s1/draft", "Session length: 60 minutes");
+
+        var result = await _memory.EditAsync("session/s1/draft", "60 minutes", "75 minutes");
+
+        Assert.IsTrue(result.IsSuccess, result.Error);
+        Assert.AreEqual(1, result.ReplacementCount);
+        Assert.AreEqual("Session length: 75 minutes", await _memory.GetAsync("session/s1/draft"));
+    }
+
+    [TestMethod]
+    public async Task EditAsync_ResetsTtlUsingTheOriginalWindow()
+    {
+        // An entry someone is still amending is still in use, but a deliberately long-lived
+        // handoff entry must not silently drop to the default TTL.
+        await _memory.SetAsync("session/s1/draft", "before", TimeSpan.FromMinutes(240));
+        var original = (await _memory.ListAsync("session/s1")).Single();
+        await Task.Delay(20);
+
+        var editedAt = DateTimeOffset.UtcNow;
+        await _memory.EditAsync("session/s1/draft", "before", "after");
+
+        var updated = (await _memory.ListAsync("session/s1")).Single();
+        Assert.IsTrue(updated.StoredAt >= editedAt.AddMilliseconds(-5), "StoredAt should move to now.");
+        Assert.IsTrue(updated.ExpiresAt > original.ExpiresAt, "The TTL should restart from now.");
+        var window = updated.ExpiresAt - updated.StoredAt;
+        Assert.IsTrue(
+            Math.Abs((window - TimeSpan.FromMinutes(240)).TotalSeconds) < 1,
+            $"Expected the original 240-minute window to be reused, got {window}.");
+    }
+
+    [TestMethod]
+    public async Task EditAsync_PreservesCategoryAndTags()
+    {
+        await _memory.SetAsync("session/s1/draft", "before", TimeSpan.FromMinutes(30),
+            category: "research/pricing", tags: ["draft", "urgent"]);
+
+        await _memory.EditAsync("session/s1/draft", "before", "after");
+
+        var entry = (await _memory.ListAsync("session/s1")).Single();
+        Assert.AreEqual("research/pricing", entry.Category);
+        CollectionAssert.AreEquivalent(new[] { "draft", "urgent" }, entry.Tags!.ToArray());
+    }
+
+    [TestMethod]
+    public async Task EditAsync_UnknownKey_Refuses()
+    {
+        var result = await _memory.EditAsync("session/s1/missing", "a", "b");
+
+        Assert.IsFalse(result.IsSuccess);
+        StringAssert.Contains(result.Error, "session/s1/missing");
+    }
+
+    [TestMethod]
+    public async Task EditAsync_ExpiredEntry_Refuses()
+    {
+        await _memory.SetAsync("session/s1/gone", "data", TimeSpan.FromMilliseconds(1));
+        await Task.Delay(50);
+
+        var result = await _memory.EditAsync("session/s1/gone", "data", "other");
+
+        Assert.IsFalse(result.IsSuccess);
+        StringAssert.Contains(result.Error, "expired");
+    }
+
+    [TestMethod]
+    public async Task EditAsync_AmbiguousMatch_Refuses_AndLeavesValueUntouched()
+    {
+        await _memory.SetAsync("session/s1/draft", "todo todo");
+
+        var result = await _memory.EditAsync("session/s1/draft", "todo", "done");
+
+        Assert.IsFalse(result.IsSuccess);
+        StringAssert.Contains(result.Error, "occurs 2 times");
+        Assert.AreEqual("todo todo", await _memory.GetAsync("session/s1/draft"));
+    }
+
+    [TestMethod]
+    public async Task EditAsync_ReplaceAll_ReplacesEveryOccurrence()
+    {
+        await _memory.SetAsync("session/s1/draft", "todo todo");
+
+        var result = await _memory.EditAsync("session/s1/draft", "todo", "done", replaceAll: true);
+
+        Assert.IsTrue(result.IsSuccess, result.Error);
+        Assert.AreEqual(2, result.ReplacementCount);
+        Assert.AreEqual("done done", await _memory.GetAsync("session/s1/draft"));
+    }
+
+    [TestMethod]
+    public async Task EditAsync_ConcurrentEdits_AllLand()
+    {
+        // Zero-padded so no marker is a prefix of another, which would read as an ambiguous edit.
+        const int markers = 12;
+        await _memory.SetAsync("session/s1/draft",
+            string.Join(" ", Enumerable.Range(0, markers).Select(i => $"M{i:D2}")));
+
+        var results = await Task.WhenAll(
+            Enumerable.Range(0, markers).Select(i => _memory.EditAsync("session/s1/draft", $"M{i:D2}", $"X{i:D2}")));
+
+        Assert.IsTrue(
+            results.All(r => r.IsSuccess),
+            string.Join("; ", results.Where(r => !r.IsSuccess).Select(r => r.Error)));
+        var value = await _memory.GetAsync("session/s1/draft");
+        for (var i = 0; i < markers; i++)
+            StringAssert.Contains(value, $"X{i:D2}");
+    }
+
     // ── List ───────────────────────────────────────────────────────────────
 
     [TestMethod]


### PR DESCRIPTION
Closes #502.

## The problem

Every memory surface was write-whole-payload. Changing one word in a long-term memory entry meant `delete_memory` + `save_memory`, which mints a new `Id`, resets `CreatedAt`/`LastSeenAt`, drops `ReinforcementCount` back to 1, and runs the replacement through the LLM extraction pass that rewrites the text anyway. The same shape applied to skills (full-body replace, summary cleared), the scheduled-task directive, working memory, and rules. A correction destroyed provenance — the same class of loss as the consolidation problem.

#504 already built the primitive for this: `TextEdit.Apply` was deliberately factored out so the remaining surfaces could reuse it, but `file_edit` is scoped to the shared volume and cannot reach anything under `/data/agent`.

## What this adds

Each surface gains an `edit_*` tool built on `TextEdit.Apply`. The whole read-modify-write cycle runs **inside the owning store's existing lock**, so a concurrent save cannot be silently discarded, and writes land atomically through a new `AtomicFile` helper.

| Tool | Preserves |
|---|---|
| `edit_memory` | `CreatedAt`, `LastSeenAt`, `ReinforcementCount`, `ImportanceScore`, `Metadata`, `SupersededBy`, `ArchivedAt`, `Category`, `Tags` — only `Content` and `UpdatedAt` move |
| `edit_working_memory` | Category and tags; TTL restarts from now reusing the entry's **original** window, so a long-lived handoff entry does not silently drop to the default |
| `edit_skill` | The summary (the save path blanks it and pays for a background LLM regeneration), plus `Manifest`, `CreatedAt`, `LastUsedAt` |
| `edit_task_directive` | Everything but the directive text; unlike `UpdateDirectiveAsync` it reports an unknown task instead of silently no-opping |
| `edit_rule` | The rule's position — remove + re-add moves it to the end and requires restating it in full |

Every new interface member is a **default interface method** returning a "not supported" `ContentEditResult`, so the ~40 store stubs across `tests/` are unaffected.

## rules.md round-trip fix

`FileRulesStore` read the file into a list of rule strings and regenerated it on every write, so any heading, prose, or blank line a human had written there was destroyed by the next `add_rule`. The file is now modelled as a document: bullets are rules, every other line is preserved verbatim in position, and a bullet keeps its original marker and indentation.

Mutations also re-read the file first. The store loads once in its constructor and has no watcher, so a `rules.md` copied to a running pod was previously clobbered by the next write.

## Guides

- Memory guide gains an "editing existing content: edit, don't rewrite" block modelled on the one #504 added for `file_edit`, plus `edit_memory` / `edit_working_memory` sections. The `delete_memory` guidance and the "delete wrong facts promptly" best practice — both of which taught delete-then-save as the correction path — are rewritten.
- Skill guide gains `edit_skill` next to `save_skill` and `edit_rule` next to `add_rule`.
- Workers keep `edit_working_memory` and `edit_rule` (as they keep the `save_*` counterparts); `edit_memory`, `edit_skill` and `edit_task_directive` join their counterparts in `ExcludedNames`.

## Tests

`dotnet build RockBot.slnx` and `dotnet test RockBot.slnx` — 2743 passed, 0 failed.

New `FileMemoryStoreEditTests` (full provenance assertion; 12 simultaneous edits must all land) and `FileRulesStoreTests` (a hand-authored `rules.md` survives `AddAsync`/`RemoveAsync` byte-for-byte apart from the bullet touched; an out-of-band edit is not clobbered), plus extensions to the working-memory, skill and scheduled-task store tests and tool-layer tests asserting refusal text reaches the model verbatim.

## Verified against the cluster

Deployed as `rockbot-agent:0.14.12` and driven through the CLI:

- `edit_memory` kept the entry's `id`, `createdAt` and `reinforcementCount` byte-identical, bumped `updatedAt`, and preserved `consolidationReviewed*` metadata a dream pass had written between the save and the edit.
- An ambiguous edit was refused with `oldText occurs 3 times…` reaching the model verbatim, and nothing written to disk.
- `edit_working_memory` persisted with `storedAt` bumped and `expiresAt` = storedAt + the original 60-minute window.
- `edit_skill` left the summary intact.
- `edit_task_directive` ran inside a real scheduled-task fire: 1 replacement, 29→27 chars, cron/description/`lastFiredAt` intact.
- A hand-authored `## Notes` section in `rules.md` survived both `add_rule` and `edit_rule`, and a bullet appended out of band showed up in the next tool call rather than being dropped.

## Known residual risk

Store-level `EditAsync` guarantees the edit applies to the latest content and lands atomically. It does **not** stop `DreamService`'s own read-modify-write cycles (consolidation merges, importance decay, contradiction sweeps) from overwriting an edit they read before it happened — those call `GetAsync` then `SaveAsync` with no compare-and-swap. Closing that needs an `expectedUpdatedAt` guard on `SaveAsync` and every dream call site updated to handle a refusal; that is a larger change. A warning log added to the memory store's write path will show whether it happens in practice. Worth a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
