### PR TITLE
Stop the consolidation merge treadmill (#550)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.14.34</Version>
+<Version>0.14.35</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/docs/dream-service.md
+++ b/docs/dream-service.md
@@ -120,6 +120,14 @@ Requires the store to implement `IArchivedMemoryMaintenance`; with a store that 
 `ArchiveAsync` falls back to a hard delete and there is nothing to purge. A non-positive
 retention keeps archived entries forever.
 
+**The high-value floor applies here too.** This is the only remaining path that destroys
+long-term memory, so an entry above `Dream:PruningProtectionImportance` or
+`Dream:PruningProtectionReinforcementCount` is kept past the retention window rather than
+purged, and the pass logs `{Purged} purged, {Kept} kept above the high-value floor`. Note that
+importance is frozen at archive time and never decays afterwards, so in practice it is the
+reinforcement half of the floor that bites — an entry observed dozens of times and then
+archived by a merge nobody reviewed is exactly what should outlive retention.
+
 ### Pass 1 — Memory consolidation
 
 **Input:** a *gated subset* of long-term memory entries + recent feedback signals (last 7
@@ -127,6 +135,25 @@ days, up to 50). Each entry is rendered with its temporal context — `first=` (
 `last=` (LastSeenAt), `reinforced=N×` (ReinforcementCount), and `subject=...` when
 subject-time metadata is present — so the LLM can reason about whether similar-sounding
 entries describe the same durable fact or distinct moments.
+
+**Minimum interval between passes.** A dream cycle fires `Dream:InitialDelay` after every
+process start as well as on the cron schedule, so consolidation cadence used to track the
+deploy schedule rather than the corpus — ten deploys over three days produced roughly fifteen
+cycles and 121 archives in one of those days, all of them re-asking the same questions about
+the same entries. A pass reached sooner than `Dream:ConsolidationMinInterval` (default 6 hours)
+after the last *completed* one logs `memory consolidation skipped — last completed …` and
+returns without calling the LLM. Completion is recorded in the dream pass ledger on the agent
+profile volume, so the interval survives the restarts it exists to absorb. Set it to zero to
+disable the floor.
+
+**Duplicates are avoided at save time, not just merged here.** `IMemoryDeduplicator` compares
+an incoming entry against the live corpus before writing it, and reinforces or extends the
+matching entry instead of creating a near-copy — see [memory.md](memory.md). Consolidation is
+still the backstop for duplicates that are worded too differently to match, but it is no longer
+the only thing standing between the corpus and unbounded growth. The save-time cosine threshold
+(`Memory:DedupeSimilarityThreshold`) is deliberately the same 0.88 as
+`Dream:ConsolidationSimilarityThreshold`: anything caught at save time would have been clustered
+as a near-duplicate here anyway. Keep them aligned when tuning either.
 
 **Candidate gating — what the LLM is allowed to see.** An entry becomes eligible only if it
 is (a) new or changed since its last review, or (b) part of a near-duplicate cluster. Anything
@@ -188,6 +215,17 @@ missing the merge is rejected outright: nothing is saved and the sources are lef
 is what catches the characteristic failure, a plausible-reading merge that keeps the
 machine-readable half of an entry and quietly drops a name or a date.
 
+**A rejected merge gets one repair attempt.** Rejection alone left the duplicate cluster in
+place, so the next cycle proposed the same merge and the check rejected it the same way — a live
+corpus rejected one six-source merge five times in eight cycles, and every one of those cycles
+spent a merge slot on it. When `Dream:MergeRepairEnabled` is set (default true), the pass makes a
+second, much narrower LLM call: here is the merged text, here are the sources, here are the exact
+strings you dropped, put them back. The revision faces the same coverage check, so a bad repair
+lands exactly where the rejection would have and the sources are still kept. Attempts are capped
+at `Dream:MergeRepairMaxPerCycle` (default 10) so a cycle that merges badly across the board
+cannot become an unbounded run of calls. Repairs are logged at Information
+(`repaired merge of [...] — restored N specific(s)`) and counted in the safeguards line.
+
 **Vocabulary is per-deployment.** Which capitalized words count as ordinary language rather
 than as detail is not portable between agents, so it lives in
 `merge-coverage-vocabulary.json` on the agent profile volume (next to `tier-selector.json`),
@@ -195,8 +233,9 @@ re-read at the top of every cycle:
 
 ```json
 {
-  "extraCommonWords":    ["briefing", "triage"],
-  "alwaysSpecificWords": ["May", "Will", "Rose"]
+  "extraCommonWords":        ["briefing", "triage"],
+  "alwaysSpecificWords":     ["May", "Will", "Rose"],
+  "numericExemptCategories": ["metrics/cost"]
 }
 ```
 
@@ -238,7 +277,26 @@ day and year intact. Two guards keep it narrow: the month must appear adjacent t
 date carries a year the numeric date must carry the same one. A merge that drops the date in
 both spellings is still rejected.
 
-Note the shape of both fixes: they widen what counts as *covering* a specific rather than
+**Corpus evidence beats position.** A word the merge's own sources also write in all-lowercase
+form is ordinary language wherever else it is capitalized. *"Marking a task complete"* reads as a
+proper noun mid-phrase, but a sibling source says *"marking"*; *"Contact IDs are account-scoped"*
+is followed by *"the contact ids"*. Both rejected the same clusters cycle after cycle. The
+evidence is the text itself rather than a curated list, so it cannot unprotect a name that never
+appears lowercase — Eventbrite, Xebia and Austin stay required — and `alwaysSpecificWords` still
+overrides it, which is the escape hatch for a character whose name is also an ordinary word in
+the same prose.
+
+**Numbers can be exempted by category.** Some entries restate figures the agent recomputes from
+telemetry every cycle — routing averages, cost ratios, call counts. By the time a merge is
+proposed the number has already moved, so demanding it verbatim rejects the same cluster forever
+to preserve a value nobody wants preserved. `numericExemptCategories` names the categories where
+numbers are not required to survive; `anti-patterns/routing` is built in and cannot be removed.
+Matching is segment-aware (`anti-patterns/routing` covers `anti-patterns/routing/high-tier` but
+not `anti-patterns/routing-notes`). The exemption skips the whole numeric check for those
+entries, **dates included** — a month-name date is still caught by the capitalized-word pass, a
+bare `2026-08-19` is not — so only list categories whose numbers are genuinely disposable.
+
+Note the shape of these fixes: they widen what counts as *covering* a specific rather than
 removing the requirement. Adding a word to a common list unprotects it everywhere, permanently;
 an equivalence can only be satisfied by an equivalent form actually being present. Prefer the
 latter — a false rejection is not one wasted merge but a duplicate cluster that re-proposes and
@@ -260,6 +318,19 @@ something to do on one model's say-so to an entry the agent has re-observed doze
 This is a deterministic floor precisely because the prompt-level version did not hold —
 `dream.md` already said reinforcement signals importance, and a live corpus still lost entries
 reinforced 214, 106 and 80 times.
+
+**Per-cycle summary line.** A completed pass logs one Information line carrying the numbers that
+say whether the corpus is converging or churning:
+
+```
+DreamService: consolidation summary — live 828, reviewed 61, created since last run 14,
+merged 3, repaired 1, rejected 2, ephemeral 5, protected 4
+```
+
+Before this, "828 live entries, 885 archived by merge over 24 days" had to be reconstructed off
+the volume after the fact. `created since last run` counts entries whose `CreatedAt` postdates
+the previous completed pass, which is the figure that shows whether save-time deduplication is
+working.
 
 **Provenance.** Merged entries carry `mergedFrom` (source IDs) and `mergedAt` in metadata.
 Source text is not duplicated: the sources are archived rather than deleted, so those IDs
@@ -480,6 +551,11 @@ public sealed class DreamOptions
     public bool DreamPassChangeGateEnabled { get; set; } = true;
     public TimeSpan DreamPassMaxSkipInterval { get; set; } = TimeSpan.FromDays(7);
     public TimeSpan TierRoutingReviewWindow { get; set; } = TimeSpan.FromDays(14);
+
+    // Memory consolidation (Pass 1)
+    public TimeSpan ConsolidationMinInterval { get; set; } = TimeSpan.FromHours(6);
+    public bool MergeRepairEnabled { get; set; } = true;
+    public int MergeRepairMaxPerCycle { get; set; } = 10;
 
     // Append-only JSONL log retention (Pass 0)
     public bool LogRetentionEnabled { get; set; } = true;

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -50,9 +50,9 @@ evolved, and they are used by the consolidation pass and by search-result format
 | Field | Meaning | When it advances |
 |---|---|---|
 | `CreatedAt` | First-seen agent-time | Set on entry creation; carried forward to `min(sources)` on merge |
-| `LastSeenAt` | Last reinforcement — last time a fresh save-event produced content that merged into this fact | Set to `max(sources.LastSeenAt)` on merge; bumped to `now` on episode reinforcement; **not** bumped on dream rephrasing, importance decay, or other record edits |
-| `UpdatedAt` | Record last rewritten | Bumped on any edit, including pure rephrasing |
-| `ReinforcementCount` | Count of distinct observations consolidated into this entry | Starts at 1; summed across sources on merge; incremented by 1 on episode reinforcement |
+| `LastSeenAt` | Last reinforcement — last time a fresh save-event produced content that merged into this fact | Set to `max(sources.LastSeenAt)` on merge; bumped to `now` on episode reinforcement **and on save-time reinforcement**; **not** bumped on dream rephrasing, importance decay, or other record edits |
+| `UpdatedAt` | Record last rewritten | Bumped on any edit, including pure rephrasing. Deliberately **not** bumped by a save-time reinforcement, which changes no text |
+| `ReinforcementCount` | Count of distinct observations consolidated into this entry | Starts at 1; summed across sources on merge; incremented by 1 on episode reinforcement **and on save-time reinforcement** |
 
 A 5×-reinforced-over-2-years entry is treated differently from a one-off — both by the
 dream LLM (see the "Temporal merging rules" section in `dream.md`) and by search
@@ -231,7 +231,7 @@ acting as actionable constraints during inference.
 |---|---|
 | `save_memory(content, category?, tags?)` | Queue a memory for background enrichment and save |
 | `search_memory(query?, category?, mode?)` | Hybrid/regex search with an optional category prefix filter; omit `query` to browse and get the category taxonomy |
-| `delete_memory(id)` | Remove a specific entry |
+| `delete_memory(id)` | Archive an entry (recoverable until purge) |
 | `update_memory_importance(id, importance)` | Re-score an existing entry |
 
 There is no separate list-categories tool. Calling `search_memory` without a `query`
@@ -240,9 +240,46 @@ taxonomy, so `search_memory()` alone answers "how is knowledge organized here?".
 taxonomy is appended even when the search matched nothing, so a `category` filter that
 misses still shows what categories do exist.
 
+`delete_memory` archives rather than hard-deletes. The model reaches it on its own judgement
+about a fact it usually cannot re-derive, so being wrong costs recall until someone notices
+rather than costing the fact; the dream archive purge does the real deleting, on a 90-day delay.
+The tool result says so, in the hope the model stops treating deletion as free.
+
 When `save_memory` is called, a background task calls the LLM to expand the raw content into
 focused, well-formed memory entries (the expansion prompt is in `memory-rules.md`). The
 original content is saved immediately; expansion never blocks the response.
+
+#### Save-time deduplication
+
+Nothing on the save path used to look for a near-duplicate before writing, so the same fact
+restated across sessions produced a fresh entry every time and `ReinforcementCount` was raised
+only by episode extraction and by merges summing their sources. An entry reading "reinforced
+243×" had in fact been saved fresh 243 times. The corpus grew from 290 to 828 live entries in 24
+days while consolidation archived 885 — churn, not convergence.
+
+`IMemoryDeduplicator` closes that. Before writing, it asks the store for the live entry the
+candidate most resembles (`IMemorySimilarityLookup` — cosine over embeddings where available,
+Jaccard over content tokens otherwise, scoped to the same top-level category) and then decides
+with the same coverage check dream consolidation uses for a merge:
+
+| Situation | Result |
+|---|---|
+| No match, or below the threshold | **Created** — saved as its own entry |
+| Match, and it already carries every specific the candidate does | **Reinforced** — `LastSeenAt`, `ReinforcementCount`, importance and tags move; the text does not |
+| Match, but the candidate carries new specifics | **Extended** — the new text is appended, `UpdatedAt` bumped |
+| Extending would exceed `DedupeMaxExtendedContentLength` | **Created** — so one busy topic cannot accrete into a hundred-paragraph entry |
+
+Reinforcement deliberately leaves `UpdatedAt` alone: it anchors importance decay and, through
+the content hash, the consolidation-reviewed stamp, so a write that changed no text must not
+stall decay or re-open a settled entry. An extend does change the text, and correctly re-opens it.
+
+Scoped categories bypass deduplication entirely — `feedback/*` is owned by the contradiction
+detector and `claim/capability/*` by the verifier, and both reason about individual ids.
+Consolidation still runs as the backstop for duplicates worded too differently to match here.
+
+Routed through it: the `save_memory` background path, dream memory mining, and dream
+tool-success learning — the three places that mint new facts. Merges, identity reflection and
+consolidation writes are not, because they carry their own ids and provenance.
 
 ---
 
@@ -506,6 +543,12 @@ The conversation log is cleared after this pass regardless of LLM success or fai
 public sealed class MemoryOptions
 {
     public string BasePath { get; set; } = "memory";   // Relative to agent data path
+
+    // Save-time deduplication
+    public bool DedupeEnabled { get; set; } = true;
+    public double DedupeSimilarityThreshold { get; set; } = 0.88;        // cosine; keep aligned with Dream:ConsolidationSimilarityThreshold
+    public double DedupeLexicalSimilarityThreshold { get; set; } = 0.6;  // Jaccard; a different scale, hence a different number
+    public int DedupeMaxExtendedContentLength { get; set; } = 2000;
 }
 
 // Working memory

--- a/src/RockBot.Agent/agent/merge-coverage-vocabulary.json
+++ b/src/RockBot.Agent/agent/merge-coverage-vocabulary.json
@@ -16,6 +16,13 @@
   // date, so a merge that only re-spells one is credited -- while a bare "August" outside a date
   // expression stays fully protected.
   //
+  // CORPUS EVIDENCE. A word the merge's own sources also write in all-lowercase form is treated
+  // as ordinary language wherever else it is capitalized -- "Marking a task complete" alongside
+  // a sibling saying "marking", "Contact IDs" alongside "the contact ids". The evidence is the
+  // text itself, so this can never unprotect a name that only ever appears capitalized
+  // (Eventbrite, Xebia, Austin). "alwaysSpecificWords" below still overrides it, which is the
+  // escape hatch for a person or character whose name is also an ordinary word in the same prose.
+  //
   // Re-read at the top of every dream cycle — no restart needed. If this file is malformed the
   // built-in list is used and a warning is logged; coverage checking is never disabled.
 
@@ -31,11 +38,28 @@
   // only what is noise mid-phrase too, and prefer alwaysSpecificWords for anything load-bearing.
   "extraCommonWords": [],
 
-  // Words to ALWAYS treat as specifics, overriding the built-in list.
+  // Words to ALWAYS treat as specifics, overriding the built-in list AND the corpus-evidence
+  // rule above.
   //
   // This matters most for agents whose people or characters collide with ordinary English.
   // The built-in list contains "may", "will", "some", "first", "last", "new" and similar, so a
   // storytelling agent with a character named May, Will, Rose, Grace or Hope MUST list them
   // here — otherwise those names carry no coverage protection and a merge can drop them.
-  "alwaysSpecificWords": []
+  "alwaysSpecificWords": [],
+
+  // Categories whose NUMBERS are not required to survive a merge.
+  //
+  // Some entries restate figures the agent recomputes from telemetry every cycle — routing
+  // averages, cost ratios, call counts. By the time a merge is proposed the number has already
+  // moved, so demanding it verbatim rejects the same cluster on every cycle to preserve a value
+  // nobody wants preserved. Matching is segment-aware: "anti-patterns/routing" also covers
+  // "anti-patterns/routing/high-tier" but not "anti-patterns/routing-notes".
+  //
+  // The exemption skips the whole numeric check for those entries, DATES INCLUDED. A date written
+  // with a month name is still picked up as a capitalized word; a bare "2026-08-19" in an exempt
+  // category is not. Only list categories whose numbers are genuinely disposable.
+  //
+  // "anti-patterns/routing" is built in and cannot be removed here; entries listed are added to
+  // it. Names are matched case-insensitively and leading/trailing slashes are ignored.
+  "numericExemptCategories": []
 }

--- a/src/RockBot.Host.Abstractions/ArchivePurgeResult.cs
+++ b/src/RockBot.Host.Abstractions/ArchivePurgeResult.cs
@@ -1,0 +1,8 @@
+namespace RockBot.Host;
+
+/// <summary>Outcome of an archive retention purge.</summary>
+/// <param name="Purged">Entries hard-deleted.</param>
+/// <param name="Kept">
+/// Entries old enough to purge that a caller-supplied predicate held back.
+/// </param>
+public sealed record ArchivePurgeResult(int Purged, int Kept);

--- a/src/RockBot.Host.Abstractions/DreamOptions.cs
+++ b/src/RockBot.Host.Abstractions/DreamOptions.cs
@@ -244,6 +244,45 @@ public sealed class DreamOptions
     public int PruningProtectionReinforcementCount { get; set; } = 5;
 
     /// <summary>
+    /// Shortest time between two consolidation passes that actually review the corpus. A pass
+    /// reached sooner than this logs and returns without calling the LLM. Set to
+    /// <see cref="TimeSpan.Zero"/> to disable the floor. Default: 6 hours.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A dream cycle fires <see cref="InitialDelay"/> after every process start as well as on
+    /// <see cref="CronSchedule"/>, so consolidation cadence tracks the deploy schedule rather
+    /// than the corpus: ten deploys over three days produced about fifteen cycles, and 121
+    /// archives in one of those days. Every one of those passes re-asked the same questions
+    /// about the same entries.
+    /// </para>
+    /// <para>
+    /// Measured from the last <em>completed</em> pass, recorded in the dream pass ledger on the
+    /// agent profile volume, so it survives the restarts it exists to absorb.
+    /// </para>
+    /// </remarks>
+    public TimeSpan ConsolidationMinInterval { get; set; } = TimeSpan.FromHours(6);
+
+    /// <summary>
+    /// Whether a merge rejected by the coverage check gets one repair attempt — a second LLM
+    /// call naming the exact specifics it dropped. Default: <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    /// Without it a rejection is terminal and the cluster is re-proposed, re-merged and
+    /// re-rejected on every subsequent cycle: a live corpus rejected one six-source merge five
+    /// times in eight cycles. The repair call is a narrow, mechanical task — put these strings
+    /// back — and its output faces the same coverage check, so a failed repair costs one call
+    /// and lands exactly where the rejection would have.
+    /// </remarks>
+    public bool MergeRepairEnabled { get; set; } = true;
+
+    /// <summary>
+    /// Ceiling on repair attempts per consolidation pass, so a cycle that rejects everything
+    /// cannot turn into an unbounded run of LLM calls. Default: 10.
+    /// </summary>
+    public int MergeRepairMaxPerCycle { get; set; } = 10;
+
+    /// <summary>
     /// Path to the merge-coverage vocabulary file, relative to
     /// <see cref="AgentProfileOptions.BasePath"/>. Re-read at the top of every dream cycle, so
     /// edits take effect without a restart. When absent, a generic-English baseline is used.
@@ -255,16 +294,18 @@ public sealed class DreamOptions
     /// operational assistant can safely ignore are not the words a storytelling agent can.
     /// </para>
     /// <para>
-    /// Shape — both fields optional:
+    /// Shape — all fields optional:
     /// <code>
     /// {
-    ///   "extraCommonWords":    ["briefing", "triage"],
-    ///   "alwaysSpecificWords": ["May", "Will", "Rose"]
+    ///   "extraCommonWords":        ["briefing", "triage"],
+    ///   "alwaysSpecificWords":     ["May", "Will", "Rose"],
+    ///   "numericExemptCategories": ["metrics/cost"]
     /// }
     /// </code>
     /// <c>alwaysSpecificWords</c> takes precedence, and matters most for agents whose characters
     /// or people collide with ordinary English — without it, a character named May or Will is
-    /// silently stripped of coverage protection.
+    /// silently stripped of coverage protection. <c>numericExemptCategories</c> names categories
+    /// whose numbers are re-derived from telemetry each cycle and so need not survive a merge.
     /// </para>
     /// </remarks>
     public string MergeCoverageVocabularyPath { get; set; } = "merge-coverage-vocabulary.json";

--- a/src/RockBot.Host.Abstractions/IArchivedMemoryMaintenance.cs
+++ b/src/RockBot.Host.Abstractions/IArchivedMemoryMaintenance.cs
@@ -22,8 +22,23 @@ public interface IArchivedMemoryMaintenance
 
     /// <summary>
     /// Hard-deletes archived entries older than <paramref name="retention"/>, measured from
-    /// <see cref="MemoryEntry.ArchivedAt"/>. Returns the number purged. A non-positive
-    /// retention disables purging so archived entries are kept indefinitely.
+    /// <see cref="MemoryEntry.ArchivedAt"/>. A non-positive retention disables purging so
+    /// archived entries are kept indefinitely.
     /// </summary>
-    Task<int> PurgeArchivedAsync(TimeSpan retention, CancellationToken cancellationToken = default);
+    /// <param name="retention">How long an archived entry is kept before it may be purged.</param>
+    /// <param name="keep">
+    /// Optional veto over an entry that is otherwise due. Entries it accepts are left on disk and
+    /// counted as kept.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <remarks>
+    /// The purge is the one place left that hard-deletes memory, so it is also the last place a
+    /// value judgement can be applied. Callers pass the same high-value floor that stops
+    /// consolidation pruning an entry outright — an entry archived by a merge nobody reviewed is
+    /// exactly the one worth keeping recoverable past the retention window.
+    /// </remarks>
+    Task<ArchivePurgeResult> PurgeArchivedAsync(
+        TimeSpan retention,
+        Func<MemoryEntry, bool>? keep = null,
+        CancellationToken cancellationToken = default);
 }

