### PR TITLE
Defer a blocked dream cycle instead of dropping it

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.14.26</Version>
+<Version>0.14.27</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.Host.Abstractions/DreamOptions.cs
+++ b/src/RockBot.Host.Abstractions/DreamOptions.cs
@@ -19,6 +19,44 @@ public sealed class DreamOptions
     public string CronSchedule { get; set; } = "0 */12 * * *";
 
     /// <summary>
+    /// Whether a dream cycle blocked by other agent work is retried with backoff instead of being
+    /// dropped until the next cron occurrence. Default: <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    /// The work serializer is acquired non-blockingly, so a cycle that fires while a patrol,
+    /// scheduled task, or user turn holds the slot used to be abandoned outright — the next
+    /// attempt was a full <see cref="CronSchedule"/> period away. That is not a rare collision:
+    /// patrols run on their own schedule, and one that habitually overlaps a cron slot can cost
+    /// the same dream every day, indefinitely, with only an info line to show for it.
+    /// </remarks>
+    public bool DeferDreamOnContention { get; set; } = true;
+
+    /// <summary>
+    /// Delay before the first retry of a dream cycle that could not acquire the work slot.
+    /// Default: 5 minutes.
+    /// </summary>
+    public TimeSpan DreamContentionRetryInitialDelay { get; set; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Growth factor applied to each successive contention retry delay. Default: 2.0.
+    /// </summary>
+    public double DreamContentionRetryMultiplier { get; set; } = 2.0;
+
+    /// <summary>
+    /// Ceiling on a single contention retry delay. Default: 1 hour — long enough that a busy
+    /// agent is not polled constantly, short enough that the cycle still lands the same day.
+    /// </summary>
+    public TimeSpan DreamContentionRetryMaxDelay { get; set; } = TimeSpan.FromHours(1);
+
+    /// <summary>
+    /// How many times a blocked cycle is retried before giving up and waiting for the next cron
+    /// occurrence. Default: 6, which with the default delays spans roughly three hours
+    /// (5m, 10m, 20m, 40m, 1h, 1h). A retry is also abandoned early if the next scheduled cycle
+    /// would arrive first, so this never delays the schedule.
+    /// </summary>
+    public int DreamContentionMaxRetries { get; set; } = 6;
+
+    /// <summary>
     /// Whether corpus-wide dream passes skip their LLM call when the input they would send has
     /// not changed since the last time they ran. Default: <c>true</c>.
     /// </summary>

--- a/src/RockBot.Host/DreamService.cs
+++ b/src/RockBot.Host/DreamService.cs
@@ -77,6 +77,7 @@ internal sealed class DreamService : IHostedService, IDisposable
     private string? _repairTicketCreationDirective;
     private IReadOnlyList<LlmPricingRow>? _pricingRows;
     private DreamPassLedger? _passLedger;
+    private int _contentionRetries;
 
     public DreamService(
         ILongTermMemory memory,
@@ -485,10 +486,82 @@ internal sealed class DreamService : IHostedService, IDisposable
         }
     }
 
