### PR TITLE
Add per-tier reasoning-effort control for reasoning models

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.14.12</Version>
+<Version>0.14.13</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/deploy/helm/rockbot/templates/secret.yaml
+++ b/deploy/helm/rockbot/templates/secret.yaml
@@ -28,6 +28,9 @@ stringData:
   LLM__Balanced__ApiKey: {{ .Values.secrets.llm.balanced.apiKey | quote }}
   {{- end }}
   LLM__Balanced__ModelId: {{ required "secrets.llm.balanced.modelId is required" .Values.secrets.llm.balanced.modelId | quote }}
+  {{- if ((.Values.secrets.llm.balanced).reasoningEffort) }}
+  LLM__Balanced__ReasoningEffort: {{ .Values.secrets.llm.balanced.reasoningEffort | quote }}
+  {{- end }}
   {{- range $i, $m := .Values.secrets.llm.balancedModels }}
   {{- if $m.provider }}
   LLM__BalancedModels__{{ $i }}__Provider: {{ $m.provider | quote }}
@@ -40,6 +43,9 @@ stringData:
   {{- end }}
   {{- if $m.modelId }}
   LLM__BalancedModels__{{ $i }}__ModelId: {{ $m.modelId | quote }}
+  {{- end }}
+  {{- if $m.reasoningEffort }}
+  LLM__BalancedModels__{{ $i }}__ReasoningEffort: {{ $m.reasoningEffort | quote }}
   {{- end }}
   {{- end }}
   {{- if ((.Values.secrets.llm.low).modelId) }}
@@ -54,6 +60,9 @@ stringData:
   LLM__Low__ApiKey: {{ .Values.secrets.llm.low.apiKey | quote }}
   {{- end }}
   LLM__Low__ModelId: {{ .Values.secrets.llm.low.modelId | quote }}
+  {{- if .Values.secrets.llm.low.reasoningEffort }}
+  LLM__Low__ReasoningEffort: {{ .Values.secrets.llm.low.reasoningEffort | quote }}
+  {{- end }}
   {{- end }}
   {{- if ((.Values.secrets.llm.high).modelId) }}
   # High tier — falls back to Balanced when not configured
@@ -67,6 +76,9 @@ stringData:
   LLM__High__ApiKey: {{ .Values.secrets.llm.high.apiKey | quote }}
   {{- end }}
   LLM__High__ModelId: {{ .Values.secrets.llm.high.modelId | quote }}
+  {{- if .Values.secrets.llm.high.reasoningEffort }}
+  LLM__High__ReasoningEffort: {{ .Values.secrets.llm.high.reasoningEffort | quote }}
+  {{- end }}
   {{- end }}
   {{- if ((.Values.secrets.llm).endpoint) }}
   # Backward compat — flat keys (remove after all deployments migrated to three-tier)

--- a/deploy/helm/rockbot/values.yaml
+++ b/deploy/helm/rockbot/values.yaml
@@ -349,20 +349,29 @@ secrets:
       endpoint: ""          # REQUIRED for OpenAI-compatible — base URL of the API
       apiKey: ""            # REQUIRED for OpenAI-compatible — API key
       modelId: ""           # REQUIRED — model ID (e.g. anthropic/claude-haiku-4.5 or gpt-4.1)
+      # Reasoning-model thinking budget: minimal | low | medium | high | none.
+      # "" (default) sends no reasoning field and leaves the provider's default alone.
+      # Reasoning tokens bill as OUTPUT and count against AgentHost__MaxOutputTokens, so an
+      # uncapped reasoning model can spend most of its budget — and most of the wall-clock —
+      # thinking. Only honoured by OpenAI-compatible endpoints that accept OpenRouter's
+      # nested "reasoning" object.
+      reasoningEffort: ""
     # Ordered fallback chain for balanced tier. First entry is preferred; subsequent
     # entries are tried in order on failure. Takes precedence over single 'balanced'
-    # when populated. Each entry has: provider, endpoint, apiKey, modelId.
+    # when populated. Each entry has: provider, endpoint, apiKey, modelId, reasoningEffort.
     balancedModels: []
     low:                    # Optional — fast/cheap model for simple factual questions
       provider: ""
       endpoint: ""
       apiKey: ""
       modelId: ""
