### PR TITLE
Support per-server timeouts for long-running MCP tool calls

### DIFF
--- a/src/RockBot.Agent/McpBridge/McpBridgeOptions.cs
+++ b/src/RockBot.Agent/McpBridge/McpBridgeOptions.cs
@@ -16,10 +16,10 @@ public sealed class McpBridgeOptions
     public int DefaultTimeoutMs { get; set; } = 60_000;
 
     /// <summary>
-    /// Maximum timeout in milliseconds that a caller may request via the TimeoutMs header.
-    /// Callers can exceed DefaultTimeoutMs up to this ceiling for large/slow operations.
+    /// Maximum tool-call timeout in milliseconds.
+    /// Caller-requested and per-server timeouts are capped at this value.
     /// </summary>
-    public int MaxTimeoutMs { get; set; } = 120_000;
+    public int MaxTimeoutMs { get; set; } = 900_000;
 
     /// <summary>
     /// When true, the bridge calls the LLM to generate a one-sentence summary of each

--- a/src/RockBot.Agent/McpBridge/McpBridgeServerConfig.cs
+++ b/src/RockBot.Agent/McpBridge/McpBridgeServerConfig.cs
@@ -51,6 +51,12 @@ public sealed class McpBridgeServerConfig
     public string TransportMode { get; set; } = "auto";
 
     /// <summary>
+    /// Optional timeout in milliseconds for tool calls to this server.
+    /// When omitted, the bridge's DefaultTimeoutMs applies.
+    /// </summary>
+    public int? ToolTimeoutMs { get; set; }
+
+    /// <summary>
     /// HTTP headers to include on every request to this server.
     /// Values may use <c>${ENV_VAR_NAME}</c> syntax for environment variable substitution.
     /// Example: <c>"X-Api-Key": "${MY_API_KEY}"</c>

--- a/src/RockBot.Agent/McpBridge/McpBridgeService.cs
+++ b/src/RockBot.Agent/McpBridge/McpBridgeService.cs
@@ -871,12 +871,35 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
         }
 
         // Parse timeout from headers — callers may request more time than the default (e.g. for
