### PR TITLE
Persist the Blazor data-protection key ring

### DIFF
--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -183,12 +183,21 @@ services:
       AgentName__Path: /data/agent/agent-name.md
     volumes:
       - ${AGENT_DATA_PATH:-agent-data}:/data/agent
+  blazor-init:
+    image: busybox:latest
+    user: root
+    command: ["/bin/sh", "-c", "mkdir -p /data/blazor/keys && chmod -R 777 /data/blazor"]
+    volumes:
+      - blazor-data:/data/blazor
+
   blazor:
     build:
       context: ../..
       dockerfile: src/RockBot.UserProxy.Blazor/Dockerfile
     image: rockylhotka/rockbot-blazor:latest
     depends_on:
+      blazor-init:
+        condition: service_completed_successfully
       rabbitmq:
         condition: service_healthy
     ports:
@@ -199,8 +208,17 @@ services:
       RabbitMq__UserName: rockbot
       RabbitMq__Password: rockbot
       RabbitMq__VirtualHost: /
+      # Persistent ASP.NET Core data-protection key ring — without it the ring is
+      # regenerated on every restart and antiforgery tokens minted before the restart
+      # are rejected. The app fails fast if this path is not writable, which is what
+      # blazor-init above exists to guarantee: Docker named volumes are root-owned and
+      # the image runs as a non-root user. Kubernetes gets this free from fsGroup.
+      DataProtection__KeyRingPath: /data/blazor/keys
+    volumes:
+      - blazor-data:/data/blazor
 
 volumes:
   rabbitmq-data:
   agent-data:
   shared:
+  blazor-data:

--- a/deploy/helm/rockbot/templates/_helpers.tpl
+++ b/deploy/helm/rockbot/templates/_helpers.tpl
@@ -74,6 +74,13 @@ Name of the shared volume PVC.
 {{- end }}
 
 {{/*
+Name of the Blazor UI PVC (data-protection key ring).
+*/}}
+{{- define "rockbot.blazorPvcName" -}}
+{{- include "rockbot.fullname" . }}-blazor-data
+{{- end }}
+
+{{/*
 find(1) exclusion clauses for shared.protectedPaths, one pair of lines per entry.
 
 Each entry is stripped of surrounding slashes first: a trailing one would render

--- a/deploy/helm/rockbot/templates/blazor/deployment.yaml
+++ b/deploy/helm/rockbot/templates/blazor/deployment.yaml
@@ -8,6 +8,12 @@ metadata:
     app.kubernetes.io/component: blazor
 spec:
   replicas: {{ .Values.blazor.replicaCount }}
+  # Recreate, not the default RollingUpdate: the data-protection volume is RWO, so a
+  # new Pod cannot mount it while the old one still holds it. With one replica a
+  # rolling update waits for the new Pod to become ready before terminating the old,
+  # and the rollout deadlocks with the new Pod Pending.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: rockbot-blazor
@@ -63,6 +69,10 @@ spec:
             # resolves AgentReply.Attachments file references under ${ROCKBOT_SHARED_PATH}/attachments.
             - name: ROCKBOT_SHARED_PATH
               value: "/rockbot/shared"
+            # Persistent ASP.NET Core data-protection key ring. Backs antiforgery tokens;
+            # in memory (the default) they are invalidated by every pod restart.
+            - name: DataProtection__KeyRingPath
+              value: "/data/blazor/keys"
             {{- if .Values.workiq.enabled }}
             # WorkIQ device-code flow needs the same Entra app registration
             # values the agent uses. Cache itself never lands on the Blazor pod.
@@ -111,7 +121,14 @@ spec:
             - name: shared-data
               mountPath: /rockbot/shared
               readOnly: true
+            # Read-write, and mounted by this Pod alone. fsGroup above applies pod-wide,
+            # so kubelet chgrp's this volume too and the non-root app user writes via group.
+            - name: blazor-data
+              mountPath: /data/blazor
       volumes:
         - name: shared-data
           persistentVolumeClaim:
             claimName: {{ include "rockbot.sharedPvcName" . }}
+        - name: blazor-data
+          persistentVolumeClaim:
+            claimName: {{ include "rockbot.blazorPvcName" . }}

--- a/deploy/helm/rockbot/templates/blazor/pvc.yaml
+++ b/deploy/helm/rockbot/templates/blazor/pvc.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "rockbot.blazorPvcName" . }}
+  namespace: {{ .Values.namespace }}
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    {{- include "rockbot.labels" . | nindent 4 }}
+    app.kubernetes.io/component: blazor
+spec:
+  # ReadWriteOnce: exactly one Pod ever mounts this. Deliberately NOT the shared
+  # RWX volume — that one is co-mounted into ephemeral script Pods running
+  # LLM-authored code, and the key ring is what mints valid authenticated cookies.
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: {{ .Values.storage.storageClass }}
+  resources:
+    requests:
+      storage: {{ .Values.blazor.storage.size }}

--- a/deploy/helm/rockbot/values.yaml
+++ b/deploy/helm/rockbot/values.yaml
@@ -68,6 +68,11 @@ blazor:
   image:
     repository: rockylhotka/rockbot-blazor
     tag: latest
+  # Leave at 1. The UI holds conversation state in memory (ChatStateService), so a
+  # second replica would serve a different, empty conversation depending on which pod
+  # the browser landed on. The data-protection volume below is ReadWriteOnce as well,
+  # so raising this does not scale the UI — it deadlocks the rollout with the second
+  # pod stuck Pending on a volume the first one already holds.
   replicaCount: 1
   resources:
     requests:
@@ -76,6 +81,28 @@ blazor:
     limits:
       cpu: 500m
       memory: 512Mi
+
+  # Small ReadWriteOnce volume mounted read-write at /data/blazor, holding only the
+  # ASP.NET Core data-protection key ring.
+  #
+  # The key ring is what protects antiforgery tokens (and, later, sign-in cookies).
+  # Without a volume it is generated in memory and thrown away on exit, so every pod
+  # restart or rollout invalidates every token the previous process issued.
+  #
+  # Deliberately NOT a subPath on the shared PVC, for two independent reasons:
+  #   1. The shared volume is co-mounted into ephemeral script pods that run
+  #      LLM-authored code. The key ring can mint valid authenticated payloads;
+  #      nothing the LLM produces should be able to read it.
+  #   2. The shared-cleanup CronJob's catch-all sweep deletes anything under
+  #      /rockbot/shared older than shared.globalTtlDays (30). Key files are written
+  #      once and never touched again, and keys live ~90 days — active keys would be
+  #      reaped silently, looking exactly like a bug.
+  #
+  # Keys are stored as plaintext XML (no encryptor is configured on Linux); the
+  # protection is that only the Blazor pod ever mounts this volume.
+  storage:
+    size: 128Mi
+
   tailscale:
     # Tailscale hostname — the UI becomes accessible at <hostname> on your tailnet.
     # Requires the Tailscale Kubernetes Operator to be installed.

--- a/docs/blazor-ui.md
+++ b/docs/blazor-ui.md
@@ -152,6 +152,45 @@ Docker image (`rockylhotka/rockbot-blazor`). It requires only:
 
 It does **not** need access to the agent data PVC or any agent-internal configuration.
 
+### Persistent storage
+
+The chart provisions one small `ReadWriteOnce` PVC, `rockbot-blazor-data` (128Mi, sized by
+`blazor.storage.size`), mounted read-write at `/data/blazor`. It holds exactly one thing: the
+ASP.NET Core **data-protection key ring**, at the path named by `DataProtection__KeyRingPath`.
+
+That ring is what protects antiforgery tokens — `Program.cs` calls `app.UseAntiforgery()`.
+Left in memory, which is the framework default when no persistent path is configured, it is
+regenerated from scratch every time the process starts, so every token the previous process
+issued is rejected after a restart or a rollout.
+
+Set `DataProtection:KeyRingPath` and the app persists the ring there, pinning the application
+name to `rockbot-blazor` so the purpose string does not drift with the container's working
+directory. Leave it empty and the ASP.NET Core defaults apply — on a developer machine those
+already resolve to a persistent per-user profile directory, so only container deployments need
+to set it. The path is probed for writability at startup and the app **fails to start** if it
+cannot be written; the alternative is silently falling back to in-memory keys, which looks
+like the feature simply not working.
+
+Two deliberate choices worth knowing:
+
+- **It is not a `subPath` on the shared PVC.** That volume is co-mounted into ephemeral script
+  pods running LLM-authored code, and it is swept by the `shared-cleanup` CronJob, whose
+  catch-all rule deletes anything older than `shared.globalTtlDays` (30 days). Key files are
+  written once and never touched again while keys live ~90 days, so active keys would be
+  reaped silently.
+- **The deployment uses `strategy: Recreate`.** An RWO volume cannot be mounted by a new pod
+  while the old one holds it, so a rolling update would deadlock with the new pod `Pending`.
+  This also means `blazor.replicaCount` must stay at 1 — which it already had to, since
+  conversation state lives in the in-memory `ChatStateService`.
+
+Keys are stored as plaintext XML (no encryptor is configured on Linux). The protection is that
+only the Blazor pod ever mounts the volume.
+
+In Kubernetes the pod's `securityContext.fsGroup` applies pod-wide, so kubelet chgrps the new
+volume and the non-root app user writes via group — no init container needed. The Docker
+Compose stack has no equivalent, so it runs a small `blazor-init` service that creates and
+chmods the directory before the app starts.
+
 The UI is exposed on the Tailscale network via the Tailscale Kubernetes Operator, in one
 of two modes.
 

--- a/src/RockBot.UserProxy.Blazor/Program.cs
+++ b/src/RockBot.UserProxy.Blazor/Program.cs
@@ -27,6 +27,11 @@ builder.Services.AddSingleton<ChatStateService>();
 builder.Services.AddWorkIqAuthClient(builder.Configuration);
 builder.Services.AddScoped<WorkIqAuthUiService>();
 
+// Persist the data-protection key ring when DataProtection:KeyRingPath is configured.
+// The ring backs antiforgery tokens (see UseAntiforgery below); left in memory it is
+// regenerated on every restart, so tokens minted by the previous process are rejected.
+builder.Services.AddRockBotDataProtection(builder.Configuration);
+
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.

--- a/src/RockBot.UserProxy.Blazor/Services/DataProtectionSetup.cs
+++ b/src/RockBot.UserProxy.Blazor/Services/DataProtectionSetup.cs
@@ -1,0 +1,91 @@
+using Microsoft.AspNetCore.DataProtection;
+
+namespace RockBot.UserProxy.Blazor.Services;
+
+/// <summary>
+/// Points the ASP.NET Core data-protection key ring at a persistent directory.
+/// </summary>
+/// <remarks>
+/// Without this the key ring is generated in memory and discarded when the process exits, so every
+/// payload protected by it — antiforgery tokens today, authentication cookies once sign-in exists —
+/// is invalidated on restart. In a container that means every pod restart or rollout.
+/// </remarks>
+public static class DataProtectionSetup
+{
+    /// <summary>
+    /// Application name (the data-protection purpose root) for the Blazor UI. Pinned rather than
+    /// derived: the default is a hash of the content root path, so changing <c>WORKDIR</c> in the
+    /// Dockerfile would silently invalidate every payload the existing key ring had protected.
+    /// </summary>
+    public const string ApplicationName = "rockbot-blazor";
+
+    /// <summary>Configuration key holding the key-ring directory. Empty means "use ASP.NET defaults".</summary>
+    public const string KeyRingPathKey = "DataProtection:KeyRingPath";
+
+    /// <summary>
+    /// Persists the data-protection key ring to <c>DataProtection:KeyRingPath</c> when that setting
+    /// is present. When it is empty the ASP.NET Core defaults are left alone — on a developer
+    /// machine those already resolve to a persistent per-user profile directory, so only container
+    /// deployments need to set the path.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The configured directory cannot be created or written to. This throws rather than falling
+    /// back because the fallback is in-memory keys: the app would start, serve traffic, and lose
+    /// every session on restart with nothing in the logs pointing at the mount.
+    /// </exception>
+    public static IServiceCollection AddRockBotDataProtection(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        var keyRingPath = configuration[KeyRingPathKey];
+        if (string.IsNullOrWhiteSpace(keyRingPath))
+            return services;
+
+        var directory = EnsureWritable(keyRingPath.Trim());
+
+        services.AddDataProtection()
+            .PersistKeysToFileSystem(directory)
+            .SetApplicationName(ApplicationName);
+
+        return services;
+    }
+
+    /// <summary>
+    /// Creates the key-ring directory if needed and proves it is writable by round-tripping a probe
+    /// file. Retired keys are never pruned — they are still required to decrypt payloads protected
+    /// before the last ~90-day rollover.
+    /// </summary>
+    private static DirectoryInfo EnsureWritable(string keyRingPath)
+    {
+        string fullPath;
+        try
+        {
+            fullPath = Path.GetFullPath(keyRingPath);
+            Directory.CreateDirectory(fullPath);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException)
+        {
+            throw new InvalidOperationException(
+                $"Data protection key ring directory '{keyRingPath}' could not be created: {ex.Message}. " +
+                "Check that the volume is mounted read-write and that the container user can write to it.", ex);
+        }
+
+        var probe = Path.Combine(fullPath, $".rockbot-write-probe-{Environment.ProcessId}");
+        try
+        {
+            File.WriteAllText(probe, string.Empty);
+            File.Delete(probe);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            throw new InvalidOperationException(
+                $"Data protection key ring directory '{fullPath}' is not writable: {ex.Message}. " +
+                "Check that the volume is mounted read-write and that the container user can write to it.", ex);
+        }
+
+        return new DirectoryInfo(fullPath);
+    }
+}

--- a/tests/RockBot.UserProxy.Blazor.Tests/DataProtectionSetupTests.cs
+++ b/tests/RockBot.UserProxy.Blazor.Tests/DataProtectionSetupTests.cs
@@ -1,0 +1,103 @@
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using RockBot.UserProxy.Blazor.Services;
+
+namespace RockBot.UserProxy.Blazor.Tests;
+
+[TestClass]
+public class DataProtectionSetupTests
+{
+    private string _root = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "rockbot-dp-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        try { Directory.Delete(_root, recursive: true); }
+        catch (IOException) { /* best effort */ }
+        catch (UnauthorizedAccessException) { /* best effort */ }
+    }
+
+    private static ServiceProvider BuildProvider(string? keyRingPath)
+    {
+        var settings = new Dictionary<string, string?>();
+        if (keyRingPath is not null)
+            settings[DataProtectionSetup.KeyRingPathKey] = keyRingPath;
+
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddRockBotDataProtection(configuration);
+        return services.BuildServiceProvider();
+    }
+
+    [TestMethod]
+    public void ProtectedPayload_SurvivesProcessRestart()
+    {
+        var keyRing = Path.Combine(_root, "keys");
+        const string payload = "antiforgery-token-stand-in";
+
+        string ciphertext;
+        using (var first = BuildProvider(keyRing))
+        {
+            ciphertext = first.GetDataProtector("test-purpose").Protect(payload);
+        }
+
+        // A second provider over the same directory is the closest in-process stand-in for a
+        // restarted pod: nothing is shared but the files on disk.
+        using var second = BuildProvider(keyRing);
+        var roundTripped = second.GetDataProtector("test-purpose").Unprotect(ciphertext);
+
+        Assert.AreEqual(payload, roundTripped);
+    }
+
+    [TestMethod]
+    public void KeyFiles_AreWrittenToConfiguredPath()
+    {
+        var keyRing = Path.Combine(_root, "keys");
+
+        using var provider = BuildProvider(keyRing);
+        provider.GetDataProtector("test-purpose").Protect("x");
+
+        var keyFiles = Directory.GetFiles(keyRing, "key-*.xml");
+        Assert.IsTrue(keyFiles.Length > 0, $"expected a key XML file under {keyRing}");
+    }
+
+    [TestMethod]
+    public void UnwritablePath_ThrowsNamingThePath()
+    {
+        // An existing file where the directory should be: CreateDirectory cannot succeed.
+        var blocked = Path.Combine(_root, "not-a-directory");
+        File.WriteAllText(blocked, "occupied");
+
+        var ex = Assert.ThrowsExactly<InvalidOperationException>(() => BuildProvider(blocked));
+
+        StringAssert.Contains(ex.Message, "not-a-directory");
+    }
+
+    [TestMethod]
+    public void EmptyConfiguration_LeavesDefaultsAloneAndCreatesNothing()
+    {
+        using var provider = BuildProvider(null);
+
+        // Registration is a no-op: no directory is probed or created, and nothing throws. The
+        // real app is left on the ASP.NET Core defaults, which already persist on a dev machine.
+        Assert.AreEqual(0, Directory.GetFileSystemEntries(_root).Length);
+    }
+
+    [TestMethod]
+    public void WhitespaceConfiguration_IsTreatedAsUnset()
+    {
+        using var provider = BuildProvider("   ");
+
+        Assert.AreEqual(0, Directory.GetFileSystemEntries(_root).Length);
+    }
+}