+      reasoningEffort: ""
     high:                   # Optional — powerful model for dream/research/complex tasks
       provider: ""
       endpoint: ""
       apiKey: ""
       modelId: ""           # leave empty to fall back to balanced
+      reasoningEffort: ""
 
     # Legacy flat keys — kept for backward compatibility; remove after all deployments migrated
     endpoint: ""

--- a/src/RockBot.Agent/Program.cs
+++ b/src/RockBot.Agent/Program.cs
@@ -147,6 +147,25 @@ IChatClient BuildOpenAIClient(LlmTierConfig config)
         Console.WriteLine($"    repetition_penalty={repetitionPenalty.Value} (body-injected)");
     }
 
+    // Reasoning effort is per-tier: a cheap Low tier and a deliberating High tier want
+    // different budgets even on the same model. Injected into the body for the same reason as
+    // repetition_penalty — ChatOptions cannot express OpenRouter's nested reasoning object,
+    // and the flat reasoning_effort field it *can* express is silently ignored by OpenRouter.
+    var reasoningEffort = ReasoningEffortPolicy.Normalise(config.ReasoningEffort);
+    if (reasoningEffort is not null)
+    {
+        clientOptions.AddPolicy(new ReasoningEffortPolicy(reasoningEffort),
+            PipelinePosition.PerCall);
+        Console.WriteLine($"    reasoning.effort={reasoningEffort} (body-injected)");
+    }
+    else if (!string.IsNullOrWhiteSpace(config.ReasoningEffort))
+    {
+        // Loud, because the symptom of a typo is silence: the model keeps its default
+        // reasoning budget and the only visible effect is a bill that never came down.
+        Console.WriteLine($"    WARNING: ignoring unrecognised ReasoningEffort " +
+                          $"'{config.ReasoningEffort}' (expected minimal/low/medium/high/none)");
+    }
+
     return new OpenAIClient(new ApiKeyCredential(config.ApiKey!), clientOptions)
         .GetChatClient(config.ModelId!).AsIChatClient();
 }

--- a/src/RockBot.Host.Abstractions/LlmTierOptions.cs
+++ b/src/RockBot.Host.Abstractions/LlmTierOptions.cs
@@ -16,6 +16,21 @@ public sealed class LlmTierConfig
     public string? ModelId  { get; set; }
 
     /// <summary>
+    /// How hard a reasoning model may think before answering: <c>minimal</c>, <c>low</c>,
+    /// <c>medium</c>, <c>high</c>, or <c>none</c> to disable reasoning outright. Null (the
+    /// default) sends no reasoning field at all, leaving the provider's own default in place
+    /// and keeping the request byte-identical to before this setting existed.
+    /// </summary>
+    /// <remarks>
+    /// Only meaningful for OpenAI-compatible providers that accept OpenRouter's nested
+    /// <c>reasoning</c> object; see <c>ReasoningEffortPolicy</c> for why the OpenAI-standard
+    /// <c>reasoning_effort</c> field cannot be used instead. Reasoning tokens bill as output
+    /// and count against <c>MaxOutputTokens</c>, so an uncapped reasoning model can spend most
+    /// of its output budget thinking and leave too little for the answer.
+    /// </remarks>
+    public string? ReasoningEffort { get; set; }
+
+    /// <summary>
     /// Returns true when Endpoint, ApiKey, and ModelId are all non-empty
     /// (OpenAI-compatible provider fully configured).
     /// </summary>

