### PR TITLE
Make the recall tools tellable apart and self-routing

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.14.17</Version>
+<Version>0.14.18</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -352,21 +352,6 @@ get_from_working_memory("subagent/t1b2c3/research_results")
 search_working_memory(namespace: "patrol")
 search_working_memory(query: "alert", namespace: "patrol/heartbeat")
 
-# Search this context's own untrimmed tool results (see below)
-search_working_memory(query: "invoice total", namespace: "stash")
-```
-
-**The `stash` namespace alias.** `ToolResultTrimmer` parks the full original of every
-overflow-trimmed tool result at `stash/{sessionId}/{callId}` with category
-`tool-result-stash`. The `[stash-registry]` system message lists those keys — but only for
-the *current* `AgentLoopRunner.RunAsync` invocation, so stashes from earlier turns in the
-same session are otherwise unreachable.
-
-The model cannot learn its own namespace, so a bare `namespace: "stash"` (or `"stash/"`)
-resolves to `stash/{own namespace}` rather than the shared `stash` root. Longer explicit
-paths (`stash/session/other`) pass through unchanged, so deliberate cross-context reads
-still work.
-
 ### The recall-search family
 
 Two adjacent searches. They are discriminated by **what the caller is after**, not by which
@@ -376,7 +361,7 @@ to know which store holds it:
 | Tool | Headline | Scope |
 |---|---|---|
 | `search_memory` | RECALL WHAT YOU CONCLUDED | Durable cross-session knowledge the agent chose to keep |
-| `search_working_memory` | RECALL WHAT A TOOL RETURNED | This session's cached payloads, including `stash/` untrimmed tool results |
+| `search_working_memory` | RECALL WHAT A TOOL RETURNED | This session's cached payloads |
 
 Two rules hold the family together, both enforced by `RecallToolFamilyTests`:
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -351,7 +351,55 @@ get_from_working_memory("subagent/t1b2c3/research_results")
 # Browse all patrol outputs
 search_working_memory(namespace: "patrol")
 search_working_memory(query: "alert", namespace: "patrol/heartbeat")
+
+# Search this context's own untrimmed tool results (see below)
+search_working_memory(query: "invoice total", namespace: "stash")
 ```
