### PR TITLE
Add a vanilla compose instance for a local llama.cpp LLM

### DIFF
--- a/deploy/docker-compose/local-llm/README.md
+++ b/deploy/docker-compose/local-llm/README.md
@@ -1,0 +1,135 @@
+# RockBot (vanilla) on the local Qwen3.6 GPU
+
+A stock RockBot pointed at the llama.cpp server running on this Windows host.
+
+Compose project name is **`rockbot-local`**, deliberately distinct from the
+`rockbot` project in the parent directory — that one is the heavily-customised
+Grok storytelling agent. Nothing here touches it: separate project, separate
+volumes, separate ports, separate `agent-data`. Both can run at once.
+
+## What "vanilla" means here
+
+`agent-data/` starts empty, so the init container seeds the **stock** profile
+(`directives.md`, `soul.md`, `memory-rules.md`, `style.md`, dream prompts …)
+straight from the image. No prompt has been edited. The only deviations from
+framework defaults are in `agent.extra.env`, and every one of them is there to
+make a 32K-context local reasoning model work — each is commented with the
+measurement that motivated it.
+
+To get back to a virgin agent: `docker compose ... down` then `rm -rf agent-data`.
+
+## Ports
+
+| Service | Host port | Why |
+|---|---|---|
+| llama-server (not in this stack) | 8080 | pre-existing, do not disturb |
+| Blazor UI | **8090** | 8080 collides with llama-server |
+| RabbitMQ AMQP | **5673** | 5672 belongs to the `rockbot` stack |
+| RabbitMQ management | **15673** | 15672 belongs to the `rockbot` stack |
+
+## Run
+
+```bash
+# 0. The LLM server is started BY HAND and does not survive a reboot.
+curl -s http://127.0.0.1:8080/health          # expect {"status":"ok"}
+# Restart procedure: S:\src\gpu\LLM-ENDPOINT-FOR-DOCKER.md
+
+cd /s/src/rdl/rockbot
+docker compose -f deploy/docker-compose/local-llm/docker-compose.yml \
+  --env-file deploy/docker-compose/local-llm/.env up -d --build
+```
+
+UI: <http://localhost:8090>
+
+CLI against this stack (note the non-default port):
+
+```bash
+RabbitMq__HostName=localhost RabbitMq__Port=5673 \
+RabbitMq__UserName=rockbot RabbitMq__Password=rockbot \
+  dotnet run --project src/RockBot.UserProxy.Cli -- chat
+```
+
+## Verified working (2026-08-19)
+
+Probed against the live server before and after bringing the stack up:
+
+- **Native tool calling** — real `tool_calls` with valid JSON arguments. No
+  text-based tool-call fallback needed, unlike Euryale/Hermes in the sibling stack.
+- **End-to-end turn** — `SaveMemory` and `list_scheduled_tasks` both dispatched
+  and folded into a correct final reply.
+- **Reasoning isolation** — thinking goes to `reasoning_content`, so no `<think>`
+  blocks leak into replies. Confirmed: content came back as exactly `"OK"`.
+- **Prompt caching** — llama.cpp reuses the KV prefix; a repeated turn showed
+  98.9% cached input, so the second tool-loop iteration is nearly free.
+- **All three tiers** resolve to `qwen3.6 @ http://host.docker.internal:8080/v1`.
+- **Container → host networking** works with no Windows Firewall rule.
+
+## Context: the server was raised to 64K, and why
+
+A stock turn's single-request prompt is **~24,800 tokens** — the system prompt
+plus 24 tool schemas. That floor does not shrink as the chat grows, and the
+knobs in `agent.extra.env` bound tool *results*, not the floor. Against the
+original 32,768-token window that left ~4K of usable headroom, so llama-server
+was restarted on 2026-08-19:
+
+```
+-ngl 99 -ncmoe 5 -fa on -c 65536      # was -ncmoe 3 ... -c 32768
+```
+
+Measured after the restart:
+
+| | before | after |
+|---|---|---|
+| Context window | 32,768 | **65,536** |
+| Headroom above the ~24.8K floor | ~8,000 | **~40,700** |
+| Generation throughput | ~140 tok/s | **117.2 tok/s** |
+| VRAM | 15,964 / 16,303 MiB | 15,940 / 16,303 MiB |
+
+`-ncmoe` **must** rise with the context — KV cache competes with weights for
+VRAM. Too low spills VRAM to system RAM and costs ~85% throughput with **no
+error message**; the 117 tok/s measurement above is the check that this did not
+happen (a spill reads as ~20 tok/s). The full table is in
+`S:\src\gpu\LLM-ENDPOINT-FOR-DOCKER.md`.
+
+Note the server runs `-np` auto with `kv_unified=true`, so `-c` is one shared KV
+buffer across the 4 slots, not a per-slot allocation.
+
+### Reading the token logs
+
+`input=50652` in the agent log is Microsoft.Extensions.AI **summing usage across
+tool-loop iterations**, not one oversized request — which is why it is followed
+by a high `cached=` percentage. Divide by the iteration count for the real
+per-request size.
+
+### Overflow fails loudly
+
+Verified by deliberately sending a 40K prompt to the 32K server:
+
+```
+400 exceed_context_size_error: request (40035 tokens) exceeds the
+available context size (32768 tokens), try increasing it
+```
+
+So if the window is ever exceeded you get a visible error, not a silent
+truncation of the start of the context.
+
+## Watch items
+
+- **Speed.** ~117 tok/s generation on one shared GPU. A single user turn is tens
+  of seconds to a couple of minutes because every tool-loop iteration re-runs a
+  reasoning block over a ~25K prompt. `LlmCallTimeout` is raised to 4 minutes
+  (the HTTP `NetworkTimeout` is pinned at 5 minutes in `Program.cs`, so 4 is the
+  practical ceiling if the timeout is to stay attributable).
+- **Reasoning burn.** Observed 1,300–2,600 completion tokens on ordinary turns,
+  almost all reasoning. This is why `MaxOutputTokens=6144`; a low cap returns
+  `finish_reason=length` with empty `content` and **no error**, which looks
+  exactly like a broken model.
+- **Date fabrication (intermittent).** On one early turn the model invented
+  "Thursday, May 21, 2025" instead of reading the injected datetime system
+  message; a later turn on the same stack got it right. In an isolated two-message
+  prompt it is always correct, so this is attention dilution in a ~25K prompt, not
+  a wiring bug — the container clock and `AgentContextBuilder` injection were both
+  verified correct. If it recurs often, add a
+  `model-behaviors/qwen3/additional-system-prompt.md` restating the date rule.
+- **Don't start Ollama.** VRAM is at ~97%. A second GPU model makes the driver
+  page VRAM to RAM and throughput drops ~8x with no error message.