--- a/src/RockBot.Host.Abstractions/ILongTermMemory.cs
+++ b/src/RockBot.Host.Abstractions/ILongTermMemory.cs
@@ -54,9 +54,11 @@ public interface ILongTermMemory
     /// Deletes a memory entry by ID. No-op if not found.
     /// </summary>
     /// <remarks>
-    /// This is a hard delete with no recovery path. Automated housekeeping should call
-    /// <see cref="ArchiveAsync"/> instead and leave hard deletion to the retention purge
-    /// and to explicit user-driven removal.
+    /// This is a hard delete with no recovery path. Only the retention purge should call it.
+    /// Every other removal — consolidation, identity reflection, the agent's own delete tool,
+    /// capability-claim eviction, aged observation theories — goes through
+    /// <see cref="ArchiveAsync"/>, so a wrong automated judgement costs recall until someone
+    /// notices rather than costing the fact.
     /// </remarks>
     Task DeleteAsync(string id, CancellationToken cancellationToken = default);
 

--- a/src/RockBot.Host.Abstractions/IMemoryDeduplicator.cs
+++ b/src/RockBot.Host.Abstractions/IMemoryDeduplicator.cs
@@ -1,0 +1,59 @@
+namespace RockBot.Host;
+
+/// <summary>What a save actually did to the corpus.</summary>
+public enum MemorySaveAction
+{
+    /// <summary>A new entry was written.</summary>
+    Created,
+
+    /// <summary>An existing entry already carried the fact; its reinforcement was raised.</summary>
+    Reinforced,
+
+    /// <summary>An existing entry carried most of the fact; the new specifics were appended.</summary>
+    Extended,
+}
+
+/// <summary>Outcome of a deduplicated save.</summary>
+/// <param name="Action">What happened.</param>
+/// <param name="Id">Id of the entry that now holds the fact — the new one, or the one reinforced.</param>
+/// <param name="Similarity">Score against the matched entry, when one was matched.</param>
+/// <param name="Measure">Which measure produced <paramref name="Similarity"/>.</param>
+public sealed record MemorySaveOutcome(
+    MemorySaveAction Action,
+    string Id,
+    double? Similarity = null,
+    MemorySimilarityMeasure? Measure = null);
+
+/// <summary>
+/// Save path that reinforces an existing entry rather than adding a near-copy of it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The corpus this was built for grew from 290 to 828 live entries in 24 days while
+/// consolidation archived 885 — the same duplicate clusters proposed, merged, re-created and
+/// proposed again. Deduplicating at save time is the root fix: consolidation can only ever
+/// clean up duplicates that already exist, and it costs an LLM call per cycle to do it.
+/// </para>
+/// <para>
+/// Deliberately not part of <see cref="ILongTermMemory"/>. Some writes must land verbatim —
+/// merges carry their own ids and provenance, identity reflection rewrites its own entries,
+/// contradiction resolution supersedes rather than merges — so this is a decision each caller
+/// opts into, not a behaviour every <c>SaveAsync</c> inherits.
+/// </para>
+/// </remarks>
+public interface IMemoryDeduplicator
+{
+    /// <summary>
+    /// Saves <paramref name="candidate"/>, or folds it into the live entry that already carries
+    /// the same fact.
+    /// </summary>
+    /// <remarks>
+    /// Folding takes one of two forms. When the existing entry already contains every specific
+    /// the candidate carries, the candidate adds nothing but evidence, so only the reinforcement
+    /// counters move. When it carries new specifics, they are appended rather than discarded —
+    /// the alternative is a silent loss, which is the failure this whole area exists to prevent.
+    /// </remarks>
+    Task<MemorySaveOutcome> SaveOrReinforceAsync(
+        MemoryEntry candidate,
+        CancellationToken cancellationToken = default);
+}

--- a/src/RockBot.Host.Abstractions/IMemorySimilarityLookup.cs
+++ b/src/RockBot.Host.Abstractions/IMemorySimilarityLookup.cs
@@ -1,0 +1,62 @@
+namespace RockBot.Host;
+
+/// <summary>How a similarity score was computed, which is what its scale means.</summary>
+public enum MemorySimilarityMeasure
+{
+    /// <summary>Cosine similarity over embedding vectors.</summary>
+    Embedding,
+
+    /// <summary>Jaccard overlap over content tokens — the fallback where embeddings are absent.</summary>
+    Lexical,
+}
+
+/// <summary>The live entry most similar to a candidate, and how similar it is.</summary>
+/// <param name="Entry">The existing entry.</param>
+/// <param name="Score">Similarity in 0..1, on the scale named by <paramref name="Measure"/>.</param>
+/// <param name="Measure">Which measure produced <paramref name="Score"/>.</param>
+public sealed record MemorySimilarityMatch(
+    MemoryEntry Entry,
+    double Score,
+    MemorySimilarityMeasure Measure);
+
+/// <summary>
+/// Optional capability for stores that can name the single existing entry a candidate most
+/// resembles, so a save can reinforce what is already there instead of adding a near-copy.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Nothing on the save path ever looked for a near-duplicate before writing. Reinforcement was
+/// raised only by episode extraction and by merges summing their sources, so an entry the live
+/// corpus had "reinforced 243 times" had in fact been saved fresh 243 times and merged back
+/// together afterwards. Consolidation was left doing the deduplication that the save should
+/// have avoided needing, twice a day, forever.
+/// </para>
+/// <para>
+/// Separate from <see cref="ILongTermMemory"/> for the same reason as
+/// <see cref="IMemoryDuplicateCandidates"/>: only the store knows whether it has embeddings, and
+/// a store that has neither them nor a lexical fallback should be able to decline rather than
+/// answer badly. Callers probe for it and save unconditionally when it is absent.
+/// </para>
+/// </remarks>
+public interface IMemorySimilarityLookup
+{
+    /// <summary>
+    /// Returns the live entry most similar to <paramref name="candidate"/>, or <c>null</c> when
+    /// there is nothing comparable to it.
+    /// </summary>
+    /// <param name="candidate">
+    /// The entry about to be saved. Passed whole rather than as text because implementations
+    /// that use embeddings must build the query from the same surface their cached vectors were
+    /// built from — content plus tags plus category words, not content alone.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <remarks>
+    /// Implementations should compare only entries that could actually be reinforced: live
+    /// (neither archived nor superseded), not the candidate itself, and in the same broad
+    /// subject area, so a lexical fallback cannot pair a user preference with an infrastructure
+    /// note that happens to share vocabulary.
+    /// </remarks>
+    Task<MemorySimilarityMatch?> FindMostSimilarAsync(
+        MemoryEntry candidate,
+        CancellationToken cancellationToken = default);
+}

--- a/src/RockBot.Host.Abstractions/MemoryOptions.cs
+++ b/src/RockBot.Host.Abstractions/MemoryOptions.cs
@@ -12,4 +12,52 @@ public sealed class MemoryOptions
     /// When absolute, used directly.
     /// </summary>
     public string BasePath { get; set; } = "memory";
+
+    /// <summary>
+    /// Whether a save looks for an existing near-duplicate and reinforces it instead of writing
+    /// a second copy. Defaults to <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    /// Turning this off restores the pre-deduplication behaviour: every save creates an entry
+    /// and dream consolidation is left to merge the duplicates back together afterwards. Only
+    /// worth doing to isolate a suspected mis-match, since the cost is a corpus that grows
+    /// without converging.
+    /// </remarks>
+    public bool DedupeEnabled { get; set; } = true;
+
+    /// <summary>
+    /// Cosine similarity at or above which an incoming entry is folded into the existing one it
+    /// matched. Defaults to 0.88.
+    /// </summary>
+    /// <remarks>
+    /// Keep this aligned with <c>DreamOptions.ConsolidationSimilarityThreshold</c>. The two
+    /// answer the same question at different times: anything caught here would have been
+    /// clustered as a near-duplicate by consolidation anyway, so a save-time threshold looser
+    /// than consolidation's folds entries consolidation would not have touched, and a tighter
+    /// one leaves work for consolidation that the save could have avoided creating.
+    /// </remarks>
+    public double DedupeSimilarityThreshold { get; set; } = 0.88;
+
+    /// <summary>
+    /// Jaccard overlap at or above which an incoming entry is folded, on stores with no
+    /// embeddings. Defaults to 0.6.
+    /// </summary>
+    /// <remarks>
+    /// A different scale from the cosine threshold and necessarily a lower number: token overlap
+    /// of 3 shared words out of 4, or 4 out of 6, is a restatement; 3 out of 7 is not. The gap
+    /// between the two figures is not a discrepancy to tidy up. A rephrasing that shares little
+    /// vocabulary is deliberately left to consolidation, which has an LLM to judge it with.
+    /// </remarks>
+    public double DedupeLexicalSimilarityThreshold { get; set; } = 0.6;
+
+    /// <summary>
+    /// Longest combined content, in characters, that may be produced by appending new specifics
+    /// to a matched entry. Past this the candidate is saved as its own entry. Defaults to 2000.
+    /// </summary>
+    /// <remarks>
+    /// Without a ceiling, a topic the agent revisits constantly accretes into one entry that
+    /// keeps matching itself — a single "Blazor Online Class" record a hundred paragraphs long,
+    /// which recall then surfaces in full for any question that brushes the subject.
+    /// </remarks>
+    public int DedupeMaxExtendedContentLength { get; set; } = 2000;
 }

--- a/src/RockBot.Host.Abstractions/MemorySaveTally.cs
+++ b/src/RockBot.Host.Abstractions/MemorySaveTally.cs
@@ -1,0 +1,28 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Counts what a batch of deduplicated saves actually did, so a pass can report "3 saved,
+/// 5 reinforced" instead of "8 entries saved" when five of them created nothing.
+/// </summary>
+public sealed class MemorySaveTally
+{
+    public int Saved { get; private set; }
+    public int Reinforced { get; private set; }
+    public int Extended { get; private set; }
+
+    public void Record(MemorySaveOutcome outcome)
+    {
+        switch (outcome.Action)
+        {
+            case MemorySaveAction.Reinforced:
+                Reinforced++;
+                break;
+            case MemorySaveAction.Extended:
+                Extended++;
+                break;
+            default:
+                Saved++;
+                break;
+        }
+    }
+}

--- a/src/RockBot.Host/AgentContextBuilder.cs
+++ b/src/RockBot.Host/AgentContextBuilder.cs
@@ -776,7 +776,10 @@ public sealed class AgentContextBuilder(
                         entry.Id, entry.Category);
                     try
                     {
-                        await longTermMemory.DeleteAsync(entry.Id, ct);
+                        // Archive rather than delete: the verifier decides on one probe run at
+                        // context-build time, and a probe can fail for reasons that have nothing
+                        // to do with the claim being wrong.
+                        await longTermMemory.ArchiveAsync(entry.Id, "falsified by capability verifier", ct);
                     }
                     catch (Exception delEx)
                     {

--- a/src/RockBot.Host/AgentMemoryExtensions.cs
+++ b/src/RockBot.Host/AgentMemoryExtensions.cs
@@ -57,6 +57,11 @@ public static class AgentMemoryExtensions
         builder.Services.TryAddSingleton<EmbeddingTextPreparer>();
         builder.Services.AddSingleton<ILongTermMemory, FileMemoryStore>();
 
+        // Save-time deduplication. Callers that want it take IMemoryDeduplicator optionally and
+        // fall back to SaveAsync, so registering it here changes behaviour without changing any
+        // signature a host or test has to satisfy.
+        builder.Services.AddSingleton<IMemoryDeduplicator, MemoryDeduplicator>();
+
         // Phase 2 self-repair: capability-claim writer and read-side verifier.
         // Both are internal services — not exposed as LLM tools.
         builder.Services.AddSingleton<ICapabilityClaimWriter, CapabilityClaimWriter>();

--- a/src/RockBot.Host/DreamService.cs
+++ b/src/RockBot.Host/DreamService.cs
@@ -53,6 +53,7 @@ internal sealed class DreamService : IHostedService, IDisposable
     private readonly RepairTicketOptions? _repairOptions;
     private readonly IReadOnlyList<IToolSkillProvider> _toolSkillProviders;
     private readonly IReadOnlyList<IPrunableLog> _prunableLogs;
+    private readonly IMemoryDeduplicator? _memoryDeduplicator;
     private Timer? _timer;
     private CronExpression? _cron;
     private string? _dreamDirective;
@@ -109,7 +110,8 @@ internal sealed class DreamService : IHostedService, IDisposable
         IOptions<RepairTicketOptions>? repairOptions = null,
         IEnumerable<IToolSkillProvider>? toolSkillProviders = null,
         TieredChatClientRegistry? tieredRegistry = null,
-        IEnumerable<IPrunableLog>? prunableLogs = null)
+        IEnumerable<IPrunableLog>? prunableLogs = null,
+        IMemoryDeduplicator? memoryDeduplicator = null)
     {
         _memory = memory;
         _skillStore = skillStores.FirstOrDefault();
@@ -147,6 +149,26 @@ internal sealed class DreamService : IHostedService, IDisposable
         }
         _toolSkillProviders = toolSkillProviders?.ToList() ?? (IReadOnlyList<IToolSkillProvider>)Array.Empty<IToolSkillProvider>();
         _prunableLogs = prunableLogs?.ToList() ?? (IReadOnlyList<IPrunableLog>)Array.Empty<IPrunableLog>();
+        _memoryDeduplicator = memoryDeduplicator;
+    }
+
+    /// <summary>
+    /// Saves through the deduplicator when one is registered, so a mined fact the corpus already
+    /// holds reinforces that entry instead of adding a near-copy for the next consolidation pass
+    /// to merge away.
+    /// </summary>
+    /// <remarks>
+    /// Only the passes that mint genuinely new facts route through here. Merges, identity
+    /// reflection and consolidation writes carry their own ids and provenance and must land
+    /// exactly as written.
+    /// </remarks>
+    private async Task<MemorySaveOutcome> SaveOrReinforceAsync(MemoryEntry entry, CancellationToken ct)
+    {
+        if (_memoryDeduplicator is not null)
+            return await _memoryDeduplicator.SaveOrReinforceAsync(entry, ct);
+
+        await _memory.SaveAsync(entry, ct);
+        return new MemorySaveOutcome(MemorySaveAction.Created, entry.Id);
     }
 
     public Task StartAsync(CancellationToken cancellationToken)
@@ -224,30 +246,7 @@ internal sealed class DreamService : IHostedService, IDisposable
         // a storytelling agent disagree about which capitalized words are ordinary language, and
         // getting it wrong in the storytelling direction strips coverage from character names.
         var vocabularyPath = ResolvePath(_options.MergeCoverageVocabularyPath, _profileOptions.BasePath);
-        if (File.Exists(vocabularyPath))
-        {
-            _mergeVocabulary = MergeCoverageVocabulary.Parse(File.ReadAllText(vocabularyPath), out var vocabError);
-            if (vocabError is not null)
-                _logger.LogWarning(
-                    "DreamService: {Path} is malformed ({Error}); using the built-in vocabulary",
-                    vocabularyPath, vocabError);
-            else
-                // Information, matching the per-cycle directive reload above: this file decides
-                // what a merge is allowed to drop, and an operator tuning it needs to see that
-                // their edit was picked up without raising the whole namespace to Debug.
-                _logger.LogInformation(
-                    "DreamService: merge-coverage vocabulary from {Path} — {Common} common words, {Specific} reclaimed as specifics{Reclaimed}",
-                    vocabularyPath,
-                    _mergeVocabulary.CommonWordCount,
-                    _mergeVocabulary.AlwaysSpecificWords.Count,
-                    _mergeVocabulary.AlwaysSpecificWords.Count > 0
-                        ? " (" + string.Join(", ", _mergeVocabulary.AlwaysSpecificWords) + ")"
-                        : string.Empty);
-        }
-        else
-        {
-            _mergeVocabulary = MergeCoverageVocabulary.Default;
-        }
+        _mergeVocabulary = MergeCoverageVocabularyFile.Load(vocabularyPath, _logger);
 
         var directivePath = ResolvePath(_options.DirectivePath, _profileOptions.BasePath);
         var dreamDirective = File.Exists(directivePath)
@@ -712,9 +711,16 @@ internal sealed class DreamService : IHostedService, IDisposable
 
     /// <summary>
     /// Hard-deletes memory entries archived longer ago than
-    /// <see cref="DreamOptions.MemoryArchiveRetention"/>. No-op when the store has no archive
-    /// tier or retention is disabled.
+    /// <see cref="DreamOptions.MemoryArchiveRetention"/>, except those above the high-value
+    /// floor. No-op when the store has no archive tier or retention is disabled.
     /// </summary>
+    /// <remarks>
+    /// This is the only remaining path that destroys long-term memory, so the same floor that
+    /// stops consolidation pruning a high-value entry outright applies here too. Note that
+    /// importance is frozen at archive time and never decays afterwards, so in practice it is the
+    /// reinforcement half of the floor that does the work — an entry observed dozens of times and
+    /// then archived by an unreviewed merge is exactly what should outlive the retention window.
+    /// </remarks>
     private async Task RunArchivePurgePassAsync(CancellationToken ct)
     {
         if (_memory is not IArchivedMemoryMaintenance maintenance)
@@ -725,11 +731,16 @@ internal sealed class DreamService : IHostedService, IDisposable
 
         await RunPassAsync("archive purge", async () =>
         {
-            var purged = await maintenance.PurgeArchivedAsync(_options.MemoryArchiveRetention, ct);
-            if (purged > 0)
+            var result = await maintenance.PurgeArchivedAsync(
+                _options.MemoryArchiveRetention,
+                e => IsProtectedFromPruning(e, _options),
+                ct);
+
+            if (result.Purged > 0 || result.Kept > 0)
                 _logger.LogInformation(
-                    "DreamService: archive purge — {Count} entries archived over {Days:F0} days ago permanently deleted",
-                    purged, _options.MemoryArchiveRetention.TotalDays);
+                    "DreamService: archive purge — {Purged} purged, {Kept} kept above the high-value floor " +
+                    "(archived over {Days:F0} days ago)",
+                    result.Purged, result.Kept, _options.MemoryArchiveRetention.TotalDays);
         });
     }
 
@@ -918,7 +929,7 @@ internal sealed class DreamService : IHostedService, IDisposable
     /// pass including memory mining. That deadlocked a fresh agent, whose memory store
     /// only becomes non-empty once mining has run.
     /// </remarks>
-    private async Task<(int Deleted, int Saved)> RunMemoryConsolidationPassAsync(CancellationToken ct)
+    internal async Task<(int Deleted, int Saved)> RunMemoryConsolidationPassAsync(CancellationToken ct)
     {
         if (!_options.MemoryConsolidationEnabled)
         {
@@ -954,6 +965,28 @@ internal sealed class DreamService : IHostedService, IDisposable
                 withheld, all.Count);
             return (0, 0);
         }