+
+**The `stash` namespace alias.** `ToolResultTrimmer` parks the full original of every
+overflow-trimmed tool result at `stash/{sessionId}/{callId}` with category
+`tool-result-stash`. The `[stash-registry]` system message lists those keys — but only for
+the *current* `AgentLoopRunner.RunAsync` invocation, so stashes from earlier turns in the
+same session are otherwise unreachable.
+
+The model cannot learn its own namespace, so a bare `namespace: "stash"` (or `"stash/"`)
+resolves to `stash/{own namespace}` rather than the shared `stash` root. Longer explicit
+paths (`stash/session/other`) pass through unchanged, so deliberate cross-context reads
+still work.
+
+### The recall-search family
+
+Two adjacent searches. They are discriminated by **what the caller is after**, not by which
+subsystem stored it — a model choosing between them knows what it wants to find and has no way
+to know which store holds it:
+
+| Tool | Headline | Scope |
+|---|---|---|
+| `search_memory` | RECALL WHAT YOU CONCLUDED | Durable cross-session knowledge the agent chose to keep |
+| `search_working_memory` | RECALL WHAT A TOOL RETURNED | This session's cached payloads, including `stash/` untrimmed tool results |
+
+Two rules hold the family together, both enforced by `RecallToolFamilyTests`:
+
+1. **Every description leads with its headline and names its siblings.** The headline is the
+   only part a model is guaranteed to read when scanning similar tools.
+2. **Every empty result names the siblings.** A query that matches nothing is where a
+   mis-routed lookup either recovers or hardens into "I was never told this" — so an empty
+   result says so explicitly ("not evidence it was never said or never known") and points
+   elsewhere. It never re-suggests the tool that just came back empty, which would be a retry
+   loop rather than a recovery.
+
+   Query-less *browses* are exempt. `search_memory()` with no query means "how is knowledge
+   organised here?" and answers itself with the category taxonomy; an empty namespace listing
+   in working memory is a fact about that namespace, not a failed lookup.
+
+The tool names, headlines, and scope phrases are `const`s on `RecallTools` in
+`RockBot.Host.Abstractions`, an assembly every registrar can see. Nothing else prevents a
+rename or a re-wording from silently desynchronising a family whose members are registered
+from assemblies that do not reference each other.
+
+A third member — `search_conversation_history`, for turns that have scrolled out of the
+context window — is tracked by [#509](https://github.com/MarimerLLC/rockbot/issues/509) and
+blocked on [#530](https://github.com/MarimerLLC/rockbot/issues/530).
 
 ---
 

--- a/src/RockBot.Host.Abstractions/RecallTools.cs
+++ b/src/RockBot.Host.Abstractions/RecallTools.cs
@@ -1,0 +1,90 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// The names of the recall tools and the one-line scope discriminators they use to describe
+/// themselves and point at each other.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The tools are split across assemblies — <c>search_memory</c> and
+/// <c>search_working_memory</c> both live in RockBot.Memory today, but their descriptions have
+/// to read as one family and each one names the others. Centralising the vocabulary here (an
+/// assembly every registrar can see) is what keeps a rename or a re-wording from silently
+/// desynchronising the set.
+/// </para>
+/// <para>
+/// The discriminator is deliberately <b>what the caller is after</b>, not where it is stored:
+/// concluded / returned. A model choosing between these tools knows what it wants to find and
+/// does not know which subsystem persisted it.
+/// </para>
+/// <para>
+/// The family is sized to hold a third member. A recall path for conversation turns that fall
+/// outside the context window (<c>search_conversation_history</c>) is tracked by #509 and
+/// blocked on #530 — adding it back means a name, a headline, a scope, a <c>Try…</c> pointer,
+/// and one arm on <see cref="ScopeOf"/>. <see cref="LookElsewhere"/> needs no change.
+/// </para>
+/// <para>
+/// Every member is <c>const</c> because these are used inside <c>[Description]</c> attributes,
+/// whose arguments must be compile-time constants.
+/// </para>
+/// </remarks>
+public static class RecallTools
+{
+    /// <summary>Durable cross-session knowledge. Registered by <c>MemoryTools</c>.</summary>
+    public const string DurableMemory = "search_memory";
+
+    /// <summary>This session's ephemeral cached payloads. Registered by <c>WorkingMemoryTools</c>.</summary>
+    public const string WorkingMemory = "search_working_memory";
+
+    /// <summary>Lead line for <see cref="DurableMemory"/>.</summary>
+    public const string DurableHeadline = "RECALL WHAT YOU CONCLUDED";
+
+    /// <summary>Lead line for <see cref="WorkingMemory"/>.</summary>
+    public const string WorkingHeadline = "RECALL WHAT A TOOL RETURNED";
+
+    /// <summary>What <see cref="DurableMemory"/> holds, phrased as the thing being looked for.</summary>
+    public const string DurableScope =
+        "durable facts and preferences you CONCLUDED and chose to keep";
+
+    /// <summary>What <see cref="WorkingMemory"/> holds, phrased as the thing being looked for.</summary>
+    public const string WorkingScope =
+        "cached payloads a TOOL RETURNED earlier this session";
+
+    /// <summary>Pointer to <see cref="DurableMemory"/>, for the other tools' descriptions.</summary>
+    public const string TryDurable = $"for {DurableScope} use {DurableMemory}";
+
+    /// <summary>Pointer to <see cref="WorkingMemory"/>, for the other tools' descriptions.</summary>
+    public const string TryWorking = $"for {WorkingScope} use {WorkingMemory}";
+
+    /// <summary>
+    /// Renders the "look elsewhere" line appended to an empty result, naming the recall tools
+    /// other than <paramref name="callingTool"/>.
+    /// </summary>
+    /// <remarks>
+    /// An empty result is the moment a mis-routed recall attempt either recovers or turns into
+    /// the agent concluding it never knew something. Without this the tools are dead ends, and
+    /// the model's only signal that it picked the wrong one is silence — which reads
+    /// identically to "this was never said."
+    /// </remarks>
+    /// <param name="callingTool">
+    /// The tool rendering the message; omitted from the suggestions. Pass one of
+    /// <see cref="DurableMemory"/> or <see cref="WorkingMemory"/>.
+    /// </param>
+    public static string LookElsewhere(string callingTool)
+    {
+        var others = new List<string>(1);
+
+        if (callingTool != DurableMemory) others.Add(TryDurable);
+        if (callingTool != WorkingMemory) others.Add(TryWorking);
+
+        return $"This searched only {ScopeOf(callingTool)}. Not finding it here is not evidence " +
+               $"it was never said or never known — {string.Join("; ", others)}.";
+    }
+
+    private static string ScopeOf(string tool) => tool switch
+    {
+        DurableMemory => DurableScope,
+        WorkingMemory => WorkingScope,
+        _ => "one recall store"
+    };
+}

--- a/src/RockBot.Memory/MemoryTools.cs
+++ b/src/RockBot.Memory/MemoryTools.cs
@@ -197,8 +197,8 @@ public sealed class MemoryTools
             ? null
             : tags.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
-    [Description("Search DURABLE cross-session knowledge — facts, preferences, and patterns saved with " +
-                 "save_memory, which survive restarts. " +
+    [Description($"{RecallTools.DurableHeadline} — DURABLE cross-session knowledge: facts, preferences, " +
+                 "and patterns saved with save_memory, which survive restarts. " +
                  "Use query for keyword search and category to scope to a knowledge area " +
                  "(prefix match, so 'project-context' also matches 'project-context/rockbot'). " +
                  "Omit query to browse: results are the most recently reinforced entries in scope, " +
@@ -206,7 +206,8 @@ public sealed class MemoryTools
                  "before narrowing. " +
                  "Set mode='regex' when you know the literal token (file path, id, version, exact phrase); " +
                  "otherwise leave mode='hybrid' (default) for semantic/keyword search. " +
-                 "For cached payloads from this session only, use search_working_memory instead.")]
+                 "This searches what you CONCLUDED and chose to keep, not what was said. " +
+                 $"Sibling recall tool — {RecallTools.TryWorking}.")]
     public async Task<string> SearchMemory(
         [Description("Optional keyword (hybrid mode) or .NET regex pattern (regex mode) to search for. Omit to browse and see the category taxonomy.")] string? query = null,
         [Description("Optional category prefix to filter by (e.g. 'user-preferences'). Matches the category and its children.")] string? category = null,
@@ -244,7 +245,14 @@ public sealed class MemoryTools
 
         if (results.Count == 0)
         {
-            const string none = "No memories found matching the search criteria.";
+            // A query-less browse that comes back empty is "this store is empty", not a failed
+            // lookup, and the taxonomy already tells the model what exists — pointing it at the
+            // sibling store there would be noise. A *query* that matches nothing is the
+            // mis-routed case worth recovering from.
+            var none = "No memories found matching the search criteria.";
+            if (trimmedQuery is not null)
+                none += $" {RecallTools.LookElsewhere(RecallTools.DurableMemory)}";
+
             return taxonomy is null ? none : $"{none}\n\n{taxonomy}";
         }
 

--- a/src/RockBot.Memory/WorkingMemoryTools.cs
+++ b/src/RockBot.Memory/WorkingMemoryTools.cs
@@ -133,22 +133,25 @@ public sealed class WorkingMemoryTools
     /// </summary>
     private const int ListingMaxResults = 500;
 
-    [Description("Search or list THIS SESSION'S ephemeral cached payloads — tool results, subagent " +
-                 "output, patrol findings, and cross-context handoffs under 'shared/'. Entries expire " +
-                 "on a TTL measured in minutes. " +
+    [Description($"{RecallTools.WorkingHeadline} — search or list THIS SESSION'S ephemeral cached " +
+                 "payloads: tool results, subagent output, patrol findings, and cross-context handoffs " +
+                 "under 'shared/'. Entries expire on a TTL measured in minutes. " +
                  "Omit query to LIST everything in scope (key, category, tags, expiry — no content preview). " +
                  "Supply query to rank cached content by relevance. Filter with category and/or tags. " +
                  "Defaults to your own namespace; pass a namespace prefix to browse another context — " +
                  "'subagent/task1' for what a completed subagent stored, 'patrol' for all patrol task " +
-                 "outputs, 'shared' for the cross-session handoff namespace. " +
-                 "For durable facts and preferences that survive restarts, use search_memory instead.")]
+                 "outputs, 'shared' for the cross-session handoff namespace, and 'stash' for the full " +
+                 "untrimmed originals of tool results that were elided from your context earlier in this " +
+                 "session (the [stash-registry] message only lists elisions from the current run — 'stash' " +
+                 "reaches the earlier ones too). " +
+                 $"Sibling recall tool — {RecallTools.TryDurable}.")]
     public async Task<string> SearchWorkingMemory(
         [Description("Keywords to search for in cached content. Omit to list all entries in the namespace/category/tag scope.")] string? query = null,
         [Description("Optional category prefix to filter by (e.g. 'research', 'email')")] string? category = null,
         [Description("Optional comma-separated tags that entries must have (e.g. 'urgent,inbox')")] string? tags = null,
-        [Description("Optional namespace prefix to search (e.g. 'subagent/task1', 'patrol'). Omit to search your own namespace.")] string? @namespace = null)
+        [Description("Optional namespace prefix to search (e.g. 'subagent/task1', 'patrol', 'stash'). Omit to search your own namespace.")] string? @namespace = null)
     {
-        var prefix = string.IsNullOrWhiteSpace(@namespace) ? _namespace : @namespace.Trim();
+        var prefix = ResolveNamespace(@namespace);
         var trimmedQuery = string.IsNullOrWhiteSpace(query) ? null : query.Trim();
 
         // No query means "browse this scope" rather than "rank by relevance" — the surface the
@@ -181,7 +184,8 @@ public sealed class WorkingMemoryTools
                     : $"No entries found in namespace '{prefix}'.";
 
             var desc = BuildSearchDesc(query, category, tags);
-            return $"No working memory entries matched {desc} in namespace '{prefix}'.";
+            return $"No working memory entries matched {desc} in namespace '{prefix}'. " +
+                   RecallTools.LookElsewhere(RecallTools.WorkingMemory);
         }
 
         var now = DateTimeOffset.UtcNow;
@@ -217,6 +221,31 @@ public sealed class WorkingMemoryTools
             sb.AppendLine($"(listing capped at {ListingMaxResults} entries \u2014 narrow the scope with namespace, category, or tags)");
 
         return sb.ToString().TrimEnd();
+    }
+
+    /// <summary>
+    /// Resolves the caller-supplied namespace to a working-memory key prefix.
+    /// </summary>
+    /// <remarks>
+    /// Bare <c>stash</c> (or <c>stash/</c>) is an alias for <b>this context's own</b> stash,
+    /// which lives at <c>stash/{namespace}</c> — see <c>AgentLoopRunner.BuildStashKey</c>.
+    /// The alias exists because the model has no way to learn its own namespace, so without it
+    /// the only reachable stash prefix would be the bare <c>stash</c> root shared by every
+    /// context. Longer explicit paths (<c>stash/session/other</c>) pass through untouched so
+    /// deliberate cross-context reads still work.
+    /// </remarks>
+    private string ResolveNamespace(string? @namespace)
+    {
+        if (string.IsNullOrWhiteSpace(@namespace)) return _namespace;
+
+        var trimmed = @namespace.Trim();
+        if (trimmed.Equals("stash", StringComparison.OrdinalIgnoreCase) ||
+            trimmed.Equals("stash/", StringComparison.OrdinalIgnoreCase))
+        {
+            return $"stash/{_namespace}";
+        }
+
+        return trimmed;
     }
 
     private static IReadOnlyList<string>? ParseTags(string? tags) =>

--- a/src/RockBot.Memory/WorkingMemoryTools.cs
+++ b/src/RockBot.Memory/WorkingMemoryTools.cs
@@ -140,18 +140,15 @@ public sealed class WorkingMemoryTools
                  "Supply query to rank cached content by relevance. Filter with category and/or tags. " +
                  "Defaults to your own namespace; pass a namespace prefix to browse another context — " +
                  "'subagent/task1' for what a completed subagent stored, 'patrol' for all patrol task " +
-                 "outputs, 'shared' for the cross-session handoff namespace, and 'stash' for the full " +
-                 "untrimmed originals of tool results that were elided from your context earlier in this " +
-                 "session (the [stash-registry] message only lists elisions from the current run — 'stash' " +
-                 "reaches the earlier ones too). " +
+                 "outputs, 'shared' for the cross-session handoff namespace. " +
                  $"Sibling recall tool — {RecallTools.TryDurable}.")]
     public async Task<string> SearchWorkingMemory(
         [Description("Keywords to search for in cached content. Omit to list all entries in the namespace/category/tag scope.")] string? query = null,
         [Description("Optional category prefix to filter by (e.g. 'research', 'email')")] string? category = null,
         [Description("Optional comma-separated tags that entries must have (e.g. 'urgent,inbox')")] string? tags = null,
-        [Description("Optional namespace prefix to search (e.g. 'subagent/task1', 'patrol', 'stash'). Omit to search your own namespace.")] string? @namespace = null)
+        [Description("Optional namespace prefix to search (e.g. 'subagent/task1', 'patrol'). Omit to search your own namespace.")] string? @namespace = null)
     {
-        var prefix = ResolveNamespace(@namespace);
+        var prefix = string.IsNullOrWhiteSpace(@namespace) ? _namespace : @namespace.Trim();
         var trimmedQuery = string.IsNullOrWhiteSpace(query) ? null : query.Trim();
 
         // No query means "browse this scope" rather than "rank by relevance" — the surface the
@@ -221,31 +218,6 @@ public sealed class WorkingMemoryTools
             sb.AppendLine($"(listing capped at {ListingMaxResults} entries \u2014 narrow the scope with namespace, category, or tags)");
 
         return sb.ToString().TrimEnd();
-    }
-
-    /// <summary>
-    /// Resolves the caller-supplied namespace to a working-memory key prefix.
-    /// </summary>
-    /// <remarks>
-    /// Bare <c>stash</c> (or <c>stash/</c>) is an alias for <b>this context's own</b> stash,
-    /// which lives at <c>stash/{namespace}</c> — see <c>AgentLoopRunner.BuildStashKey</c>.
-    /// The alias exists because the model has no way to learn its own namespace, so without it
-    /// the only reachable stash prefix would be the bare <c>stash</c> root shared by every
-    /// context. Longer explicit paths (<c>stash/session/other</c>) pass through untouched so
-    /// deliberate cross-context reads still work.
-    /// </remarks>
-    private string ResolveNamespace(string? @namespace)
-    {
-        if (string.IsNullOrWhiteSpace(@namespace)) return _namespace;
-
-        var trimmed = @namespace.Trim();
-        if (trimmed.Equals("stash", StringComparison.OrdinalIgnoreCase) ||
-            trimmed.Equals("stash/", StringComparison.OrdinalIgnoreCase))
-        {
-            return $"stash/{_namespace}";
-        }
-
-        return trimmed;
     }
 
     private static IReadOnlyList<string>? ParseTags(string? tags) =>

