### PR TITLE
Correct two doc comments that contradict the code

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -6,9 +6,10 @@
 # time of writing) and far more often than releases are cut. Tying chart publishing
 # to release/v* branches would leave chart changes unpublished for months.
 #
-# ONE-TIME SETUP: the first push creates a PRIVATE GHCR package. Make it public at
-#   https://github.com/orgs/MarimerLLC/packages/container/rockbot/settings
-# or anonymous `helm pull` fails and every consumer needs a pull secret.
+# The published package is public (it inherits the repository's visibility), so consumers
+# pull anonymously with no image pull secret. If this workflow is ever reused from a
+# PRIVATE repo the package will be private too, and would need flipping at
+#   https://github.com/orgs/<org>/packages/container/rockbot/settings
 name: Publish Helm Chart
 
 on:

--- a/src/RockBot.Host/HeartbeatBootstrapOptions.cs
+++ b/src/RockBot.Host/HeartbeatBootstrapOptions.cs
@@ -13,7 +13,7 @@ public sealed class HeartbeatBootstrapOptions
 
     /// <summary>
     /// Cron expression controlling how often the patrol fires.
-    /// Defaults to every 30 minutes.
+    /// Defaults to every 6 hours.
     /// </summary>
     public string CronExpression { get; set; } = "0 */6 * * *";
 }


### PR DESCRIPTION
Two comments that would actively mislead a reader. No behaviour change.

**1. `helm-chart.yml` header** told the reader to flip the GHCR package to public after the first push. That turns out to be wrong for this repo — the package inherits the repository's visibility, and I verified an anonymous manifest fetch against `ghcr.io/marimerllc/rockbot:0.10.19` returns `200` with no credentials. Following the old note would send someone hunting for a setting that needs no change. Reworded to describe the case where it *would* apply: reuse from a private repo.

**2. `HeartbeatBootstrapOptions.CronExpression`** documented a 30-minute default while the value has been `"0 */6 * * *"` — every 6 hours. Anyone sizing patrol cost or frequency from the comment would be off by 12x.

`dotnet build` on `RockBot.Host` clean; workflow YAML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ff7ThnvU1J9tb6vFAnW98f
