### PR TITLE
Stop a lost circuit from stranding the Blazor busy indicator

### DIFF
--- a/src/RockBot.UserProxy.Blazor/Pages/Chat.razor
+++ b/src/RockBot.UserProxy.Blazor/Pages/Chat.razor
@@ -222,7 +222,10 @@
         }
 
         @{
-            var hasActiveActivityLog = ChatState.Messages.Any(m => m.IsActivityLog && !m.IsExpanded);
+            // Only a log that is still receiving entries carries its own spinner. Testing
+            // for a collapsed bubble instead would match every finished turn's leftover
+            // log and suppress this indicator for the rest of the conversation.
+            var hasActiveActivityLog = ChatState.Messages.Any(m => m.IsActivityLog && ChatState.IsActiveActivityLog(m.MessageId));
         }
         @if ((ChatState.IsProcessing && !hasActiveActivityLog) || (!ChatState.IsProcessing && !string.IsNullOrEmpty(ChatState.CurrentThinkingMessage)))
         {

--- a/src/RockBot.UserProxy.Blazor/Services/ChatStateService.cs
+++ b/src/RockBot.UserProxy.Blazor/Services/ChatStateService.cs
@@ -58,6 +58,14 @@ public sealed class ChatStateService
         {
             _messages.Clear();
 
+            // The bubbles those entries point at were just discarded, so anything left
+            // here is a dangling reference to a message that no longer exists. This
+            // service is a singleton that outlives the circuit, so without the reset a
+            // reload mid-turn carries the previous circuit's spinner state into the
+            // restored transcript.
+            _activeActivityLogs.Clear();
+            _currentThinkingMessage = null;
+
             foreach (var turn in turns)
             {
                 // Skip system/consolidation turns — they are internal prompts not meant for the user
@@ -147,7 +155,16 @@ public sealed class ChatStateService
             // PrimaryFinal closes the PrimaryProgress log (different category names);
             // subagent / A2A / scheduled final replies close their own category's log.
             if (category == MessageCategory.PrimaryFinal)
+            {
                 _activeActivityLogs.Remove(ActivityLogKey(MessageCategory.PrimaryProgress, null));
+
+                // The primary agent's turn is over, whoever was waiting on it. The send
+                // loop clears this too, but only for the circuit that started the turn —
+                // if that circuit is gone (reload, SignalR reconnect) its continuation
+                // never runs and the busy state would stick on this singleton forever,
+                // leaving a spinner under the reply and a disabled input box.
+                _isProcessing = false;
+            }
             else
                 _activeActivityLogs.Remove(ActivityLogKey(category, reply.AgentName));
 
@@ -362,12 +379,16 @@ public sealed class ChatStateService
     /// Reconciles local activity-log state against the authoritative snapshot from
     /// the agent. Removes stale entries for subagents that are no longer running and
     /// seeds entries for subagents that are active but unknown to the UI (e.g. after
-    /// a page reload while subagents were in flight).
+    /// a page reload while subagents were in flight). The agent's own busy flag is
+    /// adopted as well, so a reload lands on the real state rather than on whatever
+    /// the previous circuit left behind.
     /// </summary>
     public void ReconcileActiveStatus(ActiveStatusResponse status)
     {
         lock (_lock)
         {
+            _isProcessing = status.IsProcessing;
+
             var activeAgentNames = status.Subagents
                 .Select(s => $"subagent-{s.TaskId}")
                 .ToHashSet(StringComparer.OrdinalIgnoreCase);

--- a/tests/RockBot.UserProxy.Tests/ChatStateServiceProcessingStateTests.cs
+++ b/tests/RockBot.UserProxy.Tests/ChatStateServiceProcessingStateTests.cs
@@ -1,0 +1,119 @@
+using RockBot.UserProxy.Blazor.Services;
+
+namespace RockBot.UserProxy.Tests;
+
+/// <summary>
+/// Covers the busy-state bookkeeping on the singleton <see cref="ChatStateService"/>.
+/// The service outlives any one Blazor circuit, so state set by a circuit that later
+/// disappears (page reload, SignalR reconnect) must not strand the UI.
+/// </summary>
+[TestClass]
+public sealed class ChatStateServiceProcessingStateTests
+{
+    private readonly ChatStateService _sut = new();
+
+    private static AgentReply Reply(string content, bool isFinal = true, string agentName = "rockbot")
+        => new()
+        {
+            Content = content,
+            SessionId = "test-session",
+            AgentName = agentName,
+            IsFinal = isFinal
+        };
+
+    private static ActiveStatusResponse Status(bool isProcessing)
+        => new() { Subagents = [], IsProcessing = isProcessing };
+
+    [TestMethod]
+    public void AddAgentReply_PrimaryFinal_ClearsProcessing()
+    {
+        _sut.SetProcessing(true);
+
+        _sut.AddAgentReply(Reply("Here you go."));
+
+        Assert.IsFalse(_sut.IsProcessing,
+            "The primary turn is over — the busy flag must clear even if the sending circuit is gone");
+    }
+
+    [TestMethod]
+    public void AddAgentReply_NonPrimaryCategory_LeavesProcessing()
+    {
+        _sut.SetProcessing(true);
+
+        _sut.AddAgentReply(Reply("Subagent finished.", agentName: "subagent-1"),
+            MessageCategory.SubagentActivity);
+
+        Assert.IsTrue(_sut.IsProcessing,
+            "A subagent result does not end the primary turn");
+    }
+
+    [TestMethod]
+    public void AddAgentReply_PrimaryFinal_ClosesProgressLog()
+    {
+        _sut.SetProcessing(true);
+        _sut.AppendActivityLogEntry("I'm working on that — I'll follow up shortly.");
+
+        var logBubble = _sut.Messages.Single(m => m.IsActivityLog);
+        Assert.IsTrue(_sut.IsActiveActivityLog(logBubble.MessageId));
+
+        _sut.AddAgentReply(Reply("Done."));
+
+        Assert.IsFalse(_sut.IsActiveActivityLog(logBubble.MessageId),
+            "The progress log stops spinning once the reply lands");
+    }
+
+    [TestMethod]
+    public void LoadHistory_ClearsStaleActivityLogState()
+    {
+        // A turn in flight when the page reloads: progress bubble open, busy flag set.
+        _sut.SetProcessing(true);
+        _sut.AppendActivityLogEntry("I'm working on that — I'll follow up shortly.");
+        var staleBubbleId = _sut.Messages.Single(m => m.IsActivityLog).MessageId;
+
+        _sut.LoadHistory(
+            [new ConversationHistoryTurn { Role = "user", Content = "Hello", Timestamp = DateTimeOffset.UtcNow }],
+            "test-session");
+
+        Assert.IsFalse(_sut.IsActiveActivityLog(staleBubbleId),
+            "The bubble was discarded with the transcript — its log entry must go too");
+        Assert.IsNull(_sut.CurrentThinkingMessage);
+        Assert.IsFalse(_sut.Messages.Any(m => m.IsActivityLog));
+    }
+
+    [TestMethod]
+    public void LoadHistory_ThenProgress_StartsAFreshLogBubble()
+    {
+        _sut.SetProcessing(true);
+        _sut.AppendActivityLogEntry("first turn progress");
+
+        _sut.LoadHistory(
+            [new ConversationHistoryTurn { Role = "user", Content = "Hello", Timestamp = DateTimeOffset.UtcNow }],
+            "test-session");
+        _sut.AppendActivityLogEntry("second turn progress");
+
+        var bubble = _sut.Messages.Single(m => m.IsActivityLog);
+        Assert.AreEqual(1, bubble.ActivityLogEntries.Count,
+            "Entries from the discarded turn must not accumulate on the new bubble");
+        Assert.AreEqual("second turn progress", bubble.Content);
+        Assert.IsTrue(_sut.IsActiveActivityLog(bubble.MessageId));
+    }
+
+    [TestMethod]
+    public void ReconcileActiveStatus_AgentIdle_ClearsStaleProcessing()
+    {
+        _sut.SetProcessing(true);
+
+        _sut.ReconcileActiveStatus(Status(isProcessing: false));
+
+        Assert.IsFalse(_sut.IsProcessing);
+    }
+
+    [TestMethod]
+    public void ReconcileActiveStatus_AgentBusy_RestoresProcessing()
+    {
+        _sut.ReconcileActiveStatus(Status(isProcessing: true));
+
+        Assert.IsTrue(_sut.IsProcessing,
+            "A reload mid-turn should show the agent as still working");
+    }
+}


### PR DESCRIPTION
## Problem

`ChatStateService` is a singleton that outlives any one Blazor circuit, but the busy flag it holds was only ever cleared by the send loop's `finally` block in `Chat.razor` — code owned by the circuit that started the turn.

Reload the page or let SignalR reconnect mid-turn and that circuit is gone. Its continuation never runs, `IsProcessing` stays `true` on state that every later page shares, and the UI is left with a spinner parked under the last reply and an input box that will not unlock. It reads as though the agent picked up a prompt nobody sent.

## Changes

All in the UI layer; no agent or transport behaviour changes.

- **`AddAgentReply` clears the busy flag on a `PrimaryFinal` reply.** The turn is over whoever was waiting on it, so ending it no longer depends on a circuit surviving to observe the result.
- **`ReconcileActiveStatus` adopts the agent's own `IsProcessing` snapshot.** The agent already published it (`ActiveStatusRequestHandler`) and the UI already fetched it on every page load — it was being discarded. A reload now lands on the real state in both directions.
- **`LoadHistory` clears the active-activity-log map and the thinking message.** Both pointed at bubbles the reload had just discarded.
- **`Chat.razor` tested "is any activity bubble collapsed"** where it meant "is any activity log still running". Every finished turn leaves a collapsed bubble behind, so from the first turn onward the condition was always true and the bottom-of-page indicator was suppressed for the rest of the conversation. This is also why the stranded spinner only became visible after a history reload — the one moment with no leftover bubbles to suppress it.

## Testing

`RockBot.UserProxy.Tests` 75 passed, including 7 new cases in `ChatStateServiceProcessingStateTests.cs` covering busy-flag clearing on a final reply, non-primary categories leaving it set, stale log state after `LoadHistory`, a fresh bubble on the next turn, and reconciliation in both directions. `RockBot.UserProxy.Blazor.Tests` 55 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CCixDE43uUpSGMJZFNcfiK