--- a/tests/RockBot.Agent.Tests/MemoryToolsTests.cs
+++ b/tests/RockBot.Agent.Tests/MemoryToolsTests.cs
@@ -489,6 +489,35 @@ public class MemoryToolsTests
     // Helpers
     // -------------------------------------------------------------------------
 
+    // ── Recall-family empty results ───────────────────────────────────────
+
+    [TestMethod]
+    public async Task SearchMemory_NoResults_PointsAtTheSiblingRecallTool()
+    {
+        // Durable memory is one of two recall stores. A query that finds nothing here is not
+        // evidence the fact was never known — it may have been returned by a tool earlier
+        // this session and cached in working memory.
+        var tools = MakeTools(new StubLongTermMemory());
+
+        var result = await tools.SearchMemory("anything");
+
+        StringAssert.Contains(result, RecallTools.WorkingMemory);
+        Assert.IsFalse(result.Contains($"use {RecallTools.DurableMemory}"),
+            "Re-suggesting the tool that just came back empty invites a retry loop.");
+    }
+
+    [TestMethod]
+    public async Task SearchMemory_EmptyBrowse_DoesNotPointElsewhere()
+    {
+        // A query-less call is "how is knowledge organised here?", not a failed lookup. It
+        // already answers itself with the category taxonomy; sibling pointers would be noise.
+        var tools = MakeTools(new StubLongTermMemory());
+
+        var result = await tools.SearchMemory();
+
+        Assert.IsFalse(result.Contains(RecallTools.WorkingMemory));
+    }
+
     private static MemoryTools MakeTools(StubLongTermMemory memory) =>
         new(memory, new StubChatClient(), Microsoft.Extensions.Options.Options.Create(new AgentProfileOptions()), NullLogger<MemoryTools>.Instance);
 

