### PR TITLE
Cut merge-coverage false rejections with position scoping and date equivalence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,8 @@ deploy/docker-compose/.env
 deploy/docker-compose/agent.extra.env
 # Compose agent runtime data (profile, memory, transcripts) — local only, never commit
 deploy/docker-compose/agent-data/
+# Same three, for every per-stack compose subdirectory (local-llm, etc.). The patterns
+# above are anchored one level up and did not cover them.
+deploy/docker-compose/*/.env
+deploy/docker-compose/*/agent.extra.env
+deploy/docker-compose/*/agent-data/

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.14.12</Version>
+<Version>0.14.13</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/docs/dream-service.md
+++ b/docs/dream-service.md
@@ -162,8 +162,45 @@ re-read at the top of every cycle:
 built-in generic-English baseline and takes precedence over it — this matters most for agents
 whose people or characters collide with ordinary English. The baseline contains `may`, `will`,
 `some`, `first` and `last`, so a storytelling agent with a character named **May** or **Will**
-must list them here or those names carry no coverage protection at all. A malformed file falls
-back to the baseline with a warning; coverage checking is never disabled by bad config.
+should list them here. A malformed file falls back to the baseline with a warning; coverage
+checking is never disabled by bad config.
+
+**The two lists are scoped differently, on purpose.** A capitalized word is only evidence of a
+proper noun when it is *not* sentence-initial, so:
+
+| | Sentence-initial | Mid-sentence |
+|---|---|---|
+| Built-in baseline | applies | **does not apply** |
+| `extraCommonWords` | applies | applies |
+| `alwaysSpecificWords` | wins over both | wins over both |
+
+The baseline is generic English that no operator chose, so applying it mid-phrase is what would
+strip a character named May of protection, and what made `Personal`, `Class`, `Benefit` and
+`Extended` too dangerous to add despite reading as noise — they name real things in *OneDrive
+Personal*, *Blazor Online Class* and *MVP Azure Extended Benefit*. Position-scoping the baseline
+protects those automatically and makes it safe to extend, which is why openers like `valid`,
+`direct`, `alternative` and `through` are now in it.
+
+`extraCommonWords` is the opposite: an explicit, corpus-specific judgement, so it applies in
+every position. That is what lets a deployment suppress framing noise such as `Rocky`, which
+appears mid-sentence (*"in Rocky's environment, calendar-mcp requires…"*) far more often than
+not. The tradeoff is real — a word added here loses protection everywhere — so the guidance to
+be conservative still stands. A name that must never be dropped goes in `alwaysSpecificWords`.
+
+**Equivalent date spellings.** A month name is credited when the merged text carries the same
+date numerically — source *"August 19, 2026"*, merge *"2026-08-19"* — and vice versa. This was
+the single largest source of false rejections on a live corpus: `August` alone accounted for 13
+of 70 rejections across eight cycles, every one a merge that normalized the date and kept the
+day and year intact. Two guards keep it narrow: the month must appear adjacent to a day or year
+*in the source* (so a person or release named August is never credited), and when the source's
+date carries a year the numeric date must carry the same one. A merge that drops the date in
+both spellings is still rejected.
+
+Note the shape of both fixes: they widen what counts as *covering* a specific rather than
+removing the requirement. Adding a word to a common list unprotects it everywhere, permanently;
+an equivalence can only be satisfied by an equivalent form actually being present. Prefer the
+latter — a false rejection is not one wasted merge but a duplicate cluster that re-proposes and
+re-fails every cycle, one of which was observed rejected five times in eight cycles.
 
 The check is deliberately biased toward rejection, because the costs are asymmetric: a false
 rejection leaves a duplicate pair alive for another cycle, while a false acceptance destroys

--- a/src/RockBot.Agent/agent/merge-coverage-vocabulary.json
+++ b/src/RockBot.Agent/agent/merge-coverage-vocabulary.json
@@ -4,16 +4,31 @@
   //
   // The check requires every proper noun, acronym and multi-digit number in a merge's sources
   // to survive into the merged text. Words listed as "common" are exempt from that requirement.
-  // A built-in generic-English list is always applied; this file layers on top of it.
+  // A built-in generic-English list is layered under this file.
+  //
+  // POSITION MATTERS. Capitalization only signals a proper noun when it is not sentence-initial,
+  // so the built-in baseline is consulted ONLY at a sentence start. Mid-sentence, a capitalized
+  // word is a specific no matter what the baseline says -- which is why "OneDrive Personal" and
+  // "Blazor Online Class" are protected without listing anything here. "extraCommonWords" below
+  // is different: it is your explicit judgement about your own corpus, so it applies EVERYWHERE.
+  //
+  // Month names need no entry. "August 19, 2026" and "2026-08-19" are recognised as the same
+  // date, so a merge that only re-spells one is credited -- while a bare "August" outside a date
+  // expression stays fully protected.
   //
   // Re-read at the top of every dream cycle — no restart needed. If this file is malformed the
   // built-in list is used and a warning is logged; coverage checking is never disabled.
 
-  // Words to ALSO ignore. Add domain noise that keeps triggering rejections you judge to be
-  // false. Be conservative: a false rejection only costs a duplicate surviving another cycle,
-  // whereas suppressing a real name lets it be deleted silently. Do not add a word that could
-  // ever name something — "Personal", "Class" and "Benefit" look generic but carry meaning in
-  // "OneDrive Personal", "Blazor Online Class" and "MVP Azure Extended Benefit".
+  // Words to ALSO ignore, in EVERY position. Add domain noise that keeps triggering rejections
+  // you judge to be false. Be conservative: suppressing a real name lets it be deleted silently.
+  // Do not add a word that could ever name something — "Personal", "Class" and "Benefit" look
+  // generic but carry meaning in "OneDrive Personal", "Blazor Online Class" and "MVP Azure
+  // Extended Benefit". Those need no entry anyway: mid-sentence they are already protected.
+  //
+  // Words that are only noise when they OPEN a sentence ("Valid email-capable IDs include…")
+  // usually need no entry either — the generic-English baseline covers that position and now
+  // includes valid/direct/alternative/through/multiple/relevant/existing and similar. Add here
+  // only what is noise mid-phrase too, and prefer alwaysSpecificWords for anything load-bearing.
   "extraCommonWords": [],
 
   // Words to ALWAYS treat as specifics, overriding the built-in list.

--- a/src/RockBot.Host/DateEquivalence.cs
+++ b/src/RockBot.Host/DateEquivalence.cs
@@ -1,0 +1,163 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace RockBot.Host;
+
+/// <summary>
+/// Credits a merge for re-spelling a date rather than dropping it — "August 19, 2026" merged
+/// as "2026-08-19", or the reverse.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This was the single largest source of false rejections on a live corpus: "August" alone
+/// accounted for 13 of 70 rejections in eight dream cycles, every one of them a merge that
+/// normalized a written date into ISO form and kept the day and year intact. Because a
+/// rejected merge is re-proposed on the next cycle, each of those was a duplicate cluster
+/// pinned open indefinitely.
+/// </para>
+/// <para>
+/// The safe way to fix this is not to add month names to the common-word list. That would
+/// unprotect "August" everywhere and forever — including a person named August, a release
+/// named August, or a merge that genuinely drops the month. Instead the month stays a required
+/// specific and gains one extra way to be satisfied: an equivalent numeric date being present
+/// in the merged text. A merge that drops the date in both spellings still fails.
+/// </para>
+/// <para>
+/// Two guards keep the equivalence narrow:
+/// </para>
+/// <list type="bullet">
+/// <item>
+/// The month must appear in a date expression <em>in the source</em> — adjacent to a day or a
+/// year. A bare "August" with no date around it is not a date and is never credited.
+/// </item>
+/// <item>
+/// When the source's date expression carries a year, the numeric date in the merged text must
+/// carry the same one, so "August 2026" is not satisfied by an unrelated "2025-08-04".
+/// </item>
+/// </list>
+/// </remarks>
+internal static partial class DateEquivalence
+{
+    /// <summary>
+    /// A month name sitting in a date expression: preceded by a day, or followed by a day
+    /// and/or a year. At least one of those groups must match for the occurrence to count.
+    /// Full names precede their abbreviations so the alternation prefers the longer form.
+    /// </summary>
+    [GeneratedRegex(
+        @"\b(?:(?<d1>\d{1,2})(?:st|nd|rd|th)?\s*,?\s*)?"
+        + @"(?<mon>January|February|March|April|May|June|July|August|September|October|"
+        + @"November|December|Jan|Feb|Mar|Apr|Jun|Jul|Aug|Sept|Sep|Oct|Nov|Dec)\.?"
+        + @"(?:\s*,?\s*(?<d2>\d{1,2})(?:st|nd|rd|th)?)?"
+        + @"(?:\s*,?\s*(?<y>\d{4}))?\b",
+        RegexOptions.IgnoreCase)]
+    private static partial Regex MonthDateExpression();
+
+    /// <summary>Year-first numeric dates: 2026-08-19, 2026/08/19.</summary>
+    [GeneratedRegex(@"\b(?<y>\d{4})[-/](?<m>\d{1,2})[-/](?<d>\d{1,2})\b")]
+    private static partial Regex IsoNumericDate();
+
+    /// <summary>Month-first numeric dates: 08/19/2026.</summary>
+    [GeneratedRegex(@"\b(?<m>\d{1,2})/(?<d>\d{1,2})/(?<y>\d{4})\b")]
+    private static partial Regex SlashNumericDate();
+
+    /// <summary>
+    /// True when <paramref name="specific"/> is a date component that survived into
+    /// <paramref name="merged"/> under a different spelling.
+    /// </summary>
+    /// <param name="specific">The required specific that failed the plain substring test.</param>
+    /// <param name="sourceText">Combined text of the merge's sources, used to guard the equivalence.</param>
+    /// <param name="merged">The proposed merged content.</param>
+    internal static bool IsCoveredByEquivalentDate(string specific, string sourceText, string merged)
+        => MonthNameCoveredByNumericDate(specific, sourceText, merged)
+        || NumericDateCoveredByMonthName(specific, merged);
+
+    /// <summary>"August" in the source, "2026-08-19" in the merge.</summary>
+    private static bool MonthNameCoveredByNumericDate(string specific, string sourceText, string merged)
+    {
+        if (MonthNumber(specific) is not { } month)
+            return false;
+
+        // Guard: only credit a month that the source actually used as part of a date.
+        var years = new HashSet<int>();
+        var usedAsDate = false;
+
+        foreach (Match m in MonthDateExpression().Matches(sourceText))
+        {
+            if (!string.Equals(m.Groups["mon"].Value, specific, StringComparison.OrdinalIgnoreCase))
+                continue;
+            if (!m.Groups["d1"].Success && !m.Groups["d2"].Success && !m.Groups["y"].Success)
+                continue;
+
+            usedAsDate = true;
+            if (m.Groups["y"].Success)
+                years.Add(int.Parse(m.Groups["y"].Value, CultureInfo.InvariantCulture));
+        }
+
+        if (!usedAsDate)
+            return false;
+
+        foreach (var (numericMonth, numericYear) in NumericDates(merged))
+            if (numericMonth == month && (years.Count == 0 || years.Contains(numericYear)))
+                return true;
+
+        return false;
+    }
+
+    /// <summary>"2026-08-19" in the source, "August 19, 2026" in the merge.</summary>
+    private static bool NumericDateCoveredByMonthName(string specific, string merged)
+    {
+        // Only a fully-qualified date is unambiguous enough to match by components; a bare
+        // "08-19" could be a version, a range or a partial date.
+        var iso = IsoNumericDate().Match(specific);
+        if (!iso.Success || iso.Length != specific.Length)
+            return false;
+
+        var year = int.Parse(iso.Groups["y"].Value, CultureInfo.InvariantCulture);
+        var month = int.Parse(iso.Groups["m"].Value, CultureInfo.InvariantCulture);
+        var day = int.Parse(iso.Groups["d"].Value, CultureInfo.InvariantCulture);
+
+        foreach (Match m in MonthDateExpression().Matches(merged))
+        {
+            if (MonthNumber(m.Groups["mon"].Value) != month)
+                continue;
+            if (!m.Groups["y"].Success || int.Parse(m.Groups["y"].Value, CultureInfo.InvariantCulture) != year)
+                continue;
+
+            var dayGroup = m.Groups["d1"].Success ? m.Groups["d1"] : m.Groups["d2"];
+            if (dayGroup.Success && int.Parse(dayGroup.Value, CultureInfo.InvariantCulture) == day)
+                return true;
+        }
+
+        return false;
+    }
+
+    private static IEnumerable<(int Month, int Year)> NumericDates(string text)
+    {
+        foreach (Match m in IsoNumericDate().Matches(text))
+            yield return (
+                int.Parse(m.Groups["m"].Value, CultureInfo.InvariantCulture),
+                int.Parse(m.Groups["y"].Value, CultureInfo.InvariantCulture));
+
+        foreach (Match m in SlashNumericDate().Matches(text))
+            yield return (
+                int.Parse(m.Groups["m"].Value, CultureInfo.InvariantCulture),
+                int.Parse(m.Groups["y"].Value, CultureInfo.InvariantCulture));
+    }
+
+    private static int? MonthNumber(string word) => word.ToLowerInvariant() switch
+    {
+        "january" or "jan" => 1,
+        "february" or "feb" => 2,
+        "march" or "mar" => 3,
+        "april" or "apr" => 4,
+        "may" => 5,
+        "june" or "jun" => 6,
+        "july" or "jul" => 7,
+        "august" or "aug" => 8,
+        "september" or "sept" or "sep" => 9,
+        "october" or "oct" => 10,
+        "november" or "nov" => 11,
+        "december" or "dec" => 12,
+        _ => null,
+    };
+}

--- a/src/RockBot.Host/MergeCoverage.cs
+++ b/src/RockBot.Host/MergeCoverage.cs
@@ -22,6 +22,32 @@ namespace RockBot.Host;
 /// surviving another cycle; the cost of a false acceptance is a fact nobody can recover the
 /// wording of. Those are not symmetric.
 /// </para>
+/// <para>
+/// That bias has a cost of its own, and it is not free the way it first looks. A rejected
+/// merge is re-proposed next cycle, so a false rejection is not one wasted merge — it is a
+/// duplicate cluster that never resolves and burns a slot on every future cycle. A live corpus
+/// showed one six-source merge rejected five times in eight cycles. Two classes of false
+/// rejection are addressed here, both by widening what counts as *covering* a specific rather
+/// than by dropping the requirement:
+/// </para>
+/// <list type="bullet">
+/// <item>
+/// Sentence position. A capitalized word is only evidence of a proper noun when it is not
+/// sentence-initial. Consulting the common-word list only in that position keeps "Personal"
+/// protected in "OneDrive Personal" while letting "Valid email-capable IDs …" pass.
+/// </item>
+/// <item>
+/// Date spelling. "August 19, 2026" and "2026-08-19" are the same fact. Crediting one for the
+/// other is guarded on the month appearing in a date expression in the source, so a bare
+/// "August" — or a person named August — stays required.
+/// </item>
+/// </list>
+/// <para>
+/// The distinction matters: adding a word to the common list unprotects it everywhere, in
+/// every context, permanently. Widening the coverage test leaves it required and can only be
+/// satisfied by an equivalent form actually being present, so a merge that drops both forms
+/// is still rejected.
+/// </para>
 /// </remarks>
 internal static partial class MergeCoverage
 {
@@ -65,10 +91,26 @@ internal static partial class MergeCoverage
         foreach (Match m in CapitalizedWord().Matches(content))
         {
             var word = Possessive().Replace(m.Value, string.Empty);
-            if (word.Length > 2 && !words.IsCommon(word))
-                specifics.Add(word);
+            if (word.Length <= 2)
+                continue;
+
+            // The generic-English baseline exists to absorb words capitalized only because they
+            // open a sentence, so it only applies there. Mid-sentence capitalization is evidence
+            // of a proper noun: "Personal", "Class" and "Benefit" are ordinary at a sentence
+            // start and load-bearing in "OneDrive Personal", "Blazor Online Class" and "MVP
+            // Azure Extended Benefit". A deployment's own extraCommonWords still applies in
+            // every position -- see MergeCoverageVocabulary.IsCommon.
+            var applyBaseline = SentencePosition.IsSentenceInitial(content, m.Index);
+            if (words.IsCommon(word, applyBaseline))
+                continue;
+
+            specifics.Add(word);
         }
 
+        // Deliberately not position-aware. An all-caps token is not capitalized by grammar, so
+        // opening a sentence tells us nothing about it -- and the live corpus showed acronym
+        // drops to be real losses ("LLC" went missing alongside Microsoft, Google, ICS and IMAP
+        // in a merge that discarded the whole account-provider map).
         foreach (Match m in Acronym().Matches(content))
             if (!words.IsCommon(m.Value))
                 specifics.Add(m.Value);
@@ -87,9 +129,10 @@ internal static partial class MergeCoverage
     /// <remarks>
     /// Matching is a case-insensitive substring test rather than a token test, so a merge is
     /// credited for reformatting — "Rockford Duane Lhotka" still covers the source token
-    /// "Rockford", and "2026-09-10" covers "2026". Reformatting that genuinely discards a
-    /// component (spelling out "September" as "09") is reported as missing, which is the
-    /// conservative direction.
+    /// "Rockford", and "2026-09-10" covers "2026". A specific that survives only as an
+    /// equivalent date spelling is credited by <see cref="DateEquivalence"/>; anything else
+    /// that fails the substring test is reported as missing, which is the conservative
+    /// direction.
     /// </remarks>
     internal static IReadOnlyList<string> FindMissingSpecifics(
         IEnumerable<MemoryEntry> sources,
@@ -98,15 +141,23 @@ internal static partial class MergeCoverage
     {
         var merged = mergedContent ?? string.Empty;
 
+        var materialized = sources as IReadOnlyCollection<MemoryEntry> ?? [.. sources];
+
         var required = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var source in sources)
+        foreach (var source in materialized)
             required.UnionWith(ExtractSpecifics(source.Content, vocabulary));
 
         if (required.Count == 0)
             return [];
 
+        var sourceText = string.Join("\n", materialized.Select(s => s.Content));
+
         return [.. required
-            .Where(s => merged.IndexOf(s, StringComparison.OrdinalIgnoreCase) < 0)
+            .Where(s => !IsCovered(s, sourceText, merged))
             .OrderBy(s => s, StringComparer.OrdinalIgnoreCase)];
     }
+
+    private static bool IsCovered(string specific, string sourceText, string merged) =>
+        merged.IndexOf(specific, StringComparison.OrdinalIgnoreCase) >= 0
+        || DateEquivalence.IsCoveredByEquivalentDate(specific, sourceText, merged);
 }

--- a/src/RockBot.Host/MergeCoverageVocabulary.cs
+++ b/src/RockBot.Host/MergeCoverageVocabulary.cs
@@ -43,19 +43,21 @@ internal sealed class MergeCoverageVocabulary
 
     private static readonly Lazy<MergeCoverageVocabulary> LazyDefault = new(() => new(null, null));
 
-    private readonly HashSet<string> _common;
+    private readonly HashSet<string> _builtIn;
+    private readonly HashSet<string> _extraCommon;
     private readonly HashSet<string> _alwaysSpecific;
 
     public MergeCoverageVocabulary(
         IEnumerable<string>? extraCommonWords,
         IEnumerable<string>? alwaysSpecificWords)
     {
-        _common = new HashSet<string>(BuiltInCommonWords, StringComparer.OrdinalIgnoreCase);
+        _builtIn = new HashSet<string>(BuiltInCommonWords, StringComparer.OrdinalIgnoreCase);
+        _extraCommon = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         _alwaysSpecific = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var word in extraCommonWords ?? [])
             if (!string.IsNullOrWhiteSpace(word))
-                _common.Add(word.Trim());
+                _extraCommon.Add(word.Trim());
 
         foreach (var word in alwaysSpecificWords ?? [])
             if (!string.IsNullOrWhiteSpace(word))
@@ -64,17 +66,37 @@ internal sealed class MergeCoverageVocabulary
 
     /// <summary>
     /// True when <paramref name="word"/> should be ignored rather than required to survive a
-    /// merge. <see cref="AlwaysSpecificWords"/> wins over the common list, so a deployment can
+    /// merge. <see cref="AlwaysSpecificWords"/> wins over both lists, so a deployment can
     /// reclaim a built-in word it needs protected.
     /// </summary>
-    public bool IsCommon(string word) =>
-        !_alwaysSpecific.Contains(word) && _common.Contains(word);
+    /// <param name="applyBaseline">
+    /// Whether the generic-English baseline applies here. False for a capitalized word in
+    /// mid-sentence position, where the capitalization is evidence of a proper noun rather
+    /// than of grammar — see <see cref="SentencePosition"/>.
+    /// </param>
+    /// <remarks>
+    /// The two lists are deliberately scoped differently. The baseline is generic English that
+    /// no operator chose: it contains "may", "will", "some", "first" and "last", so applying it
+    /// mid-sentence is what would strip a character named May or Will of protection, and what
+    /// forced "Personal", "Class" and "Benefit" to be left out of it despite reading as noise.
+    /// <c>extraCommonWords</c> is the opposite — an explicit, corpus-specific judgement — so it
+    /// applies in every position. That is what lets a deployment suppress framing noise such as
+    /// "Rocky", which appears mid-sentence far more often than not.
+    /// </remarks>
+    public bool IsCommon(string word, bool applyBaseline = true)
+    {
+        if (_alwaysSpecific.Contains(word))
+            return false;
+
+        return _extraCommon.Contains(word)
+            || (applyBaseline && _builtIn.Contains(word));
+    }
 
     /// <summary>Words reclaimed as specifics regardless of the common list.</summary>
     public IReadOnlyCollection<string> AlwaysSpecificWords => _alwaysSpecific;
 
     /// <summary>Count of words treated as ordinary language.</summary>
-    public int CommonWordCount => _common.Count;
+    public int CommonWordCount => _builtIn.Count + _extraCommon.Count;
 
     /// <summary>
     /// Parses a vocabulary file. Returns <see cref="Default"/> when <paramref name="json"/> is
@@ -146,5 +168,15 @@ internal sealed class MergeCoverageVocabulary
         "based", "across", "within", "without", "although", "though", "unless",
         "overall", "specifically", "particularly", "typically", "generally", "likely",
         "ids", "enjoys", "downloading",
+
+        // Sentence openers observed rejecting sound merges on a live corpus. Adding these was
+        // previously unsafe because the list applied in every position; now that the baseline
+        // is consulted only at a sentence start, a word here still carries full protection
+        // mid-phrase. Deliberately not extended to "personal", "class", "benefit", "extended",
+        // "power", "social" or "code" — those are already protected where they are load-bearing
+        // ("OneDrive Personal", "Blazor Online Class"), so listing them buys nothing.
+        "valid", "invalid", "direct", "directly", "alternative", "alternatively",
+        "through", "throughout", "call", "calls", "multiple", "relevant", "existing",
+        "lowering", "raising", "several", "additional", "overdue", "upcoming",
     ];
 }

--- a/src/RockBot.Host/SentencePosition.cs
+++ b/src/RockBot.Host/SentencePosition.cs
@@ -1,0 +1,98 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Decides whether a capitalized word sits where English grammar would have capitalized it
+/// anyway, which is the only position where the merge-coverage common-word list should apply.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Mid-sentence capitalization is evidence of a proper noun. Sentence-initial capitalization
+/// is evidence of nothing. Treating the two alike is what forced the common-word list into an
+/// unwinnable trade-off: a live corpus needed "Valid", "Direct", "Alternative" and "Through"
+/// suppressed as sentence openers, while "Personal", "Class", "Benefit" and "Extended" had to
+/// stay protected because they name real things mid-phrase ("OneDrive Personal", "Blazor
+/// Online Class", "MVP Azure Extended Benefit"). Splitting by position dissolves the conflict
+/// and makes the list safe to extend.
+/// </para>
+/// <para>
+/// Errs toward "not sentence-initial", because that is the direction that keeps a word
+/// required to survive a merge.
+/// </para>
+/// </remarks>
+internal static class SentencePosition
+{
+    /// <summary>
+    /// Abbreviations whose trailing period does not end a sentence. Without this, "St. Paul"
+    /// and "Dr. May" read as sentence boundaries, putting the following word in the position
+    /// where the common-word list applies — which is exactly where a storytelling agent's
+    /// character named May or Rose would silently lose coverage protection.
+    /// </summary>
+    private static readonly HashSet<string> NonTerminalAbbreviations =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            "st", "dr", "mr", "mrs", "ms", "jr", "sr", "prof", "rev", "hon",
+            "gen", "col", "sgt", "lt", "capt", "inc", "ltd", "co", "corp",
+            "no", "vs", "etc", "eg", "ie", "fig", "approx", "dept", "est",
+        };
+
+    /// <summary>
+    /// True when the token starting at <paramref name="index"/> opens a sentence, a line, or a
+    /// list item.
+    /// </summary>
+    internal static bool IsSentenceInitial(string content, int index)
+    {
+        var i = index - 1;
+
+        // Opening quotes and brackets never end a sentence, so step over them before looking
+        // for a terminator: >He said. "Personal data …< still opens a sentence at "Personal".
+        while (i >= 0 && content[i] is '"' or '\'' or '(' or '[' or '{' or '“' or '‘' or '«')
+            i--;
+
+        while (i >= 0 && char.IsWhiteSpace(content[i]))
+        {
+            // A line break starts a fresh clause regardless of how the previous line ended.
+            // Memory content is frequently bulleted or newline-delimited rather than punctuated.
+            if (content[i] is '\n' or '\r')
+                return true;
+            i--;
+        }
+
+        if (i < 0)
+            return true;
+
+        // A bullet marker counts only when nothing but whitespace precedes it on the line;
+        // otherwise this is a hyphen inside running text.
+        if (content[i] is '-' or '*' or '•' or '–' or '—')
+            return IsAtLineStart(content, i);
+
+        var prev = content[i];
+        if (prev is not ('.' or '!' or '?' or ':' or ';'))
+            return false;
+
+        return prev != '.' || !EndsWithNonTerminalAbbreviation(content, i);
+    }
+
+    private static bool IsAtLineStart(string content, int markerIndex)
+    {
+        for (var i = markerIndex - 1; i >= 0; i--)
+        {
+            if (content[i] is '\n' or '\r')
+                return true;
+            if (!char.IsWhiteSpace(content[i]))
+                return false;
+        }
+
+        return true;
+    }
+
+    private static bool EndsWithNonTerminalAbbreviation(string content, int periodIndex)
+    {
+        var end = periodIndex;
+        var start = end;
+        while (start > 0 && char.IsLetter(content[start - 1]))
+            start--;
+
+        return start != end
+            && NonTerminalAbbreviations.Contains(content[start..end]);
+    }
+}

--- a/tests/RockBot.Host.Tests/MergeCoverageTests.cs
+++ b/tests/RockBot.Host.Tests/MergeCoverageTests.cs
@@ -91,9 +91,26 @@ public class MergeCoverageTests
         // "Adding", "Flagged" and "Validated" were read as proper nouns.
         var specifics = MergeCoverage.ExtractSpecifics(
             "Candidate low-signal words were reviewed. Adding them is wrong. "
-            + "Flagged entries were Validated against telemetry.");
+            + "Flagged entries were checked against telemetry. Validated ones stayed.");
 
         Assert.AreEqual(0, specifics.Count, string.Join(", ", specifics));
+    }
+
+    [TestMethod]
+    public void OrdinaryWordsMidSentenceAreStillSpecifics()
+    {
+        // The baseline only absorbs words where capitalization is grammatical. Mid-sentence it
+        // carries signal, so "Validated" here is treated as a label worth preserving. A
+        // deployment that disagrees puts it in extraCommonWords, which applies everywhere.
+        var specifics = MergeCoverage.ExtractSpecifics("Flagged entries were Validated against telemetry.");
+
+        CollectionAssert.Contains(specifics.ToArray(), "Validated");
+
+        var suppressed = MergeCoverage.ExtractSpecifics(
+            "Flagged entries were Validated against telemetry.",
+            new MergeCoverageVocabulary(["Validated"], null));
+
+        Assert.AreEqual(0, suppressed.Count, string.Join(", ", suppressed));
     }
 
     [TestMethod]
@@ -258,7 +275,9 @@ public class MergeCoverageTests
             extraCommonWords: null,
             alwaysSpecificWords: ["May", "Will", "Rose"]);
 
-        var line = "May and Will found Rose in the garden";
+        // Sentence-initial, which is where the hazard now lives: mid-sentence these names are
+        // protected automatically by their position, so the list is only load-bearing here.
+        var line = "May left at dawn. Will followed her. Rose waited by the gate.";
 
         var unprotected = MergeCoverage.ExtractSpecifics(line);
         Assert.IsFalse(unprotected.Contains("May"), "precondition: the built-in list swallows May");
@@ -352,6 +371,150 @@ public class MergeCoverageTests
 
     private static bool MergeCoverage_IsProtected(MemoryEntry entry, DreamOptions options) =>
         DreamService.IsProtectedFromPruning(entry, options);
+
+
+    // ── Sentence position ────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void CommonWordMidSentenceIsStillASpecific()
+    {
+        // The reason the baseline was dangerous to apply everywhere. "New" opening a sentence is
+        // ordinary English and is in the built-in list; inside "New Orleans" it names a real
+        // place, and a merge that drops it has lost which Orleans is meant.
+        var sources = new[] { Entry("a", "The venue moved to New Orleans last spring.") };
+
+        CollectionAssert.Contains(
+            MergeCoverage.FindMissingSpecifics(sources, "The venue moved to Orleans last spring.").ToArray(),
+            "New");
+    }
+
+    [TestMethod]
+    public void CommonWordOpeningASentenceIsIgnored()
+    {
+        var vocabulary = new MergeCoverageVocabulary(["Valid"], null);
+        var sources = new[] { Entry("a", "Valid email-capable account IDs include marimer-work and xebia.") };
+
+        Assert.AreEqual(
+            0,
+            MergeCoverage.FindMissingSpecifics(
+                sources,
+                "Email-capable account IDs are marimer-work and xebia.",
+                vocabulary).Count);
+    }
+
+    [TestMethod]
+    public void AbbreviationPeriodDoesNotStartASentence()
+    {
+        // "St. Paul" and "Dr. May" must not put the following word in the position where the
+        // common list applies -- that is precisely where a character named May would be lost.
+        var vocabulary = new MergeCoverageVocabulary(null, null);
+        var specifics = MergeCoverage.ExtractSpecifics("The show is in St. Paul with Dr. May attending.", vocabulary);
+
+        CollectionAssert.IsSubsetOf(new[] { "Paul", "May" }, specifics.ToArray());
+    }
+
+    [TestMethod]
+    public void CommonWordOpeningALineIsIgnored()
+    {
+        var vocabulary = new MergeCoverageVocabulary(["Direct"], null);
+        var specifics = MergeCoverage.ExtractSpecifics(
+            "Accounts:" + Environment.NewLine + "- Direct billing applies",
+            vocabulary);
+
+        CollectionAssert.DoesNotContain(specifics.ToArray(), "Direct");
+    }
+
+    [TestMethod]
+    public void AlwaysSpecificStillWinsAtSentenceStart()
+    {
+        // A storytelling agent's character named Rose must survive even where the position
+        // heuristic would otherwise hand her to the common list.
+        var vocabulary = new MergeCoverageVocabulary(["Rose"], ["Rose"]);
+        var sources = new[] { Entry("a", "Rose left the harbour before dawn.") };
+
+        CollectionAssert.Contains(
+            MergeCoverage.FindMissingSpecifics(sources, "She left the harbour before dawn.", vocabulary).ToArray(),
+            "Rose");
+    }
+
+    [TestMethod]
+    public void AcronymsAreNotPositionExempt()
+    {
+        // All-caps is not grammatical capitalization, so opening a sentence says nothing about
+        // it. A live merge dropped "LLC" alongside Microsoft, Google, ICS and IMAP.
+        var sources = new[] { Entry("a", "IMAP delivery is configured for the rockbotagent account.") };
+
+        CollectionAssert.Contains(
+            MergeCoverage.FindMissingSpecifics(sources, "Delivery is configured for the rockbotagent account.").ToArray(),
+            "IMAP");
+    }
+
+    // ── Date equivalence ─────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void WrittenDateIsSatisfiedByIsoDate()
+    {
+        // 13 of 70 rejections on a live corpus were exactly this: the merge normalized the
+        // date and kept day and year intact, and was rejected for dropping "August".
+        var sources = new[] { Entry("a", "A Red Fletcher show at White Rock Lounge on August 19, 2026.") };
+
+        Assert.AreEqual(
+            0,
+            MergeCoverage.FindMissingSpecifics(
+                sources,
+                "A Red Fletcher show at White Rock Lounge on 2026-08-19.").Count);
+    }
+
+    [TestMethod]
+    public void IsoDateIsSatisfiedByWrittenDate()
+    {
+        var sources = new[] { Entry("a", "The summit ran on 2026-08-19.") };
+
+        Assert.AreEqual(0, MergeCoverage.FindMissingSpecifics(sources, "The summit ran on August 19, 2026.").Count);
+    }
+
+    [TestMethod]
+    public void MonthOutsideADateExpressionIsStillRequired()
+    {
+        // The guard that keeps this narrow. A person, product or release named August is not a
+        // date and gets no credit from an unrelated numeric date elsewhere in the text.
+        var sources = new[] { Entry("a", "August Wilson wrote the play; the ticket is dated 2026-08-19.") };
+
+        CollectionAssert.Contains(
+            MergeCoverage.FindMissingSpecifics(sources, "The ticket is dated 2026-08-19.").ToArray(),
+            "August");
+    }
+
+    [TestMethod]
+    public void DateDroppedEntirelyIsStillReported()
+    {
+        var sources = new[] { Entry("a", "The show is on August 19, 2026.") };
+
+        CollectionAssert.Contains(
+            MergeCoverage.FindMissingSpecifics(sources, "The show is scheduled for later this year.").ToArray(),
+            "August");
+    }
+
+    [TestMethod]
+    public void EquivalentDateMustMatchTheSourceYear()
+    {
+        // "August 2026" is not satisfied by an unrelated August in a different year.
+        var sources = new[] { Entry("a", "The contract was signed in August 2026.") };
+
+        CollectionAssert.Contains(
+            MergeCoverage.FindMissingSpecifics(sources, "The contract was signed on 2025-08-04.").ToArray(),
+            "August");
+    }
+
+    [TestMethod]
+    public void EquivalentDateMustMatchTheSourceMonth()
+    {
+        var sources = new[] { Entry("a", "The show is on October 3, 2026.") };
+
+        CollectionAssert.Contains(
+            MergeCoverage.FindMissingSpecifics(sources, "The show is on 2026-08-19.").ToArray(),
+            "October");
+    }
 
     private static MemoryEntry Entry(string id, string content) =>
         new(id, content, null, [], DateTimeOffset.UtcNow);


### PR DESCRIPTION
## Why

The merge-coverage check is deliberately biased toward rejection — a false acceptance destroys wording nobody can recover. But the cost of the other direction isn't free the way it first looks: a rejected merge is re-proposed next cycle, so a false rejection isn't one wasted merge, it's a duplicate cluster that never resolves and burns a slot on every future cycle. A live corpus showed one six-source merge rejected five times in eight cycles.

Two classes of false rejection are fixed here. Both widen what counts as *covering* a specific rather than dropping the requirement, and that direction is the point: adding a word to the common list unprotects it everywhere, in every context, permanently. An equivalence can only be satisfied by an equivalent form actually being present, so a merge that drops both forms is still rejected.

## Sentence position

A capitalized word is only evidence of a proper noun when it is *not* sentence-initial, so the built-in generic-English baseline is now consulted only in that position.

| | Sentence-initial | Mid-sentence |
|---|---|---|
| Built-in baseline | applies | **does not apply** |
| `extraCommonWords` | applies | applies |
| `alwaysSpecificWords` | wins over both | wins over both |

This keeps `Personal`, `Class`, `Benefit` and `Extended` protected where they're load-bearing (*OneDrive Personal*, *Blazor Online Class*, *MVP Azure Extended Benefit*) while letting "Valid email-capable IDs …" pass. It also protects a storytelling agent's character named **May** or **Will** automatically, which previously required listing them in `alwaysSpecificWords`.

That makes the baseline safe to extend, so sentence openers observed rejecting sound merges are now in it: `valid`, `invalid`, `direct`, `alternative`, `through`, `call`, `multiple`, `relevant`, `existing` and friends.

`extraCommonWords` is scoped the opposite way on purpose — it's an explicit, corpus-specific operator judgement, so it applies in every position. That's what lets a deployment suppress framing noise like `Rocky`, which appears mid-sentence (*"in Rocky's environment, calendar-mcp requires…"*) far more often than not.

## Date equivalence

*"August 19, 2026"* and *"2026-08-19"* are the same fact. `August` alone accounted for **13 of 70 rejections across eight cycles**, every one a merge that normalized the date and kept the day and year intact.

Two guards keep it narrow:
- the month must appear adjacent to a day or year *in the source*, so a person or a release named August is never credited;
- when the source's date carries a year, the numeric date must carry the same one.

A merge that drops the date in both spellings is still rejected.

## Deliberately unchanged

Acronym extraction stays position-blind. An all-caps token isn't capitalized by grammar, so opening a sentence tells us nothing about it — and the corpus showed acronym drops to be real losses (`LLC` went missing alongside Microsoft, Google, ICS and IMAP in a merge that discarded a whole account-provider map).

## Unrelated safety fix, folded in

`deploy/docker-compose/local-llm/.env` holds `LLM_API_KEY` and `BRAVE_API_KEY`. It was untracked but **not** ignored — the existing `.gitignore` patterns are anchored one directory up. Added `deploy/docker-compose/*/.env`, `*/agent.extra.env` and `*/agent-data/` so every per-stack compose subdirectory is covered. Called out separately here because it has nothing to do with merge coverage.

## Testing

`dotnet build` clean; full suite passes — 1252 in `RockBot.Host.Tests`, 0 failures across the solution (RabbitMQ integration tests skipped, no broker). `MergeCoverageTests` gains 167 lines covering position scoping, the guards on date equivalence, and the acronym carve-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CDaq9A1aiv8cNZRee4NmCF
