### PR TITLE
Stop the file-backed stores from leaving empty directories behind

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.14.28</Version>
+<Version>0.14.29</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.14.27</Version>
+<Version>0.14.28</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.14.29</Version>
+<Version>0.14.30</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.Host/DirectoryPruner.cs
+++ b/src/RockBot.Host/DirectoryPruner.cs
@@ -1,0 +1,112 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Removes directories that a file-backed store has left empty.
+///
+/// Both the skill store and the embedding cache key files by a name that may contain
+/// forward slashes, so writing <c>research/summarize</c> creates a <c>research/</c>
+/// directory that nothing cleans up when the last child is deleted. The leftovers are
+/// inert on disk but make a directory listing report entries that no longer exist.
+///
+/// Every method here is best-effort: <see cref="IOException"/> and
+/// <see cref="UnauthorizedAccessException"/> are swallowed so a write racing the prune
+/// can never fail the caller's operation, and a read-only volume can never block startup.
+/// </summary>
+internal static class DirectoryPruner
+{
+    private static readonly StringComparison PathComparison =
+        OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+    /// <summary>
+    /// Deletes <paramref name="directory"/> and every ancestor left empty by it, stopping at
+    /// <paramref name="root"/> (never itself removed) or at the first level that still holds
+    /// something.
+    /// </summary>
+    public static void PruneUpward(string root, string? directory)
+    {
+        if (string.IsNullOrEmpty(directory))
+            return;
+
+        var stop = Path.TrimEndingDirectorySeparator(Path.GetFullPath(root));
+        var current = Path.TrimEndingDirectorySeparator(Path.GetFullPath(directory));
+
+        // Containment guard: only ever touch paths strictly below the root.
+        while (current.Length > stop.Length
+            && current.StartsWith(stop + Path.DirectorySeparatorChar, PathComparison))
+        {
+            try
+            {
+                if (Directory.Exists(current))
+                {
+                    if (Directory.EnumerateFileSystemEntries(current).Any())
+                        return;
+
+                    Directory.Delete(current);
+                }
+            }
+            catch (IOException)
+            {
+                return;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return;
+            }
+
+            var parent = Path.GetDirectoryName(current);
+            if (string.IsNullOrEmpty(parent))
+                return;
+
+            current = parent;
+        }
+    }
+
+    /// <summary>
+    /// Removes every empty directory below <paramref name="root"/>, deepest first, and returns
+    /// how many were removed. <paramref name="skip"/> is consulted with each candidate's full
+    /// path and, when it returns <c>true</c>, that directory and everything under it is left
+    /// alone — used to keep a store out of a subdirectory another component owns.
+    /// </summary>
+    public static int PruneEmptyBelow(string root, Func<string, bool>? skip = null)
+    {
+        string[] children;
+        try
+        {
+            children = Directory.GetDirectories(root);
+        }
+        catch (IOException)
+        {
+            return 0;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return 0;
+        }
+
+        var removed = 0;
+        foreach (var child in children)
+        {
+            if (skip is not null && skip(child))
+                continue;
+
+            removed += PruneEmptyBelow(child, skip);
+
+            try
+            {
+                if (!Directory.EnumerateFileSystemEntries(child).Any())
+                {
+                    Directory.Delete(child);
+                    removed++;
+                }
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        }
+
+        return removed;
+    }
+}

--- a/src/RockBot.Host/EmbeddingCache.cs
+++ b/src/RockBot.Host/EmbeddingCache.cs
@@ -13,6 +13,12 @@ namespace RockBot.Host;
 /// </summary>
 internal sealed class EmbeddingCache
 {
+    /// <summary>
+    /// Name of the cache folder created under the owning store's base path.
+    /// Exposed so stores that sweep their own directory tree can leave it alone.
+    /// </summary>
+    internal const string DirectoryName = ".embeddings";
+
     private readonly IEmbeddingGenerator<string, Embedding<float>> _generator;
     private readonly string _embeddingsPath;
     private readonly ILogger _logger;
@@ -32,7 +38,7 @@ internal sealed class EmbeddingCache
         EmbeddingTextPreparer preparer)
     {
         _generator = generator;
-        _embeddingsPath = Path.Combine(storePath, ".embeddings");
+        _embeddingsPath = Path.Combine(storePath, DirectoryName);
         _logger = logger;
         _preparer = preparer;
 

--- a/src/RockBot.Host/EmbeddingCache.cs
+++ b/src/RockBot.Host/EmbeddingCache.cs
@@ -43,6 +43,13 @@ internal sealed class EmbeddingCache
         _preparer = preparer;
 
         Directory.CreateDirectory(_embeddingsPath);
+
+        // IDs may contain '/' (a namespaced skill or memory), so each one writes into a
+        // subdirectory that nothing used to clean up. Sweep the leftovers once at startup;
+        // Remove keeps the folder tidy from here on.
+        var pruned = DirectoryPruner.PruneEmptyBelow(_embeddingsPath);
+        if (pruned > 0)
+            logger.LogDebug("Pruned {Count} empty directories under {Path}", pruned, _embeddingsPath);
     }
 
     /// <summary>
@@ -210,6 +217,9 @@ internal sealed class EmbeddingCache
         var filePath = GetFilePath(id);
         if (File.Exists(filePath))
             File.Delete(filePath);
+
+        // A namespaced ID leaves its directory behind once its last entry goes.
+        DirectoryPruner.PruneUpward(_embeddingsPath, Path.GetDirectoryName(filePath));
     }
 
     /// <summary>