--- a/tests/RockBot.Agent.Tests/WorkingMemoryToolsTests.cs
+++ b/tests/RockBot.Agent.Tests/WorkingMemoryToolsTests.cs
@@ -255,45 +255,6 @@ public class WorkingMemoryToolsTests
 
     // ── Helpers ───────────────────────────────────────────────────────────
 
-    // ── stash namespace alias ─────────────────────────────────────────────
-    //
-    // The model cannot learn its own namespace, so bare "stash" has to resolve to this
-    // context's stash (stash/{namespace}) or the only reachable prefix would be the shared
-    // "stash" root holding every context's elided tool results.
-
-    [TestMethod]
-    public async Task SearchWorkingMemory_BareStashNamespace_ExpandsToOwnStashPrefix()
-    {
-        await _tools.SearchWorkingMemory(query: "invoice", @namespace: "stash");
-
-        Assert.AreEqual("stash/subagent/abc123", _memory.LastPrefix);
-    }
-
-    [TestMethod]
-    public async Task SearchWorkingMemory_StashWithTrailingSlash_ExpandsToOwnStashPrefix()
-    {
-        await _tools.SearchWorkingMemory(query: "invoice", @namespace: "stash/");
-
-        Assert.AreEqual("stash/subagent/abc123", _memory.LastPrefix);
-    }
-
-    [TestMethod]
-    public async Task SearchWorkingMemory_BareStashNamespace_IsCaseInsensitive()
-    {
-        await _tools.SearchWorkingMemory(query: "invoice", @namespace: "STASH");
-
-        Assert.AreEqual("stash/subagent/abc123", _memory.LastPrefix);
-    }
-
-    [TestMethod]
-    public async Task SearchWorkingMemory_ExplicitStashPath_PassesThroughUnchanged()
-    {
-        await _tools.SearchWorkingMemory(query: "invoice", @namespace: "stash/session/other");
-
-        Assert.AreEqual("stash/session/other", _memory.LastPrefix,
-            "An explicit cross-context stash path must not be rewritten to the caller's own stash");
-    }
-
     // ── Recall-family empty results ───────────────────────────────────────
 
     [TestMethod]