-        // large MCP operations), so allow header values up to MaxTimeoutMs (default 120s).
+        // large MCP operations), so allow header values up to MaxTimeoutMs.
         var timeoutMs = _options.DefaultTimeoutMs;
         if (envelope.Headers.TryGetValue(WellKnownHeaders.TimeoutMs, out var timeoutStr)
-            && int.TryParse(timeoutStr, out var parsedTimeout))
+            && int.TryParse(timeoutStr, out var parsedTimeout)
+            && parsedTimeout > 0)
         {
             timeoutMs = Math.Min(parsedTimeout, _options.MaxTimeoutMs);
+        }
+
+        // A per-server timeout is authoritative for that MCP server.
+        // This lets slow analytical MCPs opt into a larger budget while
+        // ordinary MCPs retain the normal caller/default timeout.
+        if (!string.IsNullOrWhiteSpace(serverName)
+            && _serverConfigs.TryGetValue(serverName, out var timeoutConfig)
+            && timeoutConfig.ToolTimeoutMs is int serverTimeoutMs)
+        {
+            if (serverTimeoutMs <= 0)
+            {
+                _logger.LogWarning(
+                    "Ignoring invalid ToolTimeoutMs={ToolTimeoutMs} for MCP server {Server}",
+                    serverTimeoutMs,
+                    serverName);
+            }
+            else
+            {
+                timeoutMs = Math.Min(
+                    serverTimeoutMs,
+                    _options.MaxTimeoutMs);
+            }
         }
 
         _logger.LogInformation("→ MCP {Server}/{Tool} args={Args}",

--- a/src/RockBot.Agent/Program.cs
+++ b/src/RockBot.Agent/Program.cs
@@ -346,9 +346,16 @@ builder.Services.AddRockBotHost(agent =>
     // The proxy must outwait the bridge: the bridge caps a tool call at MaxTimeoutMs
     // (15 min) and answers with a timeout response of its own. If the proxy gave up
     // first the caller would see a transport failure instead of that response.
+    //
+    // Configurable because the response wait is also how long the agent blocks when the
+    // bridge does not answer at all (process down, message lost) — a deployment with no
+    // slow MCP servers will want that far below the 930s default.
+    var mcpProxySection = builder.Configuration.GetSection("McpToolProxy");
     agent.AddMcpToolProxy(
-        requestTimeout: TimeSpan.FromSeconds(60),
-        responseTimeout: TimeSpan.FromSeconds(930));
+        requestTimeout: TimeSpan.FromSeconds(
+            mcpProxySection.GetValue("RequestTimeoutSeconds", 60)),
+        responseTimeout: TimeSpan.FromSeconds(
+            mcpProxySection.GetValue("ResponseTimeoutSeconds", 930)));
     agent.AddFileSystemTools(opts => builder.Configuration.GetSection("FileSystem").Bind(opts));
     agent.AddWebTools(opts => builder.Configuration.GetSection("WebTools").Bind(opts));
     agent.AddSchedulingTools();

--- a/src/RockBot.Agent/Program.cs
+++ b/src/RockBot.Agent/Program.cs
@@ -343,7 +343,12 @@ builder.Services.AddRockBotHost(agent =>
     agent.WithRepairTickets();
     agent.WithDreaming(opts => builder.Configuration.GetSection("Dream").Bind(opts));
     agent.AddToolHandler();
-    agent.AddMcpToolProxy();
+    // The proxy must outwait the bridge: the bridge caps a tool call at MaxTimeoutMs
+    // (15 min) and answers with a timeout response of its own. If the proxy gave up
+    // first the caller would see a transport failure instead of that response.
+    agent.AddMcpToolProxy(
+        requestTimeout: TimeSpan.FromSeconds(60),
+        responseTimeout: TimeSpan.FromSeconds(930));
     agent.AddFileSystemTools(opts => builder.Configuration.GetSection("FileSystem").Bind(opts));
     agent.AddWebTools(opts => builder.Configuration.GetSection("WebTools").Bind(opts));
     agent.AddSchedulingTools();

--- a/src/RockBot.Tools.Mcp/McpServiceCollectionExtensions.cs
+++ b/src/RockBot.Tools.Mcp/McpServiceCollectionExtensions.cs
@@ -1,6 +1,8 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using RockBot.Messaging;
 using RockBot.Host;
 using RockBot.Tools;
 using RockBot.Tools.Mcp.Recovery;
@@ -35,11 +37,24 @@ public static class McpServiceCollectionExtensions
     /// the handler registers exactly 5 management tools in <see cref="IToolRegistry"/>
     /// instead of one tool per schema.
     /// </summary>
-    public static AgentHostBuilder AddMcpToolProxy(this AgentHostBuilder builder)
+    public static AgentHostBuilder AddMcpToolProxy(
+        this AgentHostBuilder builder,
+        TimeSpan? requestTimeout = null,
+        TimeSpan? responseTimeout = null)
     {
         var agentName = builder.Identity.Name;
 
-        builder.Services.AddSingleton<McpToolProxy>();
+        var effectiveRequestTimeout = requestTimeout ?? TimeSpan.FromSeconds(60);
+        var effectiveResponseTimeout = responseTimeout ?? effectiveRequestTimeout;
+        builder.Services.AddSingleton(sp =>
+                new McpToolProxy(
+                    sp.GetRequiredService<IMessagePublisher>(),
+                    sp.GetRequiredService<IMessageSubscriber>(),
+                    sp.GetRequiredService<AgentIdentity>(),
+                    sp.GetRequiredService<ILogger<McpToolProxy>>(),
+                    effectiveRequestTimeout,
+                    effectiveResponseTimeout));
+
         builder.Services.AddSingleton<McpServerIndex>();
         builder.Services.AddSingleton<McpManagementExecutor>();
         builder.Services.AddHostedService<McpStartupProbeService>();

--- a/src/RockBot.Tools.Mcp/McpToolProxy.cs
+++ b/src/RockBot.Tools.Mcp/McpToolProxy.cs
@@ -39,7 +39,22 @@ public sealed class McpToolProxy : IToolExecutor, IAsyncDisposable
         _identity = identity;
         _logger = logger;
         _requestTimeout = requestTimeout ?? TimeSpan.FromSeconds(60);
-        _responseTimeout = responseTimeout ?? _requestTimeout;
+
+        // A response wait shorter than the advertised request budget defeats the point of
+        // separating them: the bridge would still be within the time it was granted when the
+        // proxy gave up, turning an in-progress call into a transport failure. Clamped rather
+        // than thrown so a misconfiguration degrades to the old single-timeout behaviour.
+        var wait = responseTimeout ?? _requestTimeout;
+        if (wait < _requestTimeout)
+        {
+            _logger.LogWarning(
+                "McpToolProxy responseTimeout ({Response}ms) is shorter than requestTimeout " +
+                "({Request}ms); clamping to requestTimeout.",
+                wait.TotalMilliseconds, _requestTimeout.TotalMilliseconds);
+            wait = _requestTimeout;
+        }
+
+        _responseTimeout = wait;
     }
 
     /// <summary>

--- a/src/RockBot.Tools.Mcp/McpToolProxy.cs
+++ b/src/RockBot.Tools.Mcp/McpToolProxy.cs
@@ -17,8 +17,8 @@ public sealed class McpToolProxy : IToolExecutor, IAsyncDisposable
     private readonly IMessageSubscriber _subscriber;
     private readonly AgentIdentity _identity;
     private readonly ILogger<McpToolProxy> _logger;
-    private readonly TimeSpan _timeout;
-
+    private readonly TimeSpan _requestTimeout;
+    private readonly TimeSpan _responseTimeout;
     private readonly ConcurrentDictionary<string, TaskCompletionSource<ToolInvokeResponse>> _pending = new();
     private ISubscription? _responseSubscription;
     private bool _initialized;
@@ -31,13 +31,15 @@ public sealed class McpToolProxy : IToolExecutor, IAsyncDisposable
         IMessageSubscriber subscriber,
         AgentIdentity identity,
         ILogger<McpToolProxy> logger,
-        TimeSpan? timeout = null)
+        TimeSpan? requestTimeout = null,
+        TimeSpan? responseTimeout = null)
     {
         _publisher = publisher;
         _subscriber = subscriber;
         _identity = identity;
         _logger = logger;
-        _timeout = timeout ?? TimeSpan.FromSeconds(60);
+        _requestTimeout = requestTimeout ?? TimeSpan.FromSeconds(60);
+        _responseTimeout = responseTimeout ?? _requestTimeout;
     }
 
     /// <summary>