+
+        // A dream cycle fires five minutes after every process start, so a day of deploys is a
+        // day of consolidation passes — ten restarts across three days produced roughly fifteen
+        // cycles and 121 archives in a single day. Nothing about the corpus justified that
+        // cadence; the deploy schedule did. The ledger already knows when this pass last
+        // completed, so the fix is to consult it.
+        if (_passLedger is not null && _options.ConsolidationMinInterval > TimeSpan.Zero)
+        {
+            var record = _passLedger.Get(ConsolidationLedgerPassName);
+            if (DreamPassLedger.ShouldSkip(
+                    record, ConsolidationLedgerFingerprint, _clock.Now, _options.ConsolidationMinInterval))
+            {
+                _logger.LogInformation(
+                    "DreamService: memory consolidation skipped — last completed {Age:g} ago, minimum interval {Interval:g}",
+                    _clock.Now - record!.LastRunAt, _options.ConsolidationMinInterval);
+                return (0, 0);
+            }
+        }
+
+        // Read before the pass records its own completion below, so "created since last run" is
+        // measured against the previous run rather than against this one.
+        var previousRunAt = _passLedger?.Get(ConsolidationLedgerPassName)?.LastRunAt;
 
         _logger.LogInformation(
             "DreamService: consolidation reviewing {Eligible} of {Total} entries ({Withheld} withheld as reviewed-and-unchanged)",
@@ -1012,6 +1045,8 @@ internal sealed class DreamService : IHostedService, IDisposable
         var deleted = 0;
         var saved = 0;
         var rejectedMerges = 0;
+        var repairedMerges = 0;
+        var repairsAttempted = 0;
         var protectedFromPruning = 0;
 
         // Sources belonging to a merge the coverage check refused. They must survive the
@@ -1052,23 +1087,56 @@ internal sealed class DreamService : IHostedService, IDisposable
             // one — and once the sources are archived nobody can tell it happened. Reject it
             // and leave the sources alone; a surviving duplicate is the cheaper mistake.
             var missing = MergeCoverage.FindMissingSpecifics(sources, dto.Content, _mergeVocabulary);
+            var applied = dto;
+
             if (missing.Count > 0)
             {
-                // The directive requires every sourceId to also appear in toDelete, so these
-                // IDs are sitting in the standalone-removal list too. Without this the
-                // ephemeral path would archive them anyway and the rejection would achieve
-                // nothing — worse than merging, since nothing replaces them at all.
-                foreach (var srcId in sourceIds)
-                    rejectedMergeSources.Add(srcId);
+                // A rejection used to be terminal, and the same cluster came back next cycle to
+                // be rejected the same way — a live corpus rejected one six-source merge five
+                // times in eight cycles. The model is not being asked to think again; it is
+                // being told exactly which strings it dropped and asked to put them back, which
+                // is a far narrower task than the merge itself.
+                string? repaired = null;
+                if (_options.MergeRepairEnabled && repairsAttempted < _options.MergeRepairMaxPerCycle)
+                {
+                    repairsAttempted++;
+                    repaired = await TryRepairMergeAsync(sources, dto.Content, missing, ct);
+                }
 
-                rejectedMerges++;
-                _logger.LogWarning(
-                    "DreamService: rejected merge of [{Sources}] — dropped {Count} specific(s): {Missing}. Sources kept. Merged text was: {Content}",
-                    string.Join(", ", sources.Select(s => s.Id)),
-                    missing.Count,
-                    string.Join(", ", missing),
-                    dto.Content.Trim());
-                continue;
+                var stillMissing = repaired is null
+                    ? missing
+                    : MergeCoverage.FindMissingSpecifics(sources, repaired, _mergeVocabulary);
+
+                if (repaired is not null && stillMissing.Count == 0)
+                {
+                    repairedMerges++;
+                    _logger.LogInformation(
+                        "DreamService: repaired merge of [{Sources}] — restored {Count} specific(s): {Missing}",
+                        string.Join(", ", sources.Select(s => s.Id)),
+                        missing.Count,
+                        string.Join(", ", missing));
+
+                    applied = dto with { Content = repaired };
+                }
+                else
+                {
+                    // The directive requires every sourceId to also appear in toDelete, so these
+                    // IDs are sitting in the standalone-removal list too. Without this the
+                    // ephemeral path would archive them anyway and the rejection would achieve
+                    // nothing — worse than merging, since nothing replaces them at all.
+                    foreach (var srcId in sourceIds)
+                        rejectedMergeSources.Add(srcId);
+
+                    rejectedMerges++;
+                    _logger.LogWarning(
+                        "DreamService: rejected merge of [{Sources}]{AfterRepair} — dropped {Count} specific(s): {Missing}. Sources kept. Merged text was: {Content}",
+                        string.Join(", ", sources.Select(s => s.Id)),
+                        repaired is null ? string.Empty : " after repair",
+                        stillMissing.Count,
+                        string.Join(", ", stillMissing),
+                        (repaired ?? dto.Content).Trim());
+                    continue;
+                }
             }
 
             // CreatedAt = earliest source (first-seen preserved); UpdatedAt = now (record rewritten)
@@ -1081,7 +1149,7 @@ internal sealed class DreamService : IHostedService, IDisposable
             var reinforcementCount = sources.Count > 0 ? sources.Sum(s => s.ReinforcementCount) : 1;
 
             // LLM-provided importance wins; otherwise carry forward max from sources
-            var importance = dto.Importance
+            var importance = applied.Importance
                 ?? (sources.Count > 0 ? sources.Max(s => s.ImportanceScore) : 0.5f);
 
             var mergedMetadata = MergeSubjectTimeMetadata(sources);
@@ -1103,9 +1171,9 @@ internal sealed class DreamService : IHostedService, IDisposable
 
             var entry = new MemoryEntry(
                 Id: Guid.NewGuid().ToString("N")[..12],
-                Content: dto.Content.Trim(),
-                Category: string.IsNullOrWhiteSpace(dto.Category) ? null : dto.Category.Trim(),
-                Tags: dto.Tags ?? [],
+                Content: applied.Content.Trim(),
+                Category: string.IsNullOrWhiteSpace(applied.Category) ? null : applied.Category.Trim(),
+                Tags: applied.Tags ?? [],
                 CreatedAt: firstSeen,
                 UpdatedAt: DateTimeOffset.UtcNow,
                 Metadata: mergedMetadata,
@@ -1149,7 +1217,7 @@ internal sealed class DreamService : IHostedService, IDisposable
                 continue;
             }
 
-            archiveReasons[id] = "flagged ephemeral by consolidation";
+            archiveReasons[id] = EphemeralArchiveReason;
         }
 
         foreach (var (id, reason) in archiveReasons)
@@ -1168,13 +1236,117 @@ internal sealed class DreamService : IHostedService, IDisposable
             eligible.Select(e => e.Id).Where(id => !archiveReasons.ContainsKey(id)),
             ct);
 
-        if (rejectedMerges > 0 || protectedFromPruning > 0)
+        if (rejectedMerges > 0 || protectedFromPruning > 0 || repairedMerges > 0)
             _logger.LogInformation(
-                "DreamService: consolidation safeguards fired — {Rejected} merge(s) rejected for dropping specifics, {Protected} entry(s) protected from pruning",
-                rejectedMerges, protectedFromPruning);
+                "DreamService: consolidation safeguards fired — {Rejected} merge(s) rejected for dropping specifics, " +
+                "{Repaired} merge(s) repaired, {Protected} entry(s) protected from pruning",
+                rejectedMerges, repairedMerges, protectedFromPruning);
+
+        // Recorded only on a pass that actually reviewed something. A disabled pass, an empty
+        // corpus, nothing eligible or a failed LLM call all return earlier, so the minimum
+        // interval measures time between real consolidations rather than between cycles.
+        _passLedger?.Record(ConsolidationLedgerPassName, ConsolidationLedgerFingerprint, _clock.Now);
+
+        var createdSinceLastRun = previousRunAt is { } since
+            ? all.Count(e => e.CreatedAt > since)
+            : 0;
+
+        // One line per completed pass, carrying the numbers that say whether the corpus is
+        // converging or churning. Before this, "828 live entries" and "885 archived by merge"
+        // had to be reconstructed off the volume after the fact.
+        _logger.LogInformation(
+            "DreamService: consolidation summary — live {Live}, reviewed {Reviewed}, created since last run {Created}, " +
+            "merged {Merged}, repaired {Repaired}, rejected {Rejected}, ephemeral {Ephemeral}, protected {Protected}",
+            all.Count, eligible.Count, createdSinceLastRun, saved, repairedMerges, rejectedMerges,
+            archiveReasons.Count(r => r.Value == EphemeralArchiveReason),
+            protectedFromPruning);
 
         return (deleted, saved);
     }
+
+    /// <summary>
+    /// Archive reason for an entry consolidation dropped outright rather than merging. A constant
+    /// because the summary line counts these apart from merge sources.
+    /// </summary>
+    internal const string EphemeralArchiveReason = "flagged ephemeral by consolidation";
+
+    /// <summary>Ledger pass name for the consolidation minimum-interval gate.</summary>
+    internal const string ConsolidationLedgerPassName = "memory consolidation";
+
+    /// <summary>
+    /// Sentinel fingerprint for the consolidation ledger entry. The ledger's gate compares a
+    /// fingerprint and then a time floor; feeding it a constant collapses it to the pure time
+    /// gate this pass wants, without a second mechanism that would then need its own persistence
+    /// and its own restart behaviour.
+    /// </summary>
+    internal const string ConsolidationLedgerFingerprint = "completed";
+
+    /// <summary>
+    /// Asks the model to restore the specifics a merge dropped, keeping everything else. Returns
+    /// the revised text, or <c>null</c> when the pass produced nothing usable.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately ungated by the change-gate ledger: the input is one rejected merge, which is
+    /// different every time it is asked about, and a gate keyed on it would never fire anyway
+    /// while adding a way for a repair to be silently skipped.
+    /// </remarks>
+    private async Task<string?> TryRepairMergeAsync(
+        List<MemoryEntry> sources,
+        string rejectedContent,
+        IReadOnlyList<string> missing,
+        CancellationToken ct)
+    {
+        var result = await InvokeDreamPassAsync<MergeRepairResultDto>(
+            "memory merge repair",
+            BuiltInMergeRepairDirective,
+            BuildMergeRepairPrompt(sources, rejectedContent, missing),
+            ct);
+
+        var content = result?.Content?.Trim();
+        return string.IsNullOrWhiteSpace(content) ? null : content;
+    }
+
+    /// <summary>
+    /// Builds the merge-repair user message: the rejected text, the sources it was built from,
+    /// and the exact strings it dropped. Pure so the prompt can be asserted without an LLM.
+    /// </summary>
+    internal static string BuildMergeRepairPrompt(
+        IReadOnlyList<MemoryEntry> sources,
+        string rejectedContent,
+        IReadOnlyList<string> missing)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("A proposed merged memory entry dropped details its sources carried. Restore them.");
+        sb.AppendLine();
+        sb.AppendLine("## Proposed merged text");
+        sb.AppendLine(rejectedContent.Trim());
+        sb.AppendLine();
+        sb.AppendLine("## Source entries it was built from");
+        for (var i = 0; i < sources.Count; i++)
+            sb.AppendLine($"{i + 1}. {sources[i].Content}");
+        sb.AppendLine();
+        sb.AppendLine("## Missing — each must appear verbatim in your revision");
+        foreach (var specific in missing)
+            sb.AppendLine($"- {specific}");
+
+        return sb.ToString();
+    }
+
+    private sealed record MergeRepairResultDto(string? Content);
+
+    private const string BuiltInMergeRepairDirective = """
+        You are repairing a merged memory entry that dropped specific details its sources carried.
+
+        Rules:
+        - Every string in the "Missing" list MUST appear verbatim in your revision.
+        - Keep everything the proposed merged text already says. You are adding back what it lost,
+          not rewriting it.
+        - Do not add any fact that is not in the proposed text or in the source entries.
+        - Keep it a single coherent memory entry, as concise as restoring the details allows.
+
+        Return ONLY valid JSON in this shape and nothing else:
+        { "content": "the repaired merged entry" }
+        """;
 
     private async Task ConsolidateSkillsAsync(CancellationToken ct)
     {
@@ -2677,7 +2849,7 @@ internal sealed class DreamService : IHostedService, IDisposable
                 userMessage.ToString(),
                 ct);
             if (result is null) return;
-            var saved = 0;
+            var tally = new MemorySaveTally();
 
             foreach (var dto in result?.ToSave ?? [])
             {
@@ -2696,13 +2868,17 @@ internal sealed class DreamService : IHostedService, IDisposable
                     CreatedAt: DateTimeOffset.UtcNow,
                     UpdatedAt: DateTimeOffset.UtcNow);
 
-                await _memory.SaveAsync(entry);
-                saved++;
-                _logger.LogDebug("DreamService: memory mining saved {Id} ({Category}): {Content}",
-                    entry.Id, entry.Category, entry.Content);
+                // Mining re-reads a rolling window of the conversation log, so a fact mentioned
+                // across several sessions is mined again on every cycle it stays in the window.
+                var outcome = await SaveOrReinforceAsync(entry, ct);
+                tally.Record(outcome);
+                _logger.LogDebug("DreamService: memory mining {Action} {Id} ({Category}): {Content}",
+                    outcome.Action.ToString().ToLowerInvariant(), outcome.Id, entry.Category, entry.Content);
             }
 
-            _logger.LogInformation("DreamService: memory mining pass complete — {Saved} entry(ies) saved", saved);
+            _logger.LogInformation(
+                "DreamService: memory mining pass complete — {Saved} saved, {Reinforced} reinforced, {Extended} extended",
+                tally.Saved, tally.Reinforced, tally.Extended);
         });
     }
 
@@ -3046,15 +3222,22 @@ internal sealed class DreamService : IHostedService, IDisposable
                 idFactory: () => Guid.NewGuid().ToString("N")[..12],
                 nowFactory: () => DateTimeOffset.UtcNow);
 
+            var tally = new MemorySaveTally();
+
             foreach (var entry in entries)
             {
-                await _memory.SaveAsync(entry);
-                _logger.LogDebug("DreamService: tool-success-learning saved {Id} ({Category}): {Content}",
-                    entry.Id, entry.Category, entry.Content);
+                // The same retry-until-success pattern is re-detected for as long as its tool
+                // calls stay inside the 7-day window, so this pass re-proposes facts it already
+                // stored on the previous cycle.
+                var outcome = await SaveOrReinforceAsync(entry, ct);
+                tally.Record(outcome);
+                _logger.LogDebug("DreamService: tool-success-learning {Action} {Id} ({Category}): {Content}",
+                    outcome.Action.ToString().ToLowerInvariant(), outcome.Id, entry.Category, entry.Content);
             }
 
             _logger.LogInformation(
-                "DreamService: tool-success-learning pass complete — {Saved} entry(ies) saved", entries.Count);
+                "DreamService: tool-success-learning pass complete — {Saved} saved, {Reinforced} reinforced, {Extended} extended",
+                tally.Saved, tally.Reinforced, tally.Extended);
         });
     }
 
@@ -4476,53 +4659,73 @@ internal sealed class DreamService : IHostedService, IDisposable
                 return;
             }
 
-            // Delete entries the LLM wants to replace
-            var deleted = 0;
-            foreach (var id in result.ToDelete ?? [])
-            {
-                await _memory.DeleteAsync(id);
-                deleted++;
-                _logger.LogDebug("DreamService: identity reflection deleted entry {Id}", id);
-            }
-
-            // Save new/updated identity entries
-            var saved = 0;
-            foreach (var dto in result.ToSave ?? [])
-            {
-                if (string.IsNullOrWhiteSpace(dto.Content))
-                    continue;
-
-                // Ensure category is under agent-identity/
-                var category = string.IsNullOrWhiteSpace(dto.Category)
-                    ? AgentIdentityCategories.SelfModel
-                    : dto.Category.Trim();
-
-                if (!category.StartsWith(AgentIdentityCategories.Prefix, StringComparison.OrdinalIgnoreCase))
-                    category = $"{AgentIdentityCategories.Prefix}/{category}";
-
-                var tags = new List<string>(dto.Tags ?? []);
-                if (!tags.Contains("identity", StringComparer.OrdinalIgnoreCase))
-                    tags.Insert(0, "identity");
-
-                var entry = new MemoryEntry(
-                    Id: Guid.NewGuid().ToString("N")[..12],
-                    Content: dto.Content.Trim(),
-                    Category: category,
-                    Tags: tags,
-                    CreatedAt: DateTimeOffset.UtcNow,
-                    UpdatedAt: DateTimeOffset.UtcNow,
-                    ImportanceScore: Math.Clamp(dto.Importance ?? 0.7f, 0f, 1f));
-
-                await _memory.SaveAsync(entry);
-                saved++;
-                _logger.LogDebug("DreamService: identity reflection saved {Id} ({Category}): {Content}",
-                    entry.Id, entry.Category, entry.Content);
-            }
+            var (archived, saved) = await ApplyIdentityReflectionResultAsync(_memory, result, _logger, ct);
 
             _logger.LogInformation(
-                "DreamService: identity reflection pass complete — {Deleted} deleted, {Saved} saved",
-                deleted, saved);
+                "DreamService: identity reflection pass complete — {Archived} archived, {Saved} saved",
+                archived, saved);
         });
+    }
+
+    /// <summary>
+    /// Applies an identity reflection result: archives the entries the model replaced and saves
+    /// the ones it rewrote. Internal so the archive-not-delete behaviour can be tested without a
+    /// real LLM call.
+    /// </summary>
+    /// <remarks>
+    /// This pass rewrites essentially all of its own entries on essentially every run, so a hard
+    /// delete here means the agent's previous self-description is gone the moment the model
+    /// produces a new one — with no way to see what changed or to put it back if the new one is
+    /// worse. Archiving costs nothing and makes the rewrite reviewable.
+    /// </remarks>
+    internal static async Task<(int Archived, int Saved)> ApplyIdentityReflectionResultAsync(
+        ILongTermMemory memory,
+        IdentityReflectionResultDto result,
+        ILogger logger,
+        CancellationToken ct)
+    {
+        var archived = 0;
+        foreach (var id in result.ToDelete ?? [])
+        {
+            await memory.ArchiveAsync(id, "replaced by identity reflection", ct);
+            archived++;
+            logger.LogDebug("DreamService: identity reflection archived entry {Id}", id);
+        }
+
+        var saved = 0;
+        foreach (var dto in result.ToSave ?? [])
+        {
+            if (string.IsNullOrWhiteSpace(dto.Content))
+                continue;
+
+            // Ensure category is under agent-identity/
+            var category = string.IsNullOrWhiteSpace(dto.Category)
+                ? AgentIdentityCategories.SelfModel
+                : dto.Category.Trim();
+
+            if (!category.StartsWith(AgentIdentityCategories.Prefix, StringComparison.OrdinalIgnoreCase))
+                category = $"{AgentIdentityCategories.Prefix}/{category}";
+
+            var tags = new List<string>(dto.Tags ?? []);
+            if (!tags.Contains("identity", StringComparer.OrdinalIgnoreCase))
+                tags.Insert(0, "identity");
+
+            var entry = new MemoryEntry(
+                Id: Guid.NewGuid().ToString("N")[..12],
+                Content: dto.Content.Trim(),
+                Category: category,
+                Tags: tags,
+                CreatedAt: DateTimeOffset.UtcNow,
+                UpdatedAt: DateTimeOffset.UtcNow,
+                ImportanceScore: Math.Clamp(dto.Importance ?? 0.7f, 0f, 1f));
+
+            await memory.SaveAsync(entry, ct);
+            saved++;
+            logger.LogDebug("DreamService: identity reflection saved {Id} ({Category}): {Content}",
+                entry.Id, entry.Category, entry.Content);
+        }
+
+        return (archived, saved);
     }
 
     /// <summary>
@@ -5466,12 +5669,12 @@ internal sealed class DreamService : IHostedService, IDisposable
 
     private sealed record DlqPatternDto(string Content, string? Detail, IReadOnlyList<string>? Queues);
 