--- a/tests/RockBot.Agent.Tests/WorkingMemoryToolsTests.cs
+++ b/tests/RockBot.Agent.Tests/WorkingMemoryToolsTests.cs
@@ -255,6 +255,59 @@ public class WorkingMemoryToolsTests
 
     // ── Helpers ───────────────────────────────────────────────────────────
 
+    // ── stash namespace alias ─────────────────────────────────────────────
+    //
+    // The model cannot learn its own namespace, so bare "stash" has to resolve to this
+    // context's stash (stash/{namespace}) or the only reachable prefix would be the shared
+    // "stash" root holding every context's elided tool results.
+
+    [TestMethod]
+    public async Task SearchWorkingMemory_BareStashNamespace_ExpandsToOwnStashPrefix()
+    {
+        await _tools.SearchWorkingMemory(query: "invoice", @namespace: "stash");
+
+        Assert.AreEqual("stash/subagent/abc123", _memory.LastPrefix);
+    }
+
+    [TestMethod]
+    public async Task SearchWorkingMemory_StashWithTrailingSlash_ExpandsToOwnStashPrefix()
+    {
+        await _tools.SearchWorkingMemory(query: "invoice", @namespace: "stash/");
+
+        Assert.AreEqual("stash/subagent/abc123", _memory.LastPrefix);
+    }
+
+    [TestMethod]
+    public async Task SearchWorkingMemory_BareStashNamespace_IsCaseInsensitive()
+    {
+        await _tools.SearchWorkingMemory(query: "invoice", @namespace: "STASH");
+
+        Assert.AreEqual("stash/subagent/abc123", _memory.LastPrefix);
+    }
+
+    [TestMethod]
+    public async Task SearchWorkingMemory_ExplicitStashPath_PassesThroughUnchanged()
+    {
+        await _tools.SearchWorkingMemory(query: "invoice", @namespace: "stash/session/other");
+
+        Assert.AreEqual("stash/session/other", _memory.LastPrefix,
+            "An explicit cross-context stash path must not be rewritten to the caller's own stash");
+    }
+
+    // ── Recall-family empty results ───────────────────────────────────────
+
+    [TestMethod]
+    public async Task SearchWorkingMemory_QueryMatchesNothing_PointsAtTheSiblingRecallTool()
+    {
+        // Working memory is one of two recall stores. Nothing cached this session does not mean
+        // nothing known — the fact may have been concluded and saved durably instead.
+        var result = await _tools.SearchWorkingMemory(query: "nothing-matches-this");
+
+        StringAssert.Contains(result, RecallTools.DurableMemory);
+        Assert.IsFalse(result.Contains($"use {RecallTools.WorkingMemory}"),
+            "Re-suggesting the tool that just came back empty invites a retry loop.");
+    }
+
     private static WorkingMemoryEntry Entry(
         string key, string value, string? category = null, IReadOnlyList<string>? tags = null) =>
         new(key, value, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddMinutes(5), category, tags);

