### PR TITLE
Give the token and duration histograms usable bucket boundaries

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.14.19</Version>
+<Version>0.14.21</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.Host/HostDiagnostics.cs
+++ b/src/RockBot.Host/HostDiagnostics.cs
@@ -15,18 +15,84 @@ public static class HostDiagnostics
     public static readonly ActivitySource Source = new(ActivitySourceName);
     public static readonly Meter Meter = new(MeterName);
 
+    // ── Histogram bucket boundaries ───────────────────────────────────────────
+    // The OTel SDK's default boundaries stop at 10,000. That ceiling is one to
+    // two orders of magnitude below every token count recorded here, and it is
+    // 10 seconds for anything measured in milliseconds. With no explicit
+    // boundaries the observations pile into the +Inf bucket, and Prometheus's
+    // histogram_quantile then returns the highest FINITE bound — so p50/p95/p99
+    // all render as a flat 10,000 line in Grafana no matter what was measured.
+    //
+    // Measured over 7d on 2026-08-28 (share of observations above 10,000):
+    //   agent.context.tokens          100%   mean     19,755 tokens
+    //   agent.turn.tokens.input        99%   mean    296,268 tokens
+    //   agent.turn.tokens.input.cached 96%   mean    216,499 tokens
+    //   agent.llm.context.tokens       93%   mean     25,509 tokens
+    //   subagent.duration             100%   mean    422,590 ms
+    //   agent.turn.duration            41%   mean     11,394 ms
+    //   llm.request.duration           39%   mean     36,449 ms
+    //   embedding.duration             29%   mean      6,458 ms
+    //   pipeline.dispatch.duration     20%   mean     21,592 ms
+    //
+    // Instruments left on the SDK defaults (turn.tokens.output, turn.tools, and
+    // the sub-second duration metrics) measured fully in range, so they keep the
+    // defaults rather than churn a working metric.
+    //
+    // These must be declared BEFORE the instruments that reference them —
+    // static field initializers run in declaration order, so moving them down
+    // the file would hand CreateHistogram a null boundary list.
+
+    /// <summary>
+    /// Buckets for per-turn cumulative token counts. These sum across every
+    /// internal LLM call in a turn, so a long tool loop reaches the millions.
+    /// </summary>
+    private static readonly IReadOnlyList<long> TurnTokenBuckets =
+        [1_000, 5_000, 10_000, 25_000, 50_000, 100_000,
+         250_000, 500_000, 1_000_000, 2_500_000, 5_000_000];
+
+    /// <summary>
+    /// Buckets for single-payload context sizes. Bounded by the model's context
+    /// window rather than by loop length, hence a tighter top end than
+    /// <see cref="TurnTokenBuckets"/>.
+    /// </summary>
+    private static readonly IReadOnlyList<long> ContextTokenBuckets =
+        [1_000, 2_500, 5_000, 10_000, 25_000, 50_000,
+         100_000, 200_000, 400_000, 1_000_000];
+
+    /// <summary>
+    /// Buckets (ms) for request-scoped work: one call out to a model or embedding
+    /// endpoint, or a single pass through the dispatch pipeline. Spans 10ms to
+    /// 10 minutes — the top end covers slow generations, which do exceed a minute.
+    /// </summary>
+    public static readonly IReadOnlyList<double> RequestDurationBuckets =
+        [10, 25, 50, 100, 250, 500, 1_000, 2_500, 5_000,
+         10_000, 30_000, 60_000, 120_000, 300_000, 600_000];
+
+    /// <summary>
+    /// Buckets (ms) for whole-turn and subagent work, which drives an entire tool
+    /// loop and routinely runs for minutes. Shared with
+    /// <c>RockBot.Subagent.SubagentDiagnostics</c> so both read on one scale.
+    /// </summary>
+    public static readonly IReadOnlyList<double> LoopDurationBuckets =
+        [500, 1_000, 2_500, 5_000, 10_000, 30_000, 60_000,
+         120_000, 300_000, 600_000, 1_200_000, 1_800_000, 3_600_000];
+
     public static readonly Histogram<double> DispatchDuration =
         Meter.CreateHistogram<double>(
             "rockbot.pipeline.dispatch.duration",
             unit: "ms",
-            description: "Duration of message dispatch through the pipeline");
+            description: "Duration of message dispatch through the pipeline",
+            tags: null,
+            advice: new InstrumentAdvice<double> { HistogramBucketBoundaries = RequestDurationBuckets });
 
     // ── LLM metrics — recorded in LlmClient (the actual call path) ───────────
     public static readonly Histogram<double> LlmRequestDuration =
         Meter.CreateHistogram<double>(
             "rockbot.llm.request.duration",
             unit: "ms",
-            description: "Duration of LLM request operations");
+            description: "Duration of LLM request operations",
+            tags: null,
+            advice: new InstrumentAdvice<double> { HistogramBucketBoundaries = RequestDurationBuckets });
 
     public static readonly Counter<long> LlmRequests =
         Meter.CreateCounter<long>(
@@ -90,7 +156,9 @@ public static class HostDiagnostics
         Meter.CreateHistogram<double>(
             "rockbot.agent.turn.duration",
             unit: "ms",
-            description: "Duration of agent turns from message receipt to final reply");
+            description: "Duration of agent turns from message receipt to final reply",
+            tags: null,
+            advice: new InstrumentAdvice<double> { HistogramBucketBoundaries = LoopDurationBuckets });
 
     /// <summary>Total agent turns completed.</summary>
     public static readonly Counter<long> Turns =
