### PR TITLE
Stop malformed repair tickets from retrying forever

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.14.25</Version>
+<Version>0.14.26</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.Host/DreamService.cs
+++ b/src/RockBot.Host/DreamService.cs
@@ -6071,6 +6071,9 @@ internal sealed class DreamService : IHostedService, IDisposable
     /// Pure status-classification function: given the post-apply attempt history
     /// and the latest verify outcome, decide what status the ticket should land in.
     /// </summary>
+    /// <summary>Prefix on <see cref="VerifyResult.Detail"/> when the applier threw.</summary>
+    internal const string ApplyErrorPrefix = "apply error: ";
+
     internal static RepairStatus ComputeNextStatus(
         IReadOnlyList<RepairAttempt> attempts,
         VerifyOutcome lastOutcome,
@@ -6082,8 +6085,35 @@ internal sealed class DreamService : IHostedService, IDisposable
                 attempts.Count(a => a.Result.Outcome == VerifyOutcome.PredicateFailed) >= maxAttempts
                     ? RepairStatus.Escalated
                     : RepairStatus.Open,
-            _ => RepairStatus.Open, // Uncertain — don't count toward MaxAttempts
+            // Uncertain normally means the world was briefly unavailable — a gateway error, a
+            // missing executor — and burning an attempt on that would escalate tickets for
+            // reasons that have nothing to do with them. A malformed ticket is the opposite:
+            // the applier rejects it identically every cycle, forever, and Uncertain guarantees
+            // it is retried forever. Observed on a live agent: one ticket failed the same
+            // validation 117 times across two months, with MaxAttempts sitting at 3 the whole
+            // time. Repetition is what separates the two, and it is the same reasoning the
+            // verify-timeout backoff already uses to promote a stuck ticket.
+            _ => IsRepeatingApplyError(attempts, maxAttempts)
+                ? RepairStatus.Escalated
+                : RepairStatus.Open,
         };
+
+    /// <summary>
+    /// True when the newest attempt failed inside the applier and the identical failure has now
+    /// happened <paramref name="maxAttempts"/> times. Matching on the detail text keeps this
+    /// independent of which exception type an applier chose to throw.
+    /// </summary>
+    internal static bool IsRepeatingApplyError(IReadOnlyList<RepairAttempt> attempts, int maxAttempts)
+    {
+        if (maxAttempts <= 0 || attempts.Count == 0) return false;
+
+        var latest = attempts[^1].Result.Detail;
+        if (string.IsNullOrEmpty(latest) || !latest.StartsWith(ApplyErrorPrefix, StringComparison.Ordinal))
+            return false;
+
+        return attempts.Count(a => string.Equals(a.Result.Detail, latest, StringComparison.Ordinal))
+            >= maxAttempts;
+    }
 
     internal static async Task<TicketCycleResult> ApplyAndVerifyTicketAsync(
         IReadOnlyDictionary<RepairTarget, IRepairTargetApplier> appliers,
@@ -6119,7 +6149,7 @@ internal sealed class DreamService : IHostedService, IDisposable
                 Attempt: new RepairAttempt(
                     DateTimeOffset.UtcNow,
                     JsonSerializer.SerializeToElement(new { error = ex.Message, type = ex.GetType().Name }, JsonOptions),
-                    new VerifyResult(VerifyOutcome.Uncertain, $"apply error: {ex.GetType().Name}: {ex.Message}")));
+                    new VerifyResult(VerifyOutcome.Uncertain, $"{ApplyErrorPrefix}{ex.GetType().Name}: {ex.Message}")));
         }
 
         // Backoff schedule for slow verify shapes: each prior timeout doubles the budget
@@ -6360,8 +6390,10 @@ internal sealed class DreamService : IHostedService, IDisposable
         'unknown'), count, distinct sessions, and a few sample error messages.
 
         Choose at most one of these target types per ticket:
-          - SkillBody: edit a named skill's body. Use ops [{op:"append"|"replaceSection"|"deleteSection", header?, text?}].
-            Use this when a skill's instructions are misleading the agent into the failure.
+          - SkillBody: edit a named skill's body
+            ({skill, ops:[{op:"append"|"replaceSection"|"deleteSection", header?, text?}]}).
+            `skill` is required and must be the exact skill name. Use this when a skill's
+            instructions are misleading the agent into the failure.
           - WorkingMemoryEvict: delete working-memory entries by keyPrefix or keys.
             Use this when a stale belief in WM ("X is broken") needs purging so the
             next session re-evaluates from current evidence.