-    private sealed record IdentityReflectionResultDto(
+    internal sealed record IdentityReflectionResultDto(
         bool? NoChange,
         List<string>? ToDelete,
         List<IdentityEntryDto>? ToSave);
 
-    private sealed record IdentityEntryDto(
+    internal sealed record IdentityEntryDto(
         string Content,
         string? Category,
         IReadOnlyList<string>? Tags,

--- a/src/RockBot.Host/FileMemoryStore.cs
+++ b/src/RockBot.Host/FileMemoryStore.cs
@@ -11,7 +11,8 @@ namespace RockBot.Host;
 /// File-based long-term memory store with category subdirectories and in-memory index.
 /// Thread safety via <see cref="SemaphoreSlim"/> for all file I/O.
 /// </summary>
-internal sealed partial class FileMemoryStore : ILongTermMemory, IArchivedMemoryMaintenance, IMemoryDuplicateCandidates
+internal sealed partial class FileMemoryStore
+    : ILongTermMemory, IArchivedMemoryMaintenance, IMemoryDuplicateCandidates, IMemorySimilarityLookup
 {
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -374,25 +375,38 @@ internal sealed partial class FileMemoryStore : ILongTermMemory, IArchivedMemory
 
     /// <summary>
     /// Hard-deletes archived entries whose <see cref="MemoryEntry.ArchivedAt"/> is older than
-    /// <paramref name="retention"/>. Returns the number purged. A non-positive retention
-    /// disables purging entirely, so archived entries are kept forever.
+    /// <paramref name="retention"/> and that <paramref name="keep"/> does not hold back. A
+    /// non-positive retention disables purging entirely, so archived entries are kept forever.
     /// </summary>
-    public async Task<int> PurgeArchivedAsync(TimeSpan retention, CancellationToken cancellationToken = default)
+    public async Task<ArchivePurgeResult> PurgeArchivedAsync(
+        TimeSpan retention,
+        Func<MemoryEntry, bool>? keep = null,
+        CancellationToken cancellationToken = default)
     {
         if (retention <= TimeSpan.Zero)
-            return 0;
+            return new ArchivePurgeResult(0, 0);
 
         var cutoff = DateTimeOffset.UtcNow - retention;
 
         List<string> expired;
+        var kept = 0;
+
         await _semaphore.WaitAsync(cancellationToken);
         try
         {
             var index = await EnsureIndexAsync(cancellationToken);
-            expired = index.Values
+            var due = index.Values
                 .Where(e => e.ArchivedAt is not null && e.ArchivedAt < cutoff)
-                .Select(e => e.Id)
                 .ToList();
+
+            expired = [];
+            foreach (var entry in due)
+            {
+                if (keep is not null && keep(entry))
+                    kept++;
+                else
+                    expired.Add(entry.Id);
+            }
         }
         finally
         {
@@ -402,7 +416,7 @@ internal sealed partial class FileMemoryStore : ILongTermMemory, IArchivedMemory
         foreach (var id in expired)
             await DeleteAsync(id, cancellationToken);
 
-        return expired.Count;
+        return new ArchivePurgeResult(expired.Count, kept);
     }
 
     public async Task<IReadOnlyList<IReadOnlyList<string>>> FindNearDuplicateClustersAsync(
@@ -484,6 +498,110 @@ internal sealed partial class FileMemoryStore : ILongTermMemory, IArchivedMemory
             clusters.Count, clusters.Sum(c => c.Count), entries.Count, similarityThreshold);
 
         return clusters;
+    }
+
+    /// <summary>
+    /// Top-level segment of a category path — the part before the first slash — used to bound
+    /// what a save-time similarity lookup will compare against.
+    /// </summary>
+    /// <remarks>
+    /// A lexical fallback scores on shared vocabulary alone, and operational memory shares a
+    /// great deal of it across subjects: a user preference about email and an infrastructure
+    /// note about an email connector overlap heavily without describing the same fact. Scoping
+    /// to the top level is coarse enough to still catch the same fact filed under sibling
+    /// subcategories, which is the common case for a duplicate.
+    /// </remarks>
+    internal static string? TopLevelCategory(string? category)
+    {
+        if (category is null)
+            return null;
+
+        var slash = category.IndexOf('/');
+        return slash < 0 ? category : category[..slash];
+    }
+
+    public async Task<MemorySimilarityMatch?> FindMostSimilarAsync(
+        MemoryEntry candidate,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(candidate.Content))
+            return null;
+
+        var scope = TopLevelCategory(candidate.Category);
+
+        List<MemoryEntry> entries;
+        await _semaphore.WaitAsync(cancellationToken);
+        try
+        {
+            var index = await EnsureIndexAsync(cancellationToken);
+            entries = index.Values
+                .Where(e => e.ArchivedAt is null && e.SupersededBy is null)
+                .Where(e => !string.Equals(e.Id, candidate.Id, StringComparison.OrdinalIgnoreCase))
+                .Where(e => string.Equals(
+                    TopLevelCategory(e.Category), scope, StringComparison.OrdinalIgnoreCase))
+                .OrderBy(e => e.Id, StringComparer.Ordinal)
+                .ToList();
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+
+        if (entries.Count == 0)
+            return null;
+
+        if (_embeddingCache is not null)
+        {
+            var queryVector = await _embeddingCache.GenerateQueryEmbeddingAsync(
+                GetDocumentText(candidate), cancellationToken);
+
+            if (queryVector is not null)
+            {
+                var batch = entries.Select(e => (e.Id, Text: GetDocumentText(e))).ToList();
+                var map = await _embeddingCache.GetOrCreateBatchAsync(batch, cancellationToken);
+
+                MemoryEntry? best = null;
+                var bestScore = double.NegativeInfinity;
+
+                foreach (var entry in entries)
+                {
+                    if (map.GetValueOrDefault(entry.Id) is not { } vector)
+                        continue;
+
+                    var score = EmbeddingCache.CosineSimilarity(queryVector, vector);
+                    if (score > bestScore)
+                    {
+                        bestScore = score;
+                        best = entry;
+                    }
+                }
+
+                // Only when every vector is missing does this fall through to the lexical scan.
+                // Mixing a cosine score and a Jaccard score in one argmax would compare two
+                // different scales and hand the caller a number its threshold cannot interpret.
+                if (best is not null)
+                    return new MemorySimilarityMatch(best, bestScore, MemorySimilarityMeasure.Embedding);
+            }
+        }
+
+        var candidateTokens = Tokenize(candidate.Content);
+
+        MemoryEntry? lexicalBest = null;
+        var lexicalBestScore = double.NegativeInfinity;
+
+        foreach (var entry in entries)
+        {
+            var score = Jaccard(candidateTokens, Tokenize(entry.Content));
+            if (score > lexicalBestScore)
+            {
+                lexicalBestScore = score;
+                lexicalBest = entry;
+            }
+        }
+
+        return lexicalBest is null
+            ? null
+            : new MemorySimilarityMatch(lexicalBest, lexicalBestScore, MemorySimilarityMeasure.Lexical);
     }
 
     /// <summary>

--- a/src/RockBot.Host/MemoryDeduplicator.cs
+++ b/src/RockBot.Host/MemoryDeduplicator.cs
@@ -1,0 +1,286 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace RockBot.Host;
+
+/// <summary>
+/// Default <see cref="IMemoryDeduplicator"/>: looks for the live entry a candidate most
+/// resembles and, when the resemblance is close enough, reinforces or extends it instead of
+/// writing a near-copy.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The decision is deliberately narrow. Similarity alone only says the two entries are about the
+/// same thing; whether the existing one can stand in for the new one is the same question dream
+/// consolidation asks about a merge, so it is answered by the same code —
+/// <see cref="MergeCoverage.FindMissingSpecifics"/> over the same vocabulary file. If the
+/// existing entry already carries every specific, the candidate is evidence and nothing more. If
+/// it carries new ones, they are appended rather than dropped: a save that silently discards a
+/// detail is the failure this whole area exists to prevent, and it would be far harder to notice
+/// here than in a merge, because there would be no second entry to compare against.
+/// </para>
+/// <para>
+/// Anything below the threshold, or in a category with its own write semantics, is saved
+/// unchanged. Consolidation still runs; this only stops it from being handed duplicates it never
+/// needed to see.
+/// </para>
+/// </remarks>
+internal sealed class MemoryDeduplicator : IMemoryDeduplicator
+{
+    private readonly ILongTermMemory _memory;
+    private readonly IMemorySimilarityLookup? _lookup;
+    private readonly MemoryOptions _options;
+    private readonly AgentProfileOptions _profileOptions;
+    private readonly DreamOptions? _dreamOptions;
+    private readonly ILogger<MemoryDeduplicator> _logger;
+
+    /// <summary>
+    /// Serializes lookup-then-write. Two background saves of the same fact — two turns
+    /// mentioning it, or a mining pass overlapping a tool call — would otherwise both look,
+    /// both find nothing, and both create.
+    /// </summary>
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    private MergeCoverageVocabulary _vocabulary = MergeCoverageVocabulary.Default;
+    private DateTime _vocabularyStamp = DateTime.MinValue;
+    private bool _vocabularyLoaded;
+    private bool _loggedMissingLookup;
+
+    public MemoryDeduplicator(
+        ILongTermMemory memory,
+        IOptions<MemoryOptions> options,
+        IOptions<AgentProfileOptions> profileOptions,
+        ILogger<MemoryDeduplicator> logger,
+        IOptions<DreamOptions>? dreamOptions = null)
+    {
+        _memory = memory;
+        _lookup = memory as IMemorySimilarityLookup;
+        _options = options.Value;
+        _profileOptions = profileOptions.Value;
+        _dreamOptions = dreamOptions?.Value;
+        _logger = logger;
+    }
+
+    public async Task<MemorySaveOutcome> SaveOrReinforceAsync(
+        MemoryEntry candidate,
+        CancellationToken cancellationToken = default)
+    {
+        if (!ShouldDeduplicate(candidate))
+        {
+            await _memory.SaveAsync(candidate, cancellationToken);
+            return new MemorySaveOutcome(MemorySaveAction.Created, candidate.Id);
+        }
+
+        await _gate.WaitAsync(cancellationToken);
+        try
+        {
+            return await DecideAndSaveAsync(candidate, cancellationToken);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    private bool ShouldDeduplicate(MemoryEntry candidate)
+    {
+        if (_lookup is null)
+        {
+            if (!_loggedMissingLookup)
+            {
+                _loggedMissingLookup = true;
+                _logger.LogDebug(
+                    "Memory dedupe: store does not support similarity lookup; saving every entry as-is");
+            }
+            return false;
+        }
+
+        if (!_options.DedupeEnabled)
+            return false;
+
+        if (string.IsNullOrWhiteSpace(candidate.Content))
+            return false;
+
+        // An entry that arrives already superseded is a record of a resolved contradiction, not
+        // a fact being asserted; folding it into its own winner would erase the audit trail.
+        if (candidate.SupersededBy is not null)
+            return false;
+
+        // Scoped categories have their own write semantics — the contradiction detector
+        // supersedes feedback entries, and capability claims are falsified and evicted by the
+        // verifier. Both reason about individual entries by id, so neither wants its writes
+        // silently redirected into an older one. Defensive rather than expected: mining can and
+        // does emit entries under these prefixes.
+        if (FeedbackMemoryCategories.IsFeedbackMemory(candidate.Category)
+            || CapabilityClaimCategories.IsCapabilityClaim(candidate.Category))
+            return false;
+
+        return true;
+    }
+
+    private async Task<MemorySaveOutcome> DecideAndSaveAsync(
+        MemoryEntry candidate,
+        CancellationToken cancellationToken)
+    {
+        var match = await _lookup!.FindMostSimilarAsync(candidate, cancellationToken);
+
+        var threshold = match?.Measure == MemorySimilarityMeasure.Embedding
+            ? _options.DedupeSimilarityThreshold
+            : _options.DedupeLexicalSimilarityThreshold;
+
+        if (match is null || match.Score < threshold)
+        {
+            if (match is not null)
+                _logger.LogDebug(
+                    "Memory dedupe: saving {Id} as new — closest existing entry {MatchId} scored " +
+                    "{Score:F2} ({Measure}), below the {Threshold:F2} threshold",
+                    candidate.Id, match.Entry.Id, match.Score, match.Measure, threshold);
+
+            await _memory.SaveAsync(candidate, cancellationToken);
+            return new MemorySaveOutcome(MemorySaveAction.Created, candidate.Id);
+        }
+
+        var existing = match.Entry;
+        var missing = MergeCoverage.FindMissingSpecifics(
+            [candidate], existing.Content, LoadVocabulary());
+
+        var now = DateTimeOffset.UtcNow;
+        var reinforced = Reinforce(existing, candidate, now);
+
+        if (missing.Count == 0)
+        {
+            await _memory.SaveAsync(reinforced, cancellationToken);
+
+            _logger.LogInformation(
+                "Memory dedupe: reinforced {Id} instead of creating (similarity {Score:F2}, " +
+                "{Measure}, reinforced={Count}×): {Content}",
+                existing.Id, match.Score, match.Measure, reinforced.ReinforcementCount, existing.Content);
+
+            return new MemorySaveOutcome(
+                MemorySaveAction.Reinforced, existing.Id, match.Score, match.Measure);
+        }
+
+        var addition = candidate.Content.Trim();
+        var kept = existing.Content.TrimEnd();
+        var combinedLength = kept.Length + 2 + addition.Length;
+
+        if (combinedLength > _options.DedupeMaxExtendedContentLength)
+        {
+            _logger.LogInformation(
+                "Memory dedupe: saving {Id} as new — extending {MatchId} would reach {Length} characters, " +
+                "over the {Cap} cap (similarity {Score:F2}, {Measure})",
+                candidate.Id, existing.Id, combinedLength,
+                _options.DedupeMaxExtendedContentLength, match.Score, match.Measure);
+
+            await _memory.SaveAsync(candidate, cancellationToken);
+            return new MemorySaveOutcome(MemorySaveAction.Created, candidate.Id);
+        }
+
+        // UpdatedAt moves here and not on the reinforce path: the content changed, so the
+        // consolidation-reviewed hash no longer matches and the entry is rightly re-reviewed
+        // next cycle. A pure reinforcement changes no text and stays withheld.
+        var extended = reinforced with
+        {
+            Content = kept + "\n\n" + addition,
+            UpdatedAt = now,
+        };
+
+        await _memory.SaveAsync(extended, cancellationToken);
+
+        _logger.LogInformation(
+            "Memory dedupe: extended {Id} with {Specifics} instead of creating (similarity {Score:F2}, {Measure})",
+            existing.Id, string.Join(", ", missing), match.Score, match.Measure);
+
+        return new MemorySaveOutcome(
+            MemorySaveAction.Extended, existing.Id, match.Score, match.Measure);
+    }
+
+    /// <summary>
+    /// Folds the candidate's evidence into <paramref name="existing"/> without touching its
+    /// text: counters, importance, tags and any metadata keys the candidate brought that the
+    /// existing entry lacks.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="MemoryEntry.UpdatedAt"/> is deliberately left alone. It anchors the importance
+    /// decay pass and, through the content hash, the consolidation-reviewed stamp; bumping it
+    /// for a write that changed no text would both stall decay and re-open a settled entry.
+    /// Leaving it also keeps the store's UpdatedAt-regression warning from firing on what is a
+    /// read-modify-write outside its lock.
+    /// </remarks>
+    internal static MemoryEntry Reinforce(MemoryEntry existing, MemoryEntry candidate, DateTimeOffset now)
+    {
+        var tags = new List<string>(existing.Tags);
+        foreach (var tag in candidate.Tags)
+            if (!tags.Contains(tag, StringComparer.OrdinalIgnoreCase))
+                tags.Add(tag);
+
+        IReadOnlyDictionary<string, string>? metadata = existing.Metadata;
+        if (candidate.Metadata is { Count: > 0 })
+        {
+            var merged = existing.Metadata is null
+                ? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                : new Dictionary<string, string>(existing.Metadata, StringComparer.OrdinalIgnoreCase);
+
+            // Existing values win. The candidate is the same fact observed again, so its
+            // metadata is a second reading of what is already recorded, not a correction.
+            foreach (var (key, value) in candidate.Metadata)
+                if (!merged.ContainsKey(key))
+                    merged[key] = value;
+
+            metadata = merged;
+        }
+
+        return existing with
+        {
+            Tags = tags,
+            Metadata = metadata,
+            ImportanceScore = Math.Max(existing.ImportanceScore, candidate.ImportanceScore),
+            LastSeenAt = now,
+            ReinforcementCount = existing.ReinforcementCount + 1,
+        };
+    }
+
+    /// <summary>
+    /// Returns the merge-coverage vocabulary, re-reading the file when it has changed on disk.
+    /// </summary>
+    /// <remarks>
+    /// The same file dream consolidation reloads at the top of every cycle. Both now decide what
+    /// counts as a load-bearing specific, and an operator who tunes the file to unblock a merge
+    /// would be confused to find the save path still judging by the old rules.
+    /// </remarks>
+    private MergeCoverageVocabulary LoadVocabulary()
+    {
+        var path = ResolveVocabularyPath();
+
+        DateTime stamp;
+        try
+        {
+            stamp = File.Exists(path) ? File.GetLastWriteTimeUtc(path) : DateTime.MinValue;
+        }
+        catch (IOException)
+        {
+            return _vocabularyLoaded ? _vocabulary : MergeCoverageVocabulary.Default;
+        }
+
+        if (_vocabularyLoaded && stamp == _vocabularyStamp)
+            return _vocabulary;
+
+        _vocabulary = MergeCoverageVocabularyFile.Load(path, _logger, source: "Memory dedupe");
+        _vocabularyStamp = stamp;
+        _vocabularyLoaded = true;
+        return _vocabulary;
+    }
+
+    private string ResolveVocabularyPath()
+    {
+        var configured = _dreamOptions?.MergeCoverageVocabularyPath ?? "merge-coverage-vocabulary.json";
+        if (Path.IsPathRooted(configured))
+            return configured;
+
+        var baseDir = Path.IsPathRooted(_profileOptions.BasePath)
+            ? _profileOptions.BasePath
+            : Path.Combine(AppContext.BaseDirectory, _profileOptions.BasePath);
+
+        return Path.Combine(baseDir, configured);
+    }
+}

--- a/src/RockBot.Host/MergeCoverage.cs
+++ b/src/RockBot.Host/MergeCoverage.cs
@@ -41,6 +41,14 @@ namespace RockBot.Host;
 /// other is guarded on the month appearing in a date expression in the source, so a bare
 /// "August" — or a person named August — stays required.
 /// </item>
+/// <item>
+/// Corpus evidence. A word the same corpus also writes in all-lowercase form is ordinary
+/// language, whatever position it was capitalized in. "Marking a task complete" reads as a
+/// proper noun mid-phrase, but a sibling source says "marking"; "Contact IDs are account-scoped"
+/// is followed by "the contact ids". The evidence comes from the text itself rather than from a
+/// curated list, so it cannot unprotect a name that never appears lowercase — Eventbrite, Xebia
+/// and Austin stay required, and <c>alwaysSpecificWords</c> still overrides it.
+/// </item>
 /// </list>
 /// <para>
 /// The distinction matters: adding a word to the common list unprotects it everywhere, in
@@ -78,9 +86,20 @@ internal static partial class MergeCoverage
     /// Which words count as ordinary language. Defaults to the generic-English baseline;
     /// deployments override it via <c>merge-coverage-vocabulary.json</c>.
     /// </param>
+    /// <param name="evidenceText">
+    /// Text consulted for the lowercase-twin rule. Defaults to <paramref name="content"/>; the
+    /// merge check passes the whole cluster, so a word one source capitalizes and a sibling
+    /// writes lowercase counts as ordinary language for that merge.
+    /// </param>
+    /// <param name="category">
+    /// Category of the entry the content came from, used only to decide whether numbers in it
+    /// are exempt — see <see cref="MergeCoverageVocabulary.IsNumericExempt"/>.
+    /// </param>
     internal static HashSet<string> ExtractSpecifics(
         string? content,
-        MergeCoverageVocabulary? vocabulary = null)
+        MergeCoverageVocabulary? vocabulary = null,
+        string? evidenceText = null,
+        string? category = null)
     {
         var words = vocabulary ?? MergeCoverageVocabulary.Default;
 
@@ -88,21 +107,32 @@ internal static partial class MergeCoverage
         if (string.IsNullOrWhiteSpace(content))
             return specifics;
 
+        var lowercaseTwins = LowercaseWords(evidenceText ?? content);
+
         foreach (Match m in CapitalizedWord().Matches(content))
         {
             var word = Possessive().Replace(m.Value, string.Empty);
             if (word.Length <= 2)
                 continue;
 
-            // The generic-English baseline exists to absorb words capitalized only because they
-            // open a sentence, so it only applies there. Mid-sentence capitalization is evidence
-            // of a proper noun: "Personal", "Class" and "Benefit" are ordinary at a sentence
-            // start and load-bearing in "OneDrive Personal", "Blazor Online Class" and "MVP
-            // Azure Extended Benefit". A deployment's own extraCommonWords still applies in
-            // every position -- see MergeCoverageVocabulary.IsCommon.
-            var applyBaseline = SentencePosition.IsSentenceInitial(content, m.Index);
-            if (words.IsCommon(word, applyBaseline))
-                continue;
+            if (!words.IsAlwaysSpecific(word))
+            {
+                // The generic-English baseline exists to absorb words capitalized only because
+                // they open a sentence, so it only applies there. Mid-sentence capitalization is
+                // evidence of a proper noun: "Personal", "Class" and "Benefit" are ordinary at a
+                // sentence start and load-bearing in "OneDrive Personal", "Blazor Online Class"
+                // and "MVP Azure Extended Benefit". A deployment's own extraCommonWords still
+                // applies in every position -- see MergeCoverageVocabulary.IsCommon.
+                var applyBaseline = SentencePosition.IsSentenceInitial(content, m.Index);
+                if (words.IsCommon(word, applyBaseline))
+                    continue;
+
+                // Corpus evidence beats position. A word this corpus also writes in lowercase is
+                // ordinary language wherever it happens to be capitalized, and no curated list
+                // has to grow for the check to know it.
+                if (lowercaseTwins.Contains(word.ToLowerInvariant()))
+                    continue;
+            }
 
             specifics.Add(word);
         }
@@ -115,10 +145,38 @@ internal static partial class MergeCoverage
             if (!words.IsCommon(m.Value))
                 specifics.Add(m.Value);
 
-        foreach (Match m in Numeric().Matches(content))
-            specifics.Add(m.Value);
+        // Categories whose entries are re-derived from telemetry every cycle carry decimals
+        // ("avg 8.33 tool calls") that are recomputed rather than recorded. Requiring them to
+        // survive verbatim rejects the same merge on every cycle over a number that has already
+        // moved on. The exemption skips the whole numeric loop, dates included; month-name dates
+        // are still picked up by the capitalized-word pass.
+        if (!words.IsNumericExempt(category))
+            foreach (Match m in Numeric().Matches(content))
+                specifics.Add(m.Value);
 
         return specifics;
+    }
+
+    /// <summary>Any run of letters and apostrophes, used to harvest lowercase twins.</summary>
+    [GeneratedRegex(@"[\p{L}'’]+")]
+    private static partial Regex WordToken();
+
+    /// <summary>
+    /// Words written entirely in lowercase somewhere in <paramref name="text"/>. Membership is
+    /// the evidence that a capitalized occurrence elsewhere is ordinary language rather than a
+    /// name.
+    /// </summary>
+    private static HashSet<string> LowercaseWords(string? text)
+    {
+        var found = new HashSet<string>(StringComparer.Ordinal);
+        if (string.IsNullOrEmpty(text))
+            return found;
+
+        foreach (Match m in WordToken().Matches(text))
+            if (!m.Value.Any(char.IsUpper))
+                found.Add(m.Value);
+
+        return found;
     }
 
     /// <summary>
@@ -143,14 +201,19 @@ internal static partial class MergeCoverage
 
         var materialized = sources as IReadOnlyCollection<MemoryEntry> ?? [.. sources];
 
+        var sourceText = string.Join("\n", materialized.Select(s => s.Content));
+
+        // Evidence for the lowercase-twin rule is the whole cluster, not one entry: these
+        // sources are being merged as a group, so a word one of them capitalizes and another
+        // writes lowercase is ordinary language for this merge.
+        var evidenceText = sourceText + "\n" + merged;
+
         var required = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var source in materialized)
-            required.UnionWith(ExtractSpecifics(source.Content, vocabulary));
+            required.UnionWith(ExtractSpecifics(source.Content, vocabulary, evidenceText, source.Category));
 
         if (required.Count == 0)
             return [];
-
-        var sourceText = string.Join("\n", materialized.Select(s => s.Content));
 
         return [.. required
             .Where(s => !IsCovered(s, sourceText, merged))

--- a/src/RockBot.Host/MergeCoverageVocabulary.cs
+++ b/src/RockBot.Host/MergeCoverageVocabulary.cs
@@ -46,14 +46,17 @@ internal sealed class MergeCoverageVocabulary
     private readonly HashSet<string> _builtIn;
     private readonly HashSet<string> _extraCommon;
     private readonly HashSet<string> _alwaysSpecific;
+    private readonly List<string> _numericExempt;
 
     public MergeCoverageVocabulary(
         IEnumerable<string>? extraCommonWords,
-        IEnumerable<string>? alwaysSpecificWords)
+        IEnumerable<string>? alwaysSpecificWords,
+        IEnumerable<string>? numericExemptCategories = null)
     {
         _builtIn = new HashSet<string>(BuiltInCommonWords, StringComparer.OrdinalIgnoreCase);
         _extraCommon = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         _alwaysSpecific = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        _numericExempt = [.. BuiltInNumericExemptCategories];
 
         foreach (var word in extraCommonWords ?? [])
             if (!string.IsNullOrWhiteSpace(word))
@@ -62,6 +65,14 @@ internal sealed class MergeCoverageVocabulary
         foreach (var word in alwaysSpecificWords ?? [])
             if (!string.IsNullOrWhiteSpace(word))
                 _alwaysSpecific.Add(word.Trim());
+
+        foreach (var category in numericExemptCategories ?? [])
+        {
+            var trimmed = category?.Trim().Trim('/');
+            if (!string.IsNullOrWhiteSpace(trimmed)
+                && !_numericExempt.Contains(trimmed, StringComparer.OrdinalIgnoreCase))
+                _numericExempt.Add(trimmed);
+        }
     }
 
     /// <summary>
@@ -92,8 +103,50 @@ internal sealed class MergeCoverageVocabulary
             || (applyBaseline && _builtIn.Contains(word));
     }
 
+    /// <summary>
+    /// True when <paramref name="word"/> is reclaimed as a specific regardless of every other
+    /// rule. Exposed separately from <see cref="IsCommon"/> because the corpus-evidence rule in
+    /// <see cref="MergeCoverage"/> has to be overridable too: a character named Brief in a story
+    /// whose prose also uses "brief" must still be protected.
+    /// </summary>
+    public bool IsAlwaysSpecific(string word) => _alwaysSpecific.Contains(word);
+
     /// <summary>Words reclaimed as specifics regardless of the common list.</summary>
     public IReadOnlyCollection<string> AlwaysSpecificWords => _alwaysSpecific;
+
+    /// <summary>Categories whose numbers are not required to survive a merge.</summary>
+    public IReadOnlyList<string> NumericExemptCategories => _numericExempt;
+
+    /// <summary>
+    /// True when entries in <paramref name="category"/> are exempt from the requirement that
+    /// their numbers survive a merge, because the category equals or sits under a listed prefix.
+    /// </summary>
+    /// <remarks>
+    /// Some categories hold figures the agent re-derives from telemetry on every cycle — routing
+    /// averages, cost ratios, call counts. Those numbers are already different by the time a
+    /// merge is proposed, so requiring them verbatim rejects the same cluster forever over a
+    /// value nobody wants preserved. Matching is segment-aware, so <c>anti-patterns/routing</c>
+    /// covers <c>anti-patterns/routing/high-tier</c> but never <c>anti-patterns/routing-notes</c>.
+    /// </remarks>
+    public bool IsNumericExempt(string? category)
+    {
+        if (string.IsNullOrWhiteSpace(category))
+            return false;
+
+        var trimmed = category.Trim().Trim('/');
+
+        foreach (var prefix in _numericExempt)
+        {
+            if (trimmed.Equals(prefix, StringComparison.OrdinalIgnoreCase))
+                return true;
+            if (trimmed.Length > prefix.Length
+                && trimmed[prefix.Length] == '/'
+                && trimmed.AsSpan(0, prefix.Length).Equals(prefix, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
+    }
 
     /// <summary>Count of words treated as ordinary language.</summary>
     public int CommonWordCount => _builtIn.Count + _extraCommon.Count;
@@ -117,7 +170,8 @@ internal sealed class MergeCoverageVocabulary
                 return Default;
             }
 
-            return new MergeCoverageVocabulary(dto.ExtraCommonWords, dto.AlwaysSpecificWords);
+            return new MergeCoverageVocabulary(
+                dto.ExtraCommonWords, dto.AlwaysSpecificWords, dto.NumericExemptCategories);
         }
         catch (JsonException ex)
         {
@@ -135,7 +189,18 @@ internal sealed class MergeCoverageVocabulary
 
     private sealed record VocabularyDto(
         [property: JsonPropertyName("extraCommonWords")] string[]? ExtraCommonWords,
-        [property: JsonPropertyName("alwaysSpecificWords")] string[]? AlwaysSpecificWords);
+        [property: JsonPropertyName("alwaysSpecificWords")] string[]? AlwaysSpecificWords,
+        [property: JsonPropertyName("numericExemptCategories")] string[]? NumericExemptCategories);
+
+    /// <summary>
+    /// Categories whose numbers are re-derived from telemetry rather than recorded, so a merge
+    /// that carries a different value is not a loss. Additive: a deployment can extend this list
+    /// through the vocabulary file but cannot remove an entry from it.
+    /// </summary>
+    private static readonly string[] BuiltInNumericExemptCategories =
+    [
+        "anti-patterns/routing",
+    ];
 
     /// <summary>
     /// Words that appear capitalized only by virtue of opening a sentence or labelling a
@@ -178,5 +243,12 @@ internal sealed class MergeCoverageVocabulary
         "valid", "invalid", "direct", "directly", "alternative", "alternatively",
         "through", "throughout", "call", "calls", "multiple", "relevant", "existing",
         "lowering", "raising", "several", "additional", "overdue", "upcoming",
+
+        // A second round of sentence openers, taken from merges the live corpus rejected on
+        // every cycle. Most of these also have a lowercase twin in the same sources, so the
+        // corpus-evidence rule would catch them on its own; listing them keeps the common case
+        // cheap and covers the sources that only ever write the word capitalized.
+        "marking", "browsing", "accessing", "together", "similar", "earlier", "later",
+        "immediately", "brief", "briefly", "web", "high", "low", "add",
     ];
 }

--- a/src/RockBot.Host/MergeCoverageVocabularyFile.cs
+++ b/src/RockBot.Host/MergeCoverageVocabularyFile.cs
@@ -1,0 +1,71 @@
+using Microsoft.Extensions.Logging;
+
+namespace RockBot.Host;
+
+/// <summary>
+/// Reads <c>merge-coverage-vocabulary.json</c> from the agent profile volume.
+/// </summary>
+/// <remarks>
+/// Shared rather than owned by <see cref="DreamService"/> because two passes now judge the same
+/// question. Consolidation asks "does this merge still carry the sources' specifics?"; save-time
+/// deduplication asks "does the entry I already have still carry this new one's specifics?" —
+/// the same coverage test over the same vocabulary. Loading the file twice from two copies of
+/// the same block is how the two would quietly drift apart.
+/// </remarks>
+internal static class MergeCoverageVocabularyFile
+{
+    /// <summary>
+    /// Loads the vocabulary at <paramref name="path"/>, falling back to
+    /// <see cref="MergeCoverageVocabulary.Default"/> when the file is absent or malformed.
+    /// </summary>
+    /// <param name="path">Resolved path to the vocabulary file.</param>
+    /// <param name="logger">Where load and parse outcomes are reported.</param>
+    /// <param name="source">
+    /// Name of the component doing the loading, used as the log-line prefix so an operator can
+    /// tell which reader picked their edit up.
+    /// </param>
+    public static MergeCoverageVocabulary Load(string path, ILogger logger, string source = "DreamService")
+    {
+        if (!File.Exists(path))
+            return MergeCoverageVocabulary.Default;
+
+        string json;
+        try
+        {
+            json = File.ReadAllText(path);
+        }
+        catch (IOException ex)
+        {
+            logger.LogWarning(ex,
+                "{Source}: could not read {Path}; using the built-in vocabulary", source, path);
+            return MergeCoverageVocabulary.Default;
+        }
+
+        var vocabulary = MergeCoverageVocabulary.Parse(json, out var error);
+
+        if (error is not null)
+        {
+            logger.LogWarning(
+                "{Source}: {Path} is malformed ({Error}); using the built-in vocabulary",
+                source, path, error);
+            return vocabulary;
+        }
+
+        // Information, matching the per-cycle directive reload: this file decides what a merge
+        // is allowed to drop, and an operator tuning it needs to see that their edit was picked
+        // up without raising the whole namespace to Debug.
+        logger.LogInformation(
+            "{Source}: merge-coverage vocabulary from {Path} — {Common} common words, " +
+            "{Specific} reclaimed as specifics{Reclaimed}, {NumericExempt} numeric-exempt categor(ies)",
+            source,
+            path,
+            vocabulary.CommonWordCount,
+            vocabulary.AlwaysSpecificWords.Count,
+            vocabulary.AlwaysSpecificWords.Count > 0
+                ? " (" + string.Join(", ", vocabulary.AlwaysSpecificWords) + ")"
+                : string.Empty,
+            vocabulary.NumericExemptCategories.Count);
+
+        return vocabulary;
+    }
+}

--- a/src/RockBot.Memory/MemoryTools.cs
+++ b/src/RockBot.Memory/MemoryTools.cs
@@ -79,6 +79,7 @@ public sealed class MemoryTools
     private readonly ILongTermMemory _memory;
     private readonly ILlmClient _llmClient;
     private readonly IMemoryContradictionDetector? _contradictionDetector;
+    private readonly IMemoryDeduplicator? _deduplicator;
     private readonly ILogger<MemoryTools> _logger;
     private readonly IList<AITool> _tools;
     private readonly string _extractionSystemPrompt;
@@ -88,11 +89,13 @@ public sealed class MemoryTools
         ILlmClient llmClient,
         IOptions<AgentProfileOptions> profileOptions,
         ILogger<MemoryTools> logger,
-        IMemoryContradictionDetector? contradictionDetector = null)
+        IMemoryContradictionDetector? contradictionDetector = null,
+        IMemoryDeduplicator? deduplicator = null)
     {
         _memory = memory;
         _llmClient = llmClient;
         _contradictionDetector = contradictionDetector;
+        _deduplicator = deduplicator;
         _logger = logger;
 
         // Load shared memory rules and prepend to the extraction prompt
@@ -413,6 +416,7 @@ public sealed class MemoryTools
     [Description("Delete a memory entry by its ID. Use this to remove facts that are wrong, outdated, or " +
                  "superseded in full. Find the ID first by calling SearchMemory — IDs appear in brackets, " +
                  "e.g. [abc123]. " +
+                 "This removes it from recall; the entry is archived, not destroyed. " +
                  "To correct part of a fact, use EditMemory instead — deleting and re-saving destroys the " +
                  "entry's age and reinforcement history.")]
     public async Task<string> DeleteMemory(
@@ -427,12 +431,17 @@ public sealed class MemoryTools
             return $"No memory entry found with id '{id}'. Use SearchMemory to find the correct ID.";
         }
 
-        await _memory.DeleteAsync(id);
+        // Archive rather than delete. The model reaches this tool on its own judgement about a
+        // fact it cannot re-derive, and it is wrong often enough that the cost of being wrong
+        // should be lost recall until someone notices, not the fact itself. Hard deletion is
+        // left to the retention purge, which runs on a delay long enough to catch it.
+        await _memory.ArchiveAsync(id, "deleted by agent tool");
 
-        _logger.LogInformation("Deleted memory entry {Id} ({Category}): {Content}",
+        _logger.LogInformation("Archived memory entry {Id} ({Category}) via DeleteMemory: {Content}",
             id, existing.Category ?? "(none)", existing.Content);
 
-        return $"Deleted memory entry '{id}': \"{existing.Content}\"";
+        return $"Archived memory entry '{id}' (recoverable by an operator until the retention purge): " +
+               $"\"{existing.Content}\"";
     }
 
     [Description("Adjust the importance score of an existing memory entry. Use this when user feedback " +
@@ -475,17 +484,41 @@ public sealed class MemoryTools
         try
         {
             var entries = await ExpandToMemoryEntriesAsync(content, category, tags);
+            var tally = new MemorySaveTally();
 
             foreach (var entry in entries)
             {
                 var resolved = await ApplyContradictionResolutionAsync(entry);
-                await _memory.SaveAsync(resolved);
-                _logger.LogInformation("Background save: {Id} ({Category}): {Content}",
-                    resolved.Id, resolved.Category ?? "(none)", resolved.Content);
+
+                // The single largest source of duplicate entries in a live corpus: the same fact
+                // restated across sessions, extracted afresh each time, and saved as a new entry
+                // for consolidation to merge back together later. Reinforcing what is already
+                // there is both cheaper and truer — the reinforcement count finally means what
+                // it says.
+                if (_deduplicator is not null)
+                {
+                    var outcome = await _deduplicator.SaveOrReinforceAsync(resolved);
+                    tally.Record(outcome);
+
+                    if (outcome.Action == MemorySaveAction.Created)
+                        _logger.LogInformation("Background save: {Id} ({Category}): {Content}",
+                            resolved.Id, resolved.Category ?? "(none)", resolved.Content);
+                    else
+                        _logger.LogInformation("Background save {Action} existing entry {Id}: {Content}",
+                            outcome.Action.ToString().ToLowerInvariant(), outcome.Id, resolved.Content);
+                }
+                else
+                {
+                    await _memory.SaveAsync(resolved);
+                    tally.Record(new MemorySaveOutcome(MemorySaveAction.Created, resolved.Id));
+                    _logger.LogInformation("Background save: {Id} ({Category}): {Content}",
+                        resolved.Id, resolved.Category ?? "(none)", resolved.Content);
+                }
             }
 
-            _logger.LogInformation("Background SaveMemory complete: {Count} new entries saved for content '{Content}'",
-                entries.Count, content);
+            _logger.LogInformation(
+                "Background SaveMemory complete: {Saved} saved, {Reinforced} reinforced, {Extended} extended for content '{Content}'",
+                tally.Saved, tally.Reinforced, tally.Extended, content);
         }
         catch (Exception ex)
         {

--- a/src/RockBot.Observation/ObservationEvaluationPhase.cs
+++ b/src/RockBot.Observation/ObservationEvaluationPhase.cs
@@ -116,13 +116,17 @@ internal sealed class ObservationEvaluationPhase(
     {
         try
         {
-            await longTermMemory.DeleteAsync(memoryEntryId, ct).ConfigureAwait(false);
+            // Archive rather than delete. A theory ages out because it stopped being re-observed
+            // in a window, which is weak evidence that it was wrong — the behaviour it described
+            // may simply not have come up.
+            await longTermMemory.ArchiveAsync(memoryEntryId, "observation theory aged out", ct)
+                .ConfigureAwait(false);
         }
         catch (OperationCanceledException) { throw; }
         catch (Exception ex)
         {
             logger.LogWarning(ex,
-                "Observation: failed to delete memory entry {MemoryEntryId} for aged theory in target {Target}",
+                "Observation: failed to archive memory entry {MemoryEntryId} for aged theory in target {Target}",
                 memoryEntryId, target.Name);
         }
     }

--- a/tests/RockBot.Agent.Tests/MemoryToolsTests.cs
+++ b/tests/RockBot.Agent.Tests/MemoryToolsTests.cs
@@ -183,15 +183,34 @@ public class MemoryToolsTests
     }
 
     [TestMethod]
-    public async Task DeleteMemory_KnownId_EntryIsRemoved()
+    public async Task DeleteMemory_ArchivesInsteadOfDeleting()
     {
+        // The model reaches this tool on its own judgement about a fact it cannot re-derive, and
+        // it is wrong often enough that being wrong should cost recall until someone notices,
+        // not the fact. Hard deletion is left to the retention purge.
         var memory = new StubLongTermMemory();
         memory.Add(Entry("id1", "To be deleted", DateTimeOffset.UtcNow));
         var tools = MakeTools(memory);
 
         await tools.DeleteMemory("id1");
 
-        Assert.IsNull(await memory.GetAsync("id1"));
+        Assert.AreEqual(0, memory.Deleted.Count, "DeleteMemory must not hard-delete.");
+        CollectionAssert.AreEqual(new[] { "id1" }, memory.Archived.Select(a => a.Id).ToArray());
+        Assert.AreEqual("deleted by agent tool", memory.Archived[0].Reason);
+        Assert.IsNotNull(await memory.GetAsync("id1"), "An archived entry stays retrievable by id.");
+    }
+
+    [TestMethod]
+    public async Task DeleteMemory_TellsTheModelTheEntryIsRecoverable()
+    {
+        var memory = new StubLongTermMemory();
+        memory.Add(Entry("id1", "To be deleted", DateTimeOffset.UtcNow));
+        var tools = MakeTools(memory);
+
+        var result = await tools.DeleteMemory("id1");
+
+        StringAssert.Contains(result, "Archived");
+        StringAssert.Contains(result, "recoverable");
     }
 
     [TestMethod]
@@ -668,16 +687,97 @@ public class MemoryToolsTests
             "Non-scoped categories should still go through the LLM extraction pass.");
     }
 
+    // -------------------------------------------------------------------------
+    // SaveMemory — save-time deduplication
+    // -------------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task SaveMemory_NonScopedCategory_RoutesThroughTheDeduplicator()
+    {
+        // The single largest source of duplicate entries in a live corpus: the same fact restated
+        // across sessions, extracted afresh each time, and saved as a new entry for consolidation
+        // to merge back together later.
+        var memory = new StubLongTermMemory();
+        var deduplicator = new FakeDeduplicator();
+        var llm = new StubChatClient { Response = ExtractionResponse };
+        var tools = MakeToolsWith(memory, llm, deduplicator: deduplicator);
+
+        await tools.SaveMemory("Rocky has a Sheltie named Milo", category: "user-preferences/pets");
+
+        await WaitForAsync(() => deduplicator.Calls.Count == 1);
+        Assert.AreEqual(0, memory.SnapshotAll().Count,
+            "The fake deduplicator persisted nothing, so a direct SaveAsync would show up here.");
+    }
+
+    [TestMethod]
+    public async Task SaveMemory_ScopedCategory_BypassesTheDeduplicator()
+    {
+        // Scoped saves go down the direct path, which the contradiction detector owns.
+        var memory = new StubLongTermMemory();
+        var deduplicator = new FakeDeduplicator();
+        var tools = MakeToolsWith(memory, new StubChatClient(), deduplicator: deduplicator);
+
+        await tools.SaveMemory(
+            "Always include a TL;DR section at the top of status reports",
+            category: "feedback/from-agent/status-reports");
+
+        await WaitForSavedAsync(memory, expected: 1);
+        Assert.AreEqual(0, deduplicator.Calls.Count);
+    }
+
+    [TestMethod]
+    public async Task SaveMemory_WithoutADeduplicator_SavesDirectly()
+    {
+        var memory = new StubLongTermMemory();
+        var tools = MakeToolsWith(memory, new StubChatClient { Response = ExtractionResponse });
+
+        await tools.SaveMemory("Rocky has a Sheltie named Milo", category: "user-preferences/pets");
+
+        var saved = await WaitForSavedAsync(memory, expected: 1);
+        Assert.AreEqual("Rocky has a Sheltie named Milo", saved[0].Content);
+    }
+
+    /// <summary>One extracted entry, so the extraction path yields something to persist.</summary>
+    private const string ExtractionResponse =
+        """[{"content": "Rocky has a Sheltie named Milo", "category": "user-preferences/pets"}]""";
+
+    /// <summary>Records what it was handed and deliberately persists nothing.</summary>
+    private sealed class FakeDeduplicator : IMemoryDeduplicator
+    {
+        public List<MemoryEntry> Calls { get; } = [];
+
+        public Task<MemorySaveOutcome> SaveOrReinforceAsync(
+            MemoryEntry candidate, CancellationToken cancellationToken = default)
+        {
+            lock (Calls)
+                Calls.Add(candidate);
+            return Task.FromResult(new MemorySaveOutcome(MemorySaveAction.Reinforced, "existing", 0.95));
+        }
+    }
+
     private static MemoryTools MakeToolsWith(
         StubLongTermMemory memory,
         StubChatClient llm,
-        IMemoryContradictionDetector? detector = null) =>
+        IMemoryContradictionDetector? detector = null,
+        IMemoryDeduplicator? deduplicator = null) =>
         new(
             memory,
             llm,
             Microsoft.Extensions.Options.Options.Create(new AgentProfileOptions()),
             NullLogger<MemoryTools>.Instance,
-            detector);
+            detector,
+            deduplicator);
+
+    private static async Task WaitForAsync(Func<bool> condition, int timeoutMs = 2000)
+    {
+        var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition()) return;
+            await Task.Delay(20);
+        }
+        Assert.Fail("Timed out waiting for the expected condition.");
+    }
 
     private static async Task<IReadOnlyList<MemoryEntry>> WaitForSavedAsync(
         StubLongTermMemory memory, int expected, int timeoutMs = 2000)