@@ -104,14 +172,18 @@ public static class HostDiagnostics
         Meter.CreateHistogram<long>(
             "rockbot.agent.context.tokens",
             unit: "{token}",
-            description: "Estimated token count of context injected before LLM call");
+            description: "Estimated token count of context injected before LLM call",
+            tags: null,
+            advice: new InstrumentAdvice<long> { HistogramBucketBoundaries = ContextTokenBuckets });
 
     /// <summary>Total input tokens consumed per turn (aggregated across all LLM calls).</summary>
     public static readonly Histogram<long> TurnTokensInput =
         Meter.CreateHistogram<long>(
             "rockbot.agent.turn.tokens.input",
             unit: "{token}",
-            description: "Input tokens per turn, aggregated across all LLM calls in the loop");
+            description: "Input tokens per turn, aggregated across all LLM calls in the loop",
+            tags: null,
+            advice: new InstrumentAdvice<long> { HistogramBucketBoundaries = TurnTokenBuckets });
 
     /// <summary>Total output tokens produced per turn (aggregated across all LLM calls).</summary>
     public static readonly Histogram<long> TurnTokensOutput =
@@ -125,7 +197,9 @@ public static class HostDiagnostics
         Meter.CreateHistogram<long>(
             "rockbot.agent.turn.tokens.input.cached",
             unit: "{token}",
-            description: "Cached input tokens per turn (subset of TurnTokensInput) — indicates prompt-cache effectiveness");
+            description: "Cached input tokens per turn (subset of TurnTokensInput) — indicates prompt-cache effectiveness",
+            tags: null,
+            advice: new InstrumentAdvice<long> { HistogramBucketBoundaries = TurnTokenBuckets });
 
     /// <summary>Number of tool calls executed per turn.</summary>
     public static readonly Histogram<long> TurnToolCalls =
@@ -145,7 +219,9 @@ public static class HostDiagnostics
         Meter.CreateHistogram<long>(
             "rockbot.agent.llm.context.tokens",
             unit: "{token}",
-            description: "Estimated context size at each LLM call boundary (per-call, not per-turn)");
+            description: "Estimated context size at each LLM call boundary (per-call, not per-turn)",
+            tags: null,
+            advice: new InstrumentAdvice<long> { HistogramBucketBoundaries = ContextTokenBuckets });
 
     // ── Completion evaluator ────────────────────────────────────────────────
 
@@ -200,7 +276,9 @@ public static class HostDiagnostics
         Meter.CreateHistogram<double>(
             "rockbot.embedding.duration",
             unit: "ms",
-            description: "Duration of text-embedding generation calls");
+            description: "Duration of text-embedding generation calls",
+            tags: null,
+            advice: new InstrumentAdvice<double> { HistogramBucketBoundaries = RequestDurationBuckets });
 
     /// <summary>Total embedding generation calls.</summary>
     public static readonly Counter<long> EmbeddingCalls =

--- a/src/RockBot.Subagent/SubagentDiagnostics.cs
+++ b/src/RockBot.Subagent/SubagentDiagnostics.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
+using RockBot.Host;
 
 namespace RockBot.Subagent;
 
@@ -34,7 +35,16 @@ internal static class SubagentDiagnostics
         Meter.CreateHistogram<double>(
             "rockbot.subagent.duration",
             unit: "ms",
-            description: "Execution duration of subagent tasks");
+            description: "Execution duration of subagent tasks",
+            tags: null,
+            // Subagents run a full tool loop — measured mean is ~7 minutes, and
+            // every observation overflowed the SDK's default 10,000ms ceiling,
+            // pinning the Grafana quantiles to a flat 10s. Shares the host's
+            // loop scale so turn and subagent durations stay comparable.
+            advice: new InstrumentAdvice<double>
+            {
+                HistogramBucketBoundaries = HostDiagnostics.LoopDurationBuckets
+            });
 
     /// <summary>Total subagent task failures (exceptions or cancellations).</summary>
     public static readonly Counter<long> Failures =


