### PR TITLE
Fix GHCR push: lowercase the registry namespace

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -33,6 +33,14 @@ jobs:
         with:
           version: v3.16.3
 
+      # OCI references must be lowercase, but github.repository_owner preserves the
+      # org's casing ("MarimerLLC"). Pushing to oci://ghcr.io/MarimerLLC fails with
+      # "invalid_reference: invalid repository". Lowercase it once, use it everywhere.
+      - name: Resolve registry namespace
+        id: reg
+        run: |
+          echo "owner=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
       - name: Read chart version
         id: chart
         run: |
@@ -58,7 +66,7 @@ jobs:
       - name: Skip if this version is already published
         id: exists
         run: |
-          if helm show chart "oci://ghcr.io/${{ github.repository_owner }}/rockbot" \
+          if helm show chart "oci://ghcr.io/${{ steps.reg.outputs.owner }}/rockbot" \
                --version "${{ steps.chart.outputs.version }}" >/dev/null 2>&1; then
             echo "already=true" >> "$GITHUB_OUTPUT"
             echo "::notice::rockbot ${{ steps.chart.outputs.version }} is already published — nothing to do. Bump version in Chart.yaml to publish a change."
@@ -71,5 +79,5 @@ jobs:
         run: |
           helm package deploy/helm/rockbot --destination ./dist
           helm push "./dist/rockbot-${{ steps.chart.outputs.version }}.tgz" \
-            "oci://ghcr.io/${{ github.repository_owner }}"
-          echo "::notice::published oci://ghcr.io/${{ github.repository_owner }}/rockbot:${{ steps.chart.outputs.version }}"
+            "oci://ghcr.io/${{ steps.reg.outputs.owner }}"
+          echo "::notice::published oci://ghcr.io/${{ steps.reg.outputs.owner }}/rockbot:${{ steps.chart.outputs.version }}"


### PR DESCRIPTION
The first run of the publish workflow failed:

```
Error: invalid_reference: invalid repository
```

OCI references must be lowercase, but `github.repository_owner` preserves the organisation's casing, so the workflow was pushing to `oci://ghcr.io/MarimerLLC`.

Lowercases it once into a step output and uses that for all three references.

Worth noting: the **skip-if-published check had the same bug**, and it looked like it passed. `helm show chart` against the invalid reference failed, that failure was swallowed by `2>/dev/null`, and the step read the result as "not published yet". So the guard was never actually exercised — it would have failed open on every run.

Consumers were already written against the correct lowercase path (`oci://ghcr.io/marimerllc/rockbot`) in the README and in the Fleet bundle that depends on this, so nothing downstream changes.

Unrelated annotation seen on the same run, not addressed here: `actions/checkout@v4` and `azure/setup-helm@v4` target Node.js 20 and are being force-run on Node 24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ff7ThnvU1J9tb6vFAnW98f
