### PR TITLE
Identify RockBot to OpenRouter instead of reporting as "unknown"

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ Each tier can use a different LLM **provider** — mix and match within the same
 
 Set a global default provider (`LLM:Provider`) and override per tier (`LLM:Low:Provider`, `LLM:Balanced:Provider`, `LLM:High:Provider`). For example: Low on Copilot, Balanced on Azure Foundry, High on OpenRouter.
 
+**OpenRouter app attribution.** OpenRouter identifies the calling app from two self-reported headers, and reports activity as "unknown" without them. `LLM:AppName` (default `rockbot`) sets `X-Title`, the display name; `LLM:AppUrl` (default `https://rockbot.dev`) sets `HTTP-Referer`, which is the key OpenRouter *groups* activity by — keep it stable, since changing it starts a fresh app with no history. Give each deployment sharing an OpenRouter account its own `LLM:AppName` to keep their spend separable. The headers are sent to OpenRouter endpoints only; every other OpenAI-compatible endpoint sees an unchanged request.
+
 Tier selection uses `KeywordTierSelector` — a lightweight keyword + prompt-length heuristic with no external calls. The thresholds and keyword lists are hot-reloadable from `tier-selector.json` on the PVC without a pod restart. A background dream pass (`TierRoutingReviewPass`) periodically reviews routing decisions logged in `tier-routing-log.jsonl` and rewrites `tier-selector.json` if it detects systematic mis-routing.
 
 ### Model-specific behaviors

--- a/deploy/helm/rockbot/templates/configmap.yaml
+++ b/deploy/helm/rockbot/templates/configmap.yaml
@@ -38,6 +38,16 @@ data:
   Dream__LogRetentionMaxFileAge: {{ dig "maxFileAge" "30.00:00:00" $logRetention | quote }}
   Dream__LogRetentionMaxFilesPerDirectory: {{ dig "maxFilesPerDirectory" 1000 $logRetention | quote }}
   Dream__LogRetentionMaxLinesPerFile: {{ dig "maxLinesPerFile" 10000 $logRetention | quote }}
+  # ── OpenRouter app attribution (non-secret) ───────────────────────────────
+  # Sent as the HTTP-Referer / X-Title headers on OpenRouter calls only, so the
+  # account's activity dashboard shows this release by name instead of "unknown".
+  # AppUrl is the grouping key on OpenRouter's side — changing it splits an app's
+  # history in two, so override appName per release and leave appUrl alone.
+  # `dig` so a --reuse-values upgrade with no llm block still gets the defaults.
+  {{- $llm := .Values.llm | default dict }}
+  LLM__AppName: {{ dig "appName" "rockbot" $llm | quote }}
+  LLM__AppUrl: {{ dig "appUrl" "https://rockbot.dev" $llm | quote }}
+
   Skill__BasePath: "/data/agent/skills"
   McpBridge__ConfigPath: "/data/agent/mcp.json"
   LlmPricing__ConfigPath: "/data/agent/llm-pricing.json"

--- a/deploy/helm/rockbot/values.yaml
+++ b/deploy/helm/rockbot/values.yaml
@@ -326,6 +326,19 @@ todoappMcp:
 # create: false → Provide existingSecretName pointing to a pre-existing Secret.
 #                  The Secret must contain all keys listed under stringData in
 #                  templates/secret.yaml.
+# ── OpenRouter app attribution (non-secret) ──────────────────────────────────
+# OpenRouter attributes activity purely from two self-reported headers. With them
+# unset, every call this agent makes lands under "unknown" on the account's
+# activity dashboard. The headers are sent to OpenRouter endpoints only.
+llm:
+  # Display name (X-Title). Override per release so two agents sharing one
+  # OpenRouter account report separately — e.g. appName: muse.
+  appName: rockbot
+  # Identity key (HTTP-Referer) and the link shown on openrouter.ai/rankings.
+  # OpenRouter groups by this value, so changing it starts a new app with no
+  # history. Keep it stable; distinguish releases with appName instead.
+  appUrl: https://rockbot.dev
+
 secrets:
   create: true
   existingSecretName: ""   # used only when create: false

--- a/src/RockBot.Agent/Program.cs
+++ b/src/RockBot.Agent/Program.cs
@@ -147,6 +147,21 @@ IChatClient BuildOpenAIClient(LlmTierConfig config)
         Console.WriteLine($"    repetition_penalty={repetitionPenalty.Value} (body-injected)");
     }
 