### PR DESCRIPTION
The Grafana "Input Tokens per Turn" panel reported a flat 10,000 regardless of load. Not a dashboard bug: the OTel SDK's default explicit bucket boundaries top out at 10,000, which is one to two orders of magnitude below every token count we record and is ten seconds for anything measured in milliseconds. Every observation landed in `+Inf`, and Prometheus's `histogram_quantile` returns the highest **finite** bound when the quantile falls there — so p50, p95 and p99 all collapsed onto one flat line.

## Measured over 7d on 2026-08-28

Share of observations above 10,000:

| instrument | above 10k | mean |
|---|---:|---:|
| `agent.context.tokens` | 100% | 19,755 tokens |
| `agent.turn.tokens.input` | 99% | 296,268 tokens |
| `agent.turn.tokens.input.cached` | 96% | 216,499 tokens |
| `agent.llm.context.tokens` | 93% | 25,509 tokens |
| `subagent.duration` | 100% | 422,590 ms |
| `agent.turn.duration` | 41% | 11,394 ms |
| `llm.request.duration` | 39% | 36,449 ms |
| `embedding.duration` | 29% | 6,458 ms |
| `pipeline.dispatch.duration` | 20% | 21,592 ms |

Turn input tokens were understating by roughly 22x.

## Change

Four boundary sets, split by what each instrument actually measures. Per-turn token counts sum across every internal FICC iteration and reach the millions; the two context metrics measure a single payload bounded by the model's context window, so they get a tighter top end. Durations split the same way: one call out to a model or embedding endpoint, versus a whole turn or subagent driving a tool loop for minutes.

`turn.tokens.output` (mean 1,633), `turn.tools` (mean 14.5) and the sub-second duration metrics measured fully in range and keep the SDK defaults rather than churning metrics that work.

`subagent.duration` lives in another assembly but `RockBot.Subagent` already references `RockBot.Host`, so it consumes the shared boundaries instead of duplicating them — turn and subagent durations stay comparable and the two cannot drift apart.

One trap, noted in the code: **the boundary arrays MUST be declared above the instruments that use them.** C# runs static field initializers in declaration order, so moving them down the file would silently hand `CreateHistogram` a null boundary list.

## Verification

Unit tests: 1298 passed in `RockBot.Host.Tests`, 69 in `RockBot.Subagent.Tests`. Verified against OpenTelemetry 1.18.0 with an InMemory exporter that the SDK honours `InstrumentAdvice.HistogramBucketBoundaries` — the change is inert if it does not — and that each metric's real measured mean now lands in a finite bucket with headroom.

**Confirmed live.** This is deployed to the cluster as `rockbot-agent:0.14.21` (helm revision 284). The new agent instance reports the new boundaries in Prometheus:

| metric | buckets | max finite bound |
|---|---:|---:|
| `rockbot_llm_request_duration_milliseconds_bucket` | 16 | 600,000 |
| `rockbot_embedding_duration_milliseconds_bucket` | 16 | 600,000 |
| `rockbot_pipeline_dispatch_duration_milliseconds_bucket` | 16 | 600,000 |

Up from 10,000, so the advice is honoured by the real SDK/exporter/Prometheus path, not just under an InMemory exporter.

## Notes for the reviewer

- **Historical data stays flat.** Buckets are fixed at write time, so every observation recorded before the rollout keeps the old boundaries. Dashboards show a discontinuity at the cutover, not a retroactive correction. For a few minutes either side, the old and new `le` sets overlap inside Prometheus's staleness window and `histogram_quantile` can briefly return nonsense until the old instances age out.
- **Includes a version bump to 0.14.21.** No commit ever carried `0.14.20`, though that image was built and is what the cluster was running — the repo sat at `0.14.19`. Skipping to `0.14.21` avoids reusing a pushed tag.
- **A companion dashboard fix is in the k8s repo**, [rockfordlhotka/lhotkalake-k8s#2](https://github.com/rockfordlhotka/lhotkalake-k8s/pull/2). Separate issue found while chasing this one: several panels used a bare `histogram_quantile(q, rate(..._bucket[5m]))` without `sum by (le)`, so they fanned out into one identically-legended series per tier and pod lifetime. That was invisible while every line was collapsed onto 10,000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3LRZE9eXYz71QEqcNGZSA
