### PR TITLE
Remove the kubectl binary committed by accident

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -37,4 +37,3 @@ Dockerfile*    text eol=lf
 *.snk    binary
 *.woff   binary
 *.woff2  binary
-kubectl  binary

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ deploy/docker-compose/agent-data/
 deploy/docker-compose/*/.env
 deploy/docker-compose/*/agent.extra.env
 deploy/docker-compose/*/agent-data/
+
+# Stray 58 MB kubectl binary was committed by accident once (#96). Use the one on PATH.
+kubectl


### PR DESCRIPTION
A 58 MB stripped ELF `kubectl` has sat at the repo root since #96, where it rode in on a feature commit about subagent spawning.

## Nothing uses it

- No `Dockerfile` `COPY`s or `ADD`s it (checked `deploy/Dockerfile.*` and `src/*/Dockerfile*`).
- No script or csproj references it by path.
- Every other `kubectl` mention in the tree — `NOTES.txt`, `deploy/k8s/research-agent-keda-secret.sh`, a few READMEs, a comment in `McpBridgeService.cs` — means the command on PATH, which anyone working on this repo already has.

## What this does and doesn't buy

It does **not** shrink an existing clone. The blob is 17.4 MB packed and stays in history — roughly 70% of the 25 MB `.git`:

```
259ae36 blob 58597560 17367211   # size / size-on-disk
```

Reclaiming that would need a history rewrite, which isn't worth it for a repo with open branches and pinned SHAs. What it does buy is 58 MB off every working tree from here on, and a root directory that doesn't invite the question again.

Gitignored so it can't wander back in, and its `binary` line comes out of `.gitattributes` with it (added in #545 only to protect it during normalisation).