### PR TITLE
Gate corpus-wide dream passes on whether their input actually changed

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.14.21</Version>
+<Version>0.15.0</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.14.24</Version>
+<Version>0.14.25</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.14.23</Version>
+<Version>0.14.24</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.14.22</Version>
+<Version>0.14.23</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.15.0</Version>
+<Version>0.14.22</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/docs/dream-service.md
+++ b/docs/dream-service.md
@@ -37,6 +37,48 @@ Each dream cycle runs a log-retention pass followed by five knowledge passes in 
 Passes that depend on optional services (`IConversationLog`, `IFeedbackStore`,
 `ISkillUsageStore`) are skipped when those services are not registered.
 
+### The change gate
+
+Most passes are *delta-driven*: they read the conversation log, a time-windowed slice of a
+telemetry log, or a work queue, and return early when there is nothing new. An idle agent costs
+nothing for those — the conversation log is cleared at the end of every cycle, so after a quiet
+day it is empty and six passes no-op on the first line.
+
+A handful are *corpus-wide* instead. Skill consolidation ships the whole skill catalog, graph
+consolidation the whole graph, the contradiction sweep the whole claim/feedback corpus, identity
+reflection its full experiential context. Ungated, these re-ask the model the same question about
+the same bytes on every cycle forever, and the prompt scales with corpus size rather than with
+how much the agent actually did. `DreamPassLedger` gates them: each hashes the corpus it is about
+to describe and skips the LLM call when the hash matches what it last ran on.
+
+Three details make it safe rather than merely cheap:
+
+- **The fingerprint covers the corpus, not statistics derived from it.** Skill usage counts and
+  co-occurrence tallies are 30-day rolling annotations that drift on their own as old events age
+  out; importance scores are rewritten by the decay pass every cycle. Hashing those would mean
+  nothing was ever "unchanged" and the gate would never fire.
+- **`DreamPassMaxSkipInterval` (default 7 days) forces a run regardless.** Some directives are
+  time-dependent in ways a content hash cannot see — graph consolidation prunes entities by
+  staleness, so an untouched graph still becomes prunable through the passage of time. The floor
+  bounds cost without switching such behaviour off.
+- **The stamp is recorded only after the model returns usable JSON.** A failed or unparseable
+  call is retried next cycle rather than being mistaken for a completed one.
+
+The ledger lives at `{BasePath}/dream-pass-ledger.json` so the gate survives a restart. A missing
+or corrupt ledger degrades to "run everything once", never to "skip something forever". Set
+`DreamPassChangeGateEnabled: false` to restore the previous run-every-cycle behaviour.
+
+Two related bounds close the same kind of leak elsewhere:
+
+- **Tier routing review** reads its append-only log through a `TierRoutingReviewWindow` (default
+  14 days). Without a window the pass always saw the same trailing 200 entries and could never
+  run out of input.
+- **Memory consolidation's duplicate-cluster carve-out** now skips clusters in which every member
+  is already reviewed-and-unchanged. Such a cluster was, by construction, shown to the model
+  together on the cycle that stamped it; re-offering it re-asks an answered question and quietly
+  undid the reviewed-and-unchanged gate for exactly the entries most likely to sit in a cluster.
+  One new or edited member re-opens the whole cluster.
+
 ### Pass 0 — Log retention
 
 Runs **first and unconditionally**, before the knowledge passes — and crucially before the
@@ -433,6 +475,11 @@ public sealed class DreamOptions
     // Feature flags
     public bool PreferenceInferenceEnabled { get; set; } = true;
     public bool SkillGapEnabled { get; set; } = true;
+
+    // Change gate — skip a corpus-wide pass whose input has not moved
+    public bool DreamPassChangeGateEnabled { get; set; } = true;
+    public TimeSpan DreamPassMaxSkipInterval { get; set; } = TimeSpan.FromDays(7);
+    public TimeSpan TierRoutingReviewWindow { get; set; } = TimeSpan.FromDays(14);
 
     // Append-only JSONL log retention (Pass 0)
     public bool LogRetentionEnabled { get; set; } = true;

--- a/src/RockBot.Host.Abstractions/DreamOptions.cs
+++ b/src/RockBot.Host.Abstractions/DreamOptions.cs
@@ -281,6 +281,26 @@ public sealed class DreamOptions
     /// </summary>
     public int CastVoiceMaxPerCycle { get; set; } = 12;
 
+    /// <summary>
+    /// Whether cast voice enrichment requires conversation activity since the last cycle.
+    /// Default: <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Without this the pass is gated only on "some character still lacks a voice card", which
+    /// stays true for months. On an idle agent it is then the one pass that keeps spending: it
+    /// ships the whole cast corpus on every cycle to invent voices for characters nobody has
+    /// played with since the last time it ran. Voices are worth writing for the cast that just
+    /// walked on stage, not for a corpus sitting untouched.
+    /// </para>
+    /// <para>
+    /// The pass runs before preference inference clears the conversation log, so an empty log at
+    /// that point means nothing happened this period. When no <see cref="IConversationLog"/> is
+    /// registered the gate cannot be evaluated and the pass runs as before.
+    /// </para>
+    /// </remarks>
+    public bool CastVoiceRequiresRecentActivity { get; set; } = true;
+
     /// <summary>Whether the tier routing self-correction review pass is enabled.</summary>
     public bool TierRoutingReviewEnabled { get; set; } = true;
 

--- a/src/RockBot.Host.Abstractions/DreamOptions.cs
+++ b/src/RockBot.Host.Abstractions/DreamOptions.cs
@@ -19,6 +19,43 @@ public sealed class DreamOptions
     public string CronSchedule { get; set; } = "0 */12 * * *";
 
     /// <summary>
+    /// Whether corpus-wide dream passes skip their LLM call when the input they would send has
+    /// not changed since the last time they ran. Default: <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Several passes are corpus-wide rather than delta-driven: skill consolidation ships the
+    /// whole skill catalog, graph consolidation the whole graph, the contradiction sweep the
+    /// whole claim/feedback corpus, identity reflection its full experiential context. Ungated,
+    /// each re-asks the model the same question about the same bytes on every cycle — twice a
+    /// day at the default <see cref="CronSchedule"/> — and the bill scales with corpus size
+    /// rather than with how much the agent actually did.
+    /// </para>
+    /// <para>
+    /// The fingerprint covers the corpus itself, not statistics derived from it. Skill usage
+    /// counts and co-occurrence tallies are 30-day rolling annotations that drift on their own
+    /// as old events age out; treating that drift as a change would keep an idle agent dreaming
+    /// for a month after its last conversation. Set to <c>false</c> to restore the previous
+    /// run-every-cycle behaviour.
+    /// </para>
+    /// </remarks>
+    public bool DreamPassChangeGateEnabled { get; set; } = true;
+
+    /// <summary>
+    /// Longest a gated dream pass may go without actually running, however unchanged its inputs
+    /// look. Default: 7 days. Set to <see cref="TimeSpan.Zero"/> or negative to make the change
+    /// gate absolute.
+    /// </summary>
+    /// <remarks>
+    /// Some directives are time-dependent in ways an input hash cannot see — graph consolidation
+    /// prunes entities by staleness, so an untouched graph still becomes prunable purely through
+    /// the passage of time. Without this floor, gating those passes on content would quietly
+    /// switch such behaviour off. With it, an idle agent runs them once a week instead of
+    /// fourteen times, and nothing stops firing altogether.
+    /// </remarks>
+    public TimeSpan DreamPassMaxSkipInterval { get; set; } = TimeSpan.FromDays(7);
+
+    /// <summary>
     /// Which LLM tier the dream passes run on. Defaults to <see cref="ModelTier.Balanced"/>,
     /// matching the previous hardcoded behaviour.
     /// <para>
@@ -246,6 +283,18 @@ public sealed class DreamOptions
 
     /// <summary>Whether the tier routing self-correction review pass is enabled.</summary>
     public bool TierRoutingReviewEnabled { get; set; } = true;
+
+    /// <summary>
+    /// How far back the tier routing review pass reads its routing log. Default: 14 days.
+    /// Set to <see cref="TimeSpan.Zero"/> or negative to read the whole log.
+    /// </summary>
+    /// <remarks>
+    /// The routing log is append-only and the pass reads the tail of it, so without a window an
+    /// agent that stopped making routing decisions still had the same trailing entries analyzed
+    /// on every cycle indefinitely. A window lets the input drain: once the newest entry ages
+    /// out, the pass falls below its minimum-entry threshold and stops on its own.
+    /// </remarks>
+    public TimeSpan TierRoutingReviewWindow { get; set; } = TimeSpan.FromDays(14);
 
     /// <summary>
     /// Routing cost floor for the tier-routing review pass. The High tier is priced at no less

--- a/src/RockBot.Host.Abstractions/DreamOptions.cs
+++ b/src/RockBot.Host.Abstractions/DreamOptions.cs
@@ -301,6 +301,28 @@ public sealed class DreamOptions
     /// </remarks>
     public bool CastVoiceRequiresRecentActivity { get; set; } = true;
 
+    /// <summary>
+    /// Substrings that mark a voice card as written in the current format. A character whose card
+    /// contains <see cref="CastVoiceMarker"/> but none of these is treated as an older card and is
+    /// offered back to the pass for an upgrade. Empty (the default) means any card counts as
+    /// finished, which is the original behaviour.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A deployment that evolves what a voice card should contain otherwise has no way to bring
+    /// the cards it already wrote up to the new shape: the pass skipped anything carrying the
+    /// marker, so a directive asking the model to upgrade older cards produced proposals the
+    /// framework silently discarded. Listing one or more markers of the current format closes
+    /// that gap without the framework knowing anything about a particular card layout.
+    /// </para>
+    /// <para>
+    /// Matching is case-insensitive, and only one of the listed markers has to be present — card
+    /// sections are usually optional individually, so requiring all of them would treat a
+    /// legitimately short card as stale and rewrite it forever.
+    /// </para>
+    /// </remarks>
+    public IList<string> CastVoiceUpgradeMarkers { get; set; } = [];
+
     /// <summary>Whether the tier routing self-correction review pass is enabled.</summary>
     public bool TierRoutingReviewEnabled { get; set; } = true;
 

