### PR TITLE
Reload rules.md when it changes on disk instead of at restart only

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.14.13</Version>
+<Version>0.14.14</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.Host/FileRulesStore.cs
+++ b/src/RockBot.Host/FileRulesStore.cs
@@ -22,6 +22,21 @@ namespace RockBot.Host;
 /// pushed to a running pod would otherwise be overwritten by the next write from a list
 /// loaded at startup. The file is a handful of lines; re-reading it costs nothing.
 /// </para>
+/// <para>
+/// <see cref="Rules"/> is likewise a read-through, gated on the file's timestamp and length so
+/// an unchanged file costs one <c>stat</c> per prompt rather than a parse. Serving a startup
+/// snapshot there was the other half of the same bug: a <c>rules.md</c> pushed to a running pod
+/// reached the prompt only after a restart, while the profile documents beside it hot-reload in
+/// about half a second. A rule the operator can see on disk but the agent is not yet following
+/// is the worst of both.
+/// </para>
+/// <para>
+/// A watcher would be the obvious alternative and is deliberately not used: these files live on
+/// a Longhorn PVC, where watchers have been observed to miss the rename half of an atomic write
+/// while polling catches it. A stat on read has no such blind spot, needs no background loop,
+/// and cannot observe a half-written file — <see cref="AtomicFile"/> replaces content by rename,
+/// so a reader sees the old bytes or the new ones and never a mixture.
+/// </para>
 /// </remarks>
 internal sealed partial class FileRulesStore : IRulesStore
 {
@@ -36,6 +51,20 @@ internal sealed partial class FileRulesStore : IRulesStore
     /// </summary>
     private IReadOnlyList<string> _rules;
 
+    /// <summary>
+    /// Timestamp and length of the file as last parsed, or <see cref="Missing"/> when there was
+    /// no file. Compared on every <see cref="Rules"/> read to decide whether a re-parse is
+    /// needed. <c>null</c> only before the first successful stat.
+    /// </summary>
+    private (DateTime LastWriteUtc, long Length)? _stamp;
+
+    /// <summary>
+    /// Guards the read-through refresh. Separate from <see cref="_lock"/>, which is async and
+    /// held across writes; <see cref="Rules"/> is read synchronously while a prompt is being
+    /// assembled and cannot wait on a semaphore.
+    /// </summary>
+    private readonly object _refreshGate = new();
+
     public FileRulesStore(IOptions<AgentProfileOptions> options, ILogger<FileRulesStore> logger)
     {
         _logger = logger;
@@ -46,6 +75,7 @@ internal sealed partial class FileRulesStore : IRulesStore
             : Path.Combine(AppContext.BaseDirectory, opts.BasePath);
 
         _filePath = Path.Combine(baseDir, "rules.md");
+        _stamp = StampOf(_filePath);
         _rules = ExtractRules(ReadLines());
 
         _logger.LogInformation("Rules store initialised — {Count} rule(s) loaded from {Path}",
@@ -53,7 +83,7 @@ internal sealed partial class FileRulesStore : IRulesStore
     }
 
     /// <inheritdoc />
-    public IReadOnlyList<string> Rules => _rules;
+    public IReadOnlyList<string> Rules => RefreshIfChanged();
 
     /// <inheritdoc />
     public async Task<IReadOnlyList<string>> ListAsync()
@@ -63,7 +93,9 @@ internal sealed partial class FileRulesStore : IRulesStore
         {
             // Read-through rather than serving the cache: this is the surface behind
             // list_rules, and answering it from a startup snapshot would hide any rule
-            // added to the file since.
+            // added to the file since. Stamped so the next Rules read does not re-parse
+            // content this call has already loaded.
+            _stamp = StampOf(_filePath);
             _rules = ExtractRules(ReadLines());
             return _rules;
         }
@@ -218,6 +250,87 @@ internal sealed partial class FileRulesStore : IRulesStore
     /// <summary>A bullet line: where it is, the marker and indentation, and the rule text.</summary>
     private readonly record struct Bullet(int Index, string Prefix, string Text);
 
+    /// <summary>
+    /// Serves the cached rules, re-parsing first when <c>rules.md</c> has changed on disk since
+    /// the last parse. Any failure to read leaves the previous rules in place: a rule already
+    /// being followed is not dropped because of a transient filesystem error, and dropping one
+    /// silently is the direction that actually causes harm.
+    /// </summary>
+    /// <remarks>
+    /// Change detection is timestamp plus length, which shares one limitation with every other
+    /// stat-based check in the host: two writes inside the same filesystem timestamp tick that
+    /// leave the length identical are indistinguishable. For an operator-pushed file of a few
+    /// bullets that is not a case worth a hash; the mutation paths above re-read unconditionally
+    /// and are unaffected.
+    /// </remarks>
+    private IReadOnlyList<string> RefreshIfChanged()
+    {
+        var stamp = StampOf(_filePath);
+
+        // Stat failed outright — distinct from the file being absent, which has its own stamp.
+        // Keep serving what we have rather than reporting no rules on a transient error.
+        if (stamp is null)
+            return _rules;
+
+        if (stamp == _stamp)
+            return _rules;
+
+        lock (_refreshGate)
+        {
+            // Re-checked inside the gate: a concurrent reader may already have reloaded this
+            // same change, and parsing it twice would be pure waste.
+            if (stamp == _stamp)
+                return _rules;
+
+            try
+            {
+                var rules = ExtractRules(ReadLines());
+                var before = _rules.Count;
+                _rules = rules;
+                _stamp = stamp;
+
+                _logger.LogInformation(
+                    "rules.md changed on disk — reloaded {Count} rule(s) (was {Before})",
+                    rules.Count, before);
+
+                return rules;
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                // Deliberately not stamping: the next read retries rather than treating the
+                // failed parse as the current state of the file.
+                _logger.LogWarning(ex,
+                    "Could not reload rules.md; continuing with the {Count} rule(s) already loaded",
+                    _rules.Count);
+                return _rules;
+            }
+        }
+    }
+
+    /// <summary>
+    /// The stamp of a file that is not there. A distinct value rather than <c>null</c> so that
+    /// deleting <c>rules.md</c> registers as a change and clears the rules, while a stat that
+    /// throws stays unknown and changes nothing.
+    /// </summary>
+    private static readonly (DateTime LastWriteUtc, long Length) Missing = (DateTime.MinValue, -1);
+
+    /// <summary>
+    /// Timestamp and length of <paramref name="path"/>, <see cref="Missing"/> when it does not
+    /// exist, or <c>null</c> when it cannot be stat'd at all.
+    /// </summary>
+    private static (DateTime LastWriteUtc, long Length)? StampOf(string path)
+    {
+        try
+        {
+            var info = new FileInfo(path);
+            return info.Exists ? (info.LastWriteTimeUtc, info.Length) : Missing;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return null;
+        }
+    }
+
     private List<string> ReadLines() =>
         File.Exists(_filePath) ? [.. File.ReadAllLines(_filePath)] : [];
 
@@ -254,6 +367,9 @@ internal sealed partial class FileRulesStore : IRulesStore
             _filePath,
             lines.Count == 0 ? string.Empty : string.Join(Environment.NewLine, lines) + Environment.NewLine);
 
+        // Stamp after the rename, so this store's own write is not mistaken for an external
+        // edit and re-parsed on the next prompt.
+        _stamp = StampOf(_filePath);
         _rules = ExtractRules(lines);
     }
 