--- a/tests/RockBot.Host.Tests/RecallToolFamilyTests.cs
+++ b/tests/RockBot.Host.Tests/RecallToolFamilyTests.cs
@@ -1,0 +1,108 @@
+using System.Reflection;
+using RockBot.Host;
+using RockBot.Memory;
+
+namespace RockBot.Host.Tests;
+
+/// <summary>
+/// Covers <see cref="RecallTools"/> and the family discipline it exists to enforce: sibling
+/// search tools whose descriptions have to be tellable apart at a glance, and whose empty
+/// results have to route a mis-aimed lookup at the right sibling instead of dead-ending.
+/// </summary>
+/// <remarks>
+/// The tools are registered from assemblies that do not reference each other, so nothing but a
+/// test like this notices when one of them drifts out of the family — descriptions are string
+/// literals no compiler checks. Descriptions are read by reflection rather than by constructing
+/// the tools, since the attribute is the thing under test and construction would drag in
+/// unrelated stores.
+/// </remarks>
+[TestClass]
+public class RecallToolFamilyTests
+{
+    private static string DescriptionOf(Type type, string method) =>
+        type.GetMethod(method, BindingFlags.Public | BindingFlags.Instance)!
+            .GetCustomAttribute<System.ComponentModel.DescriptionAttribute>()!
+            .Description;
+
+    private static string DurableDescription =>
+        DescriptionOf(typeof(MemoryTools), nameof(MemoryTools.SearchMemory));
+
+    private static string WorkingDescription =>
+        DescriptionOf(typeof(WorkingMemoryTools), nameof(WorkingMemoryTools.SearchWorkingMemory));
+
+    /// <summary>
+    /// Every member of the family. A third — <c>search_conversation_history</c>, tracked by
+    /// #509 and blocked on #530 — appends here and the assertions below cover it unchanged.
+    /// </summary>
+    private static readonly string[] Family = [RecallTools.DurableMemory, RecallTools.WorkingMemory];
+
+    // ── Scope headline ────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void EachDescription_LeadsWithItsScopeHeadline()
+    {
+        StringAssert.StartsWith(DurableDescription, RecallTools.DurableHeadline);
+        StringAssert.StartsWith(WorkingDescription, RecallTools.WorkingHeadline);
+    }
+
+    [TestMethod]
+    public void Headlines_AreDistinctFromEachOther()
+    {
+        var headlines = new[]
+        {
+            RecallTools.DurableHeadline,
+            RecallTools.WorkingHeadline
+        };
+
+        CollectionAssert.AllItemsAreUnique(headlines,
+            "The headline is the only part of the description a model is guaranteed to read " +
+            "when scanning similar tools — two that match defeat the purpose.");
+    }
+
+    // ── Cross-references ──────────────────────────────────────────────────
+
+    [TestMethod]
+    public void EachDescription_NamesItsSiblings()
+    {
+        StringAssert.Contains(DurableDescription, RecallTools.WorkingMemory);
+        StringAssert.Contains(WorkingDescription, RecallTools.DurableMemory);
+    }
+
+    // ── LookElsewhere ─────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void LookElsewhere_NamesTheSiblingButNotTheCaller()
+    {
+        var hint = RecallTools.LookElsewhere(RecallTools.DurableMemory);
+
+        StringAssert.Contains(hint, RecallTools.WorkingMemory);
+        Assert.IsFalse(hint.Contains($"use {RecallTools.DurableMemory}"),
+            "Suggesting the tool that just came back empty is a loop, not a recovery.");
+    }
+
+    [TestMethod]
+    public void LookElsewhere_WorksFromEveryMemberOfTheFamily()
+    {
+        foreach (var caller in Family)
+        {
+            var hint = RecallTools.LookElsewhere(caller);
+
+            Assert.IsFalse(hint.Contains($"use {caller}"), $"{caller} suggested itself");
+            Assert.AreEqual(Family.Length - 1, CountToolMentions(hint),
+                $"{caller} should suggest every sibling and nothing else");
+        }
+    }
+
+    [TestMethod]
+    public void LookElsewhere_SaysAnEmptyResultIsNotProofOfNeverKnowing()
+    {
+        // The whole failure this family guards against is the agent reading silence as
+        // "I was never told this" — the sentence carrying that has to survive re-wording.
+        var hint = RecallTools.LookElsewhere(RecallTools.WorkingMemory);
+
+        StringAssert.Contains(hint, "not evidence");
+    }
+
+    private static int CountToolMentions(string hint) =>
+        Family.Count(t => hint.Contains($"use {t}"));
+}