@@ -774,9 +874,32 @@ internal sealed class StubLongTermMemory : ILongTermMemory
         }
     }
 
+    /// <summary>Ids passed to <see cref="DeleteAsync"/>, so tests can assert nothing hard-deletes.</summary>
+    public List<string> Deleted { get; } = [];
+
+    /// <summary>Ids and reasons passed to <see cref="ArchiveAsync"/>.</summary>
+    public List<(string Id, string Reason)> Archived { get; } = [];
+
     public Task DeleteAsync(string id, CancellationToken cancellationToken = default)
     {
+        Deleted.Add(id);
         _entries.RemoveAll(e => e.Id == id);
+        return Task.CompletedTask;
+    }
+
+    public Task ArchiveAsync(string id, string reason, CancellationToken cancellationToken = default)
+    {
+        Archived.Add((id, reason));
+        lock (_entries)
+        {
+            var index = _entries.FindIndex(e => e.Id == id);
+            if (index >= 0)
+                _entries[index] = _entries[index] with
+                {
+                    ArchivedAt = DateTimeOffset.UtcNow,
+                    ArchiveReason = reason,
+                };
+        }
         return Task.CompletedTask;
     }
 
@@ -804,13 +927,16 @@ internal sealed class StubChatClient : ILlmClient
     public bool IsIdle => true;
     public int CallCount => Volatile.Read(ref _callCount);
 
+    /// <summary>Raw assistant text to return. Defaults to an empty array so callers fall back to a direct save.</summary>
+    public string Response { get; set; } = "[]";
+
     public Task<ChatResponse> GetResponseAsync(
         IEnumerable<ChatMessage> messages,
         ChatOptions? options = null,
         CancellationToken cancellationToken = default)
     {
         Interlocked.Increment(ref _callCount);
-        return Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, "[]")));
+        return Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, Response)));
     }
 
     public Task<ChatResponse> GetResponseAsync(

--- a/tests/RockBot.Host.Tests/AgentContextBuilderCapabilityClaimTests.cs
+++ b/tests/RockBot.Host.Tests/AgentContextBuilderCapabilityClaimTests.cs
@@ -34,8 +34,12 @@ public class AgentContextBuilderCapabilityClaimTests
 
         var messages = await builder.BuildAsync("session-1", LongMessage, CancellationToken.None);
 
-        Assert.AreEqual(1, ltm.DeletedIds.Count, "Falsified claim must be evicted from LTM.");
-        Assert.AreEqual("claim-a", ltm.DeletedIds[0]);
+        // Archived, not deleted: the verifier decides on a single probe run at context-build time,
+        // and a probe can fail for reasons that have nothing to do with the claim being wrong.
+        Assert.AreEqual(0, ltm.DeletedIds.Count, "Eviction must not hard-delete.");
+        Assert.AreEqual(1, ltm.ArchivedIds.Count, "Falsified claim must be evicted from LTM.");
+        Assert.AreEqual("claim-a", ltm.ArchivedIds[0].Id);
+        Assert.AreEqual("falsified by capability verifier", ltm.ArchivedIds[0].Reason);
         Assert.IsFalse(messages.Any(m => m.Text?.Contains("claim-a") == true),
             "Evicted claim must not appear in any injected context.");
     }
@@ -51,6 +55,7 @@ public class AgentContextBuilderCapabilityClaimTests
         var messages = await builder.BuildAsync("session-1", LongMessage, CancellationToken.None);
 
         Assert.AreEqual(0, ltm.DeletedIds.Count, "Predicate-failed claim must NOT be evicted.");
