### PR TITLE
Add an opt-in character voice enrichment dream pass

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.14.14</Version>
+<Version>0.14.15</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.Agent/agent/cast-voice-dream.md
+++ b/src/RockBot.Agent/agent/cast-voice-dream.md
@@ -1,0 +1,61 @@
+You maintain the speech profiles in a character corpus.
+
+You are given every entry in one memory category. Some entries already carry a speech profile;
+most record only appearance and events. Your task is to add a profile to characters that lack
+one, so that a character described weeks ago can be written consistently today.
+
+This is a schema-filling task. Deployment-specific guidance on how a profile should read, if
+any exists, is supplied separately by the operator.
+
+## Step 1 — resolve identities
+
+Determine how many distinct characters the entries describe. **A first name is not an
+identity**: two entries sharing a name are frequently different people, distinguished by role,
+location, age, or who they appear alongside.
+
+Assign each character a `characterKey`: the name plus the shortest tag that separates them from
+anyone sharing that name.
+
+If two entries cannot be confidently resolved as the same character, leave both alone. A wrong
+merge is more damaging than a missing profile.
+
+## Step 2 — fill the profile
+
+For each character without one, record the observable, repeatable properties of their speech:
+
+- origin and background, to the extent the entries establish it
+- typical utterance length
+- whether they use contractions
+- how they habitually break off or extend a sentence
+- any consistent error or verbal tic
+- the domain their figures of speech are drawn from
+- how they address other characters
+- **one sample utterance, in quotation marks**
+
+The sample utterance carries the most information. If an entry records something the character
+actually said, reproduce it exactly, without correcting grammar or wording. Otherwise construct
+one consistent with the properties above; a constructed sample illustrates the profile and is
+not a claim about events.
+
+Make each profile distinguishable from the profiles already present. Do not reissue properties
+that another character in the corpus already has.
+
+## Step 3 — constraints
+
+**Derive only.** Properties may be inferred from facts the entries already establish. Do not
+introduce new biography, relationships, events, or names. Where the entries are sparse, produce
+a sparse profile.
+
+**Select one target entry per character** — normally the most detailed or most recent — and
+return its id. The profile is appended; existing text in that entry is left untouched.
+
+**Skip** any character already carrying a profile, and any character you could not resolve.
+
+## Output
+
+Return only a JSON object:
+
+    { "updates": [ { "id": "...", "characterKey": "...", "voiceCard": "..." } ] }
+
+`voiceCard` contains the profile body alone — omit the marker and the character key. Return
+`{ "updates": [] }` if there is nothing to add.

--- a/src/RockBot.Host.Abstractions/DreamOptions.cs
+++ b/src/RockBot.Host.Abstractions/DreamOptions.cs
@@ -203,6 +203,47 @@ public sealed class DreamOptions
     /// </summary>
     public string MemoryMiningDirectivePath { get; set; } = "memory-mining.md";
 