### PR DESCRIPTION
Salvaged from #511, which is being closed in favour of this plus #530.

## Why this is split out

#511 built `search_conversation_history` for out-of-window turn recall and validated it live on the cluster. The mechanism worked; **the model never selected the tool unaided** — twice, in the exact scenario it exists for, with an explicit directive hot-reloaded on the PVC. That needs a structural cue rather than more prompt wording, which is now #530.

This PR is the half of #511 that stands on its own and does not depend on that tool existing.

## What it does

**`RecallTools`** (new, in `RockBot.Host.Abstractions`) centralises the recall tool names, headlines, and scope phrases. The tools are registered from assemblies that do not reference each other and their descriptions are string literals no compiler checks, so nothing else prevents a rename or a re-wording from silently desynchronising the family. `RecallToolFamilyTests` reads the descriptions by reflection and fails if one drifts.

**Descriptions lead with a headline**, discriminating by *what the caller is after* rather than which subsystem stored it — a model choosing between these knows what it wants to find and has no way to know which store holds it:

| Tool | Headline |
|---|---|
| `search_memory` | RECALL WHAT YOU CONCLUDED |
| `search_working_memory` | RECALL WHAT A TOOL RETURNED |

**Empty results name the sibling instead of dead-ending.** This is the substantive fix. Both tools previously ended on `"No memories found matching the search criteria."` and nothing else — precisely where a mis-routed lookup hardens into "I was never told this". An empty result now states the absence is not evidence, points at the sibling, and never re-suggests the tool that just came back empty (a retry loop, not a recovery).