--- a/src/RockBot.Host/DreamPassLedger.cs
+++ b/src/RockBot.Host/DreamPassLedger.cs
@@ -1,0 +1,160 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace RockBot.Host;
+
+/// <summary>
+/// Records, per dream pass, the fingerprint of the input that pass last actually ran an LLM
+/// call on and when it did so. A pass consults the ledger before calling the model: when its
+/// inputs hash to the same value as last time, the call is skipped.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This exists because several dream passes are corpus-wide rather than delta-driven — skill
+/// consolidation ships the whole skill catalog, graph consolidation the whole graph, the
+/// contradiction sweep the whole claim/feedback corpus. Without a gate they re-ask the model
+/// the same question, on the same bytes, on every cycle forever, and the prompt grows with the
+/// corpus rather than with the user's activity.
+/// </para>
+/// <para>
+/// The gate is deliberately not absolute. <see cref="DreamOptions.DreamPassMaxSkipInterval"/>
+/// forces a run once a pass has been skipped for that long, because some directives are
+/// time-dependent in ways the input hash cannot see — graph consolidation prunes entities by
+/// staleness, so an unchanged graph still becomes prunable through the mere passage of time.
+/// The floor bounds the cost (one run per interval instead of one per cycle) without silently
+/// switching those behaviours off.
+/// </para>
+/// <para>
+/// Persisted next to the agent profile so the gate survives a pod restart; a lost or corrupt
+/// ledger degrades to "run everything once", never to "skip something forever".
+/// </para>
+/// </remarks>
+internal sealed class DreamPassLedger
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = true
+    };
+
+    /// <summary>The last input a pass ran on, and when that run happened.</summary>
+    internal sealed record PassRecord(string Fingerprint, DateTimeOffset LastRunAt);
+
+    private readonly Dictionary<string, PassRecord> _records;
+    private readonly string _path;
+    private readonly ILogger _logger;
+    private bool _dirty;
+
+    private DreamPassLedger(string path, Dictionary<string, PassRecord> records, ILogger logger)
+    {
+        _path = path;
+        _records = records;
+        _logger = logger;
+    }
+
+    /// <summary>Default filename, relative to <see cref="AgentProfileOptions.BasePath"/>.</summary>
+    internal const string FileName = "dream-pass-ledger.json";
+
+    /// <summary>
+    /// Reads the ledger from disk. A missing, unreadable, or malformed file yields an empty
+    /// ledger rather than an exception: the cost of forgetting is one extra pass, and the dream
+    /// cycle must not fail over bookkeeping.
+    /// </summary>
+    public static async Task<DreamPassLedger> LoadAsync(string path, ILogger logger)
+    {
+        var records = new Dictionary<string, PassRecord>(StringComparer.OrdinalIgnoreCase);
+
+        if (File.Exists(path))
+        {
+            try
+            {
+                var json = await File.ReadAllTextAsync(path).ConfigureAwait(false);
+                var loaded = JsonSerializer.Deserialize<Dictionary<string, PassRecord>>(json, JsonOptions);
+                if (loaded is not null)
+                    foreach (var (pass, record) in loaded)
+                        if (!string.IsNullOrWhiteSpace(record?.Fingerprint))
+                            records[pass] = record;
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex,
+                    "DreamPassLedger: failed to read {Path}; every gated pass will run this cycle", path);
+            }
+        }
+
+        return new DreamPassLedger(path, records, logger);
+    }
+
+    /// <summary>The record for <paramref name="passName"/>, or <c>null</c> if it has never run.</summary>
+    public PassRecord? Get(string passName) =>
+        _records.TryGetValue(passName, out var record) ? record : null;
+
+    /// <summary>
+    /// Whether <paramref name="passName"/> may skip its LLM call this cycle.
+    /// </summary>
+    public bool ShouldSkip(
+        string passName,
+        string fingerprint,
+        DateTimeOffset now,
+        TimeSpan maxSkipInterval) =>
+        ShouldSkip(Get(passName), fingerprint, now, maxSkipInterval);
+
+    /// <summary>
+    /// Pure form of <see cref="ShouldSkip(string, string, DateTimeOffset, TimeSpan)"/>, separated
+    /// so the decision can be unit-tested without touching the filesystem.
+    /// </summary>
+    /// <remarks>
+    /// A non-positive <paramref name="maxSkipInterval"/> disables the floor, making the gate
+    /// absolute — an unchanged input is then skipped indefinitely.
+    /// </remarks>
+    internal static bool ShouldSkip(
+        PassRecord? record,
+        string fingerprint,
+        DateTimeOffset now,
+        TimeSpan maxSkipInterval)
+    {
+        // Never run: nothing to compare against.
+        if (record is null) return false;
+
+        // Inputs moved. This is the common "the agent did something" case.
+        if (!string.Equals(record.Fingerprint, fingerprint, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        if (maxSkipInterval <= TimeSpan.Zero) return true;
+
+        // Floor reached — run anyway so time-dependent directives still fire. A clock that has
+        // gone backwards (restore, timezone change) reads as "not yet due" rather than
+        // triggering a run; the next forward tick corrects it.
+        return now - record.LastRunAt < maxSkipInterval;
+    }
+
+    /// <summary>Records that <paramref name="passName"/> ran to completion on this input.</summary>
+    public void Record(string passName, string fingerprint, DateTimeOffset now)
+    {
+        _records[passName] = new PassRecord(fingerprint, now);
+        _dirty = true;
+    }
+
+    /// <summary>
+    /// Writes the ledger back to disk if anything changed. Uses <see cref="AtomicFile"/> so a
+    /// crash mid-write cannot leave a truncated ledger behind — which would read back as "every
+    /// pass is due" rather than as corruption.
+    /// </summary>
+    public async Task SaveAsync(CancellationToken ct = default)
+    {
+        if (!_dirty) return;
+
+        try
+        {
+            await AtomicFile.WriteAllTextAsync(
+                _path, JsonSerializer.Serialize(_records, JsonOptions), ct).ConfigureAwait(false);
+            _dirty = false;
+        }
+        catch (Exception ex)
+        {
+            // A ledger that fails to persist costs one redundant pass next cycle. Never fatal.
+            _logger.LogWarning(ex, "DreamPassLedger: failed to write {Path}", _path);
+        }
+    }
+}

--- a/src/RockBot.Host/DreamService.cs
+++ b/src/RockBot.Host/DreamService.cs
@@ -2282,29 +2282,82 @@ internal sealed class DreamService : IHostedService, IDisposable
             return;
         }
 
+        // A voice is worth writing for the cast that just walked on stage. "Some character still
+        // lacks a card" stays true for months, so on its own it is not a reason to spend a
+        // full-corpus call — it is what made this the one pass that kept billing an idle agent.
+        // Cast voice runs before preference inference clears the log, so an empty log here means
+        // nothing happened since the last cycle.
+        IReadOnlyList<ConversationLogEntry> recentTurns = [];
+        if (_options.CastVoiceRequiresRecentActivity && _conversationLog is not null)
+        {
+            recentTurns = await _conversationLog.ReadAllAsync(ct);
+            if (recentTurns.Count == 0)
+            {
+                _logger.LogInformation(
+                    "DreamService: cast voice enrichment — no conversation activity since the last cycle; " +
+                    "skipping ({Uncarded} character(s) still without a voice card)",
+                    uncarded);
+                return;
+            }
+        }
+
         _logger.LogInformation(
-            "DreamService: cast voice enrichment pass — {Total} entries in {Category}, {Uncarded} without a voice card",
-            cast.Count, category, uncarded);
+            "DreamService: cast voice enrichment pass — {Total} entries in {Category}, {Uncarded} without a voice card, " +
+            "{Turns} conversation turn(s) since the last cycle",
+            cast.Count, category, uncarded, recentTurns.Count);
 
         await RunPassAsync("cast voice enrichment", async () =>
         {
+            // Only uncarded entries are offered as candidates. Previously the whole corpus was
+            // listed and the model was told not to touch the finished ones — which it ignored,
+            // because the very next instruction told it to prefer the entries with the most
+            // content, and a finished entry is longer precisely because it has a card appended.
+            // The proposals then died silently against the HasVoiceMarker check: one cycle on a
+            // 160-entry corpus spent 24 proposals to land 1 update. Withholding them is a gate
+            // the model cannot talk its way past.
+            var candidates = cast.Where(e => !HasVoiceMarker(e.Content, marker)).ToList();
+            var takenVoices = cast
+                .Where(e => HasVoiceMarker(e.Content, marker))
+                .Select(e => ExtractVoiceCardLine(e.Content, marker))
+                .Where(v => !string.IsNullOrWhiteSpace(v))
+                .ToList();
+
             var userMessage = new StringBuilder();
-            userMessage.AppendLine($"Every entry currently in `{category}`, with its id.");
-            userMessage.AppendLine();
             userMessage.AppendLine(
-                $"Entries already containing \"{marker}\" are shown so you can see which characters are " +
-                "finished and which voices already exist. Never propose an update to one of those, and " +
-                "never give a new character a voice that duplicates one already on the page.");
+                $"Characters in `{category}` that do not yet have a voice. These are the only entries " +
+                "you may propose an update for — every id you return must come from this list.");
             userMessage.AppendLine();
 
-            foreach (var e in cast)
+            foreach (var e in candidates)
                 userMessage.AppendLine($"[{e.Id}] {e.Content}");
 
+            if (takenVoices.Count > 0)
+            {
+                // Voices only, not the entries themselves: the model needs to know what is already
+                // spoken for so it does not duplicate a voice, and nothing more. Shipping the full
+                // finished entries is what invited proposals against them.
+                userMessage.AppendLine();
+                userMessage.AppendLine(
+                    $"Voices already in use by other characters ({takenVoices.Count}). Do not reuse or " +
+                    "closely imitate any of these — every voice on the page must be tellable apart:");
+                foreach (var voice in takenVoices)
+                    userMessage.AppendLine($"- {voice}");
+            }
+
+            if (recentTurns.Count > 0)
+            {
+                userMessage.AppendLine();
+                userMessage.AppendLine(
+                    "The most recent play. Prefer characters who appear here — they are the ones " +
+                    "actually on stage, and the scene shows you how they already sound:");
+                foreach (var turn in recentTurns.TakeLast(40))
+                    userMessage.AppendLine($"[{turn.Role}] {Truncate(turn.Content, 600)}");
+            }
+
             userMessage.AppendLine();
             userMessage.AppendLine(
-                $"Enrich at most {_options.CastVoiceMaxPerCycle} characters this cycle. Choose the ones " +
-                "with the most entries and the most recent activity first — they are the ones most likely " +
-                "to walk back on stage.");
+                $"Enrich at most {_options.CastVoiceMaxPerCycle} characters this cycle, drawn from the " +
+                "candidate list above.");
 
             var result = await InvokeDreamPassAsync<CastVoiceResultDto>(
                 "cast voice enrichment",
@@ -2329,6 +2382,11 @@ internal sealed class DreamService : IHostedService, IDisposable
 
                 if (string.IsNullOrWhiteSpace(dto.Id) || string.IsNullOrWhiteSpace(dto.VoiceCard))
                 {
+                    // Logged, like every other skip below. A pass whose failures are silent
+                    // reports "1 given a voice, 23 skipped" and gives no way to find out why.
+                    _logger.LogWarning(
+                        "DreamService: cast voice enrichment returned a proposal with no {Missing}; skipping",
+                        string.IsNullOrWhiteSpace(dto.Id) ? "id" : "voice card");
                     skipped++;
                     continue;
                 }
@@ -2354,6 +2412,12 @@ internal sealed class DreamService : IHostedService, IDisposable
 
                 if (HasVoiceMarker(existing.Content, marker))
                 {
+                    // Still the backstop that guarantees convergence, but it should now be
+                    // unreachable: carded entries are no longer offered as candidates. If this
+                    // fires, the model is inventing ids outside the list it was given.
+                    _logger.LogWarning(
+                        "DreamService: cast voice enrichment proposed an update to {Id}, which already " +
+                        "carries a voice card and was not offered as a candidate; skipping", existing.Id);
                     skipped++;
                     continue;
                 }
@@ -2379,6 +2443,28 @@ internal sealed class DreamService : IHostedService, IDisposable
                 "DreamService: cast voice enrichment pass complete — {Updated} character(s) given a voice, {Skipped} proposal(s) skipped",
                 updated, skipped);
         });
+    }
+
+    /// <summary>
+    /// Returns just the voice-card line from an entry that carries one, so the enrichment prompt
+    /// can list the voices already spoken for without shipping the finished entries themselves.
+    /// Returns an empty string when the entry has no card.
+    /// </summary>
+    internal static string ExtractVoiceCardLine(string? content, string marker)
+    {
+        if (string.IsNullOrEmpty(content) || string.IsNullOrEmpty(marker))
+            return string.Empty;
+
+        var start = content.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
+        if (start < 0) return string.Empty;
+
+        // MergeVoiceCard appends the card as the final block, but an entry hand-edited on the PVC
+        // may have text after it. Stop at the first blank line so only the card itself is taken.
+        var rest = content[start..];
+        var end = rest.IndexOf("\n\n", StringComparison.Ordinal);
+        if (end >= 0) rest = rest[..end];
+
+        return rest.Replace('\n', ' ').Trim();
     }
 
     /// <summary>True when <paramref name="content"/> already carries a voice card marker.</summary>