+    /// <summary>
+    /// Whether the cast voice enrichment pass is enabled. Off by default, and inert until
+    /// <see cref="CastVoiceCategory"/> is also configured: it is only meaningful for agents that
+    /// maintain a character corpus in a dedicated memory category.
+    /// </summary>
+    /// <remarks>
+    /// Unlike every other memory pass, this one reads <em>existing memory</em> rather than the
+    /// conversation log, because the gap it fills is in characters whose scenes have long since
+    /// scrolled out of the transcript. It is also the one pass permitted to <em>derive</em>
+    /// rather than only record — a voice is inferred from a character's recorded background when
+    /// no line of theirs survives. That licence is bounded by the directive: derive speech habits
+    /// from facts already on record, never invent new biography or history.
+    /// </remarks>
+    public bool CastVoiceEnrichmentEnabled { get; set; }
+
+    /// <summary>
+    /// Path to the cast voice enrichment directive file, relative to
+    /// <see cref="AgentProfileOptions.BasePath"/>. When the file does not exist, a built-in
+    /// fallback directive is used.
+    /// </summary>
+    public string CastVoiceDirectivePath { get; set; } = "cast-voice-dream.md";
+
+    /// <summary>
+    /// Memory category the cast voice enrichment pass reads and writes. Has no default — the
+    /// category name is deployment-specific, and the pass no-ops until one is configured.
+    /// </summary>
+    public string CastVoiceCategory { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Marker text identifying an entry that already carries a voice card. A character with any
+    /// entry containing this marker is skipped, which is what makes the pass converge instead of
+    /// re-enriching the same cast every cycle.
+    /// </summary>
+    public string CastVoiceMarker { get; set; } = "VOICE CARD";
+
+    /// <summary>
+    /// Maximum number of characters enriched per dream cycle, so one cycle cannot rewrite an
+    /// entire cast corpus. Default: 12.
+    /// </summary>
+    public int CastVoiceMaxPerCycle { get; set; } = 12;
+
     /// <summary>Whether the tier routing self-correction review pass is enabled.</summary>
     public bool TierRoutingReviewEnabled { get; set; } = true;
 

--- a/src/RockBot.Host/DreamService.cs
+++ b/src/RockBot.Host/DreamService.cs
@@ -60,6 +60,7 @@ internal sealed class DreamService : IHostedService, IDisposable
     private string? _prefDreamDirective;
     private string? _skillGapDirective;
     private string? _memoryMiningDirective;
+    private string? _castVoiceDirective;
     private string? _episodeDirective;
     private string? _tierRoutingDirective;
     private string? _sequenceSkillDirective;
@@ -301,6 +302,11 @@ internal sealed class DreamService : IHostedService, IDisposable
                 _logger.LogDebug("DreamService: memory mining directive not found at {Path}; using built-in", memoryMiningDirectivePath);
             else
                 _logger.LogDebug("DreamService: loaded memory mining directive from {Path}", memoryMiningDirectivePath);
+
+            var castVoiceDirectivePath = ResolvePath(_options.CastVoiceDirectivePath, _profileOptions.BasePath);
+            _castVoiceDirective = File.Exists(castVoiceDirectivePath)
+                ? File.ReadAllText(castVoiceDirectivePath)
+                : null;
 
             var episodeDirectivePath = ResolvePath(_options.EpisodeDirectivePath, _profileOptions.BasePath);
             _episodeDirective = File.Exists(episodeDirectivePath)
@@ -557,6 +563,8 @@ internal sealed class DreamService : IHostedService, IDisposable
             ct.ThrowIfCancellationRequested(); await RunGraphConsolidationPassAsync(ct);
 
             ct.ThrowIfCancellationRequested(); await RunMemoryMiningPassAsync(ct);
+
+            ct.ThrowIfCancellationRequested(); await RunCastVoiceEnrichmentPassAsync(ct);
 
             // Observation framework reads the same conversation log used by
             // memory mining and preference inference, so it must run before
@@ -2179,6 +2187,190 @@ internal sealed class DreamService : IHostedService, IDisposable
     /// (which targets behavioral patterns) and skill gap detection (which targets procedures).
     /// Does NOT clear the log — that is deferred to <see cref="RunPreferenceInferencePassAsync"/>.
     /// </summary>
+    /// <summary>
+    /// Fills in missing character voices in the cast corpus.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The odd one out among the memory passes: it reads <em>existing memory</em> rather than the
+    /// conversation log. That is the whole point of it. A character's establishing dialogue scrolls
+    /// out of the context window within a session or two, and what the record keeps of them is a
+    /// face and a list of things they did — so a returning character is rebuilt from a physical
+    /// description and every one of them converges on the same neutral speaker. Mining cannot fix
+    /// that, because by the time the gap is visible the transcript that would close it is gone.
+    /// </para>
+    /// <para>
+    /// It is also the one pass allowed to <em>derive</em> rather than only record: where no line of
+    /// a character's survives, a voice is inferred from the background already on file. The licence
+    /// is bounded in the directive — speech habits derived from recorded facts, never new biography.
+    /// </para>
+    /// <para>
+    /// Updates land in place, on the character's existing entry. <see cref="MergeVoiceCard"/> is
+    /// append-only for exactly that reason: an in-place pass over a curated corpus must not be
+    /// capable of losing a recorded fact, whatever the model returns.
+    /// </para>
+    /// <para>
+    /// Convergence comes from the marker: a character carrying <see cref="DreamOptions.CastVoiceMarker"/>
+    /// on any of their entries is skipped, so a cast that has been fully enriched costs one LLM call
+    /// per cycle and writes nothing.
+    /// </para>
+    /// </remarks>
+    private async Task RunCastVoiceEnrichmentPassAsync(CancellationToken ct)
+    {
+        if (!_options.CastVoiceEnrichmentEnabled)
+            return;
+
+        var category = _options.CastVoiceCategory;
+        var marker = _options.CastVoiceMarker;
+
+        if (string.IsNullOrWhiteSpace(category) || string.IsNullOrWhiteSpace(marker))
+        {
+            _logger.LogWarning("DreamService: cast voice enrichment enabled but category or marker is empty; skipping");
+            return;
+        }
+
+        var cast = await _memory.SearchAsync(
+            new MemorySearchCriteria(Category: category, MaxResults: 1000), ct);
+
+        if (cast.Count == 0)
+        {
+            _logger.LogDebug("DreamService: cast voice enrichment — category {Category} is empty; skipping", category);
+            return;
+        }
+
+        var uncarded = cast.Count(e => !HasVoiceMarker(e.Content, marker));
+        if (uncarded == 0)
+        {
+            _logger.LogInformation(
+                "DreamService: cast voice enrichment — all {Count} entries in {Category} already carry a voice card; nothing to do",
+                cast.Count, category);
+            return;
+        }
+
+        _logger.LogInformation(
+            "DreamService: cast voice enrichment pass — {Total} entries in {Category}, {Uncarded} without a voice card",
+            cast.Count, category, uncarded);
+
+        await RunPassAsync("cast voice enrichment", async () =>
+        {
+            var userMessage = new StringBuilder();
+            userMessage.AppendLine($"Every entry currently in `{category}`, with its id.");
+            userMessage.AppendLine();
+            userMessage.AppendLine(
+                $"Entries already containing \"{marker}\" are shown so you can see which characters are " +
+                "finished and which voices already exist. Never propose an update to one of those, and " +
+                "never give a new character a voice that duplicates one already on the page.");
+            userMessage.AppendLine();
+
+            foreach (var e in cast)
+                userMessage.AppendLine($"[{e.Id}] {e.Content}");
+
+            userMessage.AppendLine();
+            userMessage.AppendLine(
+                $"Enrich at most {_options.CastVoiceMaxPerCycle} characters this cycle. Choose the ones " +
+                "with the most entries and the most recent activity first — they are the ones most likely " +
+                "to walk back on stage.");
+
+            var result = await InvokeDreamPassAsync<CastVoiceResultDto>(
+                "cast voice enrichment",
+                _castVoiceDirective ?? BuiltInCastVoiceDirective,
+                userMessage.ToString(),
+                ct);
+
+            if (result is null) return;
+
+            var updated = 0;
+            var skipped = 0;
+
+            foreach (var dto in result.Updates ?? [])
+            {
+                if (updated >= _options.CastVoiceMaxPerCycle)
+                {
+                    _logger.LogInformation(
+                        "DreamService: cast voice enrichment — per-cycle cap of {Cap} reached; remaining proposals deferred to the next cycle",
+                        _options.CastVoiceMaxPerCycle);
+                    break;
+                }
+
+                if (string.IsNullOrWhiteSpace(dto.Id) || string.IsNullOrWhiteSpace(dto.VoiceCard))
+                {
+                    skipped++;
+                    continue;
+                }
+
+                var existing = await _memory.GetAsync(dto.Id.Trim(), ct);
+                if (existing is null)
+                {
+                    // A hallucinated id is the expected failure here, so it is a skip and not a throw.
+                    _logger.LogWarning(
+                        "DreamService: cast voice enrichment proposed an update to unknown entry {Id}; skipping", dto.Id);
+                    skipped++;
+                    continue;
+                }
+
+                if (!string.Equals(existing.Category, category, StringComparison.OrdinalIgnoreCase))
+                {
+                    _logger.LogWarning(
+                        "DreamService: cast voice enrichment proposed an update to {Id} in category {Actual}, outside {Category}; skipping",
+                        existing.Id, existing.Category, category);
+                    skipped++;
+                    continue;
+                }
+
+                if (HasVoiceMarker(existing.Content, marker))
+                {
+                    skipped++;
+                    continue;
+                }
+
+                var tags = new List<string>(existing.Tags ?? []);
+                if (!tags.Contains("voice", StringComparer.OrdinalIgnoreCase))
+                    tags.Add("voice");
+
+                await _memory.SaveAsync(
+                    existing with
+                    {
+                        Content = MergeVoiceCard(existing.Content, marker, dto.CharacterKey, dto.VoiceCard),
+                        Tags = tags,
+                        UpdatedAt = DateTimeOffset.UtcNow
+                    },
+                    ct);
+
+                updated++;
+                _logger.LogDebug("DreamService: cast voice enrichment updated {Id} ({Key})", existing.Id, dto.CharacterKey);
+            }
+
+            _logger.LogInformation(
+                "DreamService: cast voice enrichment pass complete — {Updated} character(s) given a voice, {Skipped} proposal(s) skipped",
+                updated, skipped);
+        });
+    }
+
+    /// <summary>True when <paramref name="content"/> already carries a voice card marker.</summary>
+    internal static bool HasVoiceMarker(string? content, string marker) =>
+        !string.IsNullOrEmpty(content)
+        && !string.IsNullOrEmpty(marker)
+        && content.Contains(marker, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Appends a voice card to an existing cast entry, preserving the original text verbatim.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately append-only rather than a rewrite. The enrichment pass updates curated entries
+    /// in place, and the original content is the record of what actually happened in the story —
+    /// a model that returns a "merged" version of it can drop a detail without anyone noticing for
+    /// weeks. Keeping the original untouched means the worst case is a redundant card, not a lost
+    /// fact.
+    /// </remarks>
+    internal static string MergeVoiceCard(string? existingContent, string marker, string? characterKey, string voiceCard)
+    {
+        var original = (existingContent ?? string.Empty).TrimEnd();
+        var key = string.IsNullOrWhiteSpace(characterKey) ? string.Empty : $" - {characterKey.Trim()}";
+        var card = $"{marker}{key}. {voiceCard.Trim()}";
+
+        return original.Length == 0 ? card : $"{original}\n\n{card}";
+    }
+
     private async Task RunMemoryMiningPassAsync(CancellationToken ct)
     {
         if (_conversationLog is null || !_options.MemoryMiningEnabled)
@@ -4795,6 +4987,17 @@ internal sealed class DreamService : IHostedService, IDisposable
         IReadOnlyList<string>? Tags,
         float? Importance);
 
+    internal sealed record CastVoiceResultDto(List<CastVoiceUpdateDto>? Updates);
+
+    /// <param name="Id">Id of the existing cast entry the voice card is appended to.</param>
+    /// <param name="CharacterKey">Name plus the disambiguating tag that separates this character
+    /// from everyone sharing their first name.</param>
+    /// <param name="VoiceCard">The voice card body, without the marker prefix.</param>
+    internal sealed record CastVoiceUpdateDto(
+        string? Id,
+        string? CharacterKey,
+        string? VoiceCard);
+
     internal sealed record MemoryMiningResultDto(List<MemoryMiningEntryDto>? ToSave);
 
     internal sealed record MemoryMiningEntryDto(
@@ -5003,6 +5206,75 @@ internal sealed class DreamService : IHostedService, IDisposable
         "tool-knowledge/calendar", "tool-knowledge/email"). Default to "tool-knowledge".
 
         If none of the patterns prove a durable, useful fact, return: { "toSave": [] }
+        """;
+
+    /// <summary>
+    /// Fallback directive for the cast voice enrichment pass, used when
+    /// <see cref="DreamOptions.CastVoiceDirectivePath"/> does not resolve to a file.
+    /// Kept in sync with <c>src/RockBot.Agent/agent/cast-voice-dream.md</c>.
+    /// </summary>
+    private const string BuiltInCastVoiceDirective = """
+        You maintain the speech profiles in a character corpus.
+
+        You are given every entry in one memory category. Some entries already carry a speech profile;
+        most record only appearance and events. Your task is to add a profile to characters that lack
+        one, so that a character described weeks ago can be written consistently today.
+
+        This is a schema-filling task. Deployment-specific guidance on how a profile should read, if
+        any exists, is supplied separately by the operator.
+
+        ## Step 1 — resolve identities
+
+        Determine how many distinct characters the entries describe. **A first name is not an
+        identity**: two entries sharing a name are frequently different people, distinguished by role,
+        location, age, or who they appear alongside.
+
+        Assign each character a `characterKey`: the name plus the shortest tag that separates them from
+        anyone sharing that name.
+
+        If two entries cannot be confidently resolved as the same character, leave both alone. A wrong
+        merge is more damaging than a missing profile.
+
+        ## Step 2 — fill the profile
+
+        For each character without one, record the observable, repeatable properties of their speech:
+
+        - origin and background, to the extent the entries establish it
+        - typical utterance length
+        - whether they use contractions
+        - how they habitually break off or extend a sentence
+        - any consistent error or verbal tic
+        - the domain their figures of speech are drawn from
+        - how they address other characters
+        - **one sample utterance, in quotation marks**
+
+        The sample utterance carries the most information. If an entry records something the character
+        actually said, reproduce it exactly, without correcting grammar or wording. Otherwise construct
+        one consistent with the properties above; a constructed sample illustrates the profile and is
+        not a claim about events.
+
+        Make each profile distinguishable from the profiles already present. Do not reissue properties
+        that another character in the corpus already has.
+
+        ## Step 3 — constraints
+
+        **Derive only.** Properties may be inferred from facts the entries already establish. Do not
+        introduce new biography, relationships, events, or names. Where the entries are sparse, produce
+        a sparse profile.
+
+        **Select one target entry per character** — normally the most detailed or most recent — and
+        return its id. The profile is appended; existing text in that entry is left untouched.
+
+        **Skip** any character already carrying a profile, and any character you could not resolve.
+
+        ## Output
+
+        Return only a JSON object:
+
+            { "updates": [ { "id": "...", "characterKey": "...", "voiceCard": "..." } ] }
+
+        `voiceCard` contains the profile body alone — omit the marker and the character key. Return
+        `{ "updates": [] }` if there is nothing to add.
         """;
 
     private const string BuiltInMemoryMiningDirective = """

--- a/tests/RockBot.Host.Tests/DreamCastVoiceEnrichmentTests.cs
+++ b/tests/RockBot.Host.Tests/DreamCastVoiceEnrichmentTests.cs
@@ -1,0 +1,155 @@
+using Microsoft.Extensions.Configuration;
+
+namespace RockBot.Host.Tests;
+
+/// <summary>
+/// Guards the cast voice enrichment pass. The pass exists because character dialogue flattens
+/// over time for a reason no amount of prompting fixes: a character's establishing lines scroll
+/// out of the context window, the record keeps only their face and their actions, and the next
+/// appearance is written from a physical description. Memory mining cannot close that gap — it
+/// only ever reads the session that just ended.
+/// </summary>
+[TestClass]
+public class DreamCastVoiceEnrichmentTests
+{
+    private static DreamOptions Bind(Dictionary<string, string?> values)
+    {
+        var config = new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+        var opts = new DreamOptions();
+        config.GetSection("Dream").Bind(opts);
+        return opts;
+    }
+
+    [TestMethod]
+    public void DefaultsToDisabled_SoOnlyCastKeepingAgentsOptIn()
+    {
+        var opts = new DreamOptions();
+
+        Assert.IsFalse(opts.CastVoiceEnrichmentEnabled);
+        Assert.AreEqual(string.Empty, opts.CastVoiceCategory);
+        Assert.AreEqual("VOICE CARD", opts.CastVoiceMarker);
+        Assert.AreEqual("cast-voice-dream.md", opts.CastVoiceDirectivePath);
+        Assert.AreEqual(12, opts.CastVoiceMaxPerCycle);
+    }
+
+    [TestMethod]
+    public void WithNoCategoryConfigured_ThePassHasNothingToReadAndIsInert()
+    {
+        // The category name is deployment-specific and deliberately has no default, so a
+        // deployment that flips the flag without naming a category gets a no-op rather than
+        // a pass reading some arbitrary category.
+        var opts = Bind(new Dictionary<string, string?>
+        {
+            ["Dream:CastVoiceEnrichmentEnabled"] = "true",
+        });
+
+        Assert.IsTrue(opts.CastVoiceEnrichmentEnabled);
+        Assert.AreEqual(string.Empty, opts.CastVoiceCategory);
+    }
+
+    [TestMethod]
+    public void Binds_FromEnvironmentStyleConfig()
+    {
+        var opts = Bind(new Dictionary<string, string?>
+        {
+            ["Dream:CastVoiceEnrichmentEnabled"] = "true",
+            ["Dream:CastVoiceCategory"] = "story/people",
+            ["Dream:CastVoiceMarker"] = "SPEECH",
+            ["Dream:CastVoiceMaxPerCycle"] = "3",
+        });
+
+        Assert.IsTrue(opts.CastVoiceEnrichmentEnabled);
+        Assert.AreEqual("story/people", opts.CastVoiceCategory);
+        Assert.AreEqual("SPEECH", opts.CastVoiceMarker);
+        Assert.AreEqual(3, opts.CastVoiceMaxPerCycle);
+    }
+
+    [TestMethod]
+    public void IsIndependentOfMemoryConsolidation()
+    {
+        // The pass has to be usable on an agent that deliberately runs with consolidation off,
+        // which is exactly the configuration where voices were being lost.
+        var opts = Bind(new Dictionary<string, string?>
+        {
+            ["Dream:CastVoiceEnrichmentEnabled"] = "true",
+            ["Dream:MemoryConsolidationEnabled"] = "false",
+        });
+
+        Assert.IsTrue(opts.CastVoiceEnrichmentEnabled);
+        Assert.IsFalse(opts.MemoryConsolidationEnabled);
+    }
+
+    // ── MergeVoiceCard ────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void MergeVoiceCard_PreservesTheOriginalEntryVerbatim()
+    {
+        // The whole safety property of an in-place pass: the recorded facts survive whatever
+        // the model returns.
+        const string original = "Alder drives the pre-dawn delivery round and keeps the depot keys.";
+
+        var merged = DreamService.MergeVoiceCard(
+            original, "VOICE CARD", "Alder (the delivery round)", "Rural, medium sentences, never contracts.");
+
+        StringAssert.StartsWith(merged, original);
+        StringAssert.Contains(merged, "VOICE CARD - Alder (the delivery round).");
+        StringAssert.Contains(merged, "never contracts");
+    }
+
+    [TestMethod]
+    public void MergeVoiceCard_SeparatesCardFromOriginalWithABlankLine()
+    {
+        var merged = DreamService.MergeVoiceCard("Brandt runs the kitchen.", "VOICE CARD", "Brandt", "Flat and regional.");
+
+        StringAssert.Contains(merged, "Brandt runs the kitchen.\n\nVOICE CARD - Brandt.");
+    }
+
+    [TestMethod]
+    public void MergeVoiceCard_WithNoExistingContent_ReturnsTheCardAlone()
+    {
+        var merged = DreamService.MergeVoiceCard(null, "VOICE CARD", "Coyne", "Short sentences, heavy contractions.");
+
+        Assert.AreEqual("VOICE CARD - Coyne. Short sentences, heavy contractions.", merged);
+    }
+
+    [TestMethod]
+    public void MergeVoiceCard_WithNoCharacterKey_StillProducesAMarkedCard()
+    {
+        var merged = DreamService.MergeVoiceCard("Vance works the ticket window.", "VOICE CARD", "   ", "Calm and immovable.");
+
+        StringAssert.Contains(merged, "VOICE CARD. Calm and immovable.");
+        StringAssert.StartsWith(merged, "Vance works the ticket window.");
+    }
+
+    [TestMethod]
+    public void MergeVoiceCard_OutputIsDetectedByHasVoiceMarker_SoThePassConverges()
+    {
+        // A merged entry must be recognisable as done, or the pass re-enriches the same
+        // character every cycle and never terminates.
+        var merged = DreamService.MergeVoiceCard("Halloran repairs clocks.", "VOICE CARD", "Halloran", "Formal, never contracts.");
+
+        Assert.IsTrue(DreamService.HasVoiceMarker(merged, "VOICE CARD"));
+    }
+
+    // ── HasVoiceMarker ────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void HasVoiceMarker_IsCaseInsensitive()
+    {
+        Assert.IsTrue(DreamService.HasVoiceMarker("voice card - Coyne. Talks constantly.", "VOICE CARD"));
+    }
+
+    [TestMethod]
+    public void HasVoiceMarker_FalseForPlainCastEntries()
+    {
+        Assert.IsFalse(DreamService.HasVoiceMarker("Vance is six-four and wears a grey coat.", "VOICE CARD"));
+    }
+
+    [TestMethod]
+    public void HasVoiceMarker_FalseForEmptyInputs()
+    {
+        Assert.IsFalse(DreamService.HasVoiceMarker(null, "VOICE CARD"));
+        Assert.IsFalse(DreamService.HasVoiceMarker("", "VOICE CARD"));
+        Assert.IsFalse(DreamService.HasVoiceMarker("anything at all", ""));
+    }
+}


### PR DESCRIPTION
## Problem

Character dialogue in cast-keeping agents degrades over time, and additional prompting does not correct it, because the cause is not instruction.

A character's introductory dialogue leaves the context window within a session or two. What the record retains afterward is appearance and events — so the next appearance is written from a physical description alone, and returning characters converge on a single undifferentiated speaker.

**Memory mining cannot close this gap.** It reads only the conversation log of the session that just ended, so by the time a missing profile is detectable, the transcript that would supply it is gone. Consolidation is the only existing pass that reads stored memory, and a deployment running with consolidation disabled — a defensible choice for a curated corpus — has no mechanism that can repair this at all.

## Change

`RunCastVoiceEnrichmentPassAsync` reads **stored memory** rather than the conversation log. It resolves distinct characters, and for those lacking a speech profile records the observable, repeatable properties of their speech plus one sample utterance.

The sample utterance carries the most information: a description of a voice cannot be written from, whereas a concrete utterance can.

Identity is keyed on a **name plus a disambiguating tag**, never a name alone — corpora reliably contain distinct characters sharing a first name, and merging them is more damaging than a missing profile.

It is also the only pass permitted to **derive** rather than solely record, since characters needing repair generally have no surviving transcript. The directive bounds that: properties are inferred from established facts, never invented.

## Safety properties

- **Disabled by default** (`CastVoiceEnrichmentEnabled = false`) and inert until `CastVoiceCategory` is set — the category name is deployment-specific and deliberately has no default.
- **`MergeVoiceCard` is strictly append-only.** The pass edits entries in place, so it must not be able to discard a recorded fact regardless of model output. Original content is preserved verbatim; the profile is appended after a blank line.
- **Converges.** A character already carrying the marker is skipped, so an enriched corpus costs one call per cycle and writes nothing.
- **Capped** at `CastVoiceMaxPerCycle` (default 12).
- Hallucinated ids, and ids outside the configured category, are skipped with a warning rather than throwing.

The shipped directive is a structural specification only. Deployments supply their own via `CastVoiceDirectivePath`.

## Tests

12 new tests in `DreamCastVoiceEnrichmentTests`; full `RockBot.Host.Tests` suite green at **1269 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqeZB1VSrWksDtpgFs2BBq