--- a/src/RockBot.Host/SkillBodyApplier.cs
+++ b/src/RockBot.Host/SkillBodyApplier.cs
@@ -36,13 +36,15 @@ internal sealed class SkillBodyApplier : IRepairTargetApplier
         var change = ticket.Change.Deserialize<SkillBodyChange>(JsonOptions)
             ?? throw new ArgumentException("SkillBody change is empty.", nameof(ticket));
 
-        if (string.IsNullOrWhiteSpace(change.Skill))
-            throw new ArgumentException("SkillBody change missing 'skill'.", nameof(ticket));
+        var skill = change.ResolvedSkill;
+        if (string.IsNullOrWhiteSpace(skill))
+            throw new ArgumentException(
+                "SkillBody change missing 'skill' (also accepted: 'skillName', 'name').", nameof(ticket));
         if (change.Ops is null || change.Ops.Count == 0)
             throw new ArgumentException("SkillBody change has no ops.", nameof(ticket));
 
-        var existing = await _skillStore.GetAsync(change.Skill)
-            ?? throw new InvalidOperationException($"Skill '{change.Skill}' not found.");
+        var existing = await _skillStore.GetAsync(skill)
+            ?? throw new InvalidOperationException($"Skill '{skill}' not found.");
 
         var preBody = existing.Content ?? string.Empty;
         var preHash = HashOf(preBody);
@@ -65,7 +67,7 @@ internal sealed class SkillBodyApplier : IRepairTargetApplier
 
         var diff = JsonSerializer.SerializeToElement(new
         {
-            skill = change.Skill,
+            skill = skill,
             preHash,
             postHash,
             ops = change.Ops,
@@ -73,14 +75,14 @@ internal sealed class SkillBodyApplier : IRepairTargetApplier
 
         _logger.LogInformation(
             "SkillBodyApplier: applied {OpCount} op(s) to skill {Skill} (pre={PreHash} post={PostHash})",
-            change.Ops.Count, change.Skill, preHash, postHash);
+            change.Ops.Count, skill, preHash, postHash);
 
         Func<CancellationToken, Task> revert = async ct =>
         {
-            var current = await _skillStore.GetAsync(change.Skill);
+            var current = await _skillStore.GetAsync(skill);
             if (current is null)
             {
-                _logger.LogWarning("SkillBodyApplier revert: skill {Skill} no longer exists", change.Skill);
+                _logger.LogWarning("SkillBodyApplier revert: skill {Skill} no longer exists", skill);
                 return;
             }
 
@@ -92,7 +94,7 @@ internal sealed class SkillBodyApplier : IRepairTargetApplier
             {
                 _logger.LogWarning(
                     "SkillBodyApplier revert: skill {Skill} updated by another writer (expected {Expected}, found {Actual}); skipping revert",
-                    change.Skill, updated.UpdatedAt, current.UpdatedAt);
+                    skill, updated.UpdatedAt, current.UpdatedAt);
                 return;
             }
 
@@ -102,7 +104,7 @@ internal sealed class SkillBodyApplier : IRepairTargetApplier
                 UpdatedAt = preUpdatedAt ?? DateTimeOffset.UtcNow,
             };
             await _skillStore.SaveAsync(reverted);
-            _logger.LogInformation("SkillBodyApplier reverted skill {Skill} to pre-apply body", change.Skill);
+            _logger.LogInformation("SkillBodyApplier reverted skill {Skill} to pre-apply body", skill);
         };
 
         return new RepairApplyOutcome(diff, revert);
@@ -233,7 +235,29 @@ internal sealed class SkillBodyApplier : IRepairTargetApplier
     internal sealed class SkillBodyChange
     {
         public string? Skill { get; set; }
+
+        /// <summary>Accepted spelling of <see cref="Skill"/>.</summary>
+        public string? SkillName { get; set; }
+
+        /// <summary>Accepted spelling of <see cref="Skill"/>.</summary>
+        public string? Name { get; set; }
+
         public List<SkillBodyOp>? Ops { get; set; }
+
+        /// <summary>
+        /// The skill this change targets, under whichever of the accepted spellings the ticket
+        /// used.
+        /// </summary>
+        /// <remarks>
+        /// The creation directive documents the <c>ops</c> array for this target but never named
+        /// the identifier field, while it spells the fields out for every other target. Models
+        /// filled the gap with the obvious synonyms, and every such ticket then failed validation
+        /// here — on one agent, the same ticket failed 117 times over two months. Accepting the
+        /// synonyms costs nothing: the change object carries only a skill and its ops, so there is
+        /// no other field these names could plausibly mean.
+        /// </remarks>
+        public string? ResolvedSkill =>
+            new[] { Skill, SkillName, Name }.FirstOrDefault(v => !string.IsNullOrWhiteSpace(v));
     }
 
     internal sealed class SkillBodyOp