--- a/src/RockBot.Host/FileMemoryStore.cs
+++ b/src/RockBot.Host/FileMemoryStore.cs
@@ -167,6 +167,9 @@ internal sealed partial class FileMemoryStore : ILongTermMemory, IArchivedMemory
             var oldPath = GetFilePath(existing.Id, existing.Category);
             if (File.Exists(oldPath))
                 File.Delete(oldPath);
+
+            // The entry may have been the last one in its old category.
+            DirectoryPruner.PruneUpward(_basePath, Path.GetDirectoryName(oldPath));
         }
 
         index[entry.Id] = entry;
@@ -287,6 +290,10 @@ internal sealed partial class FileMemoryStore : ILongTermMemory, IArchivedMemory
             var filePath = GetFilePath(id, entry.Category);
             if (File.Exists(filePath))
                 File.Delete(filePath);
+
+            // Categories are LLM-chosen and consolidation deletes on a schedule, so an
+            // emptied category directory would otherwise linger as a phantom category.
+            DirectoryPruner.PruneUpward(_basePath, Path.GetDirectoryName(filePath));
 
             index.Remove(id);
             _embeddingCache?.Remove(id);
@@ -672,6 +679,16 @@ internal sealed partial class FileMemoryStore : ILongTermMemory, IArchivedMemory
         }
 
         _logger.LogDebug("Loaded {Count} memory entries from {Path}", _index.Count, _basePath);
+
+        // One-off sweep: every earlier delete left its category directory behind, so an
+        // existing corpus carries phantom categories no future delete would ever clear.
+        // The embedding cache owns its own folder and sweeps it itself.
+        var pruned = DirectoryPruner.PruneEmptyBelow(
+            _basePath,
+            dir => string.Equals(Path.GetFileName(dir), EmbeddingCache.DirectoryName, StringComparison.Ordinal));
+        if (pruned > 0)
+            _logger.LogDebug("Pruned {Count} empty directories under {Path}", pruned, _basePath);
+
         return _index;
     }
 

--- a/src/RockBot.Host/FileSkillStore.cs
+++ b/src/RockBot.Host/FileSkillStore.cs
@@ -344,6 +344,10 @@ internal sealed partial class FileSkillStore : ISkillStore
             if (File.Exists(resourcePath))
                 File.Delete(resourcePath);
 