+    /// <summary>How a cycle ended, which decides whether the next timer is a retry or the cron.</summary>
+    internal enum DreamCycleOutcome
+    {
+        /// <summary>The cycle ran to completion, or failed in a way retrying will not help.</summary>
+        Finished,
+
+        /// <summary>Another piece of agent work held the slot, or took it back mid-cycle.</summary>
+        Deferred,
+    }
+
     private async Task OnTimerTickAsync()
     {
-        await DreamAsync();
+        var outcome = await DreamAsync();
+
+        if (outcome == DreamCycleOutcome.Deferred && TryArmContentionRetry())
+            return;
+
+        _contentionRetries = 0;
         ArmNextCronTimer();
+    }
+
+    /// <summary>
+    /// Delay before contention retry number <paramref name="attempt"/> (0-based), growing
+    /// geometrically and capped. Computed in double space and clamped so a large attempt count or
+    /// an operator-supplied multiplier cannot overflow the <see cref="TimeSpan"/>.
+    /// </summary>
+    internal static TimeSpan ComputeContentionRetryDelay(
+        int attempt, TimeSpan initial, double multiplier, TimeSpan max)
+    {
+        if (initial <= TimeSpan.Zero) return TimeSpan.Zero;
+        if (max < initial) max = initial;
+        if (attempt <= 0 || multiplier <= 1.0) return initial;
+
+        var scaled = initial.TotalMilliseconds * Math.Pow(multiplier, attempt);
+        if (double.IsNaN(scaled) || double.IsInfinity(scaled) || scaled >= max.TotalMilliseconds)
+            return max;
+
+        return TimeSpan.FromMilliseconds(scaled);
+    }
+
+    /// <summary>
+    /// Arms a backoff retry for a cycle that could not run. Returns false when the cycle should
+    /// fall back to the ordinary cron instead — retries disabled, budget exhausted, or the next
+    /// scheduled cycle arriving sooner than the retry would.
+    /// </summary>
+    private bool TryArmContentionRetry()
+    {
+        if (!_options.DeferDreamOnContention || _timer is null)
+            return false;
+
+        if (_contentionRetries >= _options.DreamContentionMaxRetries)
+        {
+            _logger.LogWarning(
+                "DreamService: still blocked after {Count} retry attempt(s); waiting for the next scheduled cycle",
+                _contentionRetries);
+            return false;
+        }
+
+        var delay = ComputeContentionRetryDelay(
+            _contentionRetries,
+            _options.DreamContentionRetryInitialDelay,
+            _options.DreamContentionRetryMultiplier,
+            _options.DreamContentionRetryMaxDelay);
+
+        // Never let a retry push past the schedule it is standing in for. If the next cron slot
+        // lands first, that slot is the better attempt and the retry has nothing to add.
+        var next = _cron?.GetNextOccurrence(_clock.Now, _clock.Zone);
+        if (next is not null && next.Value <= _clock.Now + delay)
+            return false;
+
+        _contentionRetries++;
+        _timer.Change(delay, Timeout.InfiniteTimeSpan);
+        _logger.LogInformation(
+            "DreamService: cycle blocked by other agent work; retry {Attempt} of {Max} in {Delay:g}",
+            _contentionRetries, _options.DreamContentionMaxRetries, delay);
+        return true;
     }
 
     private void ArmNextCronTimer()
@@ -510,17 +583,17 @@ internal sealed class DreamService : IHostedService, IDisposable
         _logger.LogInformation("DreamService: next dream cycle at {Next} (in {Delay:g})", next.Value, delay);
     }
 
-    private async Task DreamAsync()
+    private async Task<DreamCycleOutcome> DreamAsync()
     {
         var sw = System.Diagnostics.Stopwatch.StartNew();
 
         // Acquire the work serializer slot so user messages can preempt the dream.
-        // TryAcquireForScheduledAsync is non-blocking: if a user loop holds the slot, skip.
+        // TryAcquireForScheduledAsync is non-blocking: if something else holds the slot, defer.
         var slot = await _workSerializer.TryAcquireForScheduledAsync(CancellationToken.None);
         if (slot is null)
         {
-            _logger.LogInformation("DreamService: user loop active, skipping dream cycle");
-            return;
+            _logger.LogInformation("DreamService: agent busy, deferring dream cycle");
+            return DreamCycleOutcome.Deferred;
         }
 
         // Re-read directives from disk so live edits to /data/agent/*-dream.md and
@@ -534,6 +607,8 @@ internal sealed class DreamService : IHostedService, IDisposable
             ResolvePath(DreamPassLedger.FileName, _profileOptions.BasePath), _logger);
 
         _logger.LogInformation("DreamService: dream cycle starting");
+
+        var outcome = DreamCycleOutcome.Finished;
 
         try
         {
@@ -610,10 +685,15 @@ internal sealed class DreamService : IHostedService, IDisposable
         }
         catch (OperationCanceledException)
         {
-            _logger.LogInformation("DreamService: dream cycle preempted by user request");
+            // Preemption is contention that arrived late. Retrying is worth it and cheap: passes
+            // that finished have already stamped the ledger, so the retry resumes rather than
+            // repeating the work.
+            _logger.LogInformation("DreamService: dream cycle preempted by other agent work");
+            outcome = DreamCycleOutcome.Deferred;
         }
         catch (Exception ex)
         {
+            // A genuine failure is not contention; retrying on a backoff would just repeat it.
             _logger.LogError(ex, "DreamService: dream cycle failed");
         }
         finally