--- a/tests/RockBot.Host.Tests/RepairTicketApplyPassTests.cs
+++ b/tests/RockBot.Host.Tests/RepairTicketApplyPassTests.cs
@@ -383,4 +383,86 @@ public class RepairTicketApplyPassTests
             return Task.FromResult(new VerifyResult(outcome, $"stub verify → {outcome}"));
         }
     }
+
+    // -- Deterministic apply failures must escalate ----------------------------
+
+    private static RepairAttempt ApplyError(string detail) =>
+        new(DateTimeOffset.UtcNow,
+            System.Text.Json.JsonSerializer.SerializeToElement(new { error = detail }),
+            new VerifyResult(VerifyOutcome.Uncertain, DreamService.ApplyErrorPrefix + detail));
+
+    private static RepairAttempt TransientUncertain(string detail) =>
+        new(DateTimeOffset.UtcNow,
+            System.Text.Json.JsonSerializer.SerializeToElement(new { error = detail }),
+            new VerifyResult(VerifyOutcome.Uncertain, detail));
+
+    [TestMethod]
+    public void RepeatedIdenticalApplyError_Escalates()
+    {
+        // Uncertain deliberately does not count toward MaxAttempts, because a gateway blip is not
+        // the ticket's fault. A malformed ticket is the opposite: it fails identically forever,
+        // so without this the cap never engages and the ticket is retried indefinitely.
+        var attempts = new List<RepairAttempt>
+        {
+            ApplyError("ArgumentException: SkillBody change missing 'skill'."),
+            ApplyError("ArgumentException: SkillBody change missing 'skill'."),
+            ApplyError("ArgumentException: SkillBody change missing 'skill'."),
+        };
+
+        Assert.AreEqual(
+            RepairStatus.Escalated,
+            DreamService.ComputeNextStatus(attempts, VerifyOutcome.Uncertain, maxAttempts: 3));
+    }
+
+    [TestMethod]
+    public void ApplyErrorBelowTheCap_StaysOpen()
+    {
+        var attempts = new List<RepairAttempt>
+        {
+            ApplyError("ArgumentException: SkillBody change missing 'skill'."),
+            ApplyError("ArgumentException: SkillBody change missing 'skill'."),
+        };
+
+        Assert.AreEqual(
+            RepairStatus.Open,
+            DreamService.ComputeNextStatus(attempts, VerifyOutcome.Uncertain, maxAttempts: 3));
+    }
+
+    [TestMethod]
+    public void DifferingApplyErrors_DoNotAccumulate()
+    {
+        // Three different failures are not evidence of a permanently broken ticket; they may be
+        // three different transient conditions. Only the identical failure repeating is.
+        var attempts = new List<RepairAttempt>
+        {
+            ApplyError("ArgumentException: missing 'skill'."),
+            ApplyError("InvalidOperationException: Skill 'todo' not found."),
+            ApplyError("HttpRequestException: gateway unavailable."),
+        };
+
+        Assert.AreEqual(
+            RepairStatus.Open,
+            DreamService.ComputeNextStatus(attempts, VerifyOutcome.Uncertain, maxAttempts: 3));
+    }
+
+    [TestMethod]
+    public void TransientUncertainWithoutAnApplyError_NeverEscalates()
+    {
+        // The original guarantee has to survive: a verify that could not reach a conclusion must
+        // not burn attempts, however many times it happens.
+        var attempts = Enumerable.Range(0, 50)
+            .Select(_ => TransientUncertain("verify inconclusive: executor missing"))
+            .ToList();
+
+        Assert.AreEqual(
+            RepairStatus.Open,
+            DreamService.ComputeNextStatus(attempts, VerifyOutcome.Uncertain, maxAttempts: 3));
+    }
+
+    [TestMethod]
+    public void IsRepeatingApplyError_IgnoresAnEmptyHistoryOrDisabledCap()
+    {
+        Assert.IsFalse(DreamService.IsRepeatingApplyError([], 3));
+        Assert.IsFalse(DreamService.IsRepeatingApplyError([ApplyError("x")], 0));
+    }
 }

--- a/tests/RockBot.Host.Tests/SkillBodyApplierTests.cs
+++ b/tests/RockBot.Host.Tests/SkillBodyApplierTests.cs
@@ -200,4 +200,25 @@ public class SkillBodyApplierTests
             CreatedAt: DateTimeOffset.UtcNow,
             UpdatedAt: DateTimeOffset.UtcNow);
     }