+        Assert.AreEqual(0, ltm.ArchivedIds.Count, "Predicate-failed claim must NOT be evicted.");
         var injected = messages.FirstOrDefault(m => m.Text?.Contains("claim-b") == true);
         Assert.IsNotNull(injected, "Predicate-failed claim must be injected as before.");
         Assert.IsFalse(injected!.Text!.Contains("verifier-uncertain"),
@@ -68,6 +73,7 @@ public class AgentContextBuilderCapabilityClaimTests
         var messages = await builder.BuildAsync("session-1", LongMessage, CancellationToken.None);
 
         Assert.AreEqual(0, ltm.DeletedIds.Count, "Uncertain claim must NOT be evicted.");
+        Assert.AreEqual(0, ltm.ArchivedIds.Count, "Uncertain claim must NOT be evicted.");
         var injected = messages.FirstOrDefault(m => m.Text?.Contains("claim-c") == true);
         Assert.IsNotNull(injected, "Uncertain claim must be injected.");
         StringAssert.Contains(injected!.Text!, "verifier-uncertain");
@@ -85,6 +91,7 @@ public class AgentContextBuilderCapabilityClaimTests
         var messages = await builder.BuildAsync("session-1", LongMessage, CancellationToken.None);
 
         Assert.AreEqual(0, ltm.DeletedIds.Count, "Non-claim entries must not be evicted.");
+        Assert.AreEqual(0, ltm.ArchivedIds.Count, "Non-claim entries must not be evicted.");
         Assert.AreEqual(0, verifier.CallCount, "Verifier must not be invoked for non-claim entries.");
         Assert.IsTrue(messages.Any(m => m.Text?.Contains("regular-1") == true),
             "Regular entry must be injected as before.");
@@ -100,6 +107,7 @@ public class AgentContextBuilderCapabilityClaimTests
         var messages = await builder.BuildAsync("session-1", LongMessage, CancellationToken.None);
 
         Assert.AreEqual(0, ltm.DeletedIds.Count);
+        Assert.AreEqual(0, ltm.ArchivedIds.Count);
         Assert.IsTrue(messages.Any(m => m.Text?.Contains("claim-d") == true),
             "Without a verifier, claim entries fall through to the existing injection path.");
     }
@@ -118,6 +126,7 @@ public class AgentContextBuilderCapabilityClaimTests
         var messages = await builder.BuildAsync("session-1", LongMessage, CancellationToken.None);
 
         Assert.AreEqual(0, ltm.DeletedIds.Count, "Verifier exceptions must not cause eviction.");
+        Assert.AreEqual(0, ltm.ArchivedIds.Count, "Verifier exceptions must not cause eviction.");
         var injected = messages.FirstOrDefault(m => m.Text?.Contains("claim-e") == true);
         Assert.IsNotNull(injected);
         StringAssert.Contains(injected!.Text!, "verifier-error");