@@ -626,6 +706,8 @@ internal sealed class DreamService : IHostedService, IDisposable
 
             await slot.DisposeAsync();
         }
+
+        return outcome;
     }
 
     /// <summary>

--- a/tests/RockBot.Host.Tests/DreamContentionBackoffTests.cs
+++ b/tests/RockBot.Host.Tests/DreamContentionBackoffTests.cs
@@ -1,0 +1,96 @@
+namespace RockBot.Host.Tests;
+
+/// <summary>
+/// Covers the backoff that keeps a dream cycle alive when other agent work holds the slot.
+/// </summary>
+/// <remarks>
+/// The work serializer is acquired non-blockingly, so a cycle firing while a patrol, scheduled
+/// task, or user turn is running used to be abandoned until the next cron occurrence — twelve
+/// hours away by default. A patrol on its own schedule can overlap the same cron slot every day,
+/// which turns "the dream was skipped once" into "the dream never runs".
+/// </remarks>
+[TestClass]
+public class DreamContentionBackoffTests
+{
+    private static readonly TimeSpan Initial = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan Max = TimeSpan.FromHours(1);
+
+    [TestMethod]
+    public void Delay_GrowsGeometricallyThenCaps()
+    {
+        TimeSpan D(int attempt) =>
+            DreamService.ComputeContentionRetryDelay(attempt, Initial, 2.0, Max);
+
+        Assert.AreEqual(TimeSpan.FromMinutes(5), D(0));
+        Assert.AreEqual(TimeSpan.FromMinutes(10), D(1));
+        Assert.AreEqual(TimeSpan.FromMinutes(20), D(2));
+        Assert.AreEqual(TimeSpan.FromMinutes(40), D(3));
+        Assert.AreEqual(Max, D(4), "80 minutes exceeds the ceiling, so the ceiling applies.");
+        Assert.AreEqual(Max, D(5));
+    }
+
+    [TestMethod]
+    public void Delay_LargeAttemptCountCannotOverflow()
+    {
+        // Math.Pow(2, 10_000) is +Infinity; without clamping this throws rather than capping.
+        Assert.AreEqual(Max, DreamService.ComputeContentionRetryDelay(10_000, Initial, 2.0, Max));
+    }
+
+    [TestMethod]
+    public void Delay_MultiplierOfOneOrLess_StaysAtTheInitialDelay()
+    {
+        Assert.AreEqual(Initial, DreamService.ComputeContentionRetryDelay(5, Initial, 1.0, Max));
+        Assert.AreEqual(Initial, DreamService.ComputeContentionRetryDelay(5, Initial, 0.5, Max));
+    }
+
+    [TestMethod]
+    public void Delay_MaxBelowInitial_NeverReturnsLessThanInitial()
+    {
+        // A misconfiguration must not collapse the backoff into a tight retry loop against a
+        // busy agent.
+        var delay = DreamService.ComputeContentionRetryDelay(
+            3, Initial, 2.0, TimeSpan.FromSeconds(1));
+
+        Assert.AreEqual(Initial, delay);
+    }
+
+    [TestMethod]
+    public void Delay_ZeroInitial_IsZero()
+    {
+        Assert.AreEqual(
+            TimeSpan.Zero,
+            DreamService.ComputeContentionRetryDelay(2, TimeSpan.Zero, 2.0, Max));
+    }
+
+    [TestMethod]
+    public void DefaultSchedule_LandsTheCycleWithinAFewHours()
+    {
+        // The point of the defaults: a collision should cost minutes, not the twelve hours a
+        // dropped cycle used to cost.
+        var opts = new DreamOptions();
+        var total = TimeSpan.Zero;
+        for (var i = 0; i < opts.DreamContentionMaxRetries; i++)
+        {
+            total += DreamService.ComputeContentionRetryDelay(
+                i,
+                opts.DreamContentionRetryInitialDelay,
+                opts.DreamContentionRetryMultiplier,
+                opts.DreamContentionRetryMaxDelay);
+        }
+
+        Assert.AreEqual(TimeSpan.FromMinutes(5 + 10 + 20 + 40 + 60 + 60), total);
+        Assert.IsTrue(total < TimeSpan.FromHours(4));
+    }
+
+    [TestMethod]
+    public void Defaults_AreOnAndReasonable()
+    {
+        var opts = new DreamOptions();
+
+        Assert.IsTrue(opts.DeferDreamOnContention);
+        Assert.AreEqual(TimeSpan.FromMinutes(5), opts.DreamContentionRetryInitialDelay);
+        Assert.AreEqual(2.0, opts.DreamContentionRetryMultiplier);
+        Assert.AreEqual(TimeSpan.FromHours(1), opts.DreamContentionRetryMaxDelay);
+        Assert.AreEqual(6, opts.DreamContentionMaxRetries);
+    }
+}


