### PR TITLE
Publish the Helm chart to GHCR as an OCI artifact

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -1,0 +1,75 @@
+# Publishes the RockBot Helm chart to GHCR as an OCI artifact, so GitOps tooling
+# (Fleet, Argo, plain `helm install`) can consume it without vendoring a copy.
+#
+# Deliberately NOT part of release.yml: the chart version in Chart.yaml moves
+# independently of the app version in Directory.Build.props (0.10.19 vs 0.14.14 at
+# time of writing) and far more often than releases are cut. Tying chart publishing
+# to release/v* branches would leave chart changes unpublished for months.
+#
+# ONE-TIME SETUP: the first push creates a PRIVATE GHCR package. Make it public at
+#   https://github.com/orgs/MarimerLLC/packages/container/rockbot/settings
+# or anonymous `helm pull` fails and every consumer needs a pull secret.
+name: Publish Helm Chart
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'deploy/helm/rockbot/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: azure/setup-helm@v4
+        with:
+          version: v3.16.3
+
+      - name: Read chart version
+        id: chart
+        run: |
+          version="$(helm show chart deploy/helm/rockbot | awk '/^version:/ {print $2}')"
+          if [ -z "$version" ]; then
+            echo "::error::could not read version from deploy/helm/rockbot/Chart.yaml"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Chart version: $version"
+
+      - name: Lint
+        run: helm lint deploy/helm/rockbot
+
+      - name: Log in to GHCR
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" \
+            | helm registry login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      # Published chart versions are immutable by convention: consumers pin an exact
+      # version, so silently replacing one would change what a pinned deployment
+      # renders. Bump the version in Chart.yaml instead.
+      - name: Skip if this version is already published
+        id: exists
+        run: |
+          if helm show chart "oci://ghcr.io/${{ github.repository_owner }}/rockbot" \
+               --version "${{ steps.chart.outputs.version }}" >/dev/null 2>&1; then
+            echo "already=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::rockbot ${{ steps.chart.outputs.version }} is already published — nothing to do. Bump version in Chart.yaml to publish a change."
+          else
+            echo "already=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Package and push
+        if: steps.exists.outputs.already == 'false'
+        run: |
+          helm package deploy/helm/rockbot --destination ./dist
+          helm push "./dist/rockbot-${{ steps.chart.outputs.version }}.tgz" \
+            "oci://ghcr.io/${{ github.repository_owner }}"
+          echo "::notice::published oci://ghcr.io/${{ github.repository_owner }}/rockbot:${{ steps.chart.outputs.version }}"

--- a/README.md
+++ b/README.md
@@ -355,6 +355,20 @@ helm upgrade --install rockbot deploy/helm/rockbot \
   --create-namespace
 ```
 
+The chart is also published to GHCR as an OCI artifact on every change to
+`deploy/helm/rockbot/**`, so GitOps tooling can consume it without vendoring a copy:
+
+```bash
+helm upgrade --install rockbot oci://ghcr.io/marimerllc/rockbot \
+  --version 0.10.19 \
+  -f deploy/values.personal.yaml \
+  --create-namespace
+```
+
+Published versions are treated as immutable — the workflow skips a version that already
+exists rather than replacing it, since consumers pin an exact version. Bump `version:` in
+`Chart.yaml` to publish a change.
+
 #### 3. Restart pods to pick up new images
 
 After pushing updated images (all tagged `latest`):


### PR DESCRIPTION
## Problem

GitOps tooling can't reference a chart that only exists inside this repo's source tree. Fleet specifically requires the chart to live *inside* the bundle directory, so consuming the RockBot chart from a GitOps repo means vendoring a full copy — ~30 files duplicated into another repo, going stale on every chart change. The chart is first-party and moves (0.10.18 → 0.10.19 today), so that copy is a treadmill, not a one-time cost.

## Change

A workflow that packages the chart and pushes it to GHCR. Consumers pin a version:

```bash
helm upgrade --install rockbot oci://ghcr.io/marimerllc/rockbot --version 0.10.19
```

### Why a separate workflow, not a step in `release.yml`

The chart version in `Chart.yaml` moves independently of the app version in `Directory.Build.props` — **0.10.19 vs 0.14.14** as of this commit — and far more often than release branches are cut (last release was v0.12.24 in May). Tying chart publishing to `release/v*` would leave chart changes unpublished for months. This triggers on any change under `deploy/helm/rockbot/**`, plus `workflow_dispatch`.

### Immutability

The workflow **skips** a version that already exists rather than replacing it. Consumers pin exact versions, so silently swapping the contents of `0.10.19` would change what an otherwise-unchanged deployment renders. To publish a change, bump `version:` in `Chart.yaml` — the workflow emits a notice saying exactly that when it skips.

### Credentials

None needed. GHCR authenticates with `GITHUB_TOKEN` + `packages: write`.

## ⚠️ One-time manual step after merge

The first push creates a **private** GHCR package. It must be made public once:

`https://github.com/orgs/MarimerLLC/packages/container/rockbot/settings`

Otherwise anonymous `helm pull` fails and every consumer needs an image pull secret. This is noted in the workflow header too.

## Validation

Ran the workflow's own commands locally against this chart:

- version extraction — `helm show chart deploy/helm/rockbot | awk '/^version:/ {print $2}'` → `0.10.19`
- `helm lint` — clean
- `helm package` → `rockbot-0.10.19.tgz`, matching the filename the push step constructs

The GHCR round-trip itself can only be exercised on merge, since it needs `GITHUB_TOKEN`.

## Note, not addressed here

`Chart.yaml` has `appVersion: "0.10.19"` while the app is at `0.14.14`, so the `app.kubernetes.io/version` label on every rendered resource is wrong. Pre-existing and out of scope for this PR, but worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ff7ThnvU1J9tb6vFAnW98f