+    // OpenRouter attributes spend to whatever app the client names in its headers; without
+    // them every call shows up as "unknown" on the activity dashboard. Registered only for
+    // OpenRouter endpoints so the app name is not disclosed to unrelated providers.
+    if (OpenRouterAttributionPolicy.IsOpenRouterEndpoint(config.Endpoint))
+    {
+        var appName = builder.Configuration["LLM:AppName"] is { Length: > 0 } n
+            ? n : OpenRouterAttributionPolicy.DefaultAppName;
+        var appUrl = builder.Configuration["LLM:AppUrl"] is { Length: > 0 } u
+            ? u : OpenRouterAttributionPolicy.DefaultAppUrl;
+
+        clientOptions.AddPolicy(
+            new OpenRouterAttributionPolicy(appName, appUrl), PipelinePosition.PerCall);
+        Console.WriteLine($"    OpenRouter attribution: {appName} <{appUrl}>");
+    }
+
     return new OpenAIClient(new ApiKeyCredential(config.ApiKey!), clientOptions)
         .GetChatClient(config.ModelId!).AsIChatClient();
 }

--- a/src/RockBot.Host/OpenRouterAttributionPolicy.cs
+++ b/src/RockBot.Host/OpenRouterAttributionPolicy.cs
@@ -1,0 +1,84 @@
+using System.ClientModel.Primitives;
+
+namespace RockBot.Host;
+
+/// <summary>
+/// Stamps outgoing requests with the OpenRouter app-attribution headers so the account's
+/// activity dashboard and public rankings show this agent by name instead of "unknown".
+/// </summary>
+/// <remarks>
+/// <para>
+/// OpenRouter attributes a request to an app purely from two self-reported headers:
+/// <c>HTTP-Referer</c> (the identity key it groups activity by) and <c>X-Title</c> (the
+/// display name). Neither is authenticated and neither has an equivalent on
+/// <see cref="Microsoft.Extensions.AI.ChatOptions"/> or <c>OpenAIClientOptions</c>, so — as
+/// with <see cref="RepetitionPenaltyPolicy"/> — the pipeline is the only place to add them.
+/// Note the header is OpenRouter's custom <c>HTTP-Referer</c> spelling, not the standard
+/// <c>Referer</c>; sending the latter attributes nothing.
+/// </para>
+/// <para>
+/// Registration is gated on <see cref="IsOpenRouterEndpoint"/> at the call site so the app
+/// name is only disclosed to the provider that asked for it. Every other OpenAI-compatible
+/// endpoint — Ollama, Foundry, a local llama.cpp — sees a byte-identical request to before.
+/// </para>
+/// </remarks>
+public sealed class OpenRouterAttributionPolicy(string appName, string appUrl) : PipelinePolicy
+{
+    /// <summary>Name reported when <c>LLM:AppName</c> is unset.</summary>
+    public const string DefaultAppName = "rockbot";
+
+    /// <summary>Referer reported when <c>LLM:AppUrl</c> is unset.</summary>
+    public const string DefaultAppUrl = "https://rockbot.dev";
+
+    /// <summary>OpenRouter's identity key. Grouping on the dashboard is by this value.</summary>
+    private const string RefererHeader = "HTTP-Referer";
+
+    /// <summary>Display name shown alongside the referer in the OpenRouter UI.</summary>
+    private const string TitleHeader = "X-Title";
+
+    public override void Process(
+        PipelineMessage message, IReadOnlyList<PipelinePolicy> pipeline, int currentIndex)
+    {
+        Apply(message);
+        ProcessNext(message, pipeline, currentIndex);
+    }
+
+    public override async ValueTask ProcessAsync(
+        PipelineMessage message, IReadOnlyList<PipelinePolicy> pipeline, int currentIndex)
+    {
+        Apply(message);
+        await ProcessNextAsync(message, pipeline, currentIndex).ConfigureAwait(false);
+    }
+
+    private void Apply(PipelineMessage message)
+    {
+        var request = message.Request;
+        if (request is null) return;
+
+        // Set, not Add: a retried message runs the per-call pipeline again, and Add would
+        // append a second value rather than replace the existing one.
+        request.Headers.Set(RefererHeader, appUrl);
+        request.Headers.Set(TitleHeader, appName);
+    }
+
+    /// <summary>
+    /// True when <paramref name="endpoint"/> is served by OpenRouter, i.e. the host is
+    /// <c>openrouter.ai</c> or a subdomain of it.
+    /// </summary>
+    /// <remarks>
+    /// Matched on the host rather than a substring of the whole URL so that a path or query
+    /// mentioning openrouter — a proxy at <c>https://gateway.internal/openrouter/v1</c> — is
+    /// not mistaken for the real thing. A deliberate proxy in front of OpenRouter therefore
+    /// needs the headers forwarded by the proxy, or this predicate widened.
+    /// </remarks>
+    public static bool IsOpenRouterEndpoint(string? endpoint)
+        => Uri.TryCreate(endpoint, UriKind.Absolute, out var uri) && IsOpenRouterEndpoint(uri);
+
+    /// <inheritdoc cref="IsOpenRouterEndpoint(string?)"/>
+    public static bool IsOpenRouterEndpoint(Uri uri)
+    {
+        var host = uri.Host;
+        return host.Equals("openrouter.ai", StringComparison.OrdinalIgnoreCase)
+            || host.EndsWith(".openrouter.ai", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/tests/RockBot.Host.Tests/OpenRouterAttributionPolicyTests.cs
+++ b/tests/RockBot.Host.Tests/OpenRouterAttributionPolicyTests.cs
@@ -1,0 +1,114 @@
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Text;
+using RockBot.Host;
+
+namespace RockBot.Host.Tests;
+
+/// <summary>
+/// Exercises the attribution policy through a real <see cref="ClientPipeline"/>. The headers
+/// only matter if they survive to the HTTP boundary, so they are asserted on the
+/// <see cref="HttpRequestMessage"/> the transport actually sends rather than on the
+/// <see cref="PipelineRequest"/> the policy touched.
+/// </summary>
+[TestClass]
+public sealed class OpenRouterAttributionPolicyTests
+{
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        public HttpRequestMessage? Captured { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Captured = request;
+            return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+            {
+                Content = new StringContent("{}", Encoding.UTF8, "application/json")
+            });
+        }
+    }
+
+    private static async Task<HttpRequestMessage> SendThroughAsync(
+        params OpenRouterAttributionPolicy[] policies)
+    {
+        var handler = new CapturingHandler();
+        var options = new ClientPipelineOptions
+        {
+            Transport = new HttpClientPipelineTransport(new HttpClient(handler))
+        };
+        foreach (var policy in policies)
+            options.AddPolicy(policy, PipelinePosition.PerCall);
+
+        var pipeline = ClientPipeline.Create(options);
+        var message = pipeline.CreateMessage();
+        message.Request.Method = "POST";
+        message.Request.Uri = new Uri("https://openrouter.ai/api/v1/chat/completions");
+        message.Request.Content = BinaryContent.Create(
+            BinaryData.FromString("""{"model":"m","messages":[]}"""));
+
+        await pipeline.SendAsync(message);
+        return handler.Captured!;
+    }
+
+    private static string? HeaderValue(HttpRequestMessage request, string name)
+        => request.Headers.TryGetValues(name, out var values)
+            ? string.Join(",", values)
+            : null;
+
+    [TestMethod]
+    public async Task Policy_StampsBothAttributionHeadersOnTheWire()
+    {
+        var sent = await SendThroughAsync(
+            new OpenRouterAttributionPolicy("muse", "https://example.test/muse"));
+
+        Assert.AreEqual("https://example.test/muse", HeaderValue(sent, "HTTP-Referer"));
+        Assert.AreEqual("muse", HeaderValue(sent, "X-Title"));
+    }
+
+    [TestMethod]
+    public async Task Policy_DoesNotSendTheStandardRefererSpelling()
+    {
+        // OpenRouter reads HTTP-Referer specifically; sending Referer instead attributes
+        // nothing, so a future "fix" that normalises the name would silently regress.
+        var sent = await SendThroughAsync(
+            new OpenRouterAttributionPolicy("rockbot", "https://example.test"));
+
+        Assert.IsNull(sent.Headers.Referrer);
+    }
+
+    [TestMethod]
+    public async Task Policy_ReplacesRatherThanAppendsWhenAppliedTwice()
+    {
+        // A retry re-runs the per-call pipeline over the same message. Add() would leave
+        // "a,b" in the header and OpenRouter would attribute to neither app.
+        var sent = await SendThroughAsync(
+            new OpenRouterAttributionPolicy("first", "https://first.test"),
+            new OpenRouterAttributionPolicy("second", "https://second.test"));
+
+        Assert.AreEqual("second", HeaderValue(sent, "X-Title"));
+        Assert.AreEqual("https://second.test", HeaderValue(sent, "HTTP-Referer"));
+    }
+
+    [TestMethod]
+    [DataRow("https://openrouter.ai/api/v1", true)]
+    [DataRow("https://OpenRouter.AI/api/v1", true)]
+    [DataRow("https://sub.openrouter.ai/api/v1", true)]
+    [DataRow("http://ollama.default.svc.cluster.local:11434/v1", false)]
+    [DataRow("https://rocky-ml1nznjr-eastus2.openai.azure.com/openai/v1", false)]
+    // Host match, not substring: a proxy that merely mentions openrouter in its path is a
+    // different server and must not be handed the app identity.
+    [DataRow("https://gateway.internal/openrouter/v1", false)]
+    [DataRow("https://openrouter.ai.evil.test/v1", false)]
+    [DataRow("not a url", false)]
+    [DataRow(null, false)]
+    public void IsOpenRouterEndpoint_MatchesOnHostOnly(string? endpoint, bool expected)
+        => Assert.AreEqual(expected, OpenRouterAttributionPolicy.IsOpenRouterEndpoint(endpoint));
+
+    [TestMethod]
+    public void Defaults_AreTheDocumentedFallbacks()
+    {
+        Assert.AreEqual("rockbot", OpenRouterAttributionPolicy.DefaultAppName);
+        Assert.AreEqual("https://rockbot.dev", OpenRouterAttributionPolicy.DefaultAppUrl);
+    }
+}


### PR DESCRIPTION
## Problem

OpenRouter attributes activity purely from two self-reported headers on each request: `HTTP-Referer`, which it **groups by**, and `X-Title`, the display name. The chat path builds a stock `OpenAIClient` (`src/RockBot.Agent/Program.cs`) with neither, so every token we spend shows up on the account's activity dashboard as "unknown".

`src/McpServer.OpenRouter/Services/OpenRouterClient.cs` already sends `HTTP-Referer`, but that client only makes admin GETs (credits, key info) — none of the inference traffic. Hence spend being anonymous while the MCP server is attributed.

## Approach

Neither header has a `ChatOptions` or `OpenAIClientOptions` equivalent, so this uses the same pipeline-policy hook `repetition_penalty` already relies on — a new `OpenRouterAttributionPolicy` in `RockBot.Host`, registered `PerCall` alongside `RepetitionPenaltyPolicy`.

Headers are set with `Set`, not `Add`: a retried message re-runs the per-call pipeline, and `Add` would leave `"a,b"` in the header, attributing to neither app.

## Scoping

Registration is gated on the endpoint host being `openrouter.ai` (or a subdomain), so the app identity is disclosed only to the provider that asked for it. Ollama, Foundry, and local llama.cpp endpoints see byte-identical requests to before.

Matching is on the **host**, not a substring of the URL — a proxy at `https://gateway.internal/openrouter/v1` deliberately does not match. A real proxy in front of OpenRouter would need the headers forwarded, or the predicate widened; noted in the XML docs.

## Configuration

| Key | Header | Default |
|---|---|---|
| `LLM:AppName` | `X-Title` | `rockbot` |
| `LLM:AppUrl` | `HTTP-Referer` | `https://rockbot.dev` |

Exposed as `llm.appName` / `llm.appUrl` in the chart and rendered into the **ConfigMap** — they're non-secret, so they sit with the other non-secret config rather than in the Secret alongside the API keys.

`AppName` is the per-release knob: deployments sharing one OpenRouter account (e.g. a second release such as muse) set their own name so spend stays separable. `AppUrl` is the grouping key on OpenRouter's side — changing it starts a fresh app with no history, so it's meant to stay constant across releases.

The template uses the `dig` pattern already established by `logRetention`, so a `--reuse-values` upgrade carrying no `llm` block still picks up the defaults rather than rendering empty. Verified across three render cases: defaults, `--set llm.appName=muse`, and the block absent entirely.

## Testing

13 new tests in `tests/RockBot.Host.Tests/OpenRouterAttributionPolicyTests.cs`, asserting on the `HttpRequestMessage` that actually reaches the transport rather than on the `PipelineRequest` the policy touched — mirroring `RepetitionPenaltyPipelineTests`. Covers both headers on the wire, the replace-not-append behaviour, a guard that we don't silently "fix" the spelling to the standard `Referer` (which attributes nothing), and the host-matching table including the proxy and `openrouter.ai.evil.test` cases.

Full `RockBot.Host.Tests` suite green: 1239 passed, 0 failed.

## Deployment note

These land in the ConfigMap, which the agent reads via `envFrom` — env is snapshotted at pod start, so picking up a name change needs a rollout, not just a `helm upgrade`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEdUUPpS68uvoTXeBksUWo