--- a/src/RockBot.Host/ReasoningEffortPolicy.cs
+++ b/src/RockBot.Host/ReasoningEffortPolicy.cs
@@ -1,0 +1,131 @@
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Text.Json.Nodes;
+
+namespace RockBot.Host;
+
+/// <summary>
+/// Adds OpenRouter's nested <c>reasoning</c> object to outgoing chat-completion request
+/// bodies, capping how many reasoning tokens a reasoning model spends before it answers.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Reasoning models bill reasoning tokens as output and count them against
+/// <c>max_tokens</c>, so an uncapped model can spend most of its output budget — and most of
+/// the wall-clock — thinking. Measured on <c>x-ai/grok-4.6</c> via OpenRouter, an uncapped
+/// request averaged ~2,900 reasoning tokens for a single paragraph of prose and ranged from
+/// 667 to 6,407; the same request at <c>low</c> averaged ~670 with a far tighter spread.
+/// </para>
+/// <para>
+/// <b>The OpenAI-standard <c>reasoning_effort</c> field does not work here.</b> Sending
+/// <c>reasoning_effort: "low"</c> to OpenRouter measured no reduction at all (3,899 reasoning
+/// tokens against a 2,574-token baseline on the same prompt) — it is accepted and ignored.
+/// Only the nested <c>reasoning: { effort: … }</c> object actually constrains the model, and
+/// <see cref="Microsoft.Extensions.AI.ChatOptions"/> has no way to express it. That is why
+/// this is injected into the serialised body rather than set through ChatOptions or through
+/// the OpenAI SDK's own reasoning-effort property.
+/// </para>
+/// <para>
+/// Follows <see cref="RepetitionPenaltyPolicy"/>: the body is already serialised, so the
+/// policy parses it, adds one field, and re-serialises. Requests that are not chat
+/// completions (no <c>messages</c> array), bodies that already carry a <c>reasoning</c>
+/// field, and bodies that fail to parse are all left untouched — a malformed rewrite would
+/// break the call outright, so the policy always fails open.
+/// </para>
+/// </remarks>
+public sealed class ReasoningEffortPolicy(string effort) : PipelinePolicy
+{
+    /// <summary>
+    /// Effort levels OpenRouter accepts inside the <c>reasoning</c> object. Values outside
+    /// this set are rejected at construction rather than sent, because an unrecognised effort
+    /// is a 400 from the provider on every single call.
+    /// </summary>
+    private static readonly string[] KnownEfforts = ["minimal", "low", "medium", "high"];
+
+    /// <summary>Values that mean "turn reasoning off entirely" rather than naming a level.</summary>
+    private static readonly string[] DisabledAliases = ["none", "off", "disabled", "false"];
+
+    /// <summary>
+    /// Returns the normalised effort for <paramref name="value"/>, or <see langword="null"/>
+    /// when it names no level this provider understands. Case- and whitespace-insensitive.
+    /// </summary>
+    public static string? Normalise(string? value)
+    {
+        var trimmed = value?.Trim().ToLowerInvariant();
+        if (string.IsNullOrEmpty(trimmed)) return null;
+        if (DisabledAliases.Contains(trimmed)) return "none";
+        return KnownEfforts.Contains(trimmed) ? trimmed : null;
+    }
+
+    public override void Process(
+        PipelineMessage message, IReadOnlyList<PipelinePolicy> pipeline, int currentIndex)
+    {
+        TryApply(message);
+        ProcessNext(message, pipeline, currentIndex);
+    }
+
+    public override async ValueTask ProcessAsync(
+        PipelineMessage message, IReadOnlyList<PipelinePolicy> pipeline, int currentIndex)
+    {
+        TryApply(message);
+        await ProcessNextAsync(message, pipeline, currentIndex).ConfigureAwait(false);
+    }
+
+    private void TryApply(PipelineMessage message)
+    {
+        var request = message.Request;
+        if (request?.Content is null) return;
+
+        try
+        {
+            using var buffer = new MemoryStream();
+            request.Content.WriteTo(buffer);
+
+            var rewritten = InjectInto(buffer.ToArray(), effort);
+            if (rewritten is null) return;
+
+            request.Content = BinaryContent.Create(BinaryData.FromString(rewritten));
+        }
+        catch
+        {
+            // Fail open: send the original body unmodified rather than break the request.
+        }
+    }
+
+    /// <summary>
+    /// Returns the request body with the <c>reasoning</c> object added, or
+    /// <see langword="null"/> when the body should be sent through unchanged — it is not a
+    /// chat completion, it already carries the field, or it is not a JSON object.
+    /// </summary>
+    internal static string? InjectInto(ReadOnlySpan<byte> body, string effort)
+    {
+        // Parsed defensively rather than leaning on the caller's catch: a helper that throws
+        // on malformed input is one refactor away from being called somewhere that does not
+        // fail open.
+        JsonObject? json;
+        try
+        {
+            json = JsonNode.Parse(System.Text.Encoding.UTF8.GetString(body)) as JsonObject;
+        }
+        catch (System.Text.Json.JsonException)
+        {
+            return null;
+        }
+
+        if (json is null) return null;
+
+        // Only chat completions; embeddings and other calls reject the field.
+        if (!json.ContainsKey("messages")) return null;
+
+        // An explicit value from the caller always wins.
+        if (json.ContainsKey("reasoning")) return null;
+
+        // "none" disables reasoning outright; every other value names a level. Sent as the
+        // nested object in both cases — the flat reasoning_effort field is ignored here.
+        json["reasoning"] = effort == "none"
+            ? new JsonObject { ["enabled"] = false }
+            : new JsonObject { ["effort"] = effort };
+
+        return json.ToJsonString();
+    }
+}