@@ -70,7 +72,7 @@ public sealed class McpToolProxy : IToolExecutor, IAsyncDisposable
             {
                 [WellKnownHeaders.ContentTrust] = WellKnownHeaders.ContentTrustValues.ToolRequest,
                 [WellKnownHeaders.ToolProvider] = "mcp",
-                [WellKnownHeaders.TimeoutMs] = ((int)_timeout.TotalMilliseconds).ToString()
+                [WellKnownHeaders.TimeoutMs] = ((int)_requestTimeout.TotalMilliseconds).ToString()
             };
 
             if (extraHeaders is not null)
@@ -91,7 +93,7 @@ public sealed class McpToolProxy : IToolExecutor, IAsyncDisposable
                 request.ToolName, correlationId);
 
             using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-            timeoutCts.CancelAfter(_timeout);
+            timeoutCts.CancelAfter(_responseTimeout);
 
             try
             {
@@ -100,13 +102,13 @@ public sealed class McpToolProxy : IToolExecutor, IAsyncDisposable
             catch (OperationCanceledException) when (!ct.IsCancellationRequested)
             {
                 _logger.LogWarning("Tool invoke timed out for {ToolName} after {Timeout}ms",
-                    request.ToolName, _timeout.TotalMilliseconds);
+                    request.ToolName, _responseTimeout.TotalMilliseconds);
 
                 return new ToolInvokeResponse
                 {
                     ToolCallId = request.ToolCallId,
                     ToolName = request.ToolName,
-                    Content = $"MCP tool '{request.ToolName}' timed out after {_timeout.TotalSeconds}s — " +
+                    Content = $"MCP tool '{request.ToolName}' timed out after {_responseTimeout.TotalSeconds}s — " +
                               $"the MCP bridge did not respond. The underlying MCP server may be temporarily " +
                               $"unavailable. Call mcp_list_services to check which servers are registered, " +
                               $"or try an alternative approach.",

--- a/tests/RockBot.Agent.Tests/McpBridgeServerConfigTests.cs
+++ b/tests/RockBot.Agent.Tests/McpBridgeServerConfigTests.cs
@@ -243,4 +243,28 @@ public class McpBridgeServerConfigTests
 
         Assert.AreEqual(a.CanonicalIdentity(), b.CanonicalIdentity());
     }
+
+    [TestMethod]
+    public void CanonicalIdentity_DiffersOnlyByToolTimeout_AreEqual()
+    {
+        // Tool timeout is invocation policy, not server identity.
+        // Different timeout budgets must not create duplicate registrations
+        // for the same underlying MCP server.
+        var a = new McpBridgeServerConfig
+        {
+            Type = "sse",
+            Url = "https://srv/"
+        };
+
+        var b = new McpBridgeServerConfig
+        {
+            Type = "sse",
+            Url = "https://srv/",
+            ToolTimeoutMs = 900_000
+        };
+
+        Assert.AreEqual(
+            a.CanonicalIdentity(),
+            b.CanonicalIdentity());
+    }
 }

