### PR TITLE
Let a deployment claim its own Tailscale ACL tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,8 @@ secrets:
 blazor:
   tailscale:
     hostname: "rockbot"   # exposes the UI at http://rockbot on your tailnet
+    # tags: ["tag:rockbot"]  # optional — give this endpoint its own tailnet ACL
+                             # identity so access rules can single it out
 
 # Optional — enable the OpenRouter MCP server
 # openrouterMcp:

--- a/deploy/helm/rockbot/Chart.yaml
+++ b/deploy/helm/rockbot/Chart.yaml
@@ -4,8 +4,8 @@ description: >
   RockBot — an event-driven autonomous agent framework built on .NET.
   Deploys the RockBot agent and the Blazor Server web UI.
 type: application
-version: 0.10.18
-appVersion: "0.10.18"
+version: 0.10.19
+appVersion: "0.10.19"
 home: https://github.com/rockylhotka/rockbot
 keywords:
   - ai

--- a/deploy/helm/rockbot/templates/_helpers.tpl
+++ b/deploy/helm/rockbot/templates/_helpers.tpl
@@ -93,3 +93,26 @@ being empty, since a blank continuation line would break the shell command.
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+Comma-joined Tailscale tag list for the Blazor proxy device, or "" when unset.
+
+The operator reads tailscale.com/tags on both the layer-3 Service and the layer-7
+Ingress, and expects a comma-separated list. Tags are what the tailnet ACL matches
+on: with none set the operator falls back to its own PROXY_TAGS default, which every
+proxy it manages in the cluster shares — so no ACL rule can single out one endpoint.
+Set this when a deployment needs its own access rule.
+
+Validated here rather than at apply time because the operator rejects an unprefixed
+tag by leaving the proxy Pod unregistered, with nothing useful surfaced on the
+Kubernetes side.
+*/}}
+{{- define "rockbot.blazor.tailscaleTags" -}}
+{{- $tags := .Values.blazor.tailscale.tags | default list }}
+{{- range $t := $tags }}
+{{- if not (hasPrefix "tag:" $t) }}
+{{- fail (printf "blazor.tailscale.tags: %q is not a valid tag — every entry must start with 'tag:' (e.g. tag:trees)" $t) }}
+{{- end }}
+{{- end }}
+{{- join "," $tags }}
+{{- end }}

