### PR TITLE
Stop busting the prompt cache with a mid-prompt datetime

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.14.33</Version>
+<Version>0.14.34</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.Host/AgentContextBuilder.cs
+++ b/src/RockBot.Host/AgentContextBuilder.cs
@@ -13,6 +13,10 @@ namespace RockBot.Host;
 /// Builds the LLM chat message context (system prompt, history, memories, skills, working memory)
 /// for a given session and user turn. Shared by UserMessageHandler, ScheduledTaskHandler, and SubagentRunner.
 /// </summary>
+// CS9113: <c>clock</c> is unread since datetime injection moved to AgentLoopRunner.EnsureDateTimeContext
+// (see the note in BuildAsync). The parameter is kept because this is a public constructor on a shipped
+// package; dropping it would be a source- and binary-breaking change for downstream consumers.
+#pragma warning disable CS9113
 public sealed class AgentContextBuilder(
     ProfileHolder profileHolder,
     AgentIdentity agent,
@@ -35,6 +39,7 @@ public sealed class AgentContextBuilder(
     ICapabilityClaimVerifier? capabilityClaimVerifier = null,
     IToolCallLog? toolCallLog = null,
     IOptions<AgentHostOptions>? agentHostOptions = null)
+#pragma warning restore CS9113
 {
     /// <summary>Host options, defaulted when not supplied so existing callers and tests are unaffected.</summary>
     private readonly AgentHostOptions _hostOptions = agentHostOptions?.Value ?? new AgentHostOptions();
@@ -86,14 +91,15 @@ public sealed class AgentContextBuilder(
         // /data/agent/prompt-hints/patrol.md is injected into patrol-task prompts only.
         var category = DerivePromptCategory(workingMemoryNamespace);
         var systemPrompt = systemPromptOverride ?? promptBuilder.Build(profile, agent, category);
+        // Datetime context is deliberately NOT injected here. AgentLoopRunner.EnsureDateTimeContext
+        // supplies it — rounded to the minute and inserted just before the last user message — so the
+        // system-prompt prefix stays byte-identical across turns and the provider prompt cache holds.
+        // A datetime string at this position diverges every request from the end of the persona onward:
+        // a few thousand tokens of needless recompute on cloud providers, and the entire prompt on
+        // llama.cpp with sliding-window attention, which cannot roll its cache back mid-sequence.
         var chatMessages = new List<ChatMessage>
         {
-            new(ChatRole.System, systemPrompt),
-            new(ChatRole.System,
-                $"Current local date and time: {clock.Now:dddd, MMMM d, yyyy} {clock.Now:HH:mm:ss zzz} ({clock.Zone.Id})\n" +
-                $"UTC equivalent: {clock.Now.UtcDateTime:yyyy-MM-dd HH:mm:ss}\n" +
-                "All dates and times must use this timezone. " +
-                "When any tool returns a UTC timestamp, convert it to this local timezone before using or displaying it.")
+            new(ChatRole.System, systemPrompt)
         };
 
         // Client rendering capabilities — only injected when the caller advertised at least
@@ -955,7 +961,7 @@ public sealed class AgentContextBuilder(
 
     /// <summary>
     /// Slim context build for the worker rung — see <c>design/worker-subagents.md</c>.
-    /// Injects only: system prompt (passed in), datetime, active rules, model
+    /// Injects only: system prompt (passed in), active rules, model
     /// guardrails, skill index + BM25 recall, service hints, and working memory
     /// (own namespace + shared). Skips LTM/episodic/identity/KG fetch entirely
     /// and the embedding generation that backs them.
@@ -978,14 +984,15 @@ public sealed class AgentContextBuilder(
         string workingMemoryNamespace,
         string systemPromptOverride)
     {
+        // Datetime context is deliberately NOT injected here. AgentLoopRunner.EnsureDateTimeContext
+        // supplies it — rounded to the minute and inserted just before the last user message — so the
+        // system-prompt prefix stays byte-identical across turns and the provider prompt cache holds.
+        // A datetime string at this position diverges every request from the end of the persona onward:
+        // a few thousand tokens of needless recompute on cloud providers, and the entire prompt on
+        // llama.cpp with sliding-window attention, which cannot roll its cache back mid-sequence.
         var chatMessages = new List<ChatMessage>
         {
-            new(ChatRole.System, systemPromptOverride),
-            new(ChatRole.System,
-                $"Current local date and time: {clock.Now:dddd, MMMM d, yyyy} {clock.Now:HH:mm:ss zzz} ({clock.Zone.Id})\n" +
-                $"UTC equivalent: {clock.Now.UtcDateTime:yyyy-MM-dd HH:mm:ss}\n" +
-                "All dates and times must use this timezone. " +
-                "When any tool returns a UTC timestamp, convert it to this local timezone before using or displaying it.")
+            new(ChatRole.System, systemPromptOverride)
         };
 
         // Active rules — safety constraints workers must honour.

--- a/src/RockBot.Host/AgentLoopRunner.cs
+++ b/src/RockBot.Host/AgentLoopRunner.cs
@@ -743,6 +743,9 @@ public sealed partial class AgentLoopRunner(
     /// the datetime string sat in front of the otherwise-stable conversation history; the
     /// new placement keeps the entire history prefix cacheable. Any pre-existing datetime
     /// system message is removed first so re-running the loop migrates the position.
+    /// This is the only datetime injection site: <see cref="AgentContextBuilder"/> used to add a
+    /// second, seconds-precision copy right behind the system prompt, which diverged every request
+    /// from that point on and defeated the cache this placement exists to preserve.
     /// </summary>
     private void EnsureDateTimeContext(List<ChatMessage> chatMessages)
     {
@@ -750,7 +753,8 @@ public sealed partial class AgentLoopRunner(
         var nowMinute = new DateTimeOffset(now.Year, now.Month, now.Day, now.Hour, now.Minute, 0, now.Offset);
         var text =
             $"The user's local date and time is: {nowMinute:dddd, MMMM d, yyyy} {nowMinute:HH:mm zzz} ({clock.Zone.Id}). " +
-            "Always express dates and times to the user in this timezone. Never assume UTC or any other timezone.";
+            "Always express dates and times to the user in this timezone. Never assume UTC or any other timezone. " +
+            "When any tool returns a UTC timestamp, convert it to this local timezone before using or displaying it.";
 
         for (var i = chatMessages.Count - 1; i >= 0; i--)
         {

--- a/tests/RockBot.Host.Tests/AgentContextBuilderDateTimeTests.cs
+++ b/tests/RockBot.Host.Tests/AgentContextBuilderDateTimeTests.cs
@@ -1,0 +1,174 @@
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using RockBot.Llm;
+using RockBot.Memory;
+using RockBot.Skills;
+
+namespace RockBot.Host.Tests;
+
+/// <summary>
+/// Guards the prompt-cache invariant: <see cref="AgentContextBuilder"/> must not inject a datetime
+/// system message. Datetime context comes from <c>AgentLoopRunner.EnsureDateTimeContext</c>, which
+/// rounds to the minute and inserts just before the last user message so the whole prefix ahead of it
+/// stays byte-identical across turns. A datetime message here sits right behind the system prompt, so
+/// every request diverges from the end of the persona onward — a few thousand tokens of needless
+/// recompute on cloud providers, and the entire prompt on llama.cpp with sliding-window attention,
+/// which cannot roll its cache back mid-sequence.
+/// </summary>
+[TestClass]
+public class AgentContextBuilderDateTimeTests
+{
+    [TestMethod]
+    public async Task BuildAsync_InjectsNoDateTimeMessage()
+    {
+        var builder = BuildBuilder();
+
+        var messages = await builder.BuildAsync("session-datetime", "current message", CancellationToken.None);
+
+        AssertNoDateTime(messages);
+    }
+
+    [TestMethod]
+    public async Task BuildForWorkerAsync_InjectsNoDateTimeMessage()
+    {
+        var builder = BuildBuilder();
+
+        var messages = await builder.BuildForWorkerAsync(
+            "worker-datetime", "do the thing", CancellationToken.None, "worker/abc", "worker system prompt");
+
+        AssertNoDateTime(messages);
+    }
+
+    [TestMethod]
+    public async Task BuildAsync_SystemPromptIsTheFirstMessage()
+    {
+        var builder = BuildBuilder();
+
+        var messages = await builder.BuildAsync("session-first", "current message", CancellationToken.None);
+
+        Assert.AreEqual(ChatRole.System, messages[0].Role);
+        StringAssert.Contains(messages[0].Text, "I am a test agent.",
+            "The agent profile must remain the very first message so it anchors the cacheable prefix.");
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static void AssertNoDateTime(IReadOnlyList<ChatMessage> messages)
+    {
+        foreach (var message in messages)
+        {
+            var text = message.Text ?? string.Empty;
+            Assert.IsFalse(text.Contains("date and time", StringComparison.OrdinalIgnoreCase),
+                $"AgentContextBuilder must not inject datetime context — it busts the prompt cache. Found: {text}");
+            Assert.IsFalse(text.Contains("UTC equivalent", StringComparison.OrdinalIgnoreCase),
+                $"AgentContextBuilder must not inject datetime context — it busts the prompt cache. Found: {text}");
+        }
+    }
+
+    private static AgentContextBuilder BuildBuilder()
+    {
+        var profileHolder = new ProfileHolder();
+        var doc = new AgentProfileDocument("soul", null, [], "I am a test agent.");
+        profileHolder.Update(new AgentProfile(doc, doc));
+        var nameHolder = new AgentNameHolder();
+
+        var agentProfileOptions = Options.Create(new AgentProfileOptions
+        {
+            BasePath = Path.Combine(Path.GetTempPath(), "rockbot-datetime-test-" + Guid.NewGuid().ToString("N"))
+        });
+        Directory.CreateDirectory(agentProfileOptions.Value.BasePath);
+
+        var clock = new AgentClock(
+            new ConfigurationBuilder().Build(),
+            agentProfileOptions,
+            NullLoggerFactory.Instance.CreateLogger<AgentClock>());
+
+        return new AgentContextBuilder(
+            profileHolder: profileHolder,
+            agent: new AgentIdentity("TestBot"),
+            promptBuilder: new DefaultSystemPromptBuilder(profileHolder, nameHolder, Options.Create(new AgentProfileOptions())),
+            rulesStore: new StubRulesStore(),
+            modelBehavior: ModelBehavior.Default,
+            conversationMemory: new StubConversationMemory(),
+            longTermMemory: new StubLongTermMemory(),
+            injectedMemoryTracker: new InjectedMemoryTracker(),
+            workingMemory: new StubWorkingMemory(),
+            skillStore: new StubSkillStore(),
+            skillIndexTracker: new SkillIndexTracker(),
+            skillRecallTracker: new SkillRecallTracker(),
+            clock: clock,
+            serviceSearchIndexProviders: [],
+            knowledgeGraphProviders: [],
+            knowledgeGraphOptions: Options.Create(new KnowledgeGraphOptions()),
+            embeddingGenerators: [],
+            logger: NullLogger<AgentContextBuilder>.Instance);
+    }
+
+    // ── Stubs ────────────────────────────────────────────────────────────────
+
+    private sealed class StubConversationMemory : IConversationMemory
+    {
+        public Task AddTurnAsync(string sessionId, ConversationTurn turn, CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
+
+        public Task<IReadOnlyList<ConversationTurn>> GetTurnsAsync(string sessionId, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<ConversationTurn>>([]);
+
+        public Task ClearAsync(string sessionId, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task<IReadOnlyList<string>> ListSessionsAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<string>>([]);
+    }
+
+    private sealed class StubLongTermMemory : ILongTermMemory
+    {
+        public Task SaveAsync(MemoryEntry entry, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task<IReadOnlyList<MemoryEntry>> SearchAsync(MemorySearchCriteria criteria, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<MemoryEntry>>([]);
+
+        public Task<MemoryEntry?> GetAsync(string id, CancellationToken cancellationToken = default) =>
+            Task.FromResult<MemoryEntry?>(null);
+
+        public Task DeleteAsync(string id, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task<IReadOnlyList<string>> ListTagsAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<string>>([]);
+
+        public Task<IReadOnlyList<string>> ListCategoriesAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<string>>([]);
+    }
+
+    private sealed class StubWorkingMemory : IWorkingMemory
+    {
+        public Task SetAsync(string key, string value, TimeSpan? ttl = null, string? category = null, IReadOnlyList<string>? tags = null) => Task.CompletedTask;
+        public Task<string?> GetAsync(string key) => Task.FromResult<string?>(null);
+        public Task<IReadOnlyList<WorkingMemoryEntry>> ListAsync(string? prefix = null) =>
+            Task.FromResult<IReadOnlyList<WorkingMemoryEntry>>([]);
+        public Task DeleteAsync(string key) => Task.CompletedTask;
+        public Task ClearAsync(string? prefix = null) => Task.CompletedTask;
+        public Task<IReadOnlyList<WorkingMemoryEntry>> SearchAsync(MemorySearchCriteria criteria, string? prefix = null) =>
+            Task.FromResult<IReadOnlyList<WorkingMemoryEntry>>([]);
+    }
+
+    private sealed class StubSkillStore : ISkillStore
+    {
+        public Task SaveAsync(Skill skill) => Task.CompletedTask;
+        public Task<Skill?> GetAsync(string name) => Task.FromResult<Skill?>(null);
+        public Task<IReadOnlyList<Skill>> ListAsync() => Task.FromResult<IReadOnlyList<Skill>>([]);
+        public Task DeleteAsync(string name) => Task.CompletedTask;
+        public Task<IReadOnlyList<Skill>> SearchAsync(string query, int maxResults, CancellationToken cancellationToken = default, float[]? queryEmbedding = null) =>
+            Task.FromResult<IReadOnlyList<Skill>>([]);
+    }
+
+    private sealed class StubRulesStore : IRulesStore
+    {
+        public IReadOnlyList<string> Rules => [];
+        public Task<IReadOnlyList<string>> ListAsync() => Task.FromResult<IReadOnlyList<string>>([]);
+        public Task AddAsync(string rule) => Task.CompletedTask;
+        public Task RemoveAsync(string rule) => Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
## The bug

`AgentContextBuilder` injected a seconds-precision datetime system message at index 1 — immediately behind the persona — in both `BuildAsync` and `BuildForWorkerAsync`. Every request therefore diverged from the end of the system prompt onward, so the provider prompt cache could only ever keep the persona prefix.

| Provider | Common prefix found | What it keeps | Wasted per turn |
| --- | --- | --- | --- |
| Grok / OpenRouter | 25.9K (the persona) | all of it — the cloud prefix cache just restarts after the timestamp | ~3K tokens |
| llama.cpp + Gemma | 25.9K (`f_keep = 0.882`) | nothing — SWA cannot roll back mid-sequence, so it drops the lot | ~29K tokens, ~16–17s |

Cloud providers hide the defect because they only lose the ~3K tail. On llama.cpp with sliding-window attention the same defect costs the entire prompt, because SWA cannot roll its cache back mid-sequence. Neither `-cms 1024 -ctxcp 32` (context checkpoints) nor `--swa-full` is a usable workaround — the latter needed 15,795 MiB at 64K single-slot and collapsed prefill to 27 tok/s.

`AgentLoopRunner.EnsureDateTimeContext` already supplies the datetime correctly: rounded to the minute, inserted just before the last user message, which keeps the whole prefix ahead of it byte-identical across turns. That fix landed in cc9e4e7 but was applied to `AgentLoopRunner` only. `AgentContextBuilder` was missed, and because its message started with a different prefix (`"Current local date and time:"`) `EnsureDateTimeContext`'s dedupe never removed it.

## The change

- Delete both `AgentContextBuilder` datetime blocks; each site keeps a comment explaining why nothing goes there.
- Fold the UTC-conversion wording into `EnsureDateTimeContext`'s string so no guidance is lost.
- New `AgentContextBuilderDateTimeTests` asserts neither build path emits a datetime message, and that the profile stays message 0.

All eleven `BuildAsync` / `BuildForWorkerAsync` callers route through `RunAsync`, so every path still gets datetime context.

## Note on the retained parameter

`clock` is now unread in `AgentContextBuilder`. The constructor parameter is kept rather than dropped: `RockBot.Host` is `IsPackable`, so removing a public constructor parameter would be a source- and binary-breaking change for downstream consumers. CS9113 is suppressed with a comment explaining that. Happy to take the break instead if preferred — it's mechanical across the DI registration and five test harnesses.

## Testing

`dotnet test RockBot.slnx` — 2,829 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DLSHESpGMgDcjg5pDGiMJy