+            // Removing the last resource leaves the folder behind; drop it so the
+            // directory listing never advertises a resource set that no longer exists.
+            PruneEmptyDirectories(folderPath);
+
             saved = existing with
             {
                 Manifest = newManifest.Count == 0 ? null : newManifest,
@@ -468,13 +472,23 @@ internal sealed partial class FileSkillStore : ISkillStore
 
     public async Task DeleteAsync(string name)
     {
+        // Callers relay LLM-supplied names here (skill consolidation prunes by name), so a
+        // malformed name has to be a quiet no-op rather than a throw — and must be rejected
+        // before any path is built from it.
+        if (!IsSafeName(name))
+        {
+            _logger.LogDebug("Ignoring delete for invalid skill name '{Name}'", name);
+            return;
+        }
+
         await _semaphore.WaitAsync();
         try
         {
             var index = await EnsureIndexAsync();
 
-            if (!index.Remove(name, out var skill))
-                return;
+            // Clean disk whether or not the index knew about the skill: an index/disk
+            // disagreement should heal on delete instead of stranding the files forever.
+            var wasIndexed = index.Remove(name);
 
             var filePath = GetFilePath(name);
             if (File.Exists(filePath))
@@ -485,9 +499,14 @@ internal sealed partial class FileSkillStore : ISkillStore
             if (Directory.Exists(folderPath))
                 Directory.Delete(folderPath, recursive: true);
 
-            _embeddingCache?.Remove(name);
+            // Drop any subcategory directories the skill leaves empty behind it.
+            PruneEmptyDirectories(Path.GetDirectoryName(filePath));
 
-            _logger.LogDebug("Deleted skill '{Name}'", skill.Name);
+            if (wasIndexed)
+            {
+                _embeddingCache?.Remove(name);
+                _logger.LogDebug("Deleted skill '{Name}'", name);
+            }
         }
         finally
         {
@@ -593,7 +612,107 @@ internal sealed partial class FileSkillStore : ISkillStore
         }
 
         _logger.LogDebug("Loaded {Count} skills from {Path}", _index.Count, _basePath);
+
+        // One-off sweep: older store versions (and out-of-band deletions) left empty
+        // directories behind, which make a listing of the store report skills that do not exist.
+        var pruned = PruneEmptyDirectoriesUnder(_basePath);
+        if (pruned > 0)
+            _logger.LogDebug("Pruned {Count} empty directories under {Path}", pruned, _basePath);
+
         return _index;
+    }
+
+    /// <summary>
+    /// Deletes <paramref name="directory"/> and every ancestor left empty by it, stopping at
+    /// <see cref="_basePath"/> (never itself removed) or at the first level that still holds
+    /// something. Best-effort: a write racing the prune must not fail the caller's operation.
+    /// </summary>
+    private void PruneEmptyDirectories(string? directory)
+    {
+        if (string.IsNullOrEmpty(directory))
+            return;
+
+        var root = Path.TrimEndingDirectorySeparator(Path.GetFullPath(_basePath));
+        var current = Path.TrimEndingDirectorySeparator(Path.GetFullPath(directory));
+
+        // Containment guard: only ever touch paths strictly below the store root.
+        while (current.Length > root.Length
+            && current.StartsWith(root + Path.DirectorySeparatorChar, PathComparison))
+        {
+            try
+            {
+                if (Directory.Exists(current))
+                {
+                    if (Directory.EnumerateFileSystemEntries(current).Any())
+                        return;
+
+                    Directory.Delete(current);
+                }
+            }
+            catch (IOException)
+            {
+                return;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return;
+            }
+
+            var parent = Path.GetDirectoryName(current);
+            if (string.IsNullOrEmpty(parent))
+                return;
+
+            current = parent;
+        }
+    }
+
+    /// <summary>
+    /// Removes every empty directory below <paramref name="root"/>, deepest first, and returns
+    /// how many were removed. <see cref="EmbeddingCache.DirectoryName"/> is skipped — that
+    /// folder belongs to the cache, which creates it eagerly and may legitimately be empty.
+    /// Best-effort: IO errors are swallowed so a read-only volume never blocks store startup.
+    /// </summary>
+    private int PruneEmptyDirectoriesUnder(string root)
+    {
+        string[] children;
+        try
+        {
+            children = Directory.GetDirectories(root);
+        }
+        catch (IOException)
+        {
+            return 0;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return 0;
+        }
+
+        var removed = 0;
+        foreach (var child in children)
+        {
+            if (string.Equals(Path.GetFileName(child), EmbeddingCache.DirectoryName, PathComparison))
+                continue;
+
+            removed += PruneEmptyDirectoriesUnder(child);
+
+            try
+            {
+                if (!Directory.EnumerateFileSystemEntries(child).Any())
+                {
+                    Directory.Delete(child);
+                    removed++;
+                }
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        }
+
+        return removed;
     }
 
     /// <summary>
@@ -624,6 +743,9 @@ internal sealed partial class FileSkillStore : ISkillStore
 
     private const string ResourceFolderSuffix = ".resources";
 
+    private static readonly StringComparison PathComparison =
+        OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
     internal static string ResolvePath(string skillBasePath, string profileBasePath)
     {
         if (Path.IsPathRooted(skillBasePath))
@@ -634,6 +756,23 @@ internal sealed partial class FileSkillStore : ISkillStore
             : Path.Combine(AppContext.BaseDirectory, profileBasePath);
 
         return Path.Combine(baseDir, skillBasePath);
+    }
+
+    /// <summary>
+    /// Non-throwing form of <see cref="ValidateName"/>, for the paths that must treat an
+    /// unusable (typically LLM-supplied) name as a no-op rather than an error.
+    /// </summary>
+    private static bool IsSafeName(string name)
+    {
+        try
+        {
+            ValidateName(name);
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
     }
 
     internal static void ValidateName(string name)

--- a/src/RockBot.Host/FileSkillStore.cs
+++ b/src/RockBot.Host/FileSkillStore.cs
@@ -346,7 +346,7 @@ internal sealed partial class FileSkillStore : ISkillStore
 
             // Removing the last resource leaves the folder behind; drop it so the
             // directory listing never advertises a resource set that no longer exists.
-            PruneEmptyDirectories(folderPath);
+            DirectoryPruner.PruneUpward(_basePath, folderPath);
 
             saved = existing with
             {
@@ -500,7 +500,7 @@ internal sealed partial class FileSkillStore : ISkillStore
                 Directory.Delete(folderPath, recursive: true);
 
             // Drop any subcategory directories the skill leaves empty behind it.
-            PruneEmptyDirectories(Path.GetDirectoryName(filePath));
+            DirectoryPruner.PruneUpward(_basePath, Path.GetDirectoryName(filePath));
 
             if (wasIndexed)
             {
@@ -615,104 +615,14 @@ internal sealed partial class FileSkillStore : ISkillStore
 
         // One-off sweep: older store versions (and out-of-band deletions) left empty
         // directories behind, which make a listing of the store report skills that do not exist.
-        var pruned = PruneEmptyDirectoriesUnder(_basePath);
+        // The embedding cache owns its own folder and sweeps it itself.
+        var pruned = DirectoryPruner.PruneEmptyBelow(
+            _basePath,
+            dir => string.Equals(Path.GetFileName(dir), EmbeddingCache.DirectoryName, StringComparison.Ordinal));
         if (pruned > 0)
             _logger.LogDebug("Pruned {Count} empty directories under {Path}", pruned, _basePath);
 
         return _index;
-    }
-
-    /// <summary>
-    /// Deletes <paramref name="directory"/> and every ancestor left empty by it, stopping at
-    /// <see cref="_basePath"/> (never itself removed) or at the first level that still holds
-    /// something. Best-effort: a write racing the prune must not fail the caller's operation.
-    /// </summary>
-    private void PruneEmptyDirectories(string? directory)
-    {
-        if (string.IsNullOrEmpty(directory))
-            return;
-
-        var root = Path.TrimEndingDirectorySeparator(Path.GetFullPath(_basePath));
-        var current = Path.TrimEndingDirectorySeparator(Path.GetFullPath(directory));
-
-        // Containment guard: only ever touch paths strictly below the store root.
-        while (current.Length > root.Length
-            && current.StartsWith(root + Path.DirectorySeparatorChar, PathComparison))
-        {
-            try
-            {
-                if (Directory.Exists(current))
-                {
-                    if (Directory.EnumerateFileSystemEntries(current).Any())
-                        return;
-
-                    Directory.Delete(current);
-                }
-            }
-            catch (IOException)
-            {
-                return;
-            }
-            catch (UnauthorizedAccessException)
-            {
-                return;
-            }
-
-            var parent = Path.GetDirectoryName(current);
-            if (string.IsNullOrEmpty(parent))
-                return;
-
-            current = parent;
-        }
-    }
-
-    /// <summary>
-    /// Removes every empty directory below <paramref name="root"/>, deepest first, and returns
-    /// how many were removed. <see cref="EmbeddingCache.DirectoryName"/> is skipped — that
-    /// folder belongs to the cache, which creates it eagerly and may legitimately be empty.
-    /// Best-effort: IO errors are swallowed so a read-only volume never blocks store startup.
-    /// </summary>
-    private int PruneEmptyDirectoriesUnder(string root)
-    {
-        string[] children;
-        try
-        {
-            children = Directory.GetDirectories(root);
-        }
-        catch (IOException)
-        {
-            return 0;
-        }
-        catch (UnauthorizedAccessException)
-        {
-            return 0;
-        }
-
-        var removed = 0;
-        foreach (var child in children)
-        {
-            if (string.Equals(Path.GetFileName(child), EmbeddingCache.DirectoryName, PathComparison))
-                continue;
-
-            removed += PruneEmptyDirectoriesUnder(child);
-
-            try
-            {
-                if (!Directory.EnumerateFileSystemEntries(child).Any())
-                {
-                    Directory.Delete(child);
-                    removed++;
-                }
-            }
-            catch (IOException)
-            {
-            }
-            catch (UnauthorizedAccessException)
-            {
-            }
-        }
-
-        return removed;
     }
 
     /// <summary>
@@ -742,9 +652,6 @@ internal sealed partial class FileSkillStore : ISkillStore
         Path.Combine(_basePath, name.Replace('/', Path.DirectorySeparatorChar) + ResourceFolderSuffix);
 
     private const string ResourceFolderSuffix = ".resources";
-
-    private static readonly StringComparison PathComparison =
-        OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
 
     internal static string ResolvePath(string skillBasePath, string profileBasePath)
     {

--- a/tests/RockBot.Host.Tests/EmbeddingCacheTests.cs
+++ b/tests/RockBot.Host.Tests/EmbeddingCacheTests.cs
@@ -1,3 +1,6 @@
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+
 namespace RockBot.Host.Tests;
 
 [TestClass]
@@ -61,5 +64,95 @@ public class EmbeddingCacheTests
     {
         var result = EmbeddingCache.CosineSimilarity([], []);
         Assert.AreEqual(0.0f, result, 0.001f);
+    }
+
+    // ── Empty-directory hygiene ──────────────────────────────
+
+    [TestMethod]
+    public void Constructor_PrunesPreexistingEmptyDirectories()
+    {
+        // Older builds deleted a namespaced entry's .bin but left its directory, so the
+        // cache mirrored the store's phantom-directory problem one level down.
+        using var temp = new TempDir();
+        var embeddings = Path.Combine(temp.Path, EmbeddingCache.DirectoryName);
+        Directory.CreateDirectory(Path.Combine(embeddings, "todo"));
+        Directory.CreateDirectory(Path.Combine(embeddings, "mcp", "calendar"));
+        Directory.CreateDirectory(Path.Combine(embeddings, "research"));
+        File.WriteAllBytes(Path.Combine(embeddings, "research", "summarize.bin"), [1, 2, 3, 4]);
+
+        _ = CreateCache(temp.Path);
+
+        Assert.IsFalse(Directory.Exists(Path.Combine(embeddings, "todo")));
+        Assert.IsFalse(Directory.Exists(Path.Combine(embeddings, "mcp")));
+        Assert.IsTrue(Directory.Exists(Path.Combine(embeddings, "research")));
+        Assert.IsTrue(Directory.Exists(embeddings), "the cache root must survive the prune");
+    }
+
+    [TestMethod]
+    public void Remove_LastEntryInNamespace_RemovesEmptyDirectory()
+    {
+        using var temp = new TempDir();
+        var embeddings = Path.Combine(temp.Path, EmbeddingCache.DirectoryName);
+        Directory.CreateDirectory(Path.Combine(embeddings, "research"));
+        File.WriteAllBytes(Path.Combine(embeddings, "research", "summarize.bin"), [1, 2, 3, 4]);
+
+        var cache = CreateCache(temp.Path);
+        cache.Remove("research/summarize");
+
+        Assert.IsFalse(File.Exists(Path.Combine(embeddings, "research", "summarize.bin")));
+        Assert.IsFalse(Directory.Exists(Path.Combine(embeddings, "research")));
+        Assert.IsTrue(Directory.Exists(embeddings));
+    }
+
+    [TestMethod]
+    public void Remove_NamespaceWithRemainingEntry_KeepsDirectory()
+    {
+        using var temp = new TempDir();
+        var embeddings = Path.Combine(temp.Path, EmbeddingCache.DirectoryName);
+        Directory.CreateDirectory(Path.Combine(embeddings, "research"));
+        File.WriteAllBytes(Path.Combine(embeddings, "research", "summarize.bin"), [1, 2, 3, 4]);
+        File.WriteAllBytes(Path.Combine(embeddings, "research", "scan.bin"), [5, 6, 7, 8]);
+
+        var cache = CreateCache(temp.Path);
+        cache.Remove("research/summarize");
+
+        Assert.IsTrue(Directory.Exists(Path.Combine(embeddings, "research")));
+        Assert.IsTrue(File.Exists(Path.Combine(embeddings, "research", "scan.bin")));
+    }
+
+    // ── Helpers ────────────────────────────────────────────
+
+    private static EmbeddingCache CreateCache(string storePath) =>
+        new(new StubEmbeddingGenerator(), storePath, NullLogger.Instance, EmbeddingTextPreparer.ForTests());
+
+    private sealed class TempDir : IDisposable
+    {
+        public string Path { get; } = System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(), "rockbot-embedding-test-" + Guid.NewGuid().ToString("N"));
+
+        public TempDir() => Directory.CreateDirectory(Path);
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+                Directory.Delete(Path, recursive: true);
+        }
+    }
+
+    private sealed class StubEmbeddingGenerator : IEmbeddingGenerator<string, Embedding<float>>
+    {
+        public Task<GeneratedEmbeddings<Embedding<float>>> GenerateAsync(
+            IEnumerable<string> values,
+            EmbeddingGenerationOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            var list = new GeneratedEmbeddings<Embedding<float>>();
+            foreach (var _ in values)
+                list.Add(new Embedding<float>(new float[] { 0f, 0f, 0f }));
+            return Task.FromResult(list);
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+        public void Dispose() { }
     }
 }

--- a/tests/RockBot.Host.Tests/FileMemoryStoreTests.cs
+++ b/tests/RockBot.Host.Tests/FileMemoryStoreTests.cs
@@ -841,6 +841,67 @@ public class FileMemoryStoreTests
         Assert.AreEqual(0.5f, entry.ImportanceScore);
     }
 
+    // ── Empty-directory hygiene ────────────────────────────────
+
+    [TestMethod]
+    public async Task DeleteAsync_LastEntryInCategory_RemovesEmptyCategoryDirectory()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(CreateEntry("test-1", "content", category: "project-context/rockbot"));
+
+        await store.DeleteAsync("test-1");
+
+        Assert.IsFalse(Directory.Exists(Path.Combine(_tempDir, "project-context", "rockbot")));
+        Assert.IsFalse(Directory.Exists(Path.Combine(_tempDir, "project-context")));
+        Assert.IsTrue(Directory.Exists(_tempDir), "the store root must survive the prune");
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_CategoryWithRemainingEntry_KeepsCategoryDirectory()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(CreateEntry("test-1", "content", category: "user-preferences"));
+        await store.SaveAsync(CreateEntry("test-2", "other", category: "user-preferences"));
+
+        await store.DeleteAsync("test-1");
+
+        Assert.IsTrue(Directory.Exists(Path.Combine(_tempDir, "user-preferences")));
+        Assert.IsTrue(File.Exists(Path.Combine(_tempDir, "user-preferences", "test-2.json")));
+    }
+
+    [TestMethod]
+    public async Task SaveAsync_CategoryChange_RemovesEmptiedOldCategoryDirectory()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(CreateEntry("test-1", "content", category: "scratch"));
+
+        await store.SaveAsync(CreateEntry("test-1", "content", category: "user-preferences"));
+
+        Assert.IsFalse(Directory.Exists(Path.Combine(_tempDir, "scratch")));
+        Assert.IsTrue(File.Exists(Path.Combine(_tempDir, "user-preferences", "test-1.json")));
+    }
+
+    [TestMethod]
+    public async Task EnsureIndexAsync_PrunesPreexistingEmptyCategoryDirectories()
+    {
+        // The live-cluster shape: category directories emptied by earlier deletes, which
+        // no future delete would ever clear.
+        var store = CreateStore();
+        await store.SaveAsync(CreateEntry("test-1", "content", category: "infrastructure"));
+
+        Directory.CreateDirectory(Path.Combine(_tempDir, "personal", "blog"));
+        Directory.CreateDirectory(Path.Combine(_tempDir, "system", "architecture"));
+
+        // A fresh store indexes the directory from scratch and sweeps it.
+        var reloaded = CreateStore();
+        var entry = await reloaded.GetAsync("test-1");
+
+        Assert.IsFalse(Directory.Exists(Path.Combine(_tempDir, "personal")));
+        Assert.IsFalse(Directory.Exists(Path.Combine(_tempDir, "system")));
+        Assert.IsTrue(Directory.Exists(Path.Combine(_tempDir, "infrastructure")));
+        Assert.IsNotNull(entry);
+    }
+
     private static MemoryEntry CreateEntry(
         string id,
         string content,

--- a/tests/RockBot.Host.Tests/FileSkillStoreTests.cs
+++ b/tests/RockBot.Host.Tests/FileSkillStoreTests.cs
@@ -377,6 +377,127 @@ public class FileSkillStoreTests
         Assert.IsFalse(Directory.Exists(Path.Combine(_tempDir, "my-skill.resources")));
     }
 