--- a/deploy/helm/rockbot/templates/blazor/ingress.yaml
+++ b/deploy/helm/rockbot/templates/blazor/ingress.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.blazor.tailscale.ingress.enabled }}
+{{- $tsTags := include "rockbot.blazor.tailscaleTags" . }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -7,9 +8,15 @@ metadata:
   labels:
     {{- include "rockbot.labels" . | nindent 4 }}
     app.kubernetes.io/component: blazor
-  {{- if .Values.blazor.tailscale.ingress.proxyGroup }}
+  {{- if or .Values.blazor.tailscale.ingress.proxyGroup $tsTags }}
   annotations:
+    {{- if .Values.blazor.tailscale.ingress.proxyGroup }}
     tailscale.com/proxy-group: {{ .Values.blazor.tailscale.ingress.proxyGroup | quote }}
+    {{- end }}
+    {{- if $tsTags }}
+    # ACL identity for this endpoint. See blazor.tailscale.tags in values.yaml.
+    tailscale.com/tags: {{ $tsTags | quote }}
+    {{- end }}
   {{- end }}
   # Deliberately absent: tailscale.com/funnel. That annotation — and only that
   # annotation — would publish this endpoint to the public internet. Without it the

--- a/deploy/helm/rockbot/templates/blazor/service.yaml
+++ b/deploy/helm/rockbot/templates/blazor/service.yaml
@@ -1,3 +1,4 @@
+{{- $tsTags := include "rockbot.blazor.tailscaleTags" . }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -12,6 +13,10 @@ metadata:
     # at <hostname> (no Funnel, private to tailnet only).
     # Requires: https://tailscale.com/kb/1236/kubernetes-operator
     tailscale.com/hostname: {{ .Values.blazor.tailscale.hostname | quote }}
+    {{- if $tsTags }}
+    # ACL identity for this endpoint. See blazor.tailscale.tags in values.yaml.
+    tailscale.com/tags: {{ $tsTags | quote }}
+    {{- end }}
 {{- end }}
 spec:
 {{- if .Values.blazor.tailscale.ingress.enabled }}
@@ -19,6 +24,9 @@ spec:
   # Service is a plain in-cluster backend. It must NOT also be a tailscale
   # LoadBalancer — two devices competing for <hostname> means the loser is renamed
   # <hostname>-1 and the certificate follows the wrong name.
+  #
+  # The tags annotation lives on the Ingress in this mode, not here — the Ingress
+  # owns the device.
   type: ClusterIP
 {{- else }}
   type: LoadBalancer

--- a/deploy/helm/rockbot/values.yaml
+++ b/deploy/helm/rockbot/values.yaml
@@ -81,6 +81,27 @@ blazor:
     # Requires the Tailscale Kubernetes Operator to be installed.
     hostname: rockbot
 
+    # Tailscale ACL tags for this endpoint's proxy device, e.g. ["tag:trees"].
+    # Every entry must start with "tag:" or the chart fails to render.
+    #
+    # Empty (default) means the operator applies its own PROXY_TAGS value, which is
+    # shared by EVERY proxy it manages in the cluster — so a tailnet ACL cannot tell
+    # this deployment apart from any other service the operator exposes. Set a tag
+    # when this instance needs an access rule of its own (e.g. one user who may reach
+    # this UI and nothing else).
+    #
+    # Two things must be true before the proxy can register:
+    #   1. The tag exists in the tailnet policy's tagOwners, AND
+    #   2. the operator's OAuth client is listed as an owner of it, because a client
+    #      may only apply tags it owns:
+    #          "tagOwners": { "tag:trees": ["tag:k8s-operator"] }
+    # Otherwise the proxy Pod never comes up and the endpoint simply never appears.
+    #
+    # NOTE: changing tags on a LIVE deployment changes the device's identity in the
+    # ACL. Grant access under the new tag before you apply, or you lock yourself out
+    # of the endpoint until the policy catches up.
+    tags: []
+
     ingress:
       # false (default) — expose over a layer-3 LoadBalancer Service. Plain HTTP
       #   at http://<hostname>. No TLS certificate is issued.

--- a/docs/blazor-ui.md
+++ b/docs/blazor-ui.md
@@ -184,6 +184,43 @@ Both modes stay **private to your tailnet**: the name resolves to a CGNAT `100.x
 that is not routable from the internet. Publishing to the public internet would require the
 `tailscale.com/funnel` annotation, which this chart never emits.
 
+### ACL tags
+
+By default the operator stamps every proxy device it creates with its own configured
+`PROXY_TAGS` value. That tag is shared by *every* service the operator exposes in the
+cluster, so a tailnet ACL cannot tell one endpoint from another — a rule granting access
+to the RockBot UI would equally grant access to any other operator-managed endpoint.
+
+Give a deployment its own tag when it needs an access rule of its own:
+
+```yaml
+blazor:
+  tailscale:
+    hostname: "trees"
+    tags: ["tag:trees"]   # every entry must start with "tag:"
+```
+
+The annotation lands on whichever resource owns the Tailscale device — the Service in
+layer-3 mode, the Ingress in layer-7 mode. A tailnet policy can then scope access to just
+this endpoint:
+
+```jsonc
+{ "action": "accept", "src": ["teresa@example.com"], "dst": ["tag:trees:443"] }
+```
+
+Two prerequisites, both in the tailnet policy file, and the proxy Pod will not register
+without them — it fails quietly, so the endpoint simply never appears:
+
+1. The tag must exist in `tagOwners`.
+2. The operator's OAuth client must own it, since a client may only apply tags it owns:
+   `"tagOwners": { "tag:trees": ["tag:k8s-operator"] }`.
+
+Add both **before** deploying with the tag set.
+
+> Changing `tags` on a live deployment changes that device's identity in the ACL. Grant
+> access under the new tag first, or you lock yourself out of the endpoint until the
+> policy catches up.
+
 Two things to know before switching an existing deployment:
 
 - **The Tailscale device is replaced.** Deploy once with `ingress.enabled: false` so the


### PR DESCRIPTION
## Problem

The Tailscale Kubernetes operator stamps every proxy device it creates with its own configured `PROXY_TAGS` value. That tag is shared by *every* service the operator exposes in a cluster, so a tailnet ACL cannot tell one endpoint from another — a rule granting access to one Blazor UI equally grants access to every other operator-managed endpoint alongside it (Rancher, Longhorn, Grafana, other RockBot instances...).

There was no way to scope tailnet access to a single RockBot deployment. That blocks running a second instance for a different person.

## Change

New `blazor.tailscale.tags` (a list, default `[]`), rendered as the `tailscale.com/tags` annotation on whichever resource owns the Tailscale device — the Ingress in layer-7 mode, the Service in layer-3.

```yaml
blazor:
  tailscale:
    hostname: "trees"
    tags: ["tag:trees"]
```

A tailnet policy can then single the endpoint out:

```jsonc
{ "action": "accept", "src": ["someone@example.com"], "dst": ["tag:trees:443"] }
```

Two details worth review:

- **The ingress annotations block was previously gated on `proxyGroup` alone.** It would have swallowed the tags annotation whenever a tag was set without a ProxyGroup — the common case. It now renders if either is set.
- **Tags are validated for the `tag:` prefix at template time.** The operator's failure mode for a malformed tag is a proxy Pod that never registers, with nothing useful surfaced on the Kubernetes side, so failing the render is much easier to diagnose than the alternative.

Layer-3 is covered as well as layer-7. It's four lines, and omitting it would make `tags` silently do nothing for anyone on the chart's default path.

## Compatibility

Defaults to `[]`. Existing deployments render byte-identically — verified below.

Chart `0.10.18` → `0.10.19`.

## Validation

`helm lint` clean. Six render cases checked:

| Case | Result |
|---|---|
| default (no tags, L3) | identical to before, no annotation |
| L3 + tags | annotation on the Service |
| L7 + tags, no proxyGroup | annotation block present — the regression fixed here |
| L7 + proxyGroup + two tags | `"tag:trees,tag:ui"`, both annotations |
| L7 + tags | Service stays `ClusterIP`, no tags annotation, so no second device competes for the hostname |
| invalid tag `trees` | render fails with a named error |

## Deploying with a tag

Ordering constraint, documented in `docs/blazor-ui.md`: the tag must exist in the tailnet policy's `tagOwners` **and** list the operator's OAuth client as an owner (`"tag:trees": ["tag:k8s-operator"]`) *before* the tagged resource is created. A client may only apply tags it owns; otherwise the proxy Pod never registers and the endpoint simply never appears.

Changing `tags` on a live deployment also changes that device's identity in the ACL — grant access under the new tag first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ff7ThnvU1J9tb6vFAnW98f