@@ -5432,9 +5518,11 @@ internal sealed class DreamService : IHostedService, IDisposable
     private const string BuiltInCastVoiceDirective = """
         You maintain the speech profiles in a character corpus.
 
-        You are given every entry in one memory category. Some entries already carry a speech profile;
-        most record only appearance and events. Your task is to add a profile to characters that lack
-        one, so that a character described weeks ago can be written consistently today.
+        You are given the entries in one memory category that do not yet carry a speech profile —
+        most record only appearance and events. Your task is to add a profile to them, so that a
+        character described weeks ago can be written consistently today. Profiles already assigned
+        to other characters are listed separately, as text only, so you can keep every voice
+        distinct; those characters are finished and are not yours to update.
 
         This is a schema-filling task. Deployment-specific guidance on how a profile should read, if
         any exists, is supplied separately by the operator.
@@ -5481,7 +5569,8 @@ internal sealed class DreamService : IHostedService, IDisposable
         **Select one target entry per character** — normally the most detailed or most recent — and
         return its id. The profile is appended; existing text in that entry is left untouched.
 
-        **Skip** any character already carrying a profile, and any character you could not resolve.
+        **Every id you return must come from the candidate list.** An id taken from the list of
+        voices already in use, or invented, is discarded. Skip any character you could not resolve.
 
         ## Output
 

--- a/src/RockBot.Host/DreamService.cs
+++ b/src/RockBot.Host/DreamService.cs
@@ -1471,7 +1471,13 @@ internal sealed class DreamService : IHostedService, IDisposable
             "skill optimization",
             _skillOptimizeDirective,
             userMessage.ToString(),
-            ct);
+            ct,
+            // Watermarked on the usage and feedback logs it reads, not on the at-risk set derived
+            // from them: that set is computed over a rolling 30-day window and drifts on its own.
+            CorpusFingerprint([
+                "usage:" + EventWatermarkFingerprint(usageEvents.Select(e => e.Timestamp)),
+                "feedback:" + EventWatermarkFingerprint(recentFeedback.Select(f => f.Timestamp)),
+            ]));
         if (result is null) return;
 
         var deleted = 0;
@@ -2874,6 +2880,12 @@ internal sealed class DreamService : IHostedService, IDisposable
             return;
         }
 
+        // Watermark the underlying log rather than the derived patterns: the patterns are computed
+        // over a rolling 7-day window, so their set drifts as old calls age out even when the agent
+        // has made no new tool call at all.
+        var toolCallWatermark = EventWatermarkFingerprint(
+            (await _toolCallLog.QueryRecentAsync(since, maxResults: 20000)).Select(e => e.Timestamp));
+
         var distinctPatterns = DedupeRetryPatterns(patterns, maxCount: 50);
 
         _logger.LogInformation(
@@ -2888,7 +2900,8 @@ internal sealed class DreamService : IHostedService, IDisposable
                 "tool-success-learning",
                 _toolSuccessLearningDirective ?? BuiltInToolSuccessLearningDirective,
                 userMessage,
-                ct);
+                ct,
+                toolCallWatermark);
             var entries = NormalizeToolSuccessLearningEntries(
                 result,
                 idFactory: () => Guid.NewGuid().ToString("N")[..12],
@@ -3392,7 +3405,8 @@ internal sealed class DreamService : IHostedService, IDisposable
                 "sequence skill detection",
                 _sequenceSkillDirective ?? BuiltInSequenceSkillDirective,
                 userMessage.ToString(),
-                ct);
+                ct,
+                EventWatermarkFingerprint(events.Select(e => e.Timestamp)));
             if (result is null) return;
             var created = 0;
 
@@ -3529,7 +3543,8 @@ internal sealed class DreamService : IHostedService, IDisposable
                 "wisp failure analysis",
                 _wispFailureDirective ?? BuiltInWispFailureDirective,
                 userMessage.ToString(),
-                ct);
+                ct,
+                EventWatermarkFingerprint(records.Select(r => r.Timestamp)));
             if (result is null) return;
             var updated = 0;
 
@@ -3729,7 +3744,8 @@ internal sealed class DreamService : IHostedService, IDisposable
                 "wisp success analysis",
                 _wispSuccessDirective ?? BuiltInWispSuccessDirective,
                 userMessage.ToString(),
-                ct);
+                ct,
+                EventWatermarkFingerprint(records.Select(r => r.Timestamp)));
             if (result is null) return;
 
             var attached = await ApplyWispSuccessPromotionsAsync(
@@ -4291,12 +4307,14 @@ internal sealed class DreamService : IHostedService, IDisposable
                 userMessage.AppendLine();
             }
 
-            // Unlike skill consolidation's usage tallies, the 14-day episode and feedback sets
-            // are this pass's actual subject matter rather than annotations on it, so they
-            // belong in the fingerprint. On an idle agent they stop changing once the windows
-            // drain, and the pass goes quiet with them.
+            // Inputs only. The identity entries are this pass's *output* — it rewrites them on
+            // essentially every run ("3 deleted, 3 saved" is a typical cycle) — so including them
+            // meant the fingerprint was guaranteed to differ from the one the pass had just
+            // stamped, and the gate could never fire. Hashing what the pass reads rather than what
+            // it writes is the difference between a gate and a no-op. The 14-day episode and
+            // feedback windows are the real subject matter; on an idle agent they drain and stop
+            // changing, and the pass goes quiet with them.
             var fingerprint = CorpusFingerprint([
-                "identity:" + MemoryCorpusFingerprint(identityEntries),
                 "episodes:" + MemoryCorpusFingerprint(recentEpisodes),
                 "prefs:" + MemoryCorpusFingerprint(recentPrefs),
                 "feedback:" + CorpusFingerprint(recentFeedback
@@ -4656,6 +4674,37 @@ internal sealed class DreamService : IHostedService, IDisposable
         var bytes = System.Security.Cryptography.SHA256.HashData(
             Encoding.UTF8.GetBytes(sb.ToString()));
         return Convert.ToHexString(bytes.AsSpan(0, 16));
+    }
+
+    /// <summary>
+    /// High-water mark over an append-only event log: the newest event's timestamp. Used as the
+    /// change-gate fingerprint for passes that mine a rolling window of a telemetry log.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Hashing the window's contents does not work for these passes. The window is relative to
+    /// now, so its membership changes on its own as old events age out of the far end, and the
+    /// pass re-runs on an agent that has generated no new events at all. Sequence skill detection
+    /// showed what that costs: mining the same unchanging 14-day tool-call window on every cycle,
+    /// it manufactured a fresh pair of near-duplicate skills each time, which skill consolidation
+    /// then merged away — a churn loop running twice a day on an idle agent, and one that also
+    /// kept skill consolidation's own fingerprint moving so that pass could never settle either.
+    /// </para>
+    /// <para>
+    /// The newest timestamp is immune to that: it only advances when the agent actually does
+    /// something. Retention pruning the newest entries would move it backwards, which costs one
+    /// extra run and then settles.
+    /// </para>
+    /// </remarks>
+    internal static string EventWatermarkFingerprint(IEnumerable<DateTimeOffset> timestamps)
+    {
+        DateTimeOffset? newest = null;
+        foreach (var t in timestamps)
+            if (newest is null || t > newest) newest = t;
+
+        return newest is null
+            ? "watermark:none"
+            : "watermark:" + newest.Value.ToUniversalTime().ToString("O", CultureInfo.InvariantCulture);
     }
 
     /// <summary>

--- a/src/RockBot.Host/DreamService.cs
+++ b/src/RockBot.Host/DreamService.cs
@@ -2279,11 +2279,15 @@ internal sealed class DreamService : IHostedService, IDisposable
             return;
         }
 
-        var uncarded = cast.Count(e => !HasVoiceMarker(e.Content, marker));
-        if (uncarded == 0)
+        var upgradeMarkers = _options.CastVoiceUpgradeMarkers;
+        var needsWork = cast.Where(e => NeedsVoiceWork(e.Content, marker, upgradeMarkers)).ToList();
+        var uncarded = needsWork.Count(e => !HasVoiceMarker(e.Content, marker));
+        var stale = needsWork.Count - uncarded;
+
+        if (needsWork.Count == 0)
         {
             _logger.LogInformation(
-                "DreamService: cast voice enrichment — all {Count} entries in {Category} already carry a voice card; nothing to do",
+                "DreamService: cast voice enrichment — all {Count} entries in {Category} carry a current voice card; nothing to do",
                 cast.Count, category);
             return;
         }
@@ -2301,16 +2305,16 @@ internal sealed class DreamService : IHostedService, IDisposable
             {
                 _logger.LogInformation(
                     "DreamService: cast voice enrichment — no conversation activity since the last cycle; " +
-                    "skipping ({Uncarded} character(s) still without a voice card)",
-                    uncarded);
+                    "skipping ({Uncarded} without a voice card, {Stale} with an older card)",
+                    uncarded, stale);
                 return;
             }
         }
 
         _logger.LogInformation(
             "DreamService: cast voice enrichment pass — {Total} entries in {Category}, {Uncarded} without a voice card, " +
-            "{Turns} conversation turn(s) since the last cycle",
-            cast.Count, category, uncarded, recentTurns.Count);
+            "{Stale} with an older card, {Turns} conversation turn(s) since the last cycle",
+            cast.Count, category, uncarded, stale, recentTurns.Count);
 
         await RunPassAsync("cast voice enrichment", async () =>
         {
@@ -2321,7 +2325,12 @@ internal sealed class DreamService : IHostedService, IDisposable
             // The proposals then died silently against the HasVoiceMarker check: one cycle on a
             // 160-entry corpus spent 24 proposals to land 1 update. Withholding them is a gate
             // the model cannot talk its way past.
-            var candidates = cast.Where(e => !HasVoiceMarker(e.Content, marker)).ToList();
+            var candidates = needsWork;
+            var newCharacters = candidates.Where(e => !HasVoiceMarker(e.Content, marker)).ToList();
+            var olderCards = candidates.Where(e => HasVoiceMarker(e.Content, marker)).ToList();
+
+            // Every card in the corpus counts as a voice in use, stale ones included — an older
+            // card is still how that character sounds, so a new character must not duplicate it.
             var takenVoices = cast
                 .Where(e => HasVoiceMarker(e.Content, marker))
                 .Select(e => ExtractVoiceCardLine(e.Content, marker))
@@ -2330,12 +2339,31 @@ internal sealed class DreamService : IHostedService, IDisposable
 
             var userMessage = new StringBuilder();
             userMessage.AppendLine(
-                $"Characters in `{category}` that do not yet have a voice. These are the only entries " +
-                "you may propose an update for — every id you return must come from this list.");
+                $"Characters in `{category}` that still need work. These are the only entries you may " +
+                "propose an update for — every id you return must come from the lists below.");
             userMessage.AppendLine();
 
-            foreach (var e in candidates)
-                userMessage.AppendLine($"[{e.Id}] {e.Content}");
+            if (newCharacters.Count > 0)
+            {
+                userMessage.AppendLine("## Characters with no voice yet — write a full card for these");
+                userMessage.AppendLine();
+                foreach (var e in newCharacters)
+                    userMessage.AppendLine($"[{e.Id}] {e.Content}");
+                userMessage.AppendLine();
+            }
+
+            if (olderCards.Count > 0)
+            {
+                // Shown with their existing card, unlike the taken-voices list: an upgrade is
+                // written against what the card already says, so the model has to see it.
+                userMessage.AppendLine(
+                    "## Characters whose card predates the current format — return only what the " +
+                    "current format adds, not the parts they already have");
+                userMessage.AppendLine();
+                foreach (var e in olderCards)
+                    userMessage.AppendLine($"[{e.Id}] {e.Content}");
+                userMessage.AppendLine();
+            }
 
             if (takenVoices.Count > 0)
             {
@@ -2416,14 +2444,19 @@ internal sealed class DreamService : IHostedService, IDisposable
                     continue;
                 }
 
-                if (HasVoiceMarker(existing.Content, marker))
+                if (!NeedsVoiceWork(existing.Content, marker, upgradeMarkers))
                 {
                     // Still the backstop that guarantees convergence, but it should now be
-                    // unreachable: carded entries are no longer offered as candidates. If this
-                    // fires, the model is inventing ids outside the list it was given.
+                    // unreachable: only entries needing work are offered as candidates. If this
+                    // fires, the model is inventing ids outside the lists it was given.
+                    //
+                    // This deliberately tests "needs work" rather than "has a marker". The marker
+                    // test rejected every upgrade to an older card, which is what made a directive
+                    // asking for those upgrades produce nothing, cycle after cycle, with no log
+                    // line to say why.
                     _logger.LogWarning(
                         "DreamService: cast voice enrichment proposed an update to {Id}, which already " +
-                        "carries a voice card and was not offered as a candidate; skipping", existing.Id);
+                        "carries a current voice card and was not offered as a candidate; skipping", existing.Id);
                     skipped++;
                     continue;
                 }
@@ -2471,6 +2504,30 @@ internal sealed class DreamService : IHostedService, IDisposable
         if (end >= 0) rest = rest[..end];
 
         return rest.Replace('\n', ' ').Trim();
+    }
+
+    /// <summary>
+    /// True when this entry is something the enrichment pass should still work on: it has no voice
+    /// card at all, or it has one written before <paramref name="upgradeMarkers"/> described the
+    /// current format.
+    /// </summary>
+    /// <remarks>
+    /// The presence of a marker used to be the whole test, which meant a deployment could never
+    /// bring already-written cards up to a newer shape — the pass skipped them, so a directive
+    /// asking for exactly that produced proposals the apply loop discarded without a word. Any one
+    /// of the upgrade markers is enough: card sections are individually optional, so demanding all
+    /// of them would classify a legitimately short card as stale and rewrite it on every cycle.
+    /// </remarks>
+    internal static bool NeedsVoiceWork(string? content, string marker, IEnumerable<string>? upgradeMarkers)
+    {
+        if (!HasVoiceMarker(content, marker))
+            return true;
+
+        var markers = upgradeMarkers?.Where(m => !string.IsNullOrWhiteSpace(m)).ToList();
+        if (markers is null || markers.Count == 0)
+            return false;
+
+        return !markers.Any(m => content!.Contains(m, StringComparison.OrdinalIgnoreCase));
     }
 
     /// <summary>True when <paramref name="content"/> already carries a voice card marker.</summary>

--- a/src/RockBot.Host/DreamService.cs
+++ b/src/RockBot.Host/DreamService.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text;
 using System.Text.Json;
 using Cronos;
@@ -75,6 +76,7 @@ internal sealed class DreamService : IHostedService, IDisposable
     private string? _contradictionSweepDirective;
     private string? _repairTicketCreationDirective;
     private IReadOnlyList<LlmPricingRow>? _pricingRows;
+    private DreamPassLedger? _passLedger;
 
     public DreamService(
         ILongTermMemory memory,
@@ -526,6 +528,11 @@ internal sealed class DreamService : IHostedService, IDisposable
         // reads) and runs once per cycle.
         LoadDirectives(initialLoad: false);
 
+        // Read the change-gate ledger once per cycle. Passes consult it before spending an LLM
+        // call on a corpus that has not moved since they last looked at it.
+        _passLedger = await DreamPassLedger.LoadAsync(
+            ResolvePath(DreamPassLedger.FileName, _profileOptions.BasePath), _logger);
+
         _logger.LogInformation("DreamService: dream cycle starting");
 
         try
@@ -611,6 +618,12 @@ internal sealed class DreamService : IHostedService, IDisposable
         }
         finally
         {
+            // Persist in the finally so a preempted or failed cycle still keeps the stamps of
+            // the passes that did complete — otherwise a cycle that dies late re-runs every
+            // gated pass next time.
+            if (_passLedger is not null)
+                await _passLedger.SaveAsync();
+
             await slot.DisposeAsync();
         }
     }
@@ -710,9 +723,12 @@ internal sealed class DreamService : IHostedService, IDisposable
         CancellationToken ct)
     {
         var eligibleIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var reviewedIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var e in all)
-            if (!IsReviewedAndUnchanged(e))
+            if (IsReviewedAndUnchanged(e))
+                reviewedIds.Add(e.Id);
+            else
                 eligibleIds.Add(e.Id);
 
         var unreviewed = eligibleIds.Count;
@@ -726,13 +742,30 @@ internal sealed class DreamService : IHostedService, IDisposable
                     options.ConsolidationMaxClusterSize,
                     ct);
 
+                var settled = 0;
                 foreach (var cluster in clusters)
+                {
+                    // A cluster in which every member is reviewed-and-unchanged was, by
+                    // construction, already shown to consolidation as a group: a cluster becomes
+                    // eligible the moment any member is new or edited, and every member shown
+                    // gets stamped on that cycle. Re-offering it now re-asks a question the model
+                    // has already answered — and keeps re-asking, twice a day, forever. That
+                    // undoes the reviewed-and-unchanged gate for exactly the entries most likely
+                    // to sit in a cluster. One new or edited member re-opens the whole cluster.
+                    if (cluster.Count > 0 && cluster.All(reviewedIds.Contains))
+                    {
+                        settled++;
+                        continue;
+                    }
+
                     foreach (var id in cluster)
                         eligibleIds.Add(id);
+                }
 
                 logger.LogDebug(
-                    "DreamService: {Unreviewed} unreviewed + {Clustered} in {Clusters} duplicate cluster(s)",
-                    unreviewed, eligibleIds.Count - unreviewed, clusters.Count);
+                    "DreamService: {Unreviewed} unreviewed + {Clustered} pulled in from {Clusters} duplicate cluster(s) " +
+                    "({Settled} cluster(s) skipped as already reviewed together)",
+                    unreviewed, eligibleIds.Count - unreviewed, clusters.Count, settled);
             }
             catch (OperationCanceledException) { throw; }
             catch (Exception ex)
@@ -1141,7 +1174,8 @@ internal sealed class DreamService : IHostedService, IDisposable
             "skill consolidation",
             _skillDreamDirective!,
             userMessage,
-            ct);
+            ct,
+            SkillCorpusFingerprint(all, singletonPrefixes));
         if (result is null) return;
 
         var deleted = 0;
@@ -2154,7 +2188,8 @@ internal sealed class DreamService : IHostedService, IDisposable
                 "graph consolidation",
                 _graphConsolidationDirective ?? BuiltInGraphConsolidationDirective,
                 userMessage.ToString(),
-                ct);
+                ct,
+                GraphFingerprint(entities, triples));
             if (result is null) return;
             var entitiesDeleted = 0;
             var triplesDeleted = 0;
@@ -3015,12 +3050,20 @@ internal sealed class DreamService : IHostedService, IDisposable
         // prompt cost is independent of entry count, so we could read more — but more entries
         // also mean more file-IO and more cluster permutations, and 200 has been shown to
         // surface every detection rule reliably. Bump if needed; do not silently widen.
-        var entries = await _tierRoutingLogger.ReadRecentAsync(200);
+        // The window matters as much as the cap. The log is append-only and this reads its tail,
+        // so an agent that has stopped routing anything still presented the same trailing
+        // entries every cycle — the pass had no way to run out of input. With a window the
+        // input drains and the ≥10 threshold below eventually stops the pass on its own.
+        var since = _options.TierRoutingReviewWindow > TimeSpan.Zero
+            ? _clock.Now - _options.TierRoutingReviewWindow
+            : (DateTimeOffset?)null;
+
+        var entries = await _tierRoutingLogger.ReadRecentAsync(200, since);
         if (entries.Count < 10)
         {
             _logger.LogDebug(
-                "DreamService: tier routing review — only {Count} entries; skipping (need ≥ 10)",
-                entries.Count);
+                "DreamService: tier routing review — only {Count} entries in the last {Days:F0}d; skipping (need ≥ 10)",
+                entries.Count, _options.TierRoutingReviewWindow.TotalDays);
             return;
         }
 
@@ -3091,7 +3134,10 @@ internal sealed class DreamService : IHostedService, IDisposable
             "tier routing review",
             _tierRoutingDirective ?? BuiltInTierRoutingDirective,
             userMessage.ToString(),
-            ct);
+            ct,
+            TierRoutingFingerprint(entries, currentConfig is null
+                ? null
+                : JsonSerializer.Serialize(currentConfig, JsonOptions)));
         if (result is null) return;
 
         // Save anti-pattern entries regardless of whether the config changed
@@ -4016,7 +4062,8 @@ internal sealed class DreamService : IHostedService, IDisposable
                 "DLQ review",
                 _dlqDirective ?? BuiltInDlqDirective,
                 userMessage.ToString(),
-                ct);
+                ct,
+                DlqFingerprint(samples));
             if (result is null) return;
 
             if (result.NoDlqIssues == true)
@@ -4158,11 +4205,26 @@ internal sealed class DreamService : IHostedService, IDisposable
                 userMessage.AppendLine();
             }
 
+            // Unlike skill consolidation's usage tallies, the 14-day episode and feedback sets
+            // are this pass's actual subject matter rather than annotations on it, so they
+            // belong in the fingerprint. On an idle agent they stop changing once the windows
+            // drain, and the pass goes quiet with them.
+            var fingerprint = CorpusFingerprint([
+                "identity:" + MemoryCorpusFingerprint(identityEntries),
+                "episodes:" + MemoryCorpusFingerprint(recentEpisodes),
+                "prefs:" + MemoryCorpusFingerprint(recentPrefs),
+                "feedback:" + CorpusFingerprint(recentFeedback
+                    .OrderBy(f => f.SessionId, StringComparer.Ordinal)
+                    .ThenBy(f => f.Summary, StringComparer.Ordinal)
+                    .Select(f => $"{f.SignalType}|{f.SessionId}|{ContentFingerprint(f.Summary + f.Detail)}"))
+            ]);
+
             var result = await InvokeDreamPassAsync<IdentityReflectionResultDto>(
                 "identity reflection",
                 _identityDirective ?? BuiltInIdentityDirective,
                 userMessage.ToString(),
-                ct);
+                ct,
+                fingerprint);
             if (result is null) return;
 
             if (result.NoChange == true)
@@ -4278,7 +4340,8 @@ internal sealed class DreamService : IHostedService, IDisposable
                 "contradiction sweep",
                 directive,
                 userMessage.ToString(),
-                ct);
+                ct,
+                MemoryCorpusFingerprint(corpus));
             if (result is null) return;
 
             var supersededCount = await ApplyContradictionSweepResultAsync(
@@ -4427,13 +4490,36 @@ internal sealed class DreamService : IHostedService, IDisposable
     /// (<see cref="IScheduledTaskSlot.Token"/>) so that user preemption interrupts
     /// the in-flight LLM call promptly — see issue #333.
     /// </summary>
+    /// <param name="inputFingerprint">
+    /// When supplied, enables the change gate for this pass: the LLM call is skipped entirely
+    /// (returning <c>null</c>, which every caller already treats as "do nothing this cycle")
+    /// while the fingerprint matches what the pass last ran on and the
+    /// <see cref="DreamOptions.DreamPassMaxSkipInterval"/> floor has not elapsed. The
+    /// fingerprint is recorded only after the model returns something usable, so a failed or
+    /// unparseable call is retried next cycle rather than being mistaken for a completed one.
+    /// Pass <c>null</c> for delta-driven passes, which already gate on having new input.
+    /// </param>
     private async Task<TResult?> InvokeDreamPassAsync<TResult>(
         string passName,
         string systemDirective,
         string userMessage,
-        CancellationToken ct)
+        CancellationToken ct,
+        string? inputFingerprint = null)
         where TResult : class
     {
+        var gated = inputFingerprint is not null
+            && _passLedger is not null
+            && _options.DreamPassChangeGateEnabled;
+
+        if (gated && _passLedger!.ShouldSkip(
+                passName, inputFingerprint!, _clock.Now, _options.DreamPassMaxSkipInterval))
+        {
+            _logger.LogInformation(
+                "DreamService: {Pass} skipped — inputs unchanged since {LastRun:u}; no LLM call",
+                passName, _passLedger.Get(passName)!.LastRunAt);
+            return null;
+        }
+
         var messages = new List<ChatMessage>
         {
             new(ChatRole.System, systemDirective),
@@ -4455,8 +4541,138 @@ internal sealed class DreamService : IHostedService, IDisposable
         }
 
         _logger.LogDebug("DreamService: {Pass} JSON ({Length} chars): {Json}", passName, json.Length, json);
-        return TryDeserializeJson<TResult>(json, passName);
+        var result = TryDeserializeJson<TResult>(json, passName);
+
+        if (gated && result is not null)
+            _passLedger!.Record(passName, inputFingerprint!, _clock.Now);
+
+        return result;
     }
+
+    // ── Change-gate fingerprints ──────────────────────────────────────────────
+    //
+    // Each corpus-wide pass hashes the corpus it is about to describe rather than the rendered
+    // prompt. The prompt carries wall-clock text ("Current date/time: …") and rolling-window
+    // statistics (usage counts over the last 30 days, co-occurrence tallies) that move on their
+    // own while the agent sits idle, so hashing it would defeat the gate it is meant to drive.
+
+    /// <summary>
+    /// Stable hash over an ordered sequence of per-item field strings. Callers are responsible
+    /// for ordering deterministically — store enumeration order is not guaranteed stable across
+    /// cycles, and an order-dependent hash would report phantom changes.
+    /// </summary>
+    internal static string CorpusFingerprint(IEnumerable<string> parts)
+    {
+        var sb = new StringBuilder();
+        foreach (var part in parts)
+            sb.Append(part).Append('\u001f');  // unit separator: cannot occur in the field text
+
+        var bytes = System.Security.Cryptography.SHA256.HashData(
+            Encoding.UTF8.GetBytes(sb.ToString()));
+        return Convert.ToHexString(bytes.AsSpan(0, 16));
+    }
+
+    /// <summary>
+    /// Fingerprint of the skill catalog as consolidation sees it: names, prose, cross-references
+    /// and attached resources. Usage counts and co-occurrence tallies are excluded — they are
+    /// 30-day rolling annotations that decay without anyone touching a skill, and re-running a
+    /// whole-catalog merge because a count went 5→4 is exactly the waste the gate exists to stop.
+    /// </summary>
+    internal static string SkillCorpusFingerprint(
+        IReadOnlyList<Skill> skills,
+        IReadOnlyCollection<string> singletonPrefixes) =>
+        CorpusFingerprint(
+            skills
+                .OrderBy(s => s.Name, StringComparer.OrdinalIgnoreCase)
+                .Select(s => string.Join('|',
+                    s.Name,
+                    ContentFingerprint(s.Summary),
+                    ContentFingerprint(s.Content),
+                    string.Join(',', (s.SeeAlso ?? [])
+                        .OrderBy(x => x, StringComparer.OrdinalIgnoreCase)),
+                    string.Join(',', (s.Manifest ?? [])
+                        .OrderBy(r => r.Filename, StringComparer.OrdinalIgnoreCase)
+                        .Select(r => $"{r.Filename}:{r.Type}:{(r.Provisional ? "prov" : "conf")}"))))
+                .Concat(singletonPrefixes
+                    .OrderBy(p => p, StringComparer.Ordinal)
+                    .Select(p => "singleton:" + p)));
+
+    /// <summary>
+    /// Fingerprint of the knowledge graph. <c>LastReferencedAt</c> is included at day granularity
+    /// — matching the precision the prompt renders it at — because a reference is real activity
+    /// and the directive prunes on staleness.
+    /// </summary>
+    internal static string GraphFingerprint(
+        IReadOnlyList<KnowledgeEntity> entities,
+        IReadOnlyList<KnowledgeTriple> triples) =>
+        CorpusFingerprint(
+            entities
+                .OrderBy(e => e.Id, StringComparer.Ordinal)
+                .Select(e => string.Join('|',
+                    "entity", e.Id, e.EntityType.ToString(), e.Name,
+                    string.Join(',', e.Aliases.OrderBy(a => a, StringComparer.OrdinalIgnoreCase)),
+                    string.Join(',', (e.Metadata ?? new Dictionary<string, string>())
+                        .OrderBy(kv => kv.Key, StringComparer.OrdinalIgnoreCase)
+                        .Select(kv => $"{kv.Key}={kv.Value}")),
+                    e.LastReferencedAt?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture) ?? "never"))
+                .Concat(triples
+                    .OrderBy(t => t.Id, StringComparer.Ordinal)
+                    .Select(t => string.Join('|',
+                        "triple", t.Id, t.Subject, t.Predicate, t.Object,
+                        t.Confidence.ToString("F2", CultureInfo.InvariantCulture)))));
+
+    /// <summary>
+    /// Fingerprint of a set of memory entries by identity and content. Importance and
+    /// reinforcement counts are excluded: the decay pass rewrites importance every cycle by
+    /// design, so including it would mean nothing was ever unchanged.
+    /// </summary>
+    internal static string MemoryCorpusFingerprint(IEnumerable<MemoryEntry> entries) =>
+        CorpusFingerprint(
+            entries
+                .OrderBy(e => e.Id, StringComparer.Ordinal)
+                .Select(e => string.Join('|',
+                    e.Id,
+                    e.Category ?? string.Empty,
+                    ContentFingerprint(e.Content),
+                    string.Join(',', e.Tags.OrderBy(t => t, StringComparer.OrdinalIgnoreCase)))));
+
+    /// <summary>
+    /// Fingerprint of the routing decisions under review plus the config the pass would tune.
+    /// A config edited by hand between cycles re-opens the pass even on an unchanged log.
+    /// </summary>
+    internal static string TierRoutingFingerprint(
+        IReadOnlyList<TierRoutingEntry> entries,
+        string? configJson) =>
+        CorpusFingerprint(
+            entries
+                .Select(e => string.Join('|',
+                    e.Timestamp.ToString("O", CultureInfo.InvariantCulture),
+                    e.Tier.ToString(),
+                    e.Context,
+                    e.ComplexityScore.ToString("F4", CultureInfo.InvariantCulture),
+                    e.PostInjectionTokenEstimate?.ToString(CultureInfo.InvariantCulture) ?? string.Empty))
+                .Append("config:" + ContentFingerprint(configJson)));
+
+    /// <summary>
+    /// Fingerprint of the sampled dead-letter messages. Queue depth is included so a growing
+    /// backlog re-opens the pass even when the sampled head of the queue is unchanged; a queue
+    /// that is merely stuck at the same depth with the same messages is not re-analyzed.
+    /// </summary>
+    internal static string DlqFingerprint(
+        IEnumerable<(DlqQueueInfo Queue, IReadOnlyList<DlqMessage> Messages)> samples) =>
+        CorpusFingerprint(
+            samples
+                .OrderBy(s => s.Queue.Name, StringComparer.Ordinal)
+                .SelectMany(s => new[] { $"queue|{s.Queue.Name}|{s.Queue.MessageCount}" }
+                    .Concat(s.Messages
+                        .OrderBy(m => m.MessageId ?? string.Empty, StringComparer.Ordinal)
+                        .Select(m => string.Join('|',
+                            s.Queue.Name,
+                            m.MessageId ?? string.Empty,
+                            m.MessageType ?? string.Empty,
+                            m.DeathReason ?? string.Empty,
+                            m.DeathCount.ToString(CultureInfo.InvariantCulture),
+                            ContentFingerprint(m.BodyPreview))))));
 
     /// <summary>
     /// Extracts the outermost JSON object from <paramref name="text"/>, tolerating

--- a/src/RockBot.Host/TierRoutingLogger.cs
+++ b/src/RockBot.Host/TierRoutingLogger.cs
@@ -83,7 +83,17 @@ public sealed class TierRoutingLogger
     /// <summary>
     /// Reads recent routing entries, newest last. Returns an empty list if the file does not exist.
     /// </summary>
-    public async Task<IReadOnlyList<TierRoutingEntry>> ReadRecentAsync(int maxResults = 200)
+    /// <param name="maxResults">Cap on entries returned, taken from the tail of the log.</param>
+    /// <param name="since">
+    /// When supplied, entries older than this are excluded. The log is append-only, so without a
+    /// window a reader always sees the same trailing entries no matter how long ago they were
+    /// written — a consumer that treats "entries present" as "there is something to analyze"
+    /// never stops. Entries with a default (unset) timestamp are kept, so records written before
+    /// the field existed are not silently dropped.
+    /// </param>
+    public async Task<IReadOnlyList<TierRoutingEntry>> ReadRecentAsync(
+        int maxResults = 200,
+        DateTimeOffset? since = null)
     {
         if (!File.Exists(_filePath))
             return [];
@@ -98,8 +108,11 @@ public sealed class TierRoutingLogger
                 try
                 {
                     var entry = JsonSerializer.Deserialize<TierRoutingEntry>(line, JsonOptions);
-                    if (entry is not null)
-                        entries.Add(entry);
+                    if (entry is null) continue;
+                    if (since is { } cutoff
+                        && entry.Timestamp != default
+                        && entry.Timestamp < cutoff) continue;
+                    entries.Add(entry);
                 }
                 catch (JsonException) { /* skip malformed lines */ }
             }

--- a/tests/RockBot.Host.Tests/ConsolidationCandidateGatingTests.cs
+++ b/tests/RockBot.Host.Tests/ConsolidationCandidateGatingTests.cs
@@ -125,6 +125,53 @@ public class ConsolidationCandidateGatingTests
     }
 
     [TestMethod]
+    public async Task ClusterOfEntriesAllReviewedAndUnchanged_IsNotReoffered()
+    {
+        // The duplicate-cluster carve-out used to re-add every clustered id unconditionally,
+        // which quietly undid the reviewed-and-unchanged gate for exactly the entries most
+        // likely to sit in a cluster: a pair the model has already declined to merge — or
+        // whose merge the coverage check rejected — was handed back to it twice a day forever.
+        // A cluster only becomes eligible when one of its members is new or edited, and every
+        // member shown gets stamped on that cycle, so "all members reviewed and unchanged"
+        // means "already asked, and answered".
+        var store = CreateStore();
+        var a = Reviewed(
+            Entry("a", "Rocky has a dog named Milo the Sheltie"),
+            "Rocky has a dog named Milo the Sheltie");
+        var b = Reviewed(
+            Entry("b", "Rocky has a Sheltie dog named Milo"),
+            "Rocky has a Sheltie dog named Milo");
+        await store.SaveAsync(a);
+        await store.SaveAsync(b);
+
+        var eligible = await Select(store, [a, b], threshold: 0.5);
+
+        Assert.AreEqual(0, eligible.Count,
+            "A settled duplicate cluster must stay withheld until one of its members changes.");
+    }
+
+    [TestMethod]
+    public async Task SettledCluster_ReopensWhenOneMemberIsEdited()
+    {
+        var store = CreateStore();
+        var a = Reviewed(
+            Entry("a", "Rocky has a dog named Milo the Sheltie"),
+            "Rocky has a dog named Milo the Sheltie");
+        var b = Reviewed(
+            Entry("b", "Rocky has a Sheltie dog named Milo"),
+            "Rocky has a Sheltie dog named Milo");
+        // Stamped against the old text, so the edit shows up as a changed fingerprint.
+        var edited = b with { Content = "Rocky has a Sheltie dog named Milo, adopted in 2019" };
+        await store.SaveAsync(a);
+        await store.SaveAsync(edited);
+
+        var eligible = await Select(store, [a, edited], threshold: 0.5);
+
+        CollectionAssert.AreEquivalent(new[] { "a", "b" }, eligible.Select(e => e.Id).ToArray(),
+            "One edited member has to bring its whole cluster back so the merge is still possible.");
+    }
+
+    [TestMethod]
     public async Task SelectionPreservesStoreOrdering()
     {
         var store = CreateStore();

--- a/tests/RockBot.Host.Tests/DreamCastVoiceEnrichmentTests.cs
+++ b/tests/RockBot.Host.Tests/DreamCastVoiceEnrichmentTests.cs
@@ -221,4 +221,93 @@ public class DreamCastVoiceEnrichmentTests
         Assert.AreEqual(string.Empty, DreamService.ExtractVoiceCardLine(null, "VOICE CARD"));
         Assert.AreEqual(string.Empty, DreamService.ExtractVoiceCardLine("anything", ""));
     }
+
+    // -- Card upgrades ---------------------------------------------------------
+
+    [TestMethod]
+    public void UpgradeMarkers_DefaultEmpty_SoAnyCardCountsAsFinished()
+    {
+        // Original behaviour: a deployment that has not described a current card format sees no
+        // change, and the pass still converges on "every character has a card".
+        Assert.AreEqual(0, new DreamOptions().CastVoiceUpgradeMarkers.Count);
+
+        var carded = DreamService.MergeVoiceCard("Coyne tends bar.", "VOICE CARD", "Coyne", "Talks constantly.");
+        Assert.IsFalse(DreamService.NeedsVoiceWork(carded, "VOICE CARD", []));
+    }
+
+    [TestMethod]
+    public void NeedsVoiceWork_UncardedEntry_AlwaysNeedsWork()
+    {
+        Assert.IsTrue(DreamService.NeedsVoiceWork("Vance wears a grey coat.", "VOICE CARD", ["Look:"]));
+        Assert.IsTrue(DreamService.NeedsVoiceWork("Vance wears a grey coat.", "VOICE CARD", []));
+    }
+
+    [TestMethod]
+    public void NeedsVoiceWork_CardWithoutAnyUpgradeMarker_IsOfferedForUpgrade()
+    {
+        // The regression this closes: the pass skipped anything carrying the marker, so a
+        // directive asking the model to bring older cards up to a newer shape produced proposals
+        // the apply loop discarded without a word.
+        var older = DreamService.MergeVoiceCard(
+            "Brandt runs the kitchen.", "VOICE CARD", "Brandt", "Flat and regional. Short sentences.");
+
+        Assert.IsTrue(DreamService.NeedsVoiceWork(older, "VOICE CARD", ["Look:", "To the others:"]));
+    }
+
+    [TestMethod]
+    public void NeedsVoiceWork_AnySingleUpgradeMarker_CountsAsCurrent()
+    {
+        // Sections are individually optional, so requiring all of them would classify a
+        // legitimately short card as stale and rewrite it on every cycle, forever.
+        var partial = DreamService.MergeVoiceCard(
+            "Brandt runs the kitchen.", "VOICE CARD", "Brandt", "Flat and regional. Look: heavy brows.");
+
+        Assert.IsFalse(DreamService.NeedsVoiceWork(partial, "VOICE CARD", ["Look:", "To the others:"]));
+    }
+
+    [TestMethod]
+    public void NeedsVoiceWork_UpgradeMarkerMatchIsCaseInsensitive()
+    {
+        var card = DreamService.MergeVoiceCard("Vance works the window.", "VOICE CARD", "Vance", "look: tired.");
+
+        Assert.IsFalse(DreamService.NeedsVoiceWork(card, "VOICE CARD", ["Look:"]));
+    }
+
+    [TestMethod]
+    public void NeedsVoiceWork_BlankUpgradeMarkersDegradeToUnconfigured()
+    {
+        // Blank entries are dropped, so a list of nothing but blanks behaves as if no format had
+        // been described: every card counts as finished. That is the safe direction to fail. The
+        // alternative — treating an empty marker set as "nothing matches, so everything is stale"
+        // — would put the whole cast back in the candidate list and rewrite it on every cycle.
+        var card = DreamService.MergeVoiceCard("Coyne tends bar.", "VOICE CARD", "Coyne", "Talks constantly.");
+
+        Assert.IsFalse(DreamService.NeedsVoiceWork(card, "VOICE CARD", ["", "   "]));
+    }
+
+    [TestMethod]
+    public void NeedsVoiceWork_BlanksAlongsideARealMarkerAreIgnored()
+    {
+        var older = DreamService.MergeVoiceCard("Coyne tends bar.", "VOICE CARD", "Coyne", "Talks constantly.");
+        var current = DreamService.MergeVoiceCard("Coyne tends bar.", "VOICE CARD", "Coyne", "Look: tired.");
+
+        Assert.IsTrue(DreamService.NeedsVoiceWork(older, "VOICE CARD", ["", "Look:"]));
+        Assert.IsFalse(DreamService.NeedsVoiceWork(current, "VOICE CARD", ["", "Look:"]));
+    }
+
+    [TestMethod]
+    public void UpgradedCard_IsAppendedSoTheOriginalCardSurvives()
+    {
+        // An upgrade adds to the record rather than replacing it: the existing card is what the
+        // character has sounded like, and losing it to a rewrite is unrecoverable.
+        var older = DreamService.MergeVoiceCard(
+            "Brandt runs the kitchen.", "VOICE CARD", "Brandt", "Flat and regional.");
+        var upgraded = DreamService.MergeVoiceCard(older, "VOICE CARD", "Brandt", "Look: heavy brows.");
+
+        StringAssert.Contains(upgraded, "Brandt runs the kitchen.");
+        StringAssert.Contains(upgraded, "Flat and regional.");
+        StringAssert.Contains(upgraded, "Look: heavy brows.");
+        Assert.IsFalse(DreamService.NeedsVoiceWork(upgraded, "VOICE CARD", ["Look:"]),
+            "Once upgraded, the character must stop being offered as a candidate.");
+    }
 }

--- a/tests/RockBot.Host.Tests/DreamCastVoiceEnrichmentTests.cs
+++ b/tests/RockBot.Host.Tests/DreamCastVoiceEnrichmentTests.cs
@@ -152,4 +152,73 @@ public class DreamCastVoiceEnrichmentTests
         Assert.IsFalse(DreamService.HasVoiceMarker("", "VOICE CARD"));
         Assert.IsFalse(DreamService.HasVoiceMarker("anything at all", ""));
     }
+
+    // -- Activity gate ---------------------------------------------------------
+
+    [TestMethod]
+    public void RequiresRecentActivity_DefaultsOn_SoAnIdleAgentStopsPaying()
+    {
+        // "Some character still lacks a card" stays true for months, so on its own it kept the
+        // pass billing a full-corpus call twice a day to invent voices for a cast nobody had
+        // played with. Voices are worth writing for the characters who just walked on stage.
+        Assert.IsTrue(new DreamOptions().CastVoiceRequiresRecentActivity);
+    }
+
+    [TestMethod]
+    public void RequiresRecentActivity_CanBeTurnedOffFromConfiguration()
+    {
+        var opts = Bind(new Dictionary<string, string?>
+        {
+            ["Dream:CastVoiceRequiresRecentActivity"] = "false",
+        });
+
+        Assert.IsFalse(opts.CastVoiceRequiresRecentActivity);
+    }
+
+    // -- ExtractVoiceCardLine --------------------------------------------------
+
+    [TestMethod]
+    public void ExtractVoiceCardLine_ReturnsOnlyTheCard_NotTheWholeEntry()
+    {
+        // The prompt lists voices already in use so the model keeps them distinct. Shipping the
+        // finished entries instead is what invited proposals against characters already done.
+        var entry = DreamService.MergeVoiceCard(
+            "Brandt runs the kitchen and shouts at the pass.",
+            "VOICE CARD", "Brandt", "Flat and regional. Short sentences.");
+
+        var line = DreamService.ExtractVoiceCardLine(entry, "VOICE CARD");
+
+        StringAssert.StartsWith(line, "VOICE CARD - Brandt.");
+        Assert.IsFalse(line.Contains("shouts at the pass"), "The entry body must not leak into the voices list.");
+    }
+
+    [TestMethod]
+    public void ExtractVoiceCardLine_StopsAtABlankLine_ForHandEditedEntries()
+    {
+        var entry = string.Join('\n',
+            "Coyne tends bar.", "", "VOICE CARD - Coyne. Talks constantly.", "", "Added by hand later.");
+
+        var line = DreamService.ExtractVoiceCardLine(entry, "VOICE CARD");
+
+        Assert.AreEqual("VOICE CARD - Coyne. Talks constantly.", line);
+    }
+
+    [TestMethod]
+    public void ExtractVoiceCardLine_FlattensAMultiLineCardToOneLine()
+    {
+        var entry = string.Join('\n',
+            "Vance works the window.", "", "VOICE CARD - Vance. Calm.", "Never contracts.");
+
+        var line = DreamService.ExtractVoiceCardLine(entry, "VOICE CARD");
+
+        Assert.AreEqual("VOICE CARD - Vance. Calm. Never contracts.", line);
+    }
+
+    [TestMethod]
+    public void ExtractVoiceCardLine_EmptyForUncardedOrBlankEntries()
+    {
+        Assert.AreEqual(string.Empty, DreamService.ExtractVoiceCardLine("Vance wears a grey coat.", "VOICE CARD"));
+        Assert.AreEqual(string.Empty, DreamService.ExtractVoiceCardLine(null, "VOICE CARD"));
+        Assert.AreEqual(string.Empty, DreamService.ExtractVoiceCardLine("anything", ""));
+    }
 }

--- a/tests/RockBot.Host.Tests/DreamPassChangeGateTests.cs
+++ b/tests/RockBot.Host.Tests/DreamPassChangeGateTests.cs
@@ -241,6 +241,74 @@ public class DreamPassChangeGateTests
             DreamService.CorpusFingerprint(["a", "bc"]));
     }
 
+    // -- Event watermarks -----------------------------------------------------
+
+    [TestMethod]
+    public void EventWatermark_IgnoresOldEventsAgingOutOfTheWindow()
+    {
+        // The load-bearing property. These passes mine a window relative to now, so hashing the
+        // window's contents makes them re-run on an agent that generated no new events -- which is
+        // how sequence skill detection came to manufacture a fresh pair of near-duplicate skills
+        // twice a day from an unchanging 14-day tool-call log.
+        var newest = Now;
+        var full = new[] { Now.AddDays(-13), Now.AddDays(-5), newest };
+        var drained = new[] { Now.AddDays(-5), newest };
+
+        Assert.AreEqual(
+            DreamService.EventWatermarkFingerprint(full),
+            DreamService.EventWatermarkFingerprint(drained),
+            "Losing the oldest event must not read as a change.");
+    }
+
+    [TestMethod]
+    public void EventWatermark_AdvancesOnANewEvent()
+    {
+        var before = new[] { Now.AddDays(-5), Now.AddHours(-1) };
+        var after = before.Append(Now).ToArray();
+
+        Assert.AreNotEqual(
+            DreamService.EventWatermarkFingerprint(before),
+            DreamService.EventWatermarkFingerprint(after),
+            "Real activity must re-open the pass.");
+    }
+
+    [TestMethod]
+    public void EventWatermark_IsOrderIndependentAndTimezoneStable()
+    {
+        var a = new[] { Now.AddDays(-2), Now, Now.AddDays(-9) };
+        var b = new[] { Now.ToOffset(TimeSpan.FromHours(9)), Now.AddDays(-9), Now.AddDays(-2) };
+
+        Assert.AreEqual(
+            DreamService.EventWatermarkFingerprint(a),
+            DreamService.EventWatermarkFingerprint(b));
+    }
+
+    [TestMethod]
+    public void EventWatermark_EmptyLogIsStable()
+    {
+        Assert.AreEqual(
+            DreamService.EventWatermarkFingerprint([]),
+            DreamService.EventWatermarkFingerprint([]));
+    }
+
+    // -- Fingerprints must cover inputs, never the pass's own output ----------
+
+    [TestMethod]
+    public void MemoryCorpusFingerprint_RewritingAnEntry_ChangesTheHash()
+    {
+        // Why identity reflection may not hash its own identity entries: it rewrites them on
+        // essentially every run, so a fingerprint covering them is guaranteed to differ from the
+        // one just stamped and the gate can never fire. Measured on a live agent: 5 gated passes,
+        // only 1 skipped, because 4 of them perturbed their own input.
+        var before = MakeEntry("i1", "I am a careful assistant.");
+        var after = before with { Content = "I am a careful, curious assistant." };
+
+        Assert.AreNotEqual(
+            DreamService.MemoryCorpusFingerprint([before]),
+            DreamService.MemoryCorpusFingerprint([after]),
+            "A rewritten entry is a changed corpus -- which is exactly why outputs stay out of the hash.");
+    }
+
     // ── Helpers ──────────────────────────────────────────────────────────────
 
     private static string NewTempDir()

--- a/tests/RockBot.Host.Tests/DreamPassChangeGateTests.cs
+++ b/tests/RockBot.Host.Tests/DreamPassChangeGateTests.cs
@@ -1,0 +1,265 @@
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace RockBot.Host.Tests;
+
+/// <summary>
+/// Covers the change gate that stops corpus-wide dream passes from re-sending an unchanged
+/// corpus to the LLM on every cycle.
+/// </summary>
+[TestClass]
+public class DreamPassChangeGateTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 8, 29, 12, 0, 0, TimeSpan.Zero);
+    private static readonly TimeSpan Week = TimeSpan.FromDays(7);
+
+    // ── ShouldSkip decision ──────────────────────────────────────────────────
+
+    [TestMethod]
+    public void ShouldSkip_NeverRun_RunsThePass()
+    {
+        Assert.IsFalse(
+            DreamPassLedger.ShouldSkip(record: null, "abc", Now, Week),
+            "A pass with no ledger entry has never run and must not be skipped.");
+    }
+
+    [TestMethod]
+    public void ShouldSkip_UnchangedFingerprintWithinFloor_SkipsThePass()
+    {
+        var record = new DreamPassLedger.PassRecord("abc", Now.AddDays(-1));
+
+        Assert.IsTrue(DreamPassLedger.ShouldSkip(record, "abc", Now, Week));
+    }
+
+    [TestMethod]
+    public void ShouldSkip_ChangedFingerprint_RunsThePass()
+    {
+        var record = new DreamPassLedger.PassRecord("abc", Now.AddMinutes(-1));
+
+        Assert.IsFalse(
+            DreamPassLedger.ShouldSkip(record, "def", Now, Week),
+            "A moved corpus must re-open the pass immediately, not wait for the floor.");
+    }
+
+    [TestMethod]
+    public void ShouldSkip_UnchangedButFloorElapsed_RunsThePass()
+    {
+        var record = new DreamPassLedger.PassRecord("abc", Now.AddDays(-7).AddSeconds(-1));
+
+        Assert.IsFalse(
+            DreamPassLedger.ShouldSkip(record, "abc", Now, Week),
+            "The max-skip floor exists so time-dependent directives (graph staleness pruning) still fire.");
+    }
+
+    [TestMethod]
+    public void ShouldSkip_FloorDisabled_SkipsIndefinitely()
+    {
+        var record = new DreamPassLedger.PassRecord("abc", Now.AddYears(-1));
+
+        Assert.IsTrue(
+            DreamPassLedger.ShouldSkip(record, "abc", Now, TimeSpan.Zero),
+            "A non-positive interval makes the gate absolute.");
+    }
+
+    [TestMethod]
+    public void ShouldSkip_ClockWentBackwards_DoesNotForceARun()
+    {
+        // A restore or timezone change can put LastRunAt in the future. That must read as
+        // "not yet due" rather than as a negative age that trips the floor.
+        var record = new DreamPassLedger.PassRecord("abc", Now.AddDays(3));
+
+        Assert.IsTrue(DreamPassLedger.ShouldSkip(record, "abc", Now, Week));
+    }
+
+    // ── Round-tripping ───────────────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task Ledger_RoundTripsThroughDisk()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var path = Path.Combine(dir, DreamPassLedger.FileName);
+
+            var ledger = await DreamPassLedger.LoadAsync(path, NullLogger.Instance);
+            ledger.Record("graph consolidation", "fingerprint-1", Now);
+            await ledger.SaveAsync();
+
+            var reloaded = await DreamPassLedger.LoadAsync(path, NullLogger.Instance);
+
+            Assert.IsTrue(
+                reloaded.ShouldSkip("graph consolidation", "fingerprint-1", Now.AddHours(12), Week),
+                "The gate must survive a pod restart, or every restart re-runs every gated pass.");
+            Assert.IsFalse(reloaded.ShouldSkip("graph consolidation", "fingerprint-2", Now.AddHours(12), Week));
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [TestMethod]
+    public async Task Ledger_CorruptFile_DegradesToRunningEverything()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var path = Path.Combine(dir, DreamPassLedger.FileName);
+            await File.WriteAllTextAsync(path, "{ this is not json");
+
+            var ledger = await DreamPassLedger.LoadAsync(path, NullLogger.Instance);
+
+            Assert.IsFalse(
+                ledger.ShouldSkip("graph consolidation", "anything", Now, Week),
+                "A damaged ledger must cost an extra pass, never silently suppress one forever.");
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [TestMethod]
+    public async Task Ledger_NotDirty_WritesNothing()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var path = Path.Combine(dir, DreamPassLedger.FileName);
+            var ledger = await DreamPassLedger.LoadAsync(path, NullLogger.Instance);
+
+            await ledger.SaveAsync();
+
+            Assert.IsFalse(File.Exists(path), "A cycle that gated nothing should not touch the PVC.");
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    // ── Fingerprint stability ────────────────────────────────────────────────
+
+    [TestMethod]
+    public void SkillCorpusFingerprint_IsOrderIndependent()
+    {
+        var a = MakeSkill("alpha", "does alpha");
+        var b = MakeSkill("beta", "does beta");
+
+        Assert.AreEqual(
+            DreamService.SkillCorpusFingerprint([a, b], []),
+            DreamService.SkillCorpusFingerprint([b, a], []),
+            "Store enumeration order is not guaranteed; an order-sensitive hash reports phantom changes.");
+    }
+
+    [TestMethod]
+    public void SkillCorpusFingerprint_ContentEdit_ChangesHash()
+    {
+        var before = MakeSkill("alpha", "does alpha");
+        var after = before with { Content = "does alpha, but better" };
+
+        Assert.AreNotEqual(
+            DreamService.SkillCorpusFingerprint([before], []),
+            DreamService.SkillCorpusFingerprint([after], []));
+    }
+
+    [TestMethod]
+    public void SkillCorpusFingerprint_IgnoresUsageTimestamps()
+    {
+        // LastUsedAt moves on every get_skill call and UpdatedAt on every rewrite, but neither
+        // reaches the consolidation prompt. Hashing them would re-open a whole-catalog merge for
+        // a skill whose text is identical.
+        var before = MakeSkill("alpha", "does alpha");
+        var after = before with
+        {
+            LastUsedAt = Now,
+            UpdatedAt = Now
+        };
+
+        Assert.AreEqual(
+            DreamService.SkillCorpusFingerprint([before], []),
+            DreamService.SkillCorpusFingerprint([after], []));
+    }
+
+    [TestMethod]
+    public void SkillCorpusFingerprint_SingletonPrefixChange_ChangesHash()
+    {
+        var skill = MakeSkill("mcp/todo", "todo server");
+
+        Assert.AreNotEqual(
+            DreamService.SkillCorpusFingerprint([skill], []),
+            DreamService.SkillCorpusFingerprint([skill], ["mcp/"]),
+            "Prefixes change the constraints paragraph the model is given, so they are part of the input.");
+    }
+
+    [TestMethod]
+    public void GraphFingerprint_IsOrderIndependent()
+    {
+        var e1 = MakeEntity("e1", "Rocky");
+        var e2 = MakeEntity("e2", "RockBot");
+        var t1 = MakeTriple("t1", "e1", "created", "e2");
+        var t2 = MakeTriple("t2", "e2", "runs_on", "k3s");
+
+        Assert.AreEqual(
+            DreamService.GraphFingerprint([e1, e2], [t1, t2]),
+            DreamService.GraphFingerprint([e2, e1], [t2, t1]));
+    }
+
+    [TestMethod]
+    public void GraphFingerprint_NewReference_ChangesHash()
+    {
+        var before = MakeEntity("e1", "Rocky");
+        var after = before with { LastReferencedAt = Now };
+
+        Assert.AreNotEqual(
+            DreamService.GraphFingerprint([before], []),
+            DreamService.GraphFingerprint([after], []),
+            "A reference is real activity and feeds the staleness-pruning directive.");
+    }
+
+    [TestMethod]
+    public void MemoryCorpusFingerprint_IgnoresImportanceDrift()
+    {
+        // The importance decay pass rewrites ImportanceScore on essentially every cycle. If the
+        // fingerprint tracked it, nothing would ever be unchanged and the gate would never fire.
+        var before = MakeEntry("m1", "the sky is blue", importance: 0.5f);
+        var after = before with { ImportanceScore = 0.47f };
+
+        Assert.AreEqual(
+            DreamService.MemoryCorpusFingerprint([before]),
+            DreamService.MemoryCorpusFingerprint([after]));
+    }
+
+    [TestMethod]
+    public void MemoryCorpusFingerprint_ContentEdit_ChangesHash()
+    {
+        var before = MakeEntry("m1", "the sky is blue");
+        var after = before with { Content = "the sky is grey" };
+
+        Assert.AreNotEqual(
+            DreamService.MemoryCorpusFingerprint([before]),
+            DreamService.MemoryCorpusFingerprint([after]));
+    }
+
+    [TestMethod]
+    public void CorpusFingerprint_FieldBoundariesAreNotAmbiguous()
+    {
+        // Without a separator, ["ab","c"] and ["a","bc"] hash identically — two different
+        // corpora reading as unchanged.
+        Assert.AreNotEqual(
+            DreamService.CorpusFingerprint(["ab", "c"]),
+            DreamService.CorpusFingerprint(["a", "bc"]));
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static string NewTempDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "rockbot-ledger-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private static Skill MakeSkill(string name, string content) =>
+        new(name, Summary: $"summary of {name}", Content: content, CreatedAt: Now.AddDays(-30));
+
+    private static KnowledgeEntity MakeEntity(string id, string name) =>
+        new(id, name, KnowledgeEntityType.Person, [], null, Now.AddDays(-30));
+
+    private static KnowledgeTriple MakeTriple(string id, string s, string p, string o) =>
+        new(id, s, p, o, 0.9f, null, Now.AddDays(-30));
+
+    private static MemoryEntry MakeEntry(string id, string content, float importance = 0.5f) =>
+        new(id, content, Category: "general", Tags: [], CreatedAt: Now.AddDays(-30),
+            UpdatedAt: Now.AddDays(-30), Metadata: null, ImportanceScore: importance);
+}

--- a/tests/RockBot.Host.Tests/TierRoutingLoggerTests.cs
+++ b/tests/RockBot.Host.Tests/TierRoutingLoggerTests.cs
@@ -20,6 +20,65 @@ public class TierRoutingLoggerTests
     }
 
     [TestMethod]
+    public async Task ReadRecent_WithSince_ExcludesEntriesOutsideTheWindow()
+    {
+        // The log is append-only and readers take its tail, so without a window an agent that
+        // has stopped routing anything still presents the same trailing entries on every dream
+        // cycle — the review pass could never run out of input and stop.
+        var (logger, dir) = CreateLogger();
+        try
+        {
+            var now = DateTimeOffset.UtcNow;
+            await logger.AppendAsync(Entry(now.AddDays(-40)));
+            await logger.AppendAsync(Entry(now.AddDays(-20)));
+            await logger.AppendAsync(Entry(now.AddDays(-2)));
+
+            var all = await logger.ReadRecentAsync();
+            var windowed = await logger.ReadRecentAsync(200, now.AddDays(-14));
+
+            Assert.AreEqual(3, all.Count, "No window should still return everything.");
+            Assert.AreEqual(1, windowed.Count);
+            Assert.IsTrue(windowed[0].Timestamp > now.AddDays(-14));
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public async Task ReadRecent_WithSince_KeepsEntriesMissingATimestamp()
+    {
+        // Records written before Timestamp was populated deserialize to default(DateTimeOffset).
+        // Dropping them on a window would silently discard history rather than age it out.
+        var (logger, dir) = CreateLogger();
+        try
+        {
+            await File.WriteAllTextAsync(
+                Path.Combine(dir, "tier-routing-log.jsonl"),
+                """{"promptPreview":"legacy","tier":"Balanced","context":"user-message"}""" + "\n");
+
+            var windowed = await logger.ReadRecentAsync(200, DateTimeOffset.UtcNow.AddDays(-14));
+
+            Assert.AreEqual(1, windowed.Count);
+            Assert.AreEqual("legacy", windowed[0].PromptPreview);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    private static TierRoutingEntry Entry(DateTimeOffset at) => new()
+    {
+        Timestamp = at,
+        PromptPreview = "test prompt",
+        Tier = ModelTier.Balanced,
+        Context = "user-message",
+        ComplexityScore = 0.42,
+    };
+
+    [TestMethod]
     public async Task AppendAndRead_RoundTripsModelId()
     {
         var (logger, dir) = CreateLogger();


### PR DESCRIPTION
## The problem

Most dream passes are delta-driven and already cost nothing on an idle agent: the conversation log is cleared at the end of every cycle, so skill gap detection, episode extraction, entity extraction, memory mining, observation and preference inference all return on their first line after a quiet day.

The rest were not gated on anything an idle agent stops producing.

**Corpus-wide passes** re-sent their whole corpus every cycle — skill consolidation the entire skill catalog, graph consolidation every entity and triple, the contradiction sweep the full claim/feedback corpus, identity reflection unconditionally. Their prompt size scaled with corpus growth rather than with user activity.

**Event-log passes** gated on *"enough events in the last N days"* — sequence skill detection, the wisp analyses, tool-success-learning, skill optimization. That window's membership drifts on its own as old events age out, so they re-ran on an agent that had generated no new events at all.

**Tier routing review** read the tail of an append-only log with no time window, so once ten entries existed it could never run out of input.

Two smaller leaks in the same family: DLQ review gated on queue depth rather than novelty, so a stuck message was re-analyzed indefinitely; and memory consolidation's near-duplicate carve-out re-added clustered ids unconditionally, quietly undoing the reviewed-and-unchanged gate for exactly the entries most likely to sit in a cluster.

## The change

`DreamPassLedger` records, per pass, the input fingerprint that pass last ran on and when. `InvokeDreamPassAsync` takes an optional `inputFingerprint` and returns `null` before the LLM call while the hash matches — every call site already treated `null` as "do nothing this cycle", so no apply logic changed.

Four rules make it work, and three of them exist because the first field measurement showed the gate firing for only **1 of 5** passes:

**Hash what a pass reads, never what it writes.** Identity reflection rewrites its identity entries on essentially every run (`3 deleted, 3 saved` is a typical cycle). With those entries in its fingerprint, the hash was guaranteed to differ from the one just stamped and the gate could never fire. It now hashes only the episode, preference and feedback windows it reads.

**Watermark event logs; do not hash their contents.** The event-log passes now fingerprint the newest event's timestamp. That is immune to aging-out and advances only when the agent actually does something. Watermarks cover the source log rather than anything derived from it — retry patterns and at-risk skill sets are themselves computed over rolling windows and drift for the same reason.

**Exclude statistics derived from the corpus.** Skill usage counts and co-occurrence tallies are 30-day rolling annotations; the decay pass rewrites `ImportanceScore` every cycle. Hashing either would mean nothing was ever unchanged.

**Keep a floor.** `DreamPassMaxSkipInterval` (default 7 days) forces a run regardless of the hash, because graph consolidation prunes entities by staleness — an untouched graph still becomes prunable through the passage of time. The floor bounds cost without switching such behaviour off.

The stamp is recorded only after the model returns parseable JSON, so a failed call retries next cycle rather than being mistaken for a completed one. The ledger lives at `{BasePath}/dream-pass-ledger.json` so the gate survives a restart; a missing or corrupt ledger degrades to "run everything once", never to "skip something forever".

`TierRoutingLogger.ReadRecentAsync` also gained a `since` parameter (`TierRoutingReviewWindow`, default 14 days) so that pass can drain; entries with an unset `Timestamp` are kept so pre-field history is not dropped.

## Measured

Five consecutive cycles on a live agent — 92 skills, 1,461 memory entries, 338 graph entities. Cycles 2, 4 and 5 are idle: the conversation log is empty and nothing was touched between them.

| Cycle | State | LLM calls | Input tokens | Elapsed |
|---|---|---|---|---|
| 1 | Baseline, empty ledger | 17 | ~290,000 | 2m 17s |
| 2 | Idle, hashing corpora only | 9 | ~243,000 | 1m 41s |
| 3 | Re-stamp under corrected formulas | 8 | ~220,000 | 1m 34s |
| 4 | Idle, corrected | 2 | 22,775 | 30s |
| 5 | Idle, steady state | **2** | **19,323** | **20s** |

**93% fewer input tokens, 88% fewer calls.** Eight passes report `skipped — inputs unchanged; no LLM call`.

Cycle 2 is the important row: it is what the corpus-hashing approach achieved on its own, and 16% is not a fix. The gap between rows 2 and 4 is entirely the input-vs-output and watermark rules.

The two remaining calls are self-limiting rather than stuck. Memory consolidation reviewed 19 entries in cycle 4 and 4 in cycle 5 — each cycle's own writes leave a few unreviewed entries for the next one, converging toward zero. Skill consolidation follows the same curve (7 deleted, then 2).

### A churn loop the measurement exposed

Sequence skill detection mined the same unchanging 14-day tool-call window on every cycle and manufactured a fresh pair of near-duplicate skills each time; skill consolidation then merged them away; repeat twice a day on an idle agent. The skill count across these cycles tells it plainly: **92 → 98 → 93**.

The loop also kept skill consolidation's own fingerprint moving, so that pass could never settle either — one bug was hiding behind the other, and watermarking the source fixed both.

## Follow-up in this PR: cast voice enrichment

A sixth pass with the same defect, in a form the gate above cannot fix. Cast voice enrichment was gated only on *"some character still lacks a voice card"* — a condition that stays true for months. On a deployment where every other LLM pass is disabled or delta-driven, it was the sole reason an idle cycle cost anything.

A content fingerprint is the wrong tool here: the corpus legitimately changes every time the pass enriches someone. The right signal is activity. The pass now requires conversation turns since the last cycle, gated by `CastVoiceRequiresRecentActivity` (default `true`). It runs before preference inference clears the log, so an empty log there means nothing happened this period. With no `IConversationLog` registered the gate cannot be evaluated and the pass runs as before.

### The convergence bug it exposed

The prompt listed the entire corpus and told the model not to touch the finished entries — then immediately told it to *"choose the ones with the most entries and the most recent activity first"*. A finished entry is longer **precisely because it has a voice card appended**, so the selection instruction pointed straight at the characters already done. Those proposals died silently against the `HasVoiceMarker` check.

One observed cycle spent 24 proposals on a 160-entry corpus to land **1** update. Random selection would have produced about 11, so the pass was performing markedly worse than chance — the signature of a heuristic aimed the wrong way.

Fixed by removing the possibility rather than re-wording the instruction:

- **Carded entries are no longer offered as candidates**, and the prompt states every returned id must come from the candidate list.
- **Voices already in use are listed as text without ids** — enough to keep voices distinct, far cheaper than shipping the finished entries.
- **Recent turns are included**, so the pass prefers characters actually on stage.
- **Both silent skip paths now log.** A pass reporting "1 given a voice, 23 skipped" with no way to learn why is how this stayed invisible.

Measured on that deployment: an idle cycle went from 4m 25s with one full-corpus call to **2.78s with zero LLM calls**.


### Cards written in an older format can now be upgraded

Investigating the rejections turned up a second, older bug in the same pass. The apply loop skipped any entry carrying the voice marker, so a deployment that evolved what a card should contain had no way to bring already-written cards up to the new shape. A directive asking the model to do exactly that — *"a card with the speech dimensions but none of the labelled sections is an older card, and is worth returning as an update"* — produced proposals the framework discarded silently, cycle after cycle. The instruction had never once been honoured, which also means some share of those 23 rejected proposals were the model following its directive correctly.

`CastVoiceUpgradeMarkers` lists substrings that mark a card as written in the current format. A card carrying the marker but none of them is offered back as an upgrade candidate. Empty (the default) preserves the original behaviour exactly: any card counts as finished. The framework stays ignorant of any particular card layout — the deployment names its own markers.

Two details worth a reviewer's eye:

- **Any one marker is enough.** Card sections are usually optional individually, so requiring all of them would classify a legitimately short card as stale and rewrite it on every cycle.
- **A list of nothing but blanks degrades to unconfigured**, not to "nothing matches, so everything is stale". The latter would put the whole corpus back in the candidate list — the wrong direction to fail in.

The prompt separates the two kinds of candidate, since they call for different work: a character with no voice gets a full card, an older card gets only what the current format adds. Older cards are shown with their existing text, unlike the voices-in-use list, because an upgrade is written against what the card already says. Every card still counts as a voice in use, stale ones included — an older card is still how that character sounds. The apply-time backstop now tests "needs work" rather than "has a marker", which is the check that was throwing upgrades away.

On the deployment that surfaced this, the corpus classified as 82 with no card, 68 carrying a card that predated the current format, and 21 current — a 68-entry backlog the directive had been requesting for months and never receiving. It stays free until someone plays: the activity gate still reports the work and skips.

```
cast voice enrichment — no conversation activity since the last cycle;
                        skipping (71 without a voice card, 68 with an older card)
dream cycle complete — elapsed 00:00:02.40
```

## Config

```csharp
public bool DreamPassChangeGateEnabled { get; set; } = true;              // false restores prior behaviour
public TimeSpan DreamPassMaxSkipInterval { get; set; } = TimeSpan.FromDays(7);   // Zero/negative = absolute gate
public TimeSpan TierRoutingReviewWindow { get; set; } = TimeSpan.FromDays(14);   // Zero/negative = whole log
public bool CastVoiceRequiresRecentActivity { get; set; } = true;
public IList<string> CastVoiceUpgradeMarkers { get; set; } = [];   // empty = any card is finished
```

Version `0.14.25`. The Helm chart is untouched, so it stays at `0.10.21`.

## Notes for review

- **`ShouldSkip` treats a backwards clock as "not yet due"** rather than letting a negative age trip the floor, so a restore or timezone change cannot stampede every gated pass at once.
- **`DlqFingerprint` includes queue depth**, so a growing backlog re-opens the pass while a queue merely stuck at the same depth is not re-analyzed.
- **Deploying this runs every gated pass once** to populate the ledger; the saving appears from the second cycle. `dream-pass-ledger.json` appearing under the profile path is the signal it is working.

## Testing

Full suite green: **2,874 passed, 0 failed.** New coverage in `DreamPassChangeGateTests` (gate decisions including the floor, a backwards clock, and the disabled-floor case; ledger disk round-trip, corrupt-file degradation, no-write-when-clean; watermark stability across aging-out and advance-on-new-event; fingerprint order-independence and insensitivity to importance and usage-timestamp drift), plus cluster-leak cases in `ConsolidationCandidateGatingTests`, window cases in `TierRoutingLoggerTests`, and activity-gate and `ExtractVoiceCardLine` cases in `DreamCastVoiceEnrichmentTests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3LRZE9eXYz71QEqcNGZSA
