### PR TITLE
Preserve the fsGroup on /data/agent so the sidecar can write

### DIFF
--- a/deploy/helm/rockbot/Chart.yaml
+++ b/deploy/helm/rockbot/Chart.yaml
@@ -4,8 +4,8 @@ description: >
   RockBot — an event-driven autonomous agent framework built on .NET.
   Deploys the RockBot agent and the Blazor Server web UI.
 type: application
-version: 0.10.20
-appVersion: "0.10.20"
+version: 0.10.21
+appVersion: "0.10.21"
 home: https://github.com/rockylhotka/rockbot
 keywords:
   - ai

--- a/deploy/helm/rockbot/templates/agent/deployment.yaml
+++ b/deploy/helm/rockbot/templates/agent/deployment.yaml
@@ -25,10 +25,12 @@ spec:
         app.kubernetes.io/component: agent
     spec:
       serviceAccountName: {{ include "rockbot.agentServiceAccountName" . }}
-      # fsGroup applies to the shared-data PVC: kubelet chgrp's the volume to
-      # this GID, sets setgid on dirs, and OR's group rw into the mode. Lets
-      # the agent (UID 999), shared-cleanup (UID 0), and script pods (UID 1000)
-      # all read/write each other's files on /rockbot/shared.
+      # fsGroup applies to every volume in this Pod: kubelet chgrp's them to this
+      # GID, sets setgid on dirs, and OR's group rw into the mode. On
+      # /rockbot/shared it lets the agent (UID 999), shared-cleanup (UID 0), and
+      # script pods (UID 1000) read/write each other's files. On /data/agent it is
+      # what lets the introspection sidecar — a different uid — write agent-name.md,
+      # so the init container must preserve this group rather than chown over it.
       securityContext:
         fsGroup: {{ .Values.shared.fsGroup }}
 
@@ -110,7 +112,17 @@ spec:
 
               # Hand ownership to the rockbot user so the main container (non-root)
               # can read and write the volume. The user exists in the image.
-              chown -R rockbot:rockbot /data/agent
+              #
+              # The GROUP is deliberately the pod's fsGroup, not rockbot's own gid.
+              # kubelet already chgrp'd this volume to fsGroup at mount time; chowning
+              # to rockbot:rockbot would clobber that and leave the volume group-owned
+              # by gid 999. The introspection sidecar runs as a different uid (1654 in
+              # its image) and is only ever in the fsGroup, so it would then fall
+              # through to "others" and lose write — which is exactly what broke
+              # set_agent_name, whose target file lives in this directory.
+              # secrets/ stays 0700 above, so it remains private to the rockbot user
+              # regardless of the group.
+              chown -R rockbot:{{ .Values.shared.fsGroup }} /data/agent
               echo "Agent data volume ready."
           volumeMounts:
             - name: agent-data


### PR DESCRIPTION
Second half of the `set_agent_name` fix. #524 removed the `readOnly` mount, and the failure changed from `Read-only file system` to `Permission denied` — a different bug underneath.

## Cause

The init container runs as root and does `chown -R rockbot:rockbot /data/agent`, clobbering the group kubelet had already set from the Pod's `fsGroup`. Measured on a live pod:

| | uid | gid | groups |
|---|---|---|---|
| agent | 999 (rockbot) | 999 | 999, 2000 |
| introspection-mcp | 1654 (app) | 1654 | 1654, **2000** |

`/data/agent` → `drwxrwsr-x rockbot rockbot`. The sidecar isn't in gid 999, so it falls through to "others" (`r-x`) and can't write `agent-name.md`.

## Fix

`chown -R rockbot:{{ .Values.shared.fsGroup }}` — stop fighting `fsGroup` instead of adding a second mechanism. Both containers are already in that group: the agent writes as owner, the sidecar by group, and the setgid bit kubelet sets means new files inherit it.

Rejected alternatives: pinning the sidecar to `runAsUser: 999` (fragile — depends on the sidecar image's own user layout) and `supplementalGroups: [999]` (hardcodes rockbot's gid, breaks if the base image renumbers).

`secrets/` is `chmod 0700` before this runs, so it stays private to the rockbot user regardless of group — the sidecar gains no access there.

Also corrects the `securityContext` comment, which claimed fsGroup "applies to the shared-data PVC". It's Pod-level and applies to every volume, which is exactly what makes this fix work.

## Scope

`agent-data` is mounted only by these two containers, so nothing else gains access. Applies to rockbot and muse on their next chart upgrade; neither is affected today since muse doesn't run the sidecar and rockbot has never had a working `set_agent_name`.

Chart `0.10.20` → `0.10.21`. `helm lint` clean; renders `chown -R rockbot:2000 /data/agent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ff7ThnvU1J9tb6vFAnW98f