+
+    // -- Accepted spellings of the skill field ---------------------------------
+
+    [TestMethod]
+    public void ResolvedSkill_PrefersSkill_ThenSkillName_ThenName()
+    {
+        // The creation directive documented this target's ops array but never named the
+        // identifier field, while spelling it out for every other target. Models filled the gap
+        // with the obvious synonyms and every such ticket failed validation -- on a live agent,
+        // the same ticket failed 117 times across two months.
+        Assert.AreEqual("a", new SkillBodyApplier.SkillBodyChange { Skill = "a", SkillName = "b", Name = "c" }.ResolvedSkill);
+        Assert.AreEqual("b", new SkillBodyApplier.SkillBodyChange { SkillName = "b", Name = "c" }.ResolvedSkill);
+        Assert.AreEqual("c", new SkillBodyApplier.SkillBodyChange { Name = "c" }.ResolvedSkill);
+    }
+
+    [TestMethod]
+    public void ResolvedSkill_TreatsBlankAsAbsent()
+    {
+        Assert.AreEqual("real", new SkillBodyApplier.SkillBodyChange { Skill = "   ", SkillName = "real" }.ResolvedSkill);
+        Assert.IsNull(new SkillBodyApplier.SkillBodyChange { Skill = " ", SkillName = "", Name = null }.ResolvedSkill);
+    }
 }


### PR DESCRIPTION
## What was happening

A repair ticket on a live agent failed the same validation **117 times across two months** — twice a day, every day — while `MaxAttempts` sat at 3 the whole time. A second failed 13 times. Of 28 tickets on disk, **not one had ever carried the field the `SkillBody` applier requires**, which means that applier has never successfully applied anything.

```
warn: Applier SkillBody failed for ticket ticket-066ecd364c1b
      System.ArgumentException: SkillBody change missing 'skill'. (Parameter 'ticket')
```

| Ticket | Field it used | Attempts | Failing since |
|---|---|---|---|
| `066ecd364c1b` | `skillName` | **117** | 2026-06-30 |
| `a375cedcef78` | `name` | 13 | 2026-08-26 |

## Three defects in a chain

**1. The directive never named the field.** It documents the `ops` array for `SkillBody` while spelling out the complete field list for every other target:

```
- SkillBody: edit a named skill's body. Use ops [{op:"append"|…, header?, text?}].
- ToolDefaultRegister: … ({server, providerName, field, tool?, value})
- PromptBuilderHint:   … ({category, hintId, text})
```

With nothing to copy, models supplied the obvious synonyms. Now documented as `{skill, ops:[...]}` like its neighbours.

**2. The applier accepted only one spelling.** It now takes `skill`, `skillName` or `name`. The change object carries a skill and its ops and nothing else, so there is no other field those names could plausibly mean — and accepting them unsticks tickets already on disk. The error message names all three.

**3. A deterministic apply failure could never escalate.** This is the one that turned a small schema slip into a two-month silent loop.

The catch maps every applier exception to `Uncertain`, and `ComputeNextStatus` deliberately excludes `Uncertain` from the attempt cap:

```csharp
_ => RepairStatus.Open, // Uncertain — don't count toward MaxAttempts
```

That is *correct* for what it was written for. A gateway blip or a missing executor is not the ticket's fault, and burning attempts on it would escalate tickets for reasons unrelated to them. But a malformed ticket is the opposite case: it fails identically every cycle, so `Uncertain` guaranteed infinite retry with no signal anywhere.

**Repetition is what separates them.** An applier error whose detail text repeats `MaxAttempts` times now escalates. Differing errors still do not accumulate — three different failures may be three different transient conditions. An `Uncertain` verify that never reached the applier still never escalates, however often it recurs.

Matching on the detail text rather than the exception type keeps this independent of what any given applier chooses to throw.

This is the reasoning the verify-timeout backoff twenty lines below already uses — promote a stuck ticket *"instead of retrying indefinitely with no signal"* — applied to the apply path, where it was missing.

## Testing

Full suite green: **2,881 passed, 0 failed.** New cases cover the accepted spellings and blank-as-absent handling; escalation on a repeated identical apply error; staying `Open` below the cap; differing errors not accumulating; and the original guarantee that 50 consecutive non-applier `Uncertain` verdicts still never escalate.

Version `0.14.26`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3LRZE9eXYz71QEqcNGZSA