+    // ── Empty-directory hygiene ──────────────────────────────────────
+
+    [TestMethod]
+    public async Task SaveAsync_WithoutResources_CreatesNoResourceFolder()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(MakeSkill("my-skill", "summary", "content"));
+
+        Assert.IsFalse(Directory.Exists(Path.Combine(_tempDir, "my-skill.resources")));
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_LastSkillInNamespace_RemovesEmptyParentDirectory()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(MakeSkill("research/summarize", "summary", "content"));
+        Assert.IsTrue(Directory.Exists(Path.Combine(_tempDir, "research")));
+
+        await store.DeleteAsync("research/summarize");
+
+        Assert.IsFalse(Directory.Exists(Path.Combine(_tempDir, "research")));
+        Assert.IsTrue(Directory.Exists(_tempDir), "the store root must survive the prune");
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_NamespaceWithRemainingSkill_KeepsParentDirectory()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(MakeSkill("research/summarize", "summary", "content"));
+        await store.SaveAsync(MakeSkill("research/scan", "summary", "content"));
+
+        await store.DeleteAsync("research/summarize");
+
+        Assert.IsTrue(Directory.Exists(Path.Combine(_tempDir, "research")));
+        Assert.IsTrue(File.Exists(Path.Combine(_tempDir, "research", "scan.json")));
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_SkillMissingFromIndex_StillRemovesFilesFromDisk()
+    {
+        // Index the store first, then plant a skill file behind its back so the index
+        // and the disk disagree — the delete must still clean the disk.
+        var store = CreateStore();
+        await store.ListAsync();
+
+        Directory.CreateDirectory(Path.Combine(_tempDir, "orphan"));
+        var stray = Path.Combine(_tempDir, "orphan", "ghost.json");
+        await File.WriteAllTextAsync(stray, "{}");
+
+        await store.DeleteAsync("orphan/ghost");
+
+        Assert.IsFalse(File.Exists(stray));
+        Assert.IsFalse(Directory.Exists(Path.Combine(_tempDir, "orphan")));
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_InvalidName_IsNoOp()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(MakeSkill("keeper", "summary", "content"));
+
+        await store.DeleteAsync("../escape");
+        await store.DeleteAsync("bad name!");
+        await store.DeleteAsync("   ");
+
+        Assert.IsTrue(File.Exists(Path.Combine(_tempDir, "keeper.json")));
+    }
+
+    [TestMethod]
+    public async Task RemoveResourceAsync_LastResource_RemovesEmptyResourceFolder()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(MakeSkill("my-skill", "summary", "content"),
+            [new("script.py", SkillResourceType.Python, "desc", "code")]);
+
+        var folder = Path.Combine(_tempDir, "my-skill.resources");
+        Assert.IsTrue(Directory.Exists(folder));
+
+        var ok = await store.RemoveResourceAsync("my-skill", "script.py");
+
+        Assert.IsTrue(ok);
+        Assert.IsFalse(Directory.Exists(folder));
+        Assert.IsTrue(File.Exists(Path.Combine(_tempDir, "my-skill.json")));
+    }
+
+    [TestMethod]
+    public async Task RemoveResourceAsync_RemainingResource_KeepsResourceFolder()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(MakeSkill("my-skill", "summary", "content"),
+            [new("a.py", SkillResourceType.Python, "desc", "code"),
+             new("b.py", SkillResourceType.Python, "desc", "code")]);
+
+        await store.RemoveResourceAsync("my-skill", "a.py");
+
+        var folder = Path.Combine(_tempDir, "my-skill.resources");
+        Assert.IsTrue(Directory.Exists(folder));
+        Assert.IsTrue(File.Exists(Path.Combine(folder, "b.py")));
+    }
+
+    [TestMethod]
+    public async Task EnsureIndexAsync_PrunesPreexistingEmptyDirectories()
+    {
+        // The live-cluster shape: leftover namespace folders with no skill in them,
+        // alongside a namespace folder that still holds one.
+        var store = CreateStore();
+        await store.SaveAsync(MakeSkill("todo/todo-add-and-verify-task", "summary", "content"));
+
+        Directory.CreateDirectory(Path.Combine(_tempDir, "calendar"));
+        Directory.CreateDirectory(Path.Combine(_tempDir, "people", "nested"));
+
+        // A fresh store indexes the directory from scratch and sweeps it.
+        var reloaded = CreateStore();
+        await reloaded.ListAsync();
+
+        Assert.IsFalse(Directory.Exists(Path.Combine(_tempDir, "calendar")));
+        Assert.IsFalse(Directory.Exists(Path.Combine(_tempDir, "people")));
+        Assert.IsTrue(Directory.Exists(Path.Combine(_tempDir, "todo")));
+        Assert.IsNotNull(await reloaded.GetAsync("todo/todo-add-and-verify-task"));
+    }
+
     [TestMethod]
     public async Task EnsureIndexAsync_SkipsResourceFolderJsonFiles()
     {


### PR DESCRIPTION
Fixes #542.

On the live agent, `skills/` held 58 directories for 38 skills — 38 of them empty with no matching skill. They are inert on disk, but anything that enumerates the directory instead of the index (a human running `ls`, most obviously) sees skills that do not exist. That actively misled the #541 debugging session, where `todo` and `calendar` looked real next to `todo-add-and-verify-task` and `calendar-email`.

Verifying the fix on the cluster turned up the same bug in two more places, so this PR covers all three file-backed stores. The pattern is identical everywhere: a store keys files by a name that may contain `/`, creates the directory on write, and only ever deletes the file.

## 1. Skill store

The issue's first cause — `SaveAsync` creating a resource folder unconditionally — was already fixed by the `.resources`-suffix refactor, which gave `SaveAsync(skill, resources)` an early return for a resource-less skill. The leftovers on the PVC predate that change (they carry no suffix), which is why they persisted. Three gaps remained.

**`DeleteAsync` prunes namespace parents.** It removed `skills/people/foo.json` and `skills/people/foo.resources/` but left `skills/people/` behind once its last child was gone. Skill consolidation deletes on a schedule, so these accumulated.

**`RemoveResourceAsync` drops an emptied `.resources` folder.** Removing the last resource deleted the file and nulled the manifest but kept the directory. Recreating the folder is safe: both `AttachResourceAsync` and the bulk `SaveAsync` `Directory.CreateDirectory` before writing.

**`DeleteAsync` cleans disk unconditionally.** `if (!index.Remove(name, out var skill)) return;` meant an index/disk disagreement was permanent. The delete now runs whether or not the index knew the skill, and the `Remove` result only gates the log line and the embedding-cache eviction. Because that removes the early return, an unsafe name is rejected before any path is built: `DreamService` passes LLM-supplied names to `DeleteAsync` at three call sites, so a malformed name has to stay a quiet no-op rather than a throw — a new non-throwing `IsSafeName` delegates to `ValidateName` so there is one source of truth for what a legal name is.

## 2. Embedding cache

`EmbeddingCache` keys `.bin` files by the same namespaced ID, so `Remove` deleted the file and left the directory. The live agent had 40 of these mirroring the skill tree. `Remove` now prunes upward, and the constructor sweeps pre-existing leftovers once. This fixes the memory store's cache at the same time — both stores construct one.

## 3. Memory store

The worst instance: **592 empty directories out of 771** on the live agent, against 1,594 real entries — 77% of the tree was phantom categories (`personal/blog`, `system/architecture`, …). Categories are LLM-chosen and consolidation deletes on a schedule, so it accumulated far faster than the skill store did. `DeleteAsync` now prunes the category chain, and `SaveAsync` prunes the old category when an entry moves and was the last one there.

## Shared helper

Rather than let a third copy of the walk appear, the prune logic lives in a new `DirectoryPruner`:

- `PruneUpward(root, dir)` — deletes `dir` and each ancestor left empty, stopping at the first level that still holds something, guarded by a full-path containment check so it can never reach the root or anything outside it.
- `PruneEmptyBelow(root, skip)` — deepest-first sweep returning a count, with a predicate for subtrees another component owns.

Both are best-effort: `IOException` and `UnauthorizedAccessException` are swallowed, so a concurrent write racing the prune cannot fail a delete, and a read-only volume cannot block startup.

Each store runs `PruneEmptyBelow` once at index load, clearing historical leftovers that the delete-path fixes alone would never touch — no delete will ever be issued for a skill or category that does not exist. `EnsureIndexAsync` memoizes and is never invalidated, so that is exactly one extra walk per process, on a tree the index load was already walking. Both stores skip `.embeddings`; the cache sweeps its own folder, keeping ownership where it belongs.

## Risk

The sweep deletes any empty directory under a store root, including one created deliberately as a placeholder. Nothing in the codebase does that — `GetFilePath` and `GetResourceFolderPath` are the only directory-creating paths — and an empty directory carries no information in these stores.

## Tests

15 new tests across `FileSkillStoreTests`, `EmbeddingCacheTests`, and `FileMemoryStoreTests`, following the existing pattern of direct `Directory.Exists`/`File.Exists` assertions on the layout: pruning and its non-empty guard for each store, a delete of a skill written to disk behind a store's back, an invalid name as a no-op, a memory entry changing category, and each store's sweep against the exact live-cluster shape. The already-correct no-resource-folder behavior is locked in so it cannot regress.

Full suite green — 0 failures across all 20 test assemblies, 1368 passing in `RockBot.Host.Tests` (up from 1353).

## Verified on the cluster

Deployed to `rockbot` as `0.14.30`:

| | before | after |
|---|---|---|
| `skills/` empty dirs | 50 | **0** |
| `skills/.embeddings/` empty dirs | 40 | **0** |
| `memory/` empty dirs | 592 (of 771) | **0** (133 dirs remain, all populated) |
| `memory/.embeddings/` empty dirs | 40 | **0** |
| skill JSONs / memory entries | 53 / 1,594 | intact (52 / 1,600 after normal churn) |

No errors in the agent log across the rollout. A skill deleted by consolidation during the observation window left no directory behind, confirming the delete path works live and not just the one-off sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
