### PR TITLE
Let the introspection sidecar write the agent name file

### DIFF
--- a/deploy/helm/rockbot/Chart.yaml
+++ b/deploy/helm/rockbot/Chart.yaml
@@ -4,8 +4,8 @@ description: >
   RockBot — an event-driven autonomous agent framework built on .NET.
   Deploys the RockBot agent and the Blazor Server web UI.
 type: application
-version: 0.10.19
-appVersion: "0.10.19"
+version: 0.10.20
+appVersion: "0.10.20"
 home: https://github.com/rockylhotka/rockbot
 keywords:
   - ai

--- a/deploy/helm/rockbot/templates/agent/deployment.yaml
+++ b/deploy/helm/rockbot/templates/agent/deployment.yaml
@@ -150,9 +150,14 @@ spec:
             - name: AgentName__Path
               value: /data/agent/agent-name.md
           volumeMounts:
+            # NOT readOnly. AgentName__Path above points the set_agent_name tool at
+            # /data/agent/agent-name.md, so a read-only mount makes that tool fail with
+            # "Read-only file system" every time — it was added after the agent-name
+            # feature and silently broke it. The sidecar's tool surface is fixed and
+            # only ever writes that one path, so this does not widen what the LLM can
+            # reach; the agent container in this same Pod already mounts the volume rw.
             - name: agent-data
               mountPath: /data/agent
-              readOnly: true
           livenessProbe:
             httpGet:
               path: /health


### PR DESCRIPTION
## The bug

`set_agent_name` has never worked, on any instance.

The chart sets `AgentName__Path` on the introspection sidecar to `/data/agent/agent-name.md`, then mounts that exact path `readOnly: true` a few lines below. Every call fails with `Read-only file system`. `get_agent_name` works fine, which is why it reads as a functioning feature right up until someone tries to set a name.

Verified live rather than inferred:

```
# in the introspection sidecar
touch: cannot touch '/data/agent/.probe': Read-only file system
# same probe in the agent container
WRITABLE
```

and no `agent-name.md` exists on the running rockbot instance.

## It's a regression

`AgentName__Path` landed in `5687018` (0.10.64). The `readOnly: true` mount was added **afterwards** in `cc9e4e7` (#434), which tightened the sidecar's mount without noticing it owned a write path.

## Why drop `readOnly` rather than carve out a narrower mount

The sidecar's tool surface is fixed — 8 tools, and `set_agent_name` is the only one that writes, always to that single path. So this doesn't widen what the LLM can reach through MCP. The agent container in the same Pod already mounts the volume read-write.

The tighter alternative would be a second read-write mount with `subPath: agent-name.md`, but kubelet creates a **directory** when the subPath source doesn't exist yet — which is exactly the first-run case this feature exists for, and it would fail confusingly.

## Impact

Affects `rockbot` and `muse` too; both pick it up on their next chart upgrade. Found while standing up a third instance for a non-technical user, where naming the agent by asking it is the only route available — there's no kubectl to fall back on.

Chart `0.10.19` → `0.10.20`.

## Validation

`helm lint` clean. Rendered mounts:

| container | volume | path | readOnly |
|---|---|---|---|
| agent | agent-data | /data/agent | false |
| agent | shared-data | /rockbot/shared | false |
| introspection-mcp | agent-data | /data/agent | false |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ff7ThnvU1J9tb6vFAnW98f