### PR DESCRIPTION
First of two PRs for #534. This half stands alone and is useful without any authentication.

## Why

The Blazor pod has no writable volume, so the ASP.NET Core data-protection key ring is generated in memory and discarded when the process exits. That already affects the app today: `Program.cs` calls `app.UseAntiforgery()`, and antiforgery tokens are protected by that same ring — every pod restart or rollout invalidates every token the previous process issued.

It is also the prerequisite that stops OAuth cookies from being invalidated on every restart in PR 2.

## What

`AddRockBotDataProtection` persists the ring to `DataProtection:KeyRingPath` when that setting is present:

- **`SetApplicationName("rockbot-blazor")`** — the purpose string otherwise derives from the content root path, so a future `WORKDIR` change in the Dockerfile would silently invalidate everything the existing ring had protected.
- **Writability probe at startup**, throwing with the path named. Without it a permissions mistake degrades to in-memory keys silently, and the feature just appears not to work.
- **Empty setting does nothing** — ASP.NET defaults already resolve to a persistent per-user profile path on a dev box. Only container deployments set it.
- **Never prunes.** Keys roll over at ~90 days, but retired keys are still needed to decrypt outstanding payloads.

## Storage: a dedicated PVC, not the shared volume

A read-write `subPath` on `rockbot-shared` is the cheap option and it is wrong, for two independent reasons:

1. **`rockbot-shared` is mounted into ephemeral script pods running LLM-generated code** (`ContainerScriptHandler.cs`, via `Scripts__Container__SharedVolumeClaim`). The key ring is the secret that mints valid authenticated payloads. Hosting it there would let LLM-authored code forge a session — against the "nothing trusts the LLM" principle the architecture rests on.
2. **The `shared-cleanup` CronJob would silently delete it.** Its catch-all sweep deletes any file under `/rockbot/shared` older than `shared.globalTtlDays` (default 30). Key files are written once and never touched again, and keys live ~90 days — so active keys would be reaped at day 30 with no error, looking exactly like a bug.

So: `rockbot-blazor-data`, RWO, 128Mi, `helm.sh/resource-policy: keep`, mounted read-write at `/data/blazor`. The existing read-only `/rockbot/shared` mount is untouched.

## Deployment notes

- **`strategy: Recreate` is not optional.** The deployment currently declares no strategy, so it defaults to `RollingUpdate`; an RWO volume cannot be mounted by the new pod while the old one holds it, and with one replica the rollout won't terminate the old pod first — the upgrade deadlocks with the new pod `Pending`. The agent deployment already sets `Recreate` for the same reason.
- No init container is needed in Kubernetes: the pod already sets `securityContext.fsGroup`, which applies pod-wide. Compose has no equivalent, so a small `blazor-init` service creates and chmods the directory — Docker named volumes are root-owned and the image runs as non-root.
- The ring is stored as plaintext XML (no encryptor on Linux). Defensible on a dedicated RWO volume only the Blazor pod mounts; `ProtectKeysWithCertificate` is left for later.

## Release note

The first upgrade after this provisions `rockbot-blazor-data` and switches Blazor to `Recreate` — a brief one-time outage, not an ongoing change.

`blazor.replicaCount` must stay at 1. Multi-replica Blazor was never supported (in-memory `ChatStateService`); an RWO key volume now makes it structurally impossible too. The values comment says so.

## Verification

- `dotnet test RockBot.slnx` — all green. The real assertion in `DataProtectionSetupTests`: protect a payload with a provider over a temp directory, dispose it, build a *second* provider over the same directory, unprotect successfully. That is "survives a restart" stated as a test. Plus key files on disk, an unwritable path throwing with the path in the message, and empty config creating nothing.
- Compose end-to-end: the same `key-*.xml` file survived `docker compose restart`, a `--force-recreate`, and two image rebuilds. The page still serves after each.
- `helm template` / `helm upgrade --dry-run` against live cluster values: the new PVC renders, the Blazor deployment shows `strategy: Recreate`, the `/data/blazor` mount and `DataProtection__KeyRingPath` are wired, and `/rockbot/shared` is still `readOnly: true`.

Part of #534.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FieTYKLKEbarXNyPrHBX9F