### PR DESCRIPTION
## The problem

The work serializer is acquired non-blockingly, so a dream cycle that fired while something else held the slot logged this and abandoned the attempt entirely:

```
DreamService: user loop active, skipping dream cycle
DreamService: next dream cycle at 08/31/2026 00:00:00 -05:00 (in 11:59:59)
```

The next attempt was a full `CronSchedule` period away — **twelve hours** on the default schedule.

**The log line also named the wrong culprit, and that mattered.** The slot is held by *any* agent work, not just an interactive turn. On a live agent today the noon cycle was lost to a heartbeat patrol, not to a user. Patrols run on their own independent schedule, so an overlap is not a one-off collision to shrug at — the same slot can lose the same dream every day, indefinitely, with a single info line to show for it. A user watching for a nightly dream would see nothing wrong.

## The change

A blocked cycle now retries with capped geometric backoff instead of being dropped:

| Retry | 1 | 2 | 3 | 4 | 5 | 6 |
|---|---|---|---|---|---|---|
| Delay | 5m | 10m | 20m | 40m | 1h | 1h |

About three hours of attempts before falling back to the ordinary schedule. A collision now costs minutes rather than half a day.

Three details worth review:

**Mid-cycle preemption counts as contention too** and retries on the same ladder. This is cheap specifically because of #540 — passes that completed have already stamped the change-gate ledger, so a retry resumes rather than repeating the work. Before that landed, retrying a half-finished cycle would have re-run everything.

**A genuine exception does not retry.** Backoff would only repeat it. Only `Deferred` — could not acquire, or lost the slot mid-cycle — arms a retry.

**A retry is abandoned early when the next cron occurrence would arrive first**, so this can never delay the schedule it is standing in for. The attempt counter resets whenever a cycle actually runs.

## Robustness

`ComputeContentionRetryDelay` is computed in double space and clamped, so neither a large attempt count nor an operator-supplied multiplier can overflow the `TimeSpan` — `Math.Pow(2, 10_000)` is `+Infinity` and would otherwise throw rather than cap. A `MaxDelay` configured below `InitialDelay` returns the initial delay rather than collapsing the backoff into a tight retry loop against an agent that is already busy.

## Config

```csharp
public bool DeferDreamOnContention { get; set; } = true;
public TimeSpan DreamContentionRetryInitialDelay { get; set; } = TimeSpan.FromMinutes(5);
public double DreamContentionRetryMultiplier { get; set; } = 2.0;
public TimeSpan DreamContentionRetryMaxDelay { get; set; } = TimeSpan.FromHours(1);
public int DreamContentionMaxRetries { get; set; } = 6;
```

The skip message is now `agent busy, deferring dream cycle`, and preemption reads `preempted by other agent work` rather than `by user request`.

## Testing

Full suite green: **2,888 passed, 0 failed.** New `DreamContentionBackoffTests` covers the geometric schedule and its cap, overflow at a large attempt count, a multiplier of 1.0 or less, a max below the initial delay, a zero initial delay, and that the shipped defaults land a blocked cycle within about three hours.

Version `0.14.27`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3LRZE9eXYz71QEqcNGZSA