--- a/tests/RockBot.Host.Tests/ReasoningEffortPipelineTests.cs
+++ b/tests/RockBot.Host.Tests/ReasoningEffortPipelineTests.cs
@@ -1,0 +1,98 @@
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Text;
+using System.Text.Json.Nodes;
+using RockBot.Host;
+
+namespace RockBot.Host.Tests;
+
+/// <summary>
+/// Exercises the policy through a real <see cref="ClientPipeline"/> rather than calling the
+/// body-rewrite helper directly. The helper being correct does not prove the policy actually
+/// mutates the request that goes on the wire.
+/// </summary>
+[TestClass]
+public sealed class ReasoningEffortPipelineTests
+{
+    /// <summary>Captures the request body at the HTTP boundary — the real wire format.</summary>
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        public string? CapturedBody { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (request.Content is not null)
+                CapturedBody = await request.Content.ReadAsStringAsync(cancellationToken);
+
+            return new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+            {
+                Content = new StringContent("{}", Encoding.UTF8, "application/json")
+            };
+        }
+    }
+
+    private static async Task<string> SendThroughAsync(string effort, string body)
+    {
+        var handler = new CapturingHandler();
+        var transport = new HttpClientPipelineTransport(new HttpClient(handler));
+        var options = new ClientPipelineOptions { Transport = transport };
+        options.AddPolicy(new ReasoningEffortPolicy(effort), PipelinePosition.PerCall);
+
+        var pipeline = ClientPipeline.Create(options);
+        var message = pipeline.CreateMessage();
+        message.Request.Method = "POST";
+        message.Request.Uri = new Uri("https://example.test/v1/chat/completions");
+        message.Request.Content = BinaryContent.Create(BinaryData.FromString(body));
+
+        await pipeline.SendAsync(message);
+        return handler.CapturedBody!;
+    }
+
+    [TestMethod]
+    public async Task Policy_RewritesTheBodyThatReachesTheTransport()
+    {
+        var sent = await SendThroughAsync("low",
+            """{"model":"x-ai/grok-4.6","temperature":0.95,"messages":[{"role":"user","content":"hi"}]}""");
+
+        var json = JsonNode.Parse(sent)!.AsObject();
+        Assert.IsTrue(json.ContainsKey("reasoning"),
+            $"reasoning missing from body actually sent: {sent}");
+        Assert.AreEqual("low", json["reasoning"]!["effort"]!.GetValue<string>());
+        Assert.AreEqual(0.95f, (float)json["temperature"]!);
+    }
+
+    [TestMethod]
+    public async Task Policy_LeavesNonChatBodiesAlone()
+    {
+        var sent = await SendThroughAsync("low", """{"model":"m","input":"text"}""");
+
+        Assert.IsFalse(JsonNode.Parse(sent)!.AsObject().ContainsKey("reasoning"));
+    }
+
+    [TestMethod]
+    public async Task Policy_CoexistsWithRepetitionPenalty()
+    {
+        // Both policies rewrite the same body; the second must not drop the first's field.
+        var handler = new CapturingHandler();
+        var options = new ClientPipelineOptions
+        {
+            Transport = new HttpClientPipelineTransport(new HttpClient(handler))
+        };
+        options.AddPolicy(new RepetitionPenaltyPolicy(1.1f), PipelinePosition.PerCall);
+        options.AddPolicy(new ReasoningEffortPolicy("low"), PipelinePosition.PerCall);
+
+        var pipeline = ClientPipeline.Create(options);
+        var message = pipeline.CreateMessage();
+        message.Request.Method = "POST";
+        message.Request.Uri = new Uri("https://example.test/v1/chat/completions");
+        message.Request.Content = BinaryContent.Create(BinaryData.FromString(
+            """{"model":"m","messages":[{"role":"user","content":"hi"}]}"""));
+
+        await pipeline.SendAsync(message);
+
+        var json = JsonNode.Parse(handler.CapturedBody!)!.AsObject();
+        Assert.AreEqual(1.1f, (float)json["repetition_penalty"]!);
+        Assert.AreEqual("low", json["reasoning"]!["effort"]!.GetValue<string>());
+    }
+}