--- a/tests/RockBot.Host.Tests/FileRulesStoreTests.cs
+++ b/tests/RockBot.Host.Tests/FileRulesStoreTests.cs
@@ -346,6 +346,104 @@ public sealed class FileRulesStoreTests
 
     // ── Helpers ───────────────────────────────────────────────────────────────
 
+    // ── Rules read-through ────────────────────────────────────────────────────
+    //
+    // Rules is consumed synchronously on every prompt build. Serving a startup snapshot meant
+    // a rules.md pushed to a running pod did nothing until the process restarted.
+
+    [TestMethod]
+    public async Task Rules_AfterTheFileIsEditedExternally_ServesTheNewRules()
+    {
+        await WriteRulesFileAsync("# Active Rules", string.Empty, "- Original rule");
+        var store = CreateStore();
+        CollectionAssert.AreEqual(new[] { "Original rule" }, store.Rules.ToArray());
+
+        await WriteRulesFileAsync("# Active Rules", string.Empty, "- Original rule", "- Pushed rule");
+        TouchRulesFile();
+
+        CollectionAssert.AreEqual(
+            new[] { "Original rule", "Pushed rule" },
+            store.Rules.ToArray(),
+            "a rules.md pushed to a running pod must reach the prompt without a restart");
+    }
+
+    [TestMethod]
+    public async Task Rules_WhenTheFileIsUnchanged_KeepsServingTheSameInstance()
+    {
+        await WriteRulesFileAsync("# Active Rules", string.Empty, "- Original rule");
+        var store = CreateStore();
+
+        var first = store.Rules;
+        var second = store.Rules;
+
+        Assert.AreSame(first, second, "an unchanged file should cost a stat, not a re-parse");
+    }
+
+    [TestMethod]
+    public async Task Rules_AfterTheFileIsDeleted_ReportsNoRules()
+    {
+        await WriteRulesFileAsync("# Active Rules", string.Empty, "- Original rule");
+        var store = CreateStore();
+        Assert.AreEqual(1, store.Rules.Count);
+
+        File.Delete(_rulesPath);
+
+        Assert.AreEqual(0, store.Rules.Count, "a deleted rules.md is a change, not a stat failure");
+    }
+
+    [TestMethod]
+    public async Task Rules_AfterAnExternalEditThenAnAdd_KeepsBothRules()
+    {
+        await WriteRulesFileAsync("# Active Rules", string.Empty, "- Original rule");
+        var store = CreateStore();
+        _ = store.Rules;
+
+        await WriteRulesFileAsync("# Active Rules", string.Empty, "- Original rule", "- Pushed rule");
+        TouchRulesFile();
+        _ = store.Rules;
+
+        await store.AddAsync("Added rule");
+
+        CollectionAssert.AreEqual(
+            new[] { "Original rule", "Pushed rule", "Added rule" },
+            store.Rules.ToArray(),
+            "the read-through must not resurrect a pre-push snapshot over the pushed file");
+    }
+
+    [TestMethod]
+    public async Task Rules_AfterAMutation_DoesNotReparse()
+    {
+        var store = CreateStore();
+        await store.AddAsync("Added rule");
+
+        var first = store.Rules;
+        var second = store.Rules;
+
+        Assert.AreSame(first, second, "the store's own write should be stamped, not re-read");
+    }
+
+    [TestMethod]
+    public async Task Rules_WhenNonRuleContentIsEditedExternally_LeavesTheRulesAlone()
+    {
+        await WriteRulesFileAsync("# Active Rules", string.Empty, "- Original rule");
+        var store = CreateStore();
+        _ = store.Rules;
+
+        await WriteRulesFileAsync(
+            "# Active Rules", string.Empty, "Some prose a human added.", string.Empty, "- Original rule");
+        TouchRulesFile();
+
+        CollectionAssert.AreEqual(new[] { "Original rule" }, store.Rules.ToArray());
+    }
+
+    /// <summary>
+    /// Forces a distinct last-write timestamp. Filesystem timestamp granularity is coarse
+    /// enough that two writes in the same test can land on the same tick, which would make
+    /// these tests pass or fail on timing rather than on behaviour.
+    /// </summary>
+    private void TouchRulesFile() =>
+        File.SetLastWriteTimeUtc(_rulesPath, DateTime.UtcNow.AddSeconds(1));
+
     private FileRulesStore CreateStore() =>
         new(Options.Create(new AgentProfileOptions { BasePath = _tempDir }),
             NullLogger<FileRulesStore>.Instance);