Query-less *browses* stay exempt: `search_memory()` with no query answers itself with the category taxonomy, and an empty namespace listing is a fact about that namespace rather than a failed lookup.

## What came out

#511's bare-`stash` namespace alias was salvaged, then **removed** — it resolved to `stash/{_namespace}`, which is never a real stash prefix on either construction path (see the comment below and #532). The gap it aimed at is real and tracked in #532 with the actual fix.

## Scope

8 files, **+294/−11**, additive. Rebuilt onto current `main` rather than cherry-picked from #511's branch, which predates #510 — a wholesale file copy would have reverted the partial-edit tools. Verified: #510's tools and tests are intact, and the diff carries no line-ending churn (`--ignore-cr-at-eol` gives an identical shortstat).

## Verification

Full solution build, 0 errors. Full suite green across all 20 test projects.

Note on what tests can and cannot show here: the family test proves the descriptions are wired to the shared constants and that an empty result names its sibling. It cannot prove the model routes better — that is the same limit #511 ran into. The change is additive to descriptions that already existed, so the downside if the model ignores it is the status quo.

The family is sized to take a third member back: adding `search_conversation_history` means a name, a headline, a scope, a `Try…` pointer, and one arm on `ScopeOf`. `LookElsewhere` and the family tests need no change. The implementation stays recoverable on `rockfordlhotka/509-conversation-turn-recall`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FieTYKLKEbarXNyPrHBX9F