@@ -209,6 +218,7 @@ public class AgentContextBuilderCapabilityClaimTests
     {
         private readonly List<MemoryEntry> _entries;
         public List<string> DeletedIds { get; } = new();
+        public List<(string Id, string Reason)> ArchivedIds { get; } = new();
 
         public RecordingMemory(IReadOnlyList<MemoryEntry> seed) => _entries = [.. seed];
 
@@ -234,6 +244,13 @@ public class AgentContextBuilderCapabilityClaimTests
         public Task DeleteAsync(string id, CancellationToken cancellationToken = default)
         {
             DeletedIds.Add(id);
+            _entries.RemoveAll(e => e.Id == id);
+            return Task.CompletedTask;
+        }
+
+        public Task ArchiveAsync(string id, string reason, CancellationToken cancellationToken = default)
+        {
+            ArchivedIds.Add((id, reason));
             _entries.RemoveAll(e => e.Id == id);
             return Task.CompletedTask;
         }

--- a/tests/RockBot.Host.Tests/AgentIdentityTests.cs
+++ b/tests/RockBot.Host.Tests/AgentIdentityTests.cs
@@ -90,7 +90,7 @@ public class AgentIdentityTests
         }
         """;
 
-        var result = JsonSerializer.Deserialize<IdentityReflectionResultDto>(json, JsonOptions);
+        var result = JsonSerializer.Deserialize<DreamService.IdentityReflectionResultDto>(json, JsonOptions);
 
         Assert.IsNotNull(result);
         Assert.IsFalse(result.NoChange);
@@ -109,12 +109,72 @@ public class AgentIdentityTests
     {
         var json = """{"noChange": true, "toDelete": [], "toSave": []}""";
 
-        var result = JsonSerializer.Deserialize<IdentityReflectionResultDto>(json, JsonOptions);
+        var result = JsonSerializer.Deserialize<DreamService.IdentityReflectionResultDto>(json, JsonOptions);
 
         Assert.IsNotNull(result);
         Assert.IsTrue(result.NoChange);
         Assert.AreEqual(0, result.ToSave?.Count);
         Assert.AreEqual(0, result.ToDelete?.Count);
+    }
+
+    // ── Applying a reflection result ────────────────────────────────────────
+
+    [TestMethod]
+    public async Task ApplyIdentityReflectionResult_ArchivesTheEntriesItReplaces()
+    {
+        // This pass rewrites essentially all of its own entries on essentially every run, so a
+        // hard delete meant the agent's previous self-description vanished the moment the model
+        // produced a new one — with nothing to compare against and no way to put it back.
+        var memory = new FakeLongTermMemory();
+        var result = new DreamService.IdentityReflectionResultDto(
+            NoChange: false,
+            ToDelete: ["old-self"],
+            ToSave: [new DreamService.IdentityEntryDto(
+                "I have become primarily a communication manager.", null, null, 0.8f)]);
+
+        var (archived, saved) = await DreamService.ApplyIdentityReflectionResultAsync(
+            memory, result, NullLogger.Instance, CancellationToken.None);
+
+        Assert.AreEqual(1, archived);
+        Assert.AreEqual(1, saved);
+        Assert.AreEqual(0, memory.Deleted.Count, "Identity reflection must not hard-delete.");
+        CollectionAssert.AreEqual(new[] { "old-self" }, memory.Archived.Select(a => a.Id).ToArray());
+        Assert.AreEqual("replaced by identity reflection", memory.Archived[0].Reason);
+
+        var written = memory.Saved.Single();
+        Assert.AreEqual(AgentIdentityCategories.SelfModel, written.Category);
+        CollectionAssert.Contains(written.Tags.ToArray(), "identity");
+    }
+
+    [TestMethod]
+    public async Task ApplyIdentityReflectionResult_ForcesTheCategoryUnderTheIdentityPrefix()
+    {
+        var memory = new FakeLongTermMemory();
+        var result = new DreamService.IdentityReflectionResultDto(
+            NoChange: false,
+            ToDelete: null,
+            ToSave: [new DreamService.IdentityEntryDto("I am careful.", "values", ["identity"], null)]);
+
+        await DreamService.ApplyIdentityReflectionResultAsync(
+            memory, result, NullLogger.Instance, CancellationToken.None);
+
+        Assert.AreEqual($"{AgentIdentityCategories.Prefix}/values", memory.Saved.Single().Category);
+    }
+
+    [TestMethod]
+    public async Task ApplyIdentityReflectionResult_SkipsBlankContent()
+    {
+        var memory = new FakeLongTermMemory();
+        var result = new DreamService.IdentityReflectionResultDto(
+            NoChange: false,
+            ToDelete: null,
+            ToSave: [new DreamService.IdentityEntryDto("   ", null, null, null)]);
+
+        var (_, saved) = await DreamService.ApplyIdentityReflectionResultAsync(
+            memory, result, NullLogger.Instance, CancellationToken.None);
+
+        Assert.AreEqual(0, saved);
+        Assert.AreEqual(0, memory.Saved.Count);
     }
 
     // ── AgentContextBuilder: identity injection ─────────────────────────────
@@ -233,8 +293,15 @@ public class AgentIdentityTests
     /// </summary>
     private sealed class FakeLongTermMemory(params MemoryEntry[] identityEntries) : ILongTermMemory
     {
+        public List<MemoryEntry> Saved { get; } = [];
+        public List<string> Deleted { get; } = [];
+        public List<(string Id, string Reason)> Archived { get; } = [];
+
         public Task SaveAsync(MemoryEntry entry, CancellationToken cancellationToken = default)
-            => Task.CompletedTask;
+        {
+            Saved.Add(entry);
+            return Task.CompletedTask;
+        }
 
         public Task<IReadOnlyList<MemoryEntry>> SearchAsync(MemorySearchCriteria criteria, CancellationToken cancellationToken = default)
         {
@@ -250,7 +317,16 @@ public class AgentIdentityTests
             => Task.FromResult<MemoryEntry?>(null);
 
         public Task DeleteAsync(string id, CancellationToken cancellationToken = default)
-            => Task.CompletedTask;
+        {
+            Deleted.Add(id);
+            return Task.CompletedTask;
+        }
+
+        public Task ArchiveAsync(string id, string reason, CancellationToken cancellationToken = default)
+        {
+            Archived.Add((id, reason));
+            return Task.CompletedTask;
+        }
 
         public Task<IReadOnlyList<string>> ListTagsAsync(CancellationToken cancellationToken = default)
             => Task.FromResult<IReadOnlyList<string>>([]);
@@ -306,17 +382,4 @@ public class AgentIdentityTests
         public Task<IReadOnlyList<Skill>> SearchAsync(string query, int maxResults, CancellationToken cancellationToken = default, float[]? queryEmbedding = null)
             => Task.FromResult<IReadOnlyList<Skill>>([]);
     }
-
-    // ── DTOs (mirrors DreamService private records for deserialization testing) ──
-
-    internal sealed record IdentityReflectionResultDto(
-        bool? NoChange,
-        List<string>? ToDelete,
-        List<IdentityEntryDto>? ToSave);
-
-    internal sealed record IdentityEntryDto(
-        string Content,
-        string? Category,
-        IReadOnlyList<string>? Tags,
-        float? Importance);
 }

--- a/tests/RockBot.Host.Tests/DreamMergeRepairTests.cs
+++ b/tests/RockBot.Host.Tests/DreamMergeRepairTests.cs
@@ -1,0 +1,218 @@
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace RockBot.Host.Tests;
+
+/// <summary>
+/// Covers the second chance a merge gets after the coverage check rejects it.
+/// </summary>
+/// <remarks>
+/// Rejection alone left the duplicate cluster in place, so the next cycle proposed the same merge
+/// and the check rejected it the same way — a live corpus rejected one six-source merge five times
+/// in eight cycles. The repair call is a narrower task than merging: the model is handed the exact
+/// strings it dropped and asked to put them back, and its answer faces the same check, so a bad
+/// repair lands exactly where the rejection would have.
+/// </remarks>
+[TestClass]
+public class DreamMergeRepairTests
+{
+    private const string SourceA = "Rockford Duane Lhotka uses timezone America/Chicago.";
+    private const string SourceB = "Accounts span Microsoft and Marimer LLC.";
+    private const string LossyMerge = "The user has accounts across providers and a default timezone.";
+    private const string RepairedMerge =
+        "Rockford Duane Lhotka uses timezone America/Chicago; accounts span Microsoft and Marimer LLC.";
+
+    [TestMethod]
+    public async Task ARejectedMerge_IsRepairedAndApplied()
+    {
+        var memory = new ArchivingStore();
+        await memory.SaveAsync(Entry("a", SourceA));
+        await memory.SaveAsync(Entry("b", SourceB));
+
+        var llm = new ScriptedLlmClient(
+            ConsolidationResponse(LossyMerge),
+            $$$"""{"content": "{{{RepairedMerge}}}"}""");
+
+        var service = CreateService(memory, new DreamOptions { Enabled = false }, llm);
+
+        var (deleted, saved) = await service.RunMemoryConsolidationPassAsync(CancellationToken.None);
+
+        Assert.AreEqual(2, llm.Calls.Count, "The rejection should have triggered exactly one repair call.");
+        StringAssert.Contains(llm.Calls[1], "America/Chicago",
+            "The repair prompt must name the specifics the merge dropped.");
+
+        Assert.AreEqual(1, saved);
+        Assert.AreEqual(2, deleted);
+
+        CollectionAssert.AreEquivalent(new[] { "a", "b" }, memory.Archived.Select(x => x.Id).ToArray());
+
+        var merged = memory.Snapshot().Single(e => e.Id is not "a" and not "b");
+        Assert.AreEqual(RepairedMerge, merged.Content);
+    }
+
+    [TestMethod]
+    public async Task ARepairThatStillDropsSpecifics_LeavesTheSourcesAlone()
+    {
+        var memory = new ArchivingStore();
+        await memory.SaveAsync(Entry("a", SourceA));
+        await memory.SaveAsync(Entry("b", SourceB));
+
+        var llm = new ScriptedLlmClient(
+            ConsolidationResponse(LossyMerge),
+            """{"content": "Rockford Duane Lhotka has accounts and a timezone."}""");
+
+        var service = CreateService(memory, new DreamOptions { Enabled = false }, llm);
+
+        var (deleted, saved) = await service.RunMemoryConsolidationPassAsync(CancellationToken.None);
+
+        Assert.AreEqual(0, saved);
+        Assert.AreEqual(0, deleted);
+        Assert.AreEqual(0, memory.Archived.Count, "A merge that is still lossy after repair keeps its sources.");
+        Assert.AreEqual(2, memory.Snapshot().Count);
+    }
+
+    [TestMethod]
+    public async Task WithRepairDisabled_TheRejectionIsTerminalAndNoSecondCallIsMade()
+    {
+        var memory = new ArchivingStore();
+        await memory.SaveAsync(Entry("a", SourceA));
+        await memory.SaveAsync(Entry("b", SourceB));
+
+        var llm = new ScriptedLlmClient(ConsolidationResponse(LossyMerge));
+        var service = CreateService(
+            memory, new DreamOptions { Enabled = false, MergeRepairEnabled = false }, llm);
+
+        var (deleted, saved) = await service.RunMemoryConsolidationPassAsync(CancellationToken.None);
+
+        Assert.AreEqual(1, llm.Calls.Count);
+        Assert.AreEqual(0, saved);
+        Assert.AreEqual(0, deleted);
+    }
+
+    [TestMethod]
+    public async Task RepairAttemptsAreCappedPerCycle()
+    {
+        // A cycle in which the model merges badly across the board must not turn into an
+        // unbounded run of LLM calls.
+        var memory = new ArchivingStore();
+        for (var i = 0; i < 4; i++)
+        {
+            await memory.SaveAsync(Entry($"a{i}", $"Rockford Lhotka owns account {i}00 at Marimer LLC."));
+            await memory.SaveAsync(Entry($"b{i}", $"Account {i}00 is administered from Austin."));
+        }
+
+        var merges = string.Join(",", Enumerable.Range(0, 4).Select(i =>
+            $$"""{"content": "An account exists.", "sourceIds": ["a{{i}}", "b{{i}}"]}"""));
+
+        var llm = new ScriptedLlmClient($$"""{"toDelete": [], "toSave": [{{merges}}]}""");
+        var service = CreateService(
+            memory,
+            new DreamOptions { Enabled = false, MergeRepairMaxPerCycle = 2 },
+            llm);
+
+        await service.RunMemoryConsolidationPassAsync(CancellationToken.None);
+
+        Assert.AreEqual(3, llm.Calls.Count,
+            "One consolidation call plus the two repairs the cap allows.");
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static string ConsolidationResponse(string mergedContent) =>
+        $$"""
+        {
+          "toDelete": ["a", "b"],
+          "toSave": [{ "content": "{{mergedContent}}", "sourceIds": ["a", "b"] }]
+        }
+        """;
+
+    private static MemoryEntry Entry(string id, string content) =>
+        new(id, content, null, [], DateTimeOffset.UtcNow.AddDays(-10));
+
+    private static DreamService CreateService(ILongTermMemory memory, DreamOptions options, ILlmClient llm) =>
+        new(memory,
+            [],
+            llm,
+            new AgentWorkSerializer(),
+            new StubActivityMonitor(),
+            new AgentClock(
+                new ConfigurationBuilder().Build(),
+                Options.Create(new AgentProfileOptions()),
+                NullLogger<AgentClock>.Instance),
+            Options.Create(options),
+            Options.Create(new AgentProfileOptions()),
+            NullLogger<DreamService>.Instance);
+
+    /// <summary>Returns the scripted responses in order, then repeats the last one.</summary>
+    private sealed class ScriptedLlmClient(params string[] responses) : ILlmClient
+    {
+        public List<string> Calls { get; } = [];
+
+        public bool IsIdle => true;
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            Calls.Add(string.Join("\n", messages.Select(m => m.Text)));
+            var index = Math.Min(Calls.Count - 1, responses.Length - 1);
+            return Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, responses[index])));
+        }
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages, ModelTier tier, ChatOptions? options = null,
+            CancellationToken cancellationToken = default) =>
+            GetResponseAsync(messages, options, cancellationToken);
+    }
+
+    private sealed class StubActivityMonitor : IUserActivityMonitor
+    {
+        public void RecordActivity() { }
+        public bool IsUserActive(TimeSpan idleThreshold) => false;
+    }
+
+    private sealed class ArchivingStore : ILongTermMemory
+    {
+        private readonly Dictionary<string, MemoryEntry> _entries = new(StringComparer.OrdinalIgnoreCase);
+
+        public List<(string Id, string Reason)> Archived { get; } = [];
+
+        public IReadOnlyList<MemoryEntry> Snapshot() => [.. _entries.Values];
+
+        public Task SaveAsync(MemoryEntry entry, CancellationToken cancellationToken = default)
+        {
+            _entries[entry.Id] = entry;
+            return Task.CompletedTask;
+        }
+
+        public Task<MemoryEntry?> GetAsync(string id, CancellationToken cancellationToken = default) =>
+            Task.FromResult(_entries.GetValueOrDefault(id));
+
+        public Task<IReadOnlyList<MemoryEntry>> SearchAsync(
+            MemorySearchCriteria criteria, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<MemoryEntry>>(
+                [.. _entries.Values.Where(e => e.ArchivedAt is null)]);
+
+        public Task DeleteAsync(string id, CancellationToken cancellationToken = default)
+        {
+            _entries.Remove(id);
+            return Task.CompletedTask;
+        }
+
+        public Task ArchiveAsync(string id, string reason, CancellationToken cancellationToken = default)
+        {
+            Archived.Add((id, reason));
+            if (_entries.TryGetValue(id, out var entry))
+                _entries[id] = entry with { ArchivedAt = DateTimeOffset.UtcNow, ArchiveReason = reason };
+            return Task.CompletedTask;
+        }
+
+        public Task<IReadOnlyList<string>> ListTagsAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<string>>([]);
+
+        public Task<IReadOnlyList<string>> ListCategoriesAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<string>>([]);
+    }
+}

--- a/tests/RockBot.Host.Tests/DreamOptionsRetentionBindingTests.cs
+++ b/tests/RockBot.Host.Tests/DreamOptionsRetentionBindingTests.cs
@@ -40,6 +40,31 @@ public class DreamOptionsRetentionBindingTests
     }
 
     [TestMethod]
+    public void Binds_ConsolidationMinInterval_FromTheConfigMapTimeSpanShape()
+    {
+        var opts = Bind(new Dictionary<string, string?>
+        {
+            ["Dream:ConsolidationMinInterval"] = "0.12:00:00",
+            ["Dream:MergeRepairEnabled"] = "false",
+            ["Dream:MergeRepairMaxPerCycle"] = "3",
+        });
+
+        Assert.AreEqual(TimeSpan.FromHours(12), opts.ConsolidationMinInterval);
+        Assert.IsFalse(opts.MergeRepairEnabled);
+        Assert.AreEqual(3, opts.MergeRepairMaxPerCycle);
+    }
+
+    [TestMethod]
+    public void ConsolidationMinInterval_DefaultsToSixHours()
+    {
+        var opts = Bind(new Dictionary<string, string?> { ["Other:Key"] = "x" });
+
+        Assert.AreEqual(TimeSpan.FromHours(6), opts.ConsolidationMinInterval);
+        Assert.IsTrue(opts.MergeRepairEnabled);
+        Assert.AreEqual(10, opts.MergeRepairMaxPerCycle);
+    }
+
+    [TestMethod]
     public void MissingSection_LeavesCodeDefaults()
     {
         var opts = Bind(new Dictionary<string, string?> { ["Other:Key"] = "x" });

--- a/tests/RockBot.Host.Tests/DreamPassChangeGateTests.cs
+++ b/tests/RockBot.Host.Tests/DreamPassChangeGateTests.cs
@@ -309,6 +309,51 @@ public class DreamPassChangeGateTests
             "A rewritten entry is a changed corpus -- which is exactly why outputs stay out of the hash.");
     }
 
+    // -- Consolidation minimum interval ---------------------------------------
+    //
+    // Consolidation reuses the ledger with a constant fingerprint. That collapses ShouldSkip to
+    // its time floor, which is exactly the semantics the pass wants — it is not gating on whether
+    // the corpus changed, it is refusing to run twice in one afternoon because the pod restarted
+    // twice. Reusing the ledger also means the interval survives those restarts.
+
+    [TestMethod]
+    public void ConsolidationSentinel_SkipsWhileTheLastRunIsYoungerThanTheInterval()
+    {
+        var record = new DreamPassLedger.PassRecord(DreamService.ConsolidationLedgerFingerprint, Now.AddHours(-2));
+
+        Assert.IsTrue(DreamPassLedger.ShouldSkip(
+            record, DreamService.ConsolidationLedgerFingerprint, Now, TimeSpan.FromHours(6)));
+    }
+
+    [TestMethod]
+    public void ConsolidationSentinel_RunsOnceTheIntervalHasElapsed()
+    {
+        var record = new DreamPassLedger.PassRecord(DreamService.ConsolidationLedgerFingerprint, Now.AddHours(-7));
+
+        Assert.IsFalse(DreamPassLedger.ShouldSkip(
+            record, DreamService.ConsolidationLedgerFingerprint, Now, TimeSpan.FromHours(6)));
+    }
+
+    [TestMethod]
+    public void ConsolidationSentinel_WithAZeroInterval_AlwaysRuns()
+    {
+        // Zero disables the floor. The ledger's own semantics for a non-positive interval are the
+        // opposite — skip forever on an unchanged fingerprint — so the pass checks the option
+        // before consulting the ledger at all. This asserts the shape the caller relies on.
+        var record = new DreamPassLedger.PassRecord(DreamService.ConsolidationLedgerFingerprint, Now.AddMinutes(-1));
+
+        Assert.IsTrue(DreamPassLedger.ShouldSkip(
+            record, DreamService.ConsolidationLedgerFingerprint, Now, TimeSpan.Zero),
+            "Guarding on ConsolidationMinInterval > Zero in the caller is what makes zero mean 'always run'.");
+    }
+
+    [TestMethod]
+    public void ConsolidationSentinel_NeverRun_DoesNotSkip()
+    {
+        Assert.IsFalse(DreamPassLedger.ShouldSkip(
+            null, DreamService.ConsolidationLedgerFingerprint, Now, TimeSpan.FromHours(6)));
+    }
+
     // ── Helpers ──────────────────────────────────────────────────────────────
 
     private static string NewTempDir()

--- a/tests/RockBot.Host.Tests/DreamServicePromptBuilderTests.cs
+++ b/tests/RockBot.Host.Tests/DreamServicePromptBuilderTests.cs
@@ -124,6 +124,35 @@ public class DreamServicePromptBuilderTests
             "mcp/* cluster must NOT appear in the abstract-parent-guide section.");
     }
 
+    // ── Merge repair prompt ──────────────────────────────────────────────────
+
+    [TestMethod]
+    public void BuildMergeRepairPrompt_NamesTheRejectedText_TheSources_AndEveryMissingSpecific()
+    {
+        // The repair call is deliberately not "try merging again". It is handed the exact strings
+        // the coverage check found missing, because that is a task a model can complete reliably
+        // where re-merging demonstrably was not — a live corpus re-proposed and re-rejected the
+        // same six-source merge five times in eight cycles.
+        var sources = new[]
+        {
+            new MemoryEntry("s1", "Rockford Duane Lhotka, timezone America/Chicago.", null, [], Now),
+            new MemoryEntry("s2", "Accounts span Microsoft, Google and Marimer LLC.", null, [], Now),
+        };
+
+        var prompt = DreamService.BuildMergeRepairPrompt(
+            sources,
+            "The user has several accounts and a default timezone.",
+            ["America/Chicago", "LLC", "Rockford"]);
+
+        StringAssert.Contains(prompt, "The user has several accounts and a default timezone.");
+        StringAssert.Contains(prompt, "1. Rockford Duane Lhotka, timezone America/Chicago.");
+        StringAssert.Contains(prompt, "2. Accounts span Microsoft, Google and Marimer LLC.");
+        StringAssert.Contains(prompt, "- America/Chicago");
+        StringAssert.Contains(prompt, "- LLC");
+        StringAssert.Contains(prompt, "- Rockford");
+        StringAssert.Contains(prompt, "verbatim");
+    }
+
     private static Skill MakeSkill(string name) => new(
         Name: name,
         Summary: $"summary for {name}",

--- a/tests/RockBot.Host.Tests/FileMemoryStoreSimilarityLookupTests.cs
+++ b/tests/RockBot.Host.Tests/FileMemoryStoreSimilarityLookupTests.cs
@@ -1,0 +1,154 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace RockBot.Host.Tests;
+
+/// <summary>
+/// Covers the store-side lookup that lets a save reinforce an existing entry instead of adding a
+/// near-copy of it.
+/// </summary>
+/// <remarks>
+/// No embedding generator is registered, so every case here exercises the lexical fallback. That
+/// is deliberate: the framework supports BM25-only deployments, and the fallback is the path that
+/// decides whether they get deduplication at all.
+/// </remarks>
+[TestClass]
+public class FileMemoryStoreSimilarityLookupTests
+{
+    private string _tempDir = null!;
+
+    [TestInitialize]
+    public void Init() =>
+        _tempDir = Path.Combine(Path.GetTempPath(), "rockbot-similarity-" + Guid.NewGuid().ToString("N"));
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    [TestMethod]
+    public async Task FindMostSimilarAsync_ReturnsTheNearVerbatimEntry_WithALexicalScore()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(Entry("existing", "Rocky prefers concise status"));
+        await store.SaveAsync(Entry("unrelated", "Longhorn backup retention spans roughly four days"));
+
+        var match = await store.FindMostSimilarAsync(Entry("candidate", "Rocky prefers concise"));
+
+        Assert.IsNotNull(match);
+        Assert.AreEqual("existing", match.Entry.Id);
+        Assert.AreEqual(MemorySimilarityMeasure.Lexical, match.Measure);
+
+        // Three shared tokens over a four-token union. Asserted exactly because the deduplicator's
+        // default threshold is calibrated against this scale, not against cosine's.
+        Assert.AreEqual(0.75, match.Score, 0.001);
+    }
+
+    [TestMethod]
+    public async Task FindMostSimilarAsync_IgnoresEntriesInADifferentTopLevelCategory()
+    {
+        // Lexical scoring runs on shared vocabulary alone, and operational memory reuses a lot of
+        // it across subjects. Without the scope bound a preference could be folded into an
+        // infrastructure note that merely talks about the same nouns.
+        var store = CreateStore();
+        await store.SaveAsync(Entry("infra", "Rocky prefers concise status", category: "agent-knowledge/infrastructure"));
+
+        var match = await store.FindMostSimilarAsync(
+            Entry("candidate", "Rocky prefers concise", category: "user-preferences/reporting"));
+
+        Assert.IsNull(match);
+    }
+
+    [TestMethod]
+    public async Task FindMostSimilarAsync_MatchesWithinTheSameTopLevelCategory()
+    {
+        // The same fact filed under sibling subcategories is the common duplicate, so the bound is
+        // the top-level segment rather than the whole path.
+        var store = CreateStore();
+        await store.SaveAsync(Entry("existing", "Rocky prefers concise status", category: "user-preferences/status"));
+
+        var match = await store.FindMostSimilarAsync(
+            Entry("candidate", "Rocky prefers concise", category: "user-preferences/reporting"));
+
+        Assert.IsNotNull(match);
+        Assert.AreEqual("existing", match.Entry.Id);
+    }
+
+    [TestMethod]
+    public async Task FindMostSimilarAsync_NullCategoryMatchesOnlyUncategorizedEntries()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(Entry("categorized", "Rocky prefers concise status", category: "user-preferences"));
+
+        Assert.IsNull(await store.FindMostSimilarAsync(Entry("candidate", "Rocky prefers concise")));
+
+        await store.SaveAsync(Entry("uncategorized", "Rocky prefers concise status"));
+
+        var match = await store.FindMostSimilarAsync(Entry("candidate", "Rocky prefers concise"));
+        Assert.IsNotNull(match);
+        Assert.AreEqual("uncategorized", match.Entry.Id);
+    }
+
+    [TestMethod]
+    public async Task FindMostSimilarAsync_IgnoresArchivedAndSupersededEntries()
+    {
+        // Reinforcing something already withdrawn from recall would resurrect it by the back door.
+        var store = CreateStore();
+        await store.SaveAsync(Entry("archived", "Rocky prefers concise status"));
+        await store.SaveAsync(Entry("superseded", "Rocky prefers concise status"));
+        await store.ArchiveAsync("archived", "merged");
+
+        var superseded = (await store.GetAsync("superseded"))!;
+        await store.SaveAsync(superseded with { SupersededBy = "somewhere-else" });
+
+        Assert.IsNull(await store.FindMostSimilarAsync(Entry("candidate", "Rocky prefers concise")));
+    }
+
+    [TestMethod]
+    public async Task FindMostSimilarAsync_IgnoresTheCandidateItself()
+    {
+        // Re-saving an existing entry must not be able to match it against itself and inflate its
+        // own reinforcement count.
+        var store = CreateStore();
+        await store.SaveAsync(Entry("same", "Rocky prefers concise status"));
+
+        Assert.IsNull(await store.FindMostSimilarAsync(Entry("same", "Rocky prefers concise status")));
+    }
+
+    [TestMethod]
+    public async Task FindMostSimilarAsync_OnAnEmptyStore_ReturnsNull()
+    {
+        var store = CreateStore();
+
+        Assert.IsNull(await store.FindMostSimilarAsync(Entry("candidate", "anything at all here")));
+    }
+
+    [TestMethod]
+    public async Task FindMostSimilarAsync_WithBlankContent_ReturnsNull()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(Entry("existing", "Rocky prefers concise status"));
+
+        Assert.IsNull(await store.FindMostSimilarAsync(Entry("candidate", "   ")));
+    }
+
+    [TestMethod]
+    public void TopLevelCategory_SplitsOnTheFirstSlash()
+    {
+        Assert.AreEqual("user-preferences", FileMemoryStore.TopLevelCategory("user-preferences/status/daily"));
+        Assert.AreEqual("general", FileMemoryStore.TopLevelCategory("general"));
+        Assert.IsNull(FileMemoryStore.TopLevelCategory(null));
+    }
+
+    private FileMemoryStore CreateStore() =>
+        new(Options.Create(new MemoryOptions { BasePath = _tempDir }),
+            Options.Create(new AgentProfileOptions()),
+            Options.Create(new EmbeddingOptions()),
+            NullLogger<FileMemoryStore>.Instance,
+            EmbeddingTextPreparer.ForTests());
+
+    private static MemoryEntry Entry(string id, string content, string? category = null) =>
+        new(id, content, category, [], DateTimeOffset.UtcNow);
+}

--- a/tests/RockBot.Host.Tests/MemoryArchiveTests.cs
+++ b/tests/RockBot.Host.Tests/MemoryArchiveTests.cs
@@ -141,12 +141,42 @@ public class MemoryArchiveTests
         var old = (await store.GetAsync("old"))!;
         await store.SaveAsync(old with { ArchivedAt = DateTimeOffset.UtcNow.AddDays(-120) });
 
-        var purged = await store.PurgeArchivedAsync(TimeSpan.FromDays(90));
+        var result = await store.PurgeArchivedAsync(TimeSpan.FromDays(90));
 
-        Assert.AreEqual(1, purged);
+        Assert.AreEqual(1, result.Purged);
+        Assert.AreEqual(0, result.Kept);
         Assert.IsNull(await store.GetAsync("old"));
         Assert.IsNotNull(await store.GetAsync("recent"));
         Assert.IsNotNull(await store.GetAsync("live"));
+    }
+
+    [TestMethod]
+    public async Task PurgeArchivedAsync_KeepsEntriesAboveTheFloor()
+    {
+        // The purge is the last place that destroys memory, so the floor that stops consolidation
+        // pruning a high-value entry applies here too. Importance is frozen at archive time and
+        // never decays afterwards, so in practice it is the reinforcement half that bites.
+        var store = CreateStore();
+        await store.SaveAsync(Entry("valuable", "seen over and over") with { ReinforcementCount = 5 });
+        await store.SaveAsync(Entry("ordinary", "seen once") with { ReinforcementCount = 1 });
+
+        await store.ArchiveAsync("valuable", "merged");
+        await store.ArchiveAsync("ordinary", "merged");
+
+        foreach (var id in new[] { "valuable", "ordinary" })
+        {
+            var archived = (await store.GetAsync(id))!;
+            await store.SaveAsync(archived with { ArchivedAt = DateTimeOffset.UtcNow.AddDays(-120) });
+        }
+
+        var options = new DreamOptions();
+        var result = await store.PurgeArchivedAsync(
+            TimeSpan.FromDays(90), e => DreamService.IsProtectedFromPruning(e, options));
+
+        Assert.AreEqual(1, result.Purged);
+        Assert.AreEqual(1, result.Kept);
+        Assert.IsNotNull(await store.GetAsync("valuable"));
+        Assert.IsNull(await store.GetAsync("ordinary"));
     }
 
     [TestMethod]
@@ -158,7 +188,7 @@ public class MemoryArchiveTests
         var old = (await store.GetAsync("old"))!;
         await store.SaveAsync(old with { ArchivedAt = DateTimeOffset.UtcNow.AddYears(-5) });
 
-        Assert.AreEqual(0, await store.PurgeArchivedAsync(TimeSpan.Zero));
+        Assert.AreEqual(0, (await store.PurgeArchivedAsync(TimeSpan.Zero)).Purged);
         Assert.IsNotNull(await store.GetAsync("old"));
     }
 

--- a/tests/RockBot.Host.Tests/MemoryDeduplicatorTests.cs
+++ b/tests/RockBot.Host.Tests/MemoryDeduplicatorTests.cs
@@ -1,0 +1,370 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace RockBot.Host.Tests;
+
+/// <summary>
+/// Covers the save path that reinforces an existing entry instead of writing a near-copy of it.
+/// </summary>
+/// <remarks>
+/// The behaviour under test is what makes <see cref="MemoryEntry.ReinforcementCount"/> mean what
+/// it says. Before it, the only writers of that field were episode extraction and merges summing
+/// their sources, so a live corpus entry reading "reinforced 243×" had in fact been saved fresh
+/// 243 times and merged back together — and the corpus grew from 290 to 828 entries in 24 days
+/// while consolidation archived 885.
+/// </remarks>
+[TestClass]
+public class MemoryDeduplicatorTests
+{
+    [TestMethod]
+    public async Task StoreWithoutSimilarityLookup_SavesEveryEntry()
+    {
+        var memory = new PlainMemory();
+        var deduplicator = Create(memory);
+
+        var outcome = await deduplicator.SaveOrReinforceAsync(Entry("new", "Rocky prefers concise status"));
+
+        Assert.AreEqual(MemorySaveAction.Created, outcome.Action);
+        Assert.AreEqual(1, memory.Entries.Count);
+    }
+
+    [TestMethod]
+    public async Task Disabled_SavesWithoutConsultingTheLookup()
+    {
+        var memory = new ScriptedLookupMemory();
+        memory.Seed(Entry("existing", "Rocky prefers concise status"));
+        memory.NextMatch = Match(memory.Entries[0], 1.0, MemorySimilarityMeasure.Lexical);
+
+        var deduplicator = Create(memory, o => o.DedupeEnabled = false);
+
+        var outcome = await deduplicator.SaveOrReinforceAsync(Entry("new", "Rocky prefers concise status"));
+
+        Assert.AreEqual(MemorySaveAction.Created, outcome.Action);
+        Assert.AreEqual(0, memory.LookupCalls);
+        Assert.AreEqual(2, memory.Entries.Count);
+    }
+
+    [TestMethod]
+    [DataRow("feedback/from-agent/status-reports")]
+    [DataRow("claim/capability/calendar-mcp/list_events")]
+    public async Task ScopedCategories_BypassDeduplication(string category)
+    {
+        // The contradiction detector supersedes feedback entries and the verifier evicts
+        // capability claims; both reason about individual ids, so neither wants its write
+        // redirected into an older entry.
+        var memory = new ScriptedLookupMemory();
+        memory.Seed(Entry("existing", "Always lead with a TL;DR", category: category));
+        memory.NextMatch = Match(memory.Entries[0], 1.0, MemorySimilarityMeasure.Lexical);
+
+        var deduplicator = Create(memory);
+
+        var outcome = await deduplicator.SaveOrReinforceAsync(
+            Entry("new", "Always lead with a TL;DR", category: category));
+
+        Assert.AreEqual(MemorySaveAction.Created, outcome.Action);
+        Assert.AreEqual(0, memory.LookupCalls);
+    }
+
+    [TestMethod]
+    public async Task SupersededCandidate_IsSavedAsIs()
+    {
+        var memory = new ScriptedLookupMemory();
+        memory.Seed(Entry("existing", "Rocky prefers concise status"));
+        memory.NextMatch = Match(memory.Entries[0], 1.0, MemorySimilarityMeasure.Lexical);
+
+        var deduplicator = Create(memory);
+        var candidate = Entry("new", "Rocky prefers concise status") with { SupersededBy = "winner" };
+
+        Assert.AreEqual(MemorySaveAction.Created,
+            (await deduplicator.SaveOrReinforceAsync(candidate)).Action);
+        Assert.AreEqual(0, memory.LookupCalls);
+    }
+
+    [TestMethod]
+    public async Task EmbeddingScoreBelowTheThreshold_Creates()
+    {
+        var memory = new ScriptedLookupMemory();
+        memory.Seed(Entry("existing", "Rocky prefers concise status"));
+        memory.NextMatch = Match(memory.Entries[0], 0.80, MemorySimilarityMeasure.Embedding);
+
+        var deduplicator = Create(memory);
+
+        var outcome = await deduplicator.SaveOrReinforceAsync(Entry("new", "Rocky prefers concise"));
+
+        Assert.AreEqual(MemorySaveAction.Created, outcome.Action);
+        Assert.AreEqual(2, memory.Entries.Count);
+    }
+
+    [TestMethod]
+    public async Task TheTwoMeasuresUseTheirOwnThresholds()
+    {
+        // 0.70 is a restatement on the Jaccard scale and merely a related subject on the cosine
+        // one. Sharing a single number between them would either fold unrelated entries or stop
+        // deduplicating BM25-only deployments altogether.
+        var lexical = new ScriptedLookupMemory();
+        lexical.Seed(Entry("existing", "Rocky prefers concise status"));
+        lexical.NextMatch = Match(lexical.Entries[0], 0.70, MemorySimilarityMeasure.Lexical);
+
+        Assert.AreEqual(
+            MemorySaveAction.Reinforced,
+            (await Create(lexical).SaveOrReinforceAsync(Entry("new", "Rocky prefers concise"))).Action);
+
+        var embedding = new ScriptedLookupMemory();
+        embedding.Seed(Entry("existing", "Rocky prefers concise status"));
+        embedding.NextMatch = Match(embedding.Entries[0], 0.70, MemorySimilarityMeasure.Embedding);
+
+        Assert.AreEqual(
+            MemorySaveAction.Created,
+            (await Create(embedding).SaveOrReinforceAsync(Entry("new", "Rocky prefers concise"))).Action);
+    }
+
+    [TestMethod]
+    public async Task CoveredSpecifics_ReinforceTheExistingEntryInPlace()
+    {
+        var createdAt = DateTimeOffset.UtcNow.AddDays(-30);
+        var existing = new MemoryEntry(
+            "existing",
+            "The Xebia teams bridge JSON lives on OneDrive Personal, refreshed 2026-08-19.",
+            "agent-knowledge/infrastructure",
+            ["bridge"],
+            createdAt,
+            UpdatedAt: createdAt,
+            Metadata: new Dictionary<string, string> { ["subjectTime"] = "2026-08-19" },
+            ImportanceScore: 0.6f)
+        {
+            LastSeenAt = createdAt,
+            ReinforcementCount = 3,
+        };
+
+        // Stamp it as consolidation-reviewed so the test can assert that a pure reinforcement
+        // leaves the entry withheld from the next consolidation pass rather than re-opening it.
+        existing = existing with
+        {
+            Metadata = new Dictionary<string, string>(existing.Metadata!)
+            {
+                [DreamService.ConsolidationReviewedHashKey] = DreamService.ContentFingerprint(existing.Content),
+            },
+        };
+
+        var memory = new ScriptedLookupMemory();
+        memory.Seed(existing);
+        memory.NextMatch = Match(existing, 0.95, MemorySimilarityMeasure.Embedding);
+
+        var candidate = new MemoryEntry(
+            "new",
+            "The Xebia teams bridge JSON is on OneDrive Personal (2026-08-19).",
+            "agent-knowledge/infrastructure",
+            ["teams"],
+            DateTimeOffset.UtcNow,
+            Metadata: new Dictionary<string, string> { ["source"] = "mining" },
+            ImportanceScore: 0.9f);
+
+        var outcome = await Create(memory).SaveOrReinforceAsync(candidate);
+
+        Assert.AreEqual(MemorySaveAction.Reinforced, outcome.Action);
+        Assert.AreEqual("existing", outcome.Id);
+
+        var stored = Assert.ContainsSingle(memory.Entries);
+        Assert.AreEqual(existing.Content, stored.Content, "Reinforcement must not rewrite the text.");
+        Assert.AreEqual(4, stored.ReinforcementCount);
+        Assert.IsGreaterThan(createdAt, stored.LastSeenAt);
+        Assert.AreEqual(createdAt, stored.UpdatedAt, "UpdatedAt anchors importance decay; a no-text write must not move it.");
+        Assert.AreEqual(0.9f, stored.ImportanceScore);
+        CollectionAssert.AreEquivalent(new[] { "bridge", "teams" }, stored.Tags.ToArray());
+        Assert.AreEqual("2026-08-19", stored.Metadata!["subjectTime"]);
+        Assert.AreEqual("mining", stored.Metadata!["source"]);
+        Assert.IsTrue(DreamService.IsReviewedAndUnchanged(stored),
+            "An unchanged entry must stay withheld from the next consolidation pass.");
+    }
+
+    [TestMethod]
+    public async Task ADateSpelledDifferently_CountsAsCovered()
+    {
+        // The coverage check credits "August 19, 2026" against "2026-08-19", so a restatement that
+        // only re-spells the date is evidence rather than a new specific.
+        var memory = new ScriptedLookupMemory();
+        memory.Seed(Entry("existing", "The bridge refresh runs on 2026-08-19 for the Xebia tenant."));
+        memory.NextMatch = Match(memory.Entries[0], 0.95, MemorySimilarityMeasure.Embedding);
+
+        var outcome = await Create(memory).SaveOrReinforceAsync(
+            Entry("new", "The Xebia bridge refresh runs on August 19, 2026."));
+
+        Assert.AreEqual(MemorySaveAction.Reinforced, outcome.Action);
+    }
+
+    [TestMethod]
+    public async Task NewSpecifics_AreAppendedRatherThanDropped()
+    {
+        var createdAt = DateTimeOffset.UtcNow.AddDays(-10);
+        var existing = new MemoryEntry(
+            "existing",
+            "The Xebia teams bridge JSON lives on OneDrive Personal.",
+            null, [], createdAt, UpdatedAt: createdAt)
+        {
+            Metadata = new Dictionary<string, string>
+            {
+                [DreamService.ConsolidationReviewedHashKey] =
+                    DreamService.ContentFingerprint("The Xebia teams bridge JSON lives on OneDrive Personal."),
+            },
+        };
+
+        var memory = new ScriptedLookupMemory();
+        memory.Seed(existing);
+        memory.NextMatch = Match(existing, 0.95, MemorySimilarityMeasure.Embedding);
+
+        var outcome = await Create(memory).SaveOrReinforceAsync(
+            Entry("new", "The Xebia teams bridge JSON is served by Marimer LLC."));
+
+        Assert.AreEqual(MemorySaveAction.Extended, outcome.Action);
+        Assert.AreEqual("existing", outcome.Id);
+
+        var stored = Assert.ContainsSingle(memory.Entries);
+        Assert.AreEqual(
+            "The Xebia teams bridge JSON lives on OneDrive Personal.\n\n"
+            + "The Xebia teams bridge JSON is served by Marimer LLC.",
+            stored.Content);
+        Assert.AreEqual(2, stored.ReinforcementCount);
+        Assert.IsGreaterThan(createdAt, stored.UpdatedAt!.Value);
+        Assert.IsFalse(DreamService.IsReviewedAndUnchanged(stored),
+            "Changed text must re-open the entry for the next consolidation pass.");
+    }
+
+    [TestMethod]
+    public async Task ExtendingPastTheLengthCap_CreatesInstead()
+    {
+        // Otherwise a subject the agent revisits constantly accretes into one entry that keeps
+        // matching itself, and recall surfaces the whole thing for any brush with the topic.
+        var existing = Entry("existing", "Blazor Online Class notes. " + new string('x', 400));
+
+        var memory = new ScriptedLookupMemory();
+        memory.Seed(existing);
+        memory.NextMatch = Match(existing, 0.95, MemorySimilarityMeasure.Embedding);
+
+        var deduplicator = Create(memory, o => o.DedupeMaxExtendedContentLength = 500);
+
+        var outcome = await deduplicator.SaveOrReinforceAsync(
+            Entry("new", "Blazor Online Class runs through Marimer LLC. " + new string('y', 200)));
+
+        Assert.AreEqual(MemorySaveAction.Created, outcome.Action);
+        Assert.AreEqual(2, memory.Entries.Count);
+    }
+
+    [TestMethod]
+    public async Task ConcurrentSavesOfTheSameFact_ProduceOneReinforcedEntry()
+    {
+        // Two background saves of the same fact — two turns mentioning it, or a mining pass
+        // overlapping a tool call — would otherwise both look, both find nothing, and both create.
+        var memory = new ScriptedLookupMemory();
+
+        // Stand in for a real store: answer from whatever has actually been written so far.
+        memory.LookupOverride = candidate =>
+        {
+            var other = memory.Entries.FirstOrDefault(e => e.Id != candidate.Id);
+            return other is null ? null : Match(other, 1.0, MemorySimilarityMeasure.Lexical);
+        };
+
+        var deduplicator = Create(memory);
+
+        var content = "The Xebia teams bridge JSON lives on OneDrive Personal.";
+        await Task.WhenAll(
+            deduplicator.SaveOrReinforceAsync(Entry("a", content)),
+            deduplicator.SaveOrReinforceAsync(Entry("b", content)));
+
+        var stored = Assert.ContainsSingle(memory.Entries);
+        Assert.AreEqual(2, stored.ReinforcementCount);
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static MemoryDeduplicator Create(
+        ILongTermMemory memory,
+        Action<MemoryOptions>? configure = null)
+    {
+        var options = new MemoryOptions();
+        configure?.Invoke(options);
+
+        return new MemoryDeduplicator(
+            memory,
+            Options.Create(options),
+            Options.Create(new AgentProfileOptions()),
+            NullLogger<MemoryDeduplicator>.Instance);
+    }
+
+    private static MemorySimilarityMatch Match(MemoryEntry entry, double score, MemorySimilarityMeasure measure) =>
+        new(entry, score, measure);
+
+    private static MemoryEntry Entry(string id, string content, string? category = null) =>
+        new(id, content, category, [], DateTimeOffset.UtcNow);
+
+    /// <summary>A store with no similarity capability at all.</summary>
+    private class PlainMemory : ILongTermMemory
+    {
+        public List<MemoryEntry> Entries { get; } = [];
+
+        public Task SaveAsync(MemoryEntry entry, CancellationToken cancellationToken = default)
+        {
+            lock (Entries)
+            {
+                Entries.RemoveAll(e => e.Id == entry.Id);
+                Entries.Add(entry);
+            }
+            return Task.CompletedTask;
+        }
+
+        public Task<IReadOnlyList<MemoryEntry>> SearchAsync(
+            MemorySearchCriteria criteria, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<MemoryEntry>>([.. Entries]);
+
+        public Task<MemoryEntry?> GetAsync(string id, CancellationToken cancellationToken = default) =>
+            Task.FromResult(Entries.FirstOrDefault(e => e.Id == id));
+
+        public Task DeleteAsync(string id, CancellationToken cancellationToken = default)
+        {
+            Entries.RemoveAll(e => e.Id == id);
+            return Task.CompletedTask;
+        }
+
+        public Task<IReadOnlyList<string>> ListTagsAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<string>>([]);
+
+        public Task<IReadOnlyList<string>> ListCategoriesAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<string>>([]);
+    }
+
+    /// <summary>A store whose similarity answer is scripted by the test.</summary>
+    private sealed class ScriptedLookupMemory : PlainMemory, IMemorySimilarityLookup
+    {
+        public MemorySimilarityMatch? NextMatch { get; set; }
+        public Func<MemoryEntry, MemorySimilarityMatch?>? LookupOverride { get; set; }
+        public int LookupCalls { get; private set; }
+
+        public void Seed(MemoryEntry entry) => Entries.Add(entry);
+
+        public Task<MemorySimilarityMatch?> FindMostSimilarAsync(
+            MemoryEntry candidate, CancellationToken cancellationToken = default)
+        {
+            LookupCalls++;
+            return Task.FromResult(LookupOverride is not null ? LookupOverride(candidate) : NextMatch);
+        }
+    }
+}
+
+/// <summary>Covers the counter behind the "N saved, N reinforced, N extended" pass summaries.</summary>
+[TestClass]
+public class MemorySaveTallyTests
+{
+    [TestMethod]
+    public void Record_CountsEachActionSeparately()
+    {
+        var tally = new MemorySaveTally();
+
+        tally.Record(new MemorySaveOutcome(MemorySaveAction.Created, "a"));
+        tally.Record(new MemorySaveOutcome(MemorySaveAction.Reinforced, "b"));
+        tally.Record(new MemorySaveOutcome(MemorySaveAction.Reinforced, "c"));
+        tally.Record(new MemorySaveOutcome(MemorySaveAction.Extended, "d"));
+
+        Assert.AreEqual(1, tally.Saved);
+        Assert.AreEqual(2, tally.Reinforced);
+        Assert.AreEqual(1, tally.Extended);
+    }
+}

--- a/tests/RockBot.Host.Tests/MergeCoverageTests.cs
+++ b/tests/RockBot.Host.Tests/MergeCoverageTests.cs
@@ -516,6 +516,153 @@ public class MergeCoverageTests
             "October");
     }
 
+    // ── Corpus-evidence rule ─────────────────────────────────────────────────
+
+    [TestMethod]
+    public void WordWithALowercaseTwinInTheSources_IsOrdinaryLanguage()
+    {
+        // Live rejection: "Marking" opens a clause mid-sentence, so position alone protected it,
+        // and the same cluster was re-proposed and re-rejected every cycle. A sibling source
+        // writes "marking" in lowercase — that is the corpus saying it is an ordinary verb.
+        var sources = new[]
+        {
+            Entry("a", "Todo items are not accepted for updates. Marking a task complete needs the id."),
+            Entry("b", "The agent keeps marking finished todos so the list stays short."),
+        };
+
+        Assert.AreEqual(
+            0,
+            MergeCoverage.FindMissingSpecifics(
+                sources,
+                "Todo items are not accepted for updates; completing one needs the id, and the agent "
+                + "keeps finished todos off the list.").Count);
+    }
+
+    [TestMethod]
+    public void MidSentenceIdsWithLowercaseTwin_IsNotASpecific()
+    {
+        // "IDs" is not an acronym match (the trailing lowercase s breaks the all-caps regex), so
+        // it arrived through the capitalized-word pass and outlived every merge proposal.
+        var sources = new[]
+        {
+            Entry("a", "Contact IDs are account-scoped, so the contact ids differ per mailbox."),
+        };
+
+        CollectionAssert.DoesNotContain(
+            MergeCoverage.FindMissingSpecifics(
+                sources, "Contacts are account-scoped and differ per mailbox.").ToArray(),
+            "IDs");
+    }
+
+    [TestMethod]
+    public void ProperNounWithoutLowercaseTwin_StaysProtected()
+    {
+        // The whole point of sourcing the evidence from the text: a real name never appears
+        // lowercase, so nothing about this rule can unprotect it.
+        var sources = new[]
+        {
+            Entry("a", "The Eventbrite listing was set up by Xebia for the Austin workshop."),
+        };
+
+        var missing = MergeCoverage.FindMissingSpecifics(sources, "The listing was set up for a workshop.");
+
+        CollectionAssert.Contains(missing.ToArray(), "Eventbrite");
+        CollectionAssert.Contains(missing.ToArray(), "Xebia");
+        CollectionAssert.Contains(missing.ToArray(), "Austin");
+    }
+
+    [TestMethod]
+    public void AlwaysSpecific_BeatsTheCorpusEvidenceRule()
+    {
+        // A storytelling corpus writes "may" constantly and also has a character named May.
+        // alwaysSpecificWords is the documented override, and it has to outrank corpus evidence
+        // exactly as it outranks the baseline.
+        var vocabulary = new MergeCoverageVocabulary(null, ["May"]);
+        var sources = new[] { Entry("a", "May said the crossing may take three days.") };
+
+        CollectionAssert.Contains(
+            MergeCoverage.FindMissingSpecifics(
+                sources, "The crossing takes three days.", vocabulary).ToArray(),
+            "May");
+    }
+
+    // ── Numeric category exemption ───────────────────────────────────────────
+
+    [TestMethod]
+    public void RoutingTelemetryDecimals_AreExemptByCategory()
+    {
+        // Routing anti-patterns restate figures recomputed from the routing log every cycle, so
+        // "8.33" is already stale when the merge is proposed. Requiring it verbatim rejected the
+        // same cluster indefinitely.
+        var sources = new[]
+        {
+            Categorized("a", "Balanced sessions average 8.33 tool calls before escalating.", "anti-patterns/routing"),
+        };
+
+        Assert.AreEqual(
+            0,
+            MergeCoverage.FindMissingSpecifics(
+                sources, "Balanced sessions make many tool calls before escalating.").Count);
+    }
+
+    [TestMethod]
+    public void SameTextOutsideAnExemptCategory_StillRequiresTheNumber()
+    {
+        var sources = new[]
+        {
+            Categorized("a", "Balanced sessions average 8.33 tool calls before escalating.", "agent-knowledge/infrastructure"),
+        };
+
+        CollectionAssert.Contains(
+            MergeCoverage.FindMissingSpecifics(
+                sources, "Balanced sessions make many tool calls before escalating.").ToArray(),
+            "8.33");
+    }
+
+    [TestMethod]
+    public void NumericExemptCategories_MatchNestedCategoriesButNotSiblingPrefixes()
+    {
+        var vocabulary = MergeCoverageVocabulary.Default;
+
+        Assert.IsTrue(vocabulary.IsNumericExempt("anti-patterns/routing"));
+        Assert.IsTrue(vocabulary.IsNumericExempt("anti-patterns/routing/high-tier"));
+        Assert.IsFalse(vocabulary.IsNumericExempt("anti-patterns/routing-notes"));
+        Assert.IsFalse(vocabulary.IsNumericExempt("anti-patterns"));
+        Assert.IsFalse(vocabulary.IsNumericExempt(null));
+    }
+
+    [TestMethod]
+    public void NumericExemptCategories_RoundTripFromJson()
+    {
+        var vocabulary = MergeCoverageVocabulary.Parse(
+            """{ "numericExemptCategories": ["metrics/cost"] }""", out var error);
+
+        Assert.IsNull(error);
+        Assert.IsTrue(vocabulary.IsNumericExempt("metrics/cost"));
+
+        // Additive: the built-in entry survives a file that names its own categories.
+        Assert.IsTrue(vocabulary.IsNumericExempt("anti-patterns/routing"));
+    }
+
+    [TestMethod]
+    public void DateInAnExemptCategory_IsStillRequiredWhenSpelledWithAMonthName()
+    {
+        // The exemption skips the numeric loop wholesale, so "2026-08-19" in an exempt category
+        // is droppable. A month-name date still comes through the capitalized-word pass, which is
+        // the documented boundary of the exemption.
+        var sources = new[]
+        {
+            Categorized("a", "The routing review ran on August 19, 2026.", "anti-patterns/routing"),
+        };
+
+        CollectionAssert.Contains(
+            MergeCoverage.FindMissingSpecifics(sources, "The routing review ran recently.").ToArray(),
+            "August");
+    }
+
     private static MemoryEntry Entry(string id, string content) =>
         new(id, content, null, [], DateTimeOffset.UtcNow);
+
+    private static MemoryEntry Categorized(string id, string content, string category) =>
+        new(id, content, category, [], DateTimeOffset.UtcNow);
 }

--- a/tests/RockBot.Observation.Tests/ObservationEvaluationPhaseTests.cs
+++ b/tests/RockBot.Observation.Tests/ObservationEvaluationPhaseTests.cs
@@ -420,6 +420,7 @@ public class ObservationEvaluationPhaseTests
     {
         public Dictionary<string, RockBot.Host.MemoryEntry> Saved { get; } = new(StringComparer.Ordinal);
         public List<string> Deleted { get; } = [];
+        public List<(string Id, string Reason)> Archived { get; } = [];
         public bool ThrowOnSave { get; set; }
         public bool ThrowOnDelete { get; set; }
 
@@ -436,6 +437,15 @@ public class ObservationEvaluationPhaseTests
             cancellationToken.ThrowIfCancellationRequested();
             if (ThrowOnDelete) throw new InvalidOperationException("simulated memory delete failure");
             Deleted.Add(id);
+            Saved.Remove(id);
+            return Task.CompletedTask;
+        }
+
+        public Task ArchiveAsync(string id, string reason, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (ThrowOnDelete) throw new InvalidOperationException("simulated memory archive failure");
+            Archived.Add((id, reason));
             Saved.Remove(id);
             return Task.CompletedTask;
         }
@@ -489,7 +499,7 @@ public class ObservationEvaluationPhaseTests
     }
 
     [TestMethod]
-    public async Task ExecuteAsync_AgedTheoryRemovedFromMemory()
+    public async Task ExecuteAsync_AgedTheoryArchivedNotDeleted()
     {
         var target = MakeTarget(theoryAgingDays: 30);
         var now = DateTimeOffset.UtcNow;
@@ -513,8 +523,13 @@ public class ObservationEvaluationPhaseTests
 
         await MakePhase(new StubEvaluator(), stubMemory).ExecuteAsync(target, CancellationToken.None);
 
-        CollectionAssert.AreEqual(new[] { "obs_existing_stale" }, stubMemory.Deleted.ToArray(),
-            "Aged theory's memory entry should be deleted; fresh theory's preserved");
+        // Archived rather than deleted: a theory ages out because it stopped being re-observed in
+        // a window, which is weak evidence that it was wrong — the behaviour may simply not have
+        // come up.
+        Assert.AreEqual(0, stubMemory.Deleted.Count, "Ageing out must not hard-delete.");
+        CollectionAssert.AreEqual(new[] { "obs_existing_stale" }, stubMemory.Archived.Select(a => a.Id).ToArray(),
+            "Aged theory's memory entry should be archived; fresh theory's preserved");
+        Assert.AreEqual("observation theory aged out", stubMemory.Archived[0].Reason);
         Assert.IsTrue(stubMemory.Saved.ContainsKey("obs_existing_fresh"));
     }
 


### PR DESCRIPTION
Closes #550.

PR #506 stopped consolidation from destroying memories, and three weeks of live data confirm it: 0 hard deletes, 96% of specifics surviving merges, the high-value floor blocking prune proposals on 0.99/149× entries. Retention is fine.

What is not fine is that the corpus churns instead of converging — 290 → 828 live entries in 24 days, 885 archived by merge, 541 of those themselves merge successors (chains up to 8 deep), and the same duplicate clusters proposed and rejected every cycle. Six causes, all addressed here.

## 1. Reinforce instead of re-create

Nothing on the save path looked for a near-duplicate before writing, so `ReinforcementCount` was raised only by episode extraction and by merges summing their sources. An entry reading "reinforced 243×" had in fact been saved fresh 243 times and merged back together afterwards.

`IMemoryDeduplicator` now asks the store for the closest live entry (`IMemorySimilarityLookup`: cosine where embeddings exist, Jaccard otherwise, scoped to the same top-level category) and folds the candidate in — **reinforce** when the existing entry already carries every specific, **extend** when it does not, **create** otherwise. The decision uses the same `MergeCoverage` check and the same vocabulary file consolidation uses, so a save cannot silently drop a detail.

Routed through it: the `save_memory` background path, dream memory mining, tool-success learning. Scoped categories bypass it — the contradiction detector and the capability verifier reason about individual ids. Merges, identity reflection and consolidation writes are not routed, because they carry their own ids and provenance.

## 2. Coverage check: two classes of false rejection

- **Corpus evidence.** A word the merge's own sources also write in lowercase ("Marking" beside "marking", "IDs" beside "ids") is ordinary language wherever it is capitalized. The evidence comes from the text, so it cannot unprotect a name that never appears lowercase — Eventbrite, Xebia, Austin stay required — and `alwaysSpecificWords` still overrides it.
- **Numeric exemption by category.** Entries that restate figures recomputed from telemetry each cycle carry numbers that have already moved by the time a merge is proposed. `numericExemptCategories` (with `anti-patterns/routing` built in) stops those rejecting the same cluster forever.

## 3. Repair a rejected merge once

A rejection was terminal, so the cluster came back next cycle to fail the same way — one six-source merge was rejected five times in eight cycles. The pass now makes a second, much narrower call naming the exact strings that went missing. The revision faces the same coverage check, so a bad repair lands exactly where the rejection would have. Capped by `MergeRepairMaxPerCycle`.

## 4. Minimum interval between passes

A dream cycle fires 5 minutes after every process start, so consolidation cadence tracked the deploy schedule — ten deploys over three days meant ~15 cycles and 121 archives in one day. `ConsolidationMinInterval` (6h) gates on the dream pass ledger, which survives the restarts it exists to absorb.

## 5. Archive on every remaining delete path

Identity reflection, the `delete_memory` tool, capability-claim eviction, and aged observation theories all archive now. `DeleteAsync` is the retention purge's alone.

## 6. Purge floor

`PurgeArchivedAsync` takes a `keep` predicate and returns `ArchivePurgeResult`; the purge pass passes the high-value floor. Importance is frozen at archive time, so in practice the reinforcement half is what bites.

## Observability

One Information line per completed pass:

```
consolidation summary — live 828, reviewed 61, created since last run 14,
merged 3, repaired 1, rejected 2, ephemeral 5, protected 4
```

`created since last run` is the figure that shows whether save-time dedupe is working. Mining and tool-success-learning summaries become `{Saved} saved, {Reinforced} reinforced, {Extended} extended`.

## Verification

`dotnet build RockBot.slnx` clean; `dotnet test RockBot.slnx` green — 2969 passed, 0 failed across 20 suites (Host.Tests 1387 → 1424, Agent.Tests 279 → 283).

Deployed to the live cluster as `0.14.35` and observed on the real 834-entry corpus:

| Phase | Live evidence |
|---|---|
| 1 | `Memory dedupe: reinforced 82efd784ee81 instead of creating (similarity 0.96, Embedding)` — one message extracted into two entries, both folded into one existing entry; `0 saved, 2 reinforced, 0 extended`. On the previous build this created two duplicates. On disk: count 2 → 4, `lastSeenAt` advanced, `updatedAt` and content unchanged, tags unioned, `consolidationReviewedHash` still valid so the entry stays withheld from the next pass. |
| 2 | The repair below landed in `anti-patterns/routing` — telemetry numbers exempt, proper nouns still required. |
| 3 | `repaired merge of [...] — restored 3 specific(s): Atlanta, Tuesday, Xebia` and a 9-source merge restoring `Weekly`. `0 rejected, 2 repaired`. Merged text inspected: a genuine consolidation that kept the concrete examples, not a degenerate append. |
| 4 | After a pod restart: `memory consolidation skipped — last completed 0:06:31 ago, minimum interval 6:00:00`. Gated cycle 21s / 0 changes vs 63s / 8 merges ungated. |
| 5 | `identity reflection pass complete — 2 archived, 2 saved` (was "deleted"). |
| 6 | Code only — nothing is due for purge until ~November. |

## Deployment note

`numericExemptCategories` and the corpus-evidence rule are both live-tunable through `merge-coverage-vocabulary.json` on the agent volume; no restart needed. The rockbot deployment's file is unchanged (`extraCommonWords: ["Rocky"]`) — zero merges were rejected in the first cycle, so there is no evidence yet that `high`/`low`/`balanced` need adding. Worth re-checking after a few cycles of `rejected merge` lines.

## Follow-up, not from this branch

Loki shows `Unhandled exception. System.ObjectDisposedException: The CancellationTokenSource has been disposed.` on essentially every agent pod shutdown — 20 occurrences in 14 days, including on 0.14.34 during this deploy. Pre-existing shutdown race; deserves its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GsCZ7jPi8GLu14CoDovvP