--- a/tests/RockBot.Tools.Tests/McpToolProxyTests.cs
+++ b/tests/RockBot.Tools.Tests/McpToolProxyTests.cs
@@ -222,6 +222,49 @@ public class McpToolProxyTests
     }
 
     [TestMethod]
+    public async Task ExecuteAsync_ResponseTimeoutShorterThanRequestTimeout_IsClampedUp()
+    {
+        // A response wait below the advertised budget would abandon a call the bridge is
+        // still legitimately working on, reporting a transport failure for a request that
+        // had not yet run out of time. Clamped rather than rejected so a misconfiguration
+        // degrades to the old single-timeout behaviour instead of failing startup.
+        var proxy = CreateProxy(
+            timeout: TimeSpan.FromMilliseconds(400),
+            responseTimeout: TimeSpan.FromMilliseconds(50));
+
+        var request = new ToolInvokeRequest
+        {
+            ToolCallId = "call-clamped",
+            ToolName = "slow_tool",
+            Arguments = "{}"
+        };
+
+        var executeTask = proxy.ExecuteAsync(request, CancellationToken.None);
+
+        await Task.Delay(150);
+
+        Assert.IsFalse(
+            executeTask.IsCompleted,
+            "Proxy gave up at the shorter responseTimeout instead of clamping to requestTimeout.");
+
+        var envelope = _publisher.Published[0].Envelope;
+
+        await _subscriber.DeliverAsync(
+            $"tool.result.{_identity.Name}",
+            new ToolInvokeResponse
+            {
+                ToolCallId = "call-clamped",
+                ToolName = "slow_tool",
+                Content = "completed"
+            }.ToEnvelope("bridge", correlationId: envelope.CorrelationId!));
+
+        var result = await executeTask;
+
+        Assert.IsFalse(result.IsError);
+        Assert.AreEqual("completed", result.Content);
+    }
+
+    [TestMethod]
     public async Task ExecuteAsync_Timeout_ReturnsErrorResponse()
     {
         var proxy = CreateProxy(timeout: TimeSpan.FromMilliseconds(100));

--- a/tests/RockBot.Tools.Tests/McpToolProxyTests.cs
+++ b/tests/RockBot.Tools.Tests/McpToolProxyTests.cs
@@ -12,14 +12,17 @@ public class McpToolProxyTests
     private readonly StubSubscriber _subscriber = new();
     private readonly AgentIdentity _identity = new("test-agent");
 
-    private McpToolProxy CreateProxy(TimeSpan? timeout = null)
+    private McpToolProxy CreateProxy(
+        TimeSpan? timeout = null,
+        TimeSpan? responseTimeout = null)
     {
         return new McpToolProxy(
             _publisher,
             _subscriber,
             _identity,
             NullLogger<McpToolProxy>.Instance,
-            timeout);
+            timeout,
+            responseTimeout);
     }
 
     [TestMethod]
@@ -161,6 +164,61 @@ public class McpToolProxyTests
             $"tool.result.{_identity.Name}",
             response.ToEnvelope("bridge", correlationId: correlationId));
         await executeTask;