--- a/tests/RockBot.Host.Tests/ReasoningEffortPolicyTests.cs
+++ b/tests/RockBot.Host.Tests/ReasoningEffortPolicyTests.cs
@@ -1,0 +1,90 @@
+using System.Text;
+using System.Text.Json.Nodes;
+using RockBot.Host;
+
+namespace RockBot.Host.Tests;
+
+/// <summary>
+/// Covers the body-rewrite helper. The wire-level behaviour is covered separately by
+/// <see cref="ReasoningEffortPipelineTests"/>.
+/// </summary>
+[TestClass]
+public sealed class ReasoningEffortPolicyTests
+{
+    private static string? Inject(string body, string effort) =>
+        ReasoningEffortPolicy.InjectInto(Encoding.UTF8.GetBytes(body), effort);
+
+    private const string ChatBody = """{"model":"x-ai/grok-4.6","messages":[{"role":"user","content":"hi"}]}""";
+
+    [TestMethod]
+    public void InjectInto_AddsNestedReasoningObject_NotFlatReasoningEffort()
+    {
+        // The whole reason this policy exists: OpenRouter accepts and ignores the flat
+        // reasoning_effort field, so emitting it instead would be a silent no-op.
+        var json = (JsonObject)JsonNode.Parse(Inject(ChatBody, "low")!)!;
+
+        Assert.IsFalse(json.ContainsKey("reasoning_effort"),
+            "flat reasoning_effort is ignored by OpenRouter and must not be sent");
+        Assert.AreEqual("low", json["reasoning"]!["effort"]!.GetValue<string>());
+    }
+
+    [TestMethod]
+    public void InjectInto_None_DisablesReasoningRatherThanNamingALevel()
+    {
+        var json = (JsonObject)JsonNode.Parse(Inject(ChatBody, "none")!)!;
+
+        Assert.IsFalse(json["reasoning"]!.AsObject().ContainsKey("effort"));
+        Assert.IsFalse(json["reasoning"]!["enabled"]!.GetValue<bool>());
+    }
+
+    [TestMethod]
+    public void InjectInto_PreservesExistingBodyFields()
+    {
+        var json = (JsonObject)JsonNode.Parse(Inject(ChatBody, "high")!)!;
+
+        Assert.AreEqual("x-ai/grok-4.6", json["model"]!.GetValue<string>());
+        Assert.AreEqual(1, json["messages"]!.AsArray().Count);
+    }
+
+    [TestMethod]
+    public void InjectInto_ReturnsNull_ForNonChatCompletionBody()
+    {
+        // Embeddings and other calls share the pipeline and reject the field.
+        Assert.IsNull(Inject("""{"model":"nomic-embed-text","input":"hi"}""", "low"));
+    }
+
+    [TestMethod]
+    public void InjectInto_ReturnsNull_WhenCallerAlreadySetReasoning()
+    {
+        Assert.IsNull(Inject(
+            """{"messages":[],"reasoning":{"effort":"high"}}""", "low"));
+    }
+
+    [TestMethod]
+    public void InjectInto_ReturnsNull_ForUnparseableOrNonObjectBody()
+    {
+        Assert.IsNull(Inject("not json at all", "low"));
+        Assert.IsNull(Inject("[1,2,3]", "low"));
+    }
+
+    [DataTestMethod]
+    [DataRow("low", "low")]
+    [DataRow("  HIGH  ", "high")]
+    [DataRow("Medium", "medium")]
+    [DataRow("minimal", "minimal")]
+    [DataRow("none", "none")]
+    [DataRow("off", "none")]
+    [DataRow("Disabled", "none")]
+    public void Normalise_AcceptsKnownLevelsCaseAndWhitespaceInsensitively(string input, string expected)
+        => Assert.AreEqual(expected, ReasoningEffortPolicy.Normalise(input));
+
+    [DataTestMethod]
+    [DataRow(null)]
+    [DataRow("")]
+    [DataRow("   ")]
+    [DataRow("lowest")]
+    [DataRow("verbose")]
+    [DataRow("2")]
+    public void Normalise_RejectsUnknownValues_SoTyposDoNot400EveryCall(string? input)
+        => Assert.IsNull(ReasoningEffortPolicy.Normalise(input));
+}