### PR DESCRIPTION
## The gap

`rules.md` is injected into every prompt as its own system message — *"Active rules — always follow these, regardless of context or other instructions"* — which makes it the highest-salience place in the profile to put an absolute constraint.

But `IRulesStore.Rules`, the property `AgentContextBuilder` reads while assembling each prompt, served a list parsed once in the constructor. A `rules.md` pushed to a running pod did **nothing** until the process restarted, while `soul.md`, `directives.md` and `style.md` sitting beside it on the same PVC hot-reload in about half a second. Nothing logged to say the file on disk and the file in the prompt had diverged.

A rule the operator can see on disk and the agent is demonstrably not following is the worst of both states. Hit this for real pushing two standing directives to the `muse` release: the `soul.md`/`style.md` copies went live immediately, the matching `rules.md` bullets sat inert.

## The fix

`Rules` is now a read-through gated on the file's timestamp and length — an unchanged file costs one `stat` per prompt rather than a parse, and a change is picked up on the next turn. The mutation paths (`AddAsync`/`RemoveAsync`/`EditAsync`/`ListAsync`) already re-read before writing and are unchanged; they now also stamp, so the store's own write isn't mistaken for an external edit.

**Deliberately not a `FileSystemWatcher.`** These files live on a Longhorn PVC, where watchers have been observed to miss the rename half of an atomic write while polling catches it — the same reason `mcp.json` carries a poll fallback. A stat on read has no such blind spot, needs no background loop, and cannot observe a half-written file: `AtomicFile` replaces content by rename, so a reader sees the old bytes or the new ones, never a mixture.

## Three cases, not two

Two of these fail in the direction that silently drops a constraint the agent is meant to be following, so they're kept distinct rather than collapsed into "couldn't read it":

| | Behaviour |
|---|---|
| **Changed** | Re-parse, and log what the rule count went from and to |
| **Absent** | A real stamp of its own, so deleting `rules.md` clears the rules |
| **Unreadable** | Keep serving the rules already loaded, and *don't* stamp — the next read retries rather than treating a failed parse as the file's state |

## Known limitation

Change detection shares the limitation of every stat-based check in the host (including `DefaultSystemPromptBuilder`'s category-hint check): two writes inside one filesystem timestamp tick that leave the length identical are indistinguishable. For an operator-pushed file of a few bullets that doesn't earn a hash, and the mutation paths are unaffected.

## Testing

Six tests added. Two of them fail against the old `Rules => _rules` and pass with the fix — verified by reverting that one line:

```
Failed Rules_AfterTheFileIsEditedExternally_ServesTheNewRules
Failed Rules_AfterTheFileIsDeleted_ReportsNoRules
```

The other four are regression guards on the caching: unchanged file returns the same instance, a mutation doesn't trigger a re-parse, an external push followed by `AddAsync` keeps both rules, and editing non-rule prose leaves the rules alone. Tests force a distinct mtime explicitly rather than relying on timestamp granularity, so they don't pass or fail on timing.

Full suite green — 20 assemblies, 0 failures (RabbitMQ integration skipped, no broker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CDaq9A1aiv8cNZRee4NmCF