+    }
+
+    [TestMethod]
+    public async Task ExecuteAsync_ResponseTimeoutCanExceedAdvertisedRequestTimeout()
+    {
+        var proxy = CreateProxy(
+            timeout: TimeSpan.FromMilliseconds(50),
+            responseTimeout: TimeSpan.FromMilliseconds(500));
+
+        var request = new ToolInvokeRequest
+        {
+            ToolCallId = "call-long-response",
+            ToolName = "slow_tool"
+        };
+
+        var executeTask = proxy.ExecuteAsync(
+            request,
+            CancellationToken.None);
+
+        // Existing tests use 100ms here as well.
+        // This is deliberately longer than the 50ms timeout advertised
+        // to the bridge, but shorter than the proxy's 500ms response wait.
+        await Task.Delay(100);
+
+        Assert.AreEqual(1, _publisher.Published.Count);
+
+        var envelope = _publisher.Published[0].Envelope;
+
+        // The downstream timeout remains 50ms.
+        Assert.AreEqual(
+            "50",
+            envelope.Headers[WellKnownHeaders.TimeoutMs]);
+
+        // But the proxy itself must still be waiting for the bridge response.
+        Assert.IsFalse(
+            executeTask.IsCompleted,
+            "Proxy stopped waiting at the advertised MCP request timeout.");
+
+        var response = new ToolInvokeResponse
+        {
+            ToolCallId = "call-long-response",
+            ToolName = "slow_tool",
+            Content = "completed"
+        };
+
+        await _subscriber.DeliverAsync(
+            $"tool.result.{_identity.Name}",
+            response.ToEnvelope(
+                "bridge",
+                correlationId: envelope.CorrelationId!));
+
+        var result = await executeTask;
+
+        Assert.IsFalse(result.IsError);
+        Assert.AreEqual("completed", result.Content);
     }
 
     [TestMethod]


### PR DESCRIPTION
Replaces #515. **Authored by @praaline** (George Christodoulides) — the commit retains their authorship; I only rebased it.

Closes #514.

## Why this is a new PR rather than #515

#515's diff read as +3336/−3206 because the contributor's editor rewrote six `.cs` files LF-wholesale. The real change is 148 lines. That churn also caused the `Program.cs` conflict against main.

I rebased it onto current main to strip the churn. While force-pushing the result to the fork branch I pushed an empty commit by mistake, which left #515 with zero commits — GitHub auto-closed it and cleared `maintainerCanModify`, so I could not push the correction back. **That was my error, not the contributor's, and none of their work was lost:** the original commit `4b5f8ac` is preserved and the change is reproduced here in full, with authorship intact.

@praaline — apologies for the disruption to your branch. Nothing here differs from what you wrote except the line endings and the added comment noted below.

## The change

Adds optional `ToolTimeoutMs` to `McpBridgeServerConfig` so MCP servers whose tool calls legitimately take minutes can opt into a larger budget, while ordinary servers keep the existing `DefaultTimeoutMs`.

- **Per-server `ToolTimeoutMs`**, capped at `MaxTimeoutMs` and ignored with a warning when non-positive.
- **`MaxTimeoutMs` raised 120s → 900s** so a 15-minute call is expressible. The per-call default is still `DefaultTimeoutMs` (60s), so this raises only the ceiling a caller may explicitly request.
- **`McpToolProxy` separates the timeout it advertises to the bridge from how long it waits for a reply.** This is the non-obvious part: the bridge caps the call itself and answers with a timeout response of its own, so the proxy has to outwait it — otherwise the caller sees a transport failure instead of that response. Hence `requestTimeout: 60s` / `responseTimeout: 930s` at the registration site.

```json
{
  "file-analysis": {
    "toolTimeoutMs": 900000
  }
}
```

## What I changed during the rebase

Nothing functional. Line endings preserved to match main (`--ignore-cr-at-eol` gives an identical shortstat, so there is no whitespace noise), and I added a three-line comment at the `AddMcpToolProxy` call site explaining why the proxy outwaits the bridge — the reason is in the PR description but was not in the code.

Diff is **+151/−18 across 8 files** (148 original + the 3-line comment).

## Verification

Full solution build, 0 errors. Full suite green across all 20 test projects.

Carries @rockfordlhotka's approval from #515.