### PR DESCRIPTION
## Why

Reasoning models bill reasoning tokens as **output** and count them against `max_tokens`, so an uncapped model can spend most of its output budget — and most of the wall-clock — thinking before it writes anything. RockBot had no way to constrain that.

This surfaced on a live deployment that moved `x-ai/grok-4.3` → `x-ai/grok-4.6`:

| | grok-4.3 | grok-4.6 |
|---|---|---|
| median input tokens | 23,996 | 23,635 |
| median **output** tokens | **874** | **5,725** |

Input unchanged, output up **6.6×** — essentially all of it reasoning. Cost went to **2.9×** rather than the 1.7× the price sheet implies, replies got visibly slower, and output landed within 17% of the configured `MaxOutputTokens` cap, where reasoning starts truncating the actual answer.

## The non-obvious part

**The OpenAI-standard `reasoning_effort` field does not work against OpenRouter — it is accepted and ignored.** Measured on the same prompt:

| request | reasoning tokens |
|---|---|
| baseline (no param) | 2,574 |
| `reasoning_effort: "low"` | **3,899** (no reduction) |
| `reasoning: {effort: "low"}` | **441** |

Repeated sampling: uncapped averages ~2,900 and ranges 667–6,407; `low` averages ~670 with a far tighter spread.

So `ChatCompletionOptions.ReasoningEffortLevel` — the obvious implementation — would have been a silent no-op. Only the nested `reasoning: { effort: … }` object constrains the model, and `ChatOptions` has no way to express it.

## What this does

Follows the existing `RepetitionPenaltyPolicy` pattern: the body is already serialised, so a `PipelinePolicy` parses it, adds one field, and re-serialises.

- Adds `LlmTierConfig.ReasoningEffort` — `minimal` / `low` / `medium` / `high` / `none`. **Per-tier**, because a cheap Low tier and a deliberating High tier want different budgets even on the same model.
- Unset sends no reasoning field at all, so request bodies stay **byte-identical** for anyone who does not set it.
- Unrecognised values are rejected at construction and logged loudly rather than sent — the symptom of a typo is otherwise silence: the model keeps its default budget and the only visible effect is a bill that never comes down.
- Fails open on any body it cannot rewrite; skips non-chat-completion bodies (embeddings share the pipeline and reject the field).
- Helm: `secrets.llm.<tier>.reasoningEffort`, including the `balancedModels` fallback chain.

## Testing

22 new tests across two files — the body-rewrite helper plus wire-level tests through a real `ClientPipeline` with a capturing transport, since the helper being correct does not prove the policy mutates what actually goes out. Includes a test asserting the flat `reasoning_effort` field is **not** emitted, and one covering coexistence with `RepetitionPenaltyPolicy` (both rewrite the same body).

Full suite: **2,743 passed, 0 failed**.

Verified in production on the deployment above — `reasoning.effort=low (body-injected)` at startup, agent healthy on `0.14.13`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)