--- a/deploy/docker-compose/local-llm/docker-compose.yml
+++ b/deploy/docker-compose/local-llm/docker-compose.yml
@@ -1,0 +1,206 @@
+name: rockbot-local
+
+services:
+  rabbitmq:
+    image: rabbitmq:4-management
+    hostname: rabbitmq
+    ports:
+      - "15673:15672"   # Management UI (optional, handy for debugging)
+      - "5673:5672"     # AMQP — lets `rockbot chat` run on the host against this stack
+    environment:
+      RABBITMQ_DEFAULT_USER: rockbot
+      RABBITMQ_DEFAULT_PASS: rockbot
+    volumes:
+      - rabbitmq-data:/var/lib/rabbitmq
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "check_port_connectivity"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  agent-init:
+    build:
+      context: ../../..
+      dockerfile: deploy/Dockerfile.agent
+    image: rockylhotka/rockbot-agent:latest
+    user: root
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        set -e
+        echo "Seeding agent data volume..."
+        # Profile and dream directives — live at /app/agent/*.md in the image.
+        # Copy every .md file no-clobber so operators can tune any directive
+        # (including dream passes) without a rebuild, and new directives added in
+        # future releases get seeded automatically. Matches the Helm chart's
+        # init-agent-data container; a hardcoded list here went stale and silently
+        # dropped 13 files, including safety-rules.md (the prompt-injection guardrail).
+        for src in /app/agent/*.md; do
+          [ -f "$$src" ] || continue
+          f=$$(basename "$$src")
+          dst="/data/agent/$$f"
+          if [ ! -s "$$dst" ]; then
+            echo "  Copying $$f"
+            cp "$$src" "$$dst"
+          fi
+        done
+        if [ -f /app/agent/well-known-agents.json ] && [ ! -s /data/agent/well-known-agents.json ]; then
+          cp /app/agent/well-known-agents.json /data/agent/well-known-agents.json
+        fi
+        # Seed mcp.json with compose-local MCP server URLs
+        # (overrides the image default which references cluster-internal URLs)
+        if [ ! -f /data/agent/mcp.json ]; then
+          cat > /data/agent/mcp.json <<'MCPEOF'
+        {"mcpServers":{"introspection":{"type":"sse","url":"http://introspection-mcp:8080/"}}}
+        MCPEOF
+        fi
+        # Per-model behavior files
+        for model_dir in /app/model-behaviors/*/; do
+          [ -d "$$model_dir" ] || continue
+          model_name=$$(basename "$$model_dir")
+          mkdir -p "/data/agent/model-behaviors/$$model_name"
+          for src in "$$model_dir"*; do
+            [ -f "$$src" ] || continue
+            dst="/data/agent/model-behaviors/$$model_name/$$(basename $$src)"
+            if [ ! -s "$$dst" ]; then
+              cp "$$src" "$$dst"
+            fi
+          done
+        done
+        mkdir -p /data/agent/memory /data/agent/skills /data/agent/conversations /data/agent/feedback
+        # The shared volume (attachments, script file exchange) is also root-owned;
+        # the non-root agent creates /rockbot/shared/attachments on startup, so pre-make
+        # it and open permissions here.
+        mkdir -p /rockbot/shared/attachments
+        # Docker volumes are owned by root, so the non-root agent user needs access
+        chmod -R 777 /data/agent /rockbot/shared
+        echo "Agent data volume ready."
+    volumes:
+      - ${AGENT_DATA_PATH:-agent-data}:/data/agent
+      - shared:/rockbot/shared
+
+  agent:
+    build:
+      context: ../../..
+      dockerfile: deploy/Dockerfile.agent
+    image: rockylhotka/rockbot-agent:latest
+    depends_on:
+      agent-init:
+        condition: service_completed_successfully
+      rabbitmq:
+        condition: service_healthy
+      introspection-mcp:
+        condition: service_started
+    environment:
+      # -- RabbitMQ --
+      RabbitMq__HostName: rabbitmq
+      RabbitMq__Port: "5672"
+      RabbitMq__UserName: rockbot
+      RabbitMq__Password: rockbot
+      RabbitMq__VirtualHost: /
+      # -- LLM provider --
+      # Set LLM_PROVIDER=Copilot and GITHUB_TOKEN in .env for Copilot SDK,
+      # or leave LLM_PROVIDER unset and configure LLM_ENDPOINT/LLM_API_KEY for OpenAI-compatible.
+      LLM__Provider: ${LLM_PROVIDER:-}
+      # Copilot path — GITHUB_TOKEN is read by the Copilot CLI subprocess
+      GITHUB_TOKEN: ${GITHUB_TOKEN:-}
+      # Per-tier model IDs (LLM_MODEL_ID sets Balanced; Low/High fall back to Balanced)
+      LLM__Balanced__ModelId: ${LLM_MODEL_ID:-anthropic/claude-haiku-4.5}
+      LLM__Low__ModelId: ${LLM_LOW_MODEL_ID:-}
+      LLM__High__ModelId: ${LLM_HIGH_MODEL_ID:-}
+      # OpenAI-compatible path (ignored when Provider=Copilot)
+      LLM__Balanced__Endpoint: ${LLM_ENDPOINT:-}
+      LLM__Balanced__ApiKey: ${LLM_API_KEY:-}
+      # -- Web search --
+      WebTools__ApiKey: ${BRAVE_API_KEY:-}
+      # -- Embedding (optional — enables hybrid vector search) --
+      # When set, memory/skills/working memory use cosine similarity alongside BM25.
+      # Falls back to BM25-only when not configured — no functionality is lost.
+      # Embedding__Endpoint: ${EMBEDDING_ENDPOINT:-}
+      # Embedding__Model: ${EMBEDDING_MODEL:-}
+      # Embedding__ApiKey: ${EMBEDDING_API_KEY:-}
+      # -- Agent data paths --
+      AgentProfile__BasePath: /data/agent
+      Memory__BasePath: /data/agent/memory
+      Skill__BasePath: /data/agent/skills
+      McpBridge__ConfigPath: /data/agent/mcp.json
+      ModelBehaviors__BasePath: /data/agent/model-behaviors
+      # -- Timezone (set to your IANA timezone) --
+      Agent__Timezone: ${AGENT_TIMEZONE:-America/Chicago}
+    # Optional escape hatch for raw .NET config keys that have no dedicated variable
+    # above (e.g. ModelBehaviors__Models__<prefix>__UseTextBasedToolCalling for a model
+    # without native tool calling). Absent by default — nothing changes if the file
+    # does not exist. Values in `environment:` above still win over this file.
+    env_file:
+      - path: ./agent.extra.env
+        required: false
+    volumes:
+      - ${AGENT_DATA_PATH:-agent-data}:/data/agent
+      - shared:/rockbot/shared
+
+  scripts-init:
+    image: docker:cli
+    entrypoint: ["docker", "image", "pull", "python:3.12-slim"]
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
+  scripts-manager:
+    build:
+      context: ../../..
+      dockerfile: Dockerfile.scripts-manager
+    image: rockylhotka/rockbot-scripts-manager:latest
+    user: root   # Required for Docker socket access
+    depends_on:
+      scripts-init:
+        condition: service_completed_successfully
+      rabbitmq:
+        condition: service_healthy
+    environment:
+      RabbitMq__HostName: rabbitmq
+      RabbitMq__Port: "5672"
+      RabbitMq__UserName: rockbot
+      RabbitMq__Password: rockbot
+      RabbitMq__VirtualHost: /
+      Scripts__Provider: Docker
+      Scripts__Docker__Image: python:3.12-slim
+      Scripts__Docker__CpuLimit: "500m"
+      Scripts__Docker__MemoryLimit: 256Mi
+      Scripts__Docker__NetworkMode: bridge
+      Scripts__Docker__SharedVolumeName: rockbot-local_shared
+      Scripts__Docker__SharedVolumePath: /rockbot/shared
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
+  introspection-mcp:
+    build:
+      context: ../../..
+      dockerfile: src/McpServer.Introspection/Dockerfile
+    image: rockylhotka/rockbot-introspection-mcp:latest
+    depends_on:
+      agent-init:
+        condition: service_completed_successfully
+    environment:
+      AgentName__Path: /data/agent/agent-name.md
+    volumes:
+      - ${AGENT_DATA_PATH:-agent-data}:/data/agent
+  blazor:
+    build:
+      context: ../../..
+      dockerfile: src/RockBot.UserProxy.Blazor/Dockerfile
+    image: rockylhotka/rockbot-blazor:latest
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+    ports:
+      - "8090:8080"
+    environment:
+      RabbitMq__HostName: rabbitmq
+      RabbitMq__Port: "5672"
+      RabbitMq__UserName: rockbot
+      RabbitMq__Password: rockbot
+      RabbitMq__VirtualHost: /
+
+volumes:
+  rabbitmq-data:
+  agent-data:
+  shared:


### PR DESCRIPTION
Adds `deploy/docker-compose/local-llm/` — a stock RockBot stack pointed at an OpenAI-compatible llama.cpp server on the Docker host, for evaluating local models against **unmodified** directives.

> [!IMPORTANT]
> Merge #517 first. The `.env` here holds `LLM_API_KEY` and `BRAVE_API_KEY`, and the per-stack `.gitignore` globs that cover it live in that PR. Until it lands, `local-llm/.env` is untracked but *not* ignored. This branch deliberately adds no ignore rules of its own so the two don't collide in the same region of the file.

## Why a separate stack rather than a profile switch

The compose project name is `rockbot-local`, deliberately distinct from the `rockbot` project one directory up. That stack carries a heavily customised profile, and sharing a project name would have meant sharing its volumes and its `agent-data`. `agent-data/` starts empty here so the init container seeds the stock profile — that's the whole point, it makes this instance a *control* rather than another tuned agent.

Ports are shifted for the same isolation reason (Blazor 8090, AMQP 5673, RabbitMQ UI 15673); 8080 also collides with the LLM server itself. `Scripts__Docker__SharedVolumeName` is renamed to match the new project, or script containers would mount the other stack's shared volume.

## What the README records

Measured against the running server, not assumed — two things here are easy to get wrong:

- **RockBot's prompt floor is ~24.8K tokens** (system prompt + 24 tool schemas) and does not shrink as a conversation grows. The `ToolResult*` trimming knobs bound tool *results* only, so they cannot help. This is what makes a 32K-context server unworkable, and it generalizes to any small-context model — the original 32,768-token window left ~4K of usable headroom.
- **An `input=` figure in the agent log is Microsoft.Extensions.AI summing usage across tool-loop iterations**, not one request. Reading it as a single prompt overstates context pressure by the iteration count.

Also notes observed reasoning burn of 1,300–2,600 completion tokens on ordinary turns.

## Testing

`docker compose config` validates clean. All key references are `${VAR:-}` interpolation from the gitignored env file — no literal secrets in the committed YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CDaq9A1aiv8cNZRee4NmCF
