### PR TITLE
Stop the dream cycle throwing ObjectDisposedException at shutdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ deploy/docker-compose/*/agent-data/
 
 # Stray 58 MB kubectl binary was committed by accident once (#96). Use the one on PATH.
 kubectl
+.claude/plans/

--- a/src/RockBot.Host/AgentWorkSerializer.cs
+++ b/src/RockBot.Host/AgentWorkSerializer.cs
@@ -15,6 +15,11 @@ internal sealed class AgentWorkSerializer : IAgentWorkSerializer, IDisposable
     private CancellationTokenSource _preemptCts = new();
     private readonly object _preemptLock = new();
 
+    // Set under _preemptLock at disposal. Scheduled acquisitions check it so a
+    // timer callback that outruns host shutdown reports "no slot" instead of
+    // throwing ObjectDisposedException out of an unobserved task.
+    private bool _disposed;
+
     // ── User loop ─────────────────────────────────────────────────────────────
 
     public async Task<IAsyncDisposable> AcquireForUserAsync(CancellationToken ct)
@@ -38,13 +43,23 @@ internal sealed class AgentWorkSerializer : IAgentWorkSerializer, IDisposable
 
     public Task<IScheduledTaskSlot?> TryAcquireForScheduledAsync(CancellationToken ct)
     {
-        // Non-blocking: if the slot is held by a user loop, skip this run.
-        if (!_slot.Wait(0))
-            return Task.FromResult<IScheduledTaskSlot?>(null);
-
         CancellationToken preemptToken;
+
+        // Both the disposal check and the semaphore wait happen under the lock so
+        // Dispose cannot land between them and leave us reading a disposed token.
+        // The wait is non-blocking (0 timeout), so holding the lock across it is safe —
+        // AcquireForUserAsync does its blocking wait outside the lock.
         lock (_preemptLock)
         {
+            // Shutting down. "No slot available" is an outcome every caller already
+            // handles, and it is the honest answer once the host is tearing down.
+            if (_disposed)
+                return Task.FromResult<IScheduledTaskSlot?>(null);
+
+            // Non-blocking: if the slot is held by a user loop, skip this run.
+            if (!_slot.Wait(0))
+                return Task.FromResult<IScheduledTaskSlot?>(null);
+
             preemptToken = _preemptCts.Token;
         }
 
@@ -56,18 +71,38 @@ internal sealed class AgentWorkSerializer : IAgentWorkSerializer, IDisposable
     {
         lock (_preemptLock)
         {
+            if (_disposed) return;
+            _disposed = true;
+
             _preemptCts.Dispose();
+            _slot.Dispose();
         }
-        _slot.Dispose();
     }
 
     // ── Handles ───────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Releases the slot, tolerating a serializer that was disposed while the work was
+    /// still running. Work that outruns host shutdown has nothing left to hand the slot
+    /// back to, so the release is a no-op rather than a failure.
+    /// </summary>
+    private static void ReleaseQuietly(SemaphoreSlim slot)
+    {
+        try
+        {
+            slot.Release();
+        }
+        catch (ObjectDisposedException)
+        {
+            // Serializer disposed during shutdown; nobody is waiting on the slot.
+        }
+    }
 
     private sealed class SlotHandle(SemaphoreSlim slot) : IAsyncDisposable
     {
         public ValueTask DisposeAsync()
         {
-            slot.Release();
+            ReleaseQuietly(slot);
             return ValueTask.CompletedTask;
         }
     }
@@ -79,7 +114,7 @@ internal sealed class AgentWorkSerializer : IAgentWorkSerializer, IDisposable
 
         public ValueTask DisposeAsync()
         {
-            slot.Release();
+            ReleaseQuietly(slot);
             cts.Dispose();
             return ValueTask.CompletedTask;
         }

--- a/src/RockBot.Host/DreamService.cs
+++ b/src/RockBot.Host/DreamService.cs
@@ -80,6 +80,15 @@ internal sealed class DreamService : IHostedService, IDisposable
     private DreamPassLedger? _passLedger;
     private int _contentionRetries;
 
+    // Fires at StopAsync so an in-flight cycle unwinds through its existing
+    // OperationCanceledException path instead of running on into a disposed host.
+    private readonly CancellationTokenSource _stopping = new();
+
+    // The timer callback's task, kept (rather than discarded) so StopAsync can wait
+    // on a cycle that is already running. Guarded by _cycleLock.
+    private readonly object _cycleLock = new();
+    private Task _cycleTask = Task.CompletedTask;
+
     public DreamService(
         ILongTermMemory memory,
         IEnumerable<ISkillStore> skillStores,
@@ -197,7 +206,13 @@ internal sealed class DreamService : IHostedService, IDisposable
         }
 
         _timer = new Timer(
-            state => { _ = OnTimerTickAsync(); },
+            state =>
+            {
+                // Keep the task so StopAsync can wait for a cycle already in flight.
+                // OnTimerTickAsync never throws, so this is not an unobserved fault.
+                lock (_cycleLock)
+                    _cycleTask = OnTimerTickAsync();
+            },
             null,
             _options.InitialDelay,
             Timeout.InfiniteTimeSpan);
@@ -209,13 +224,59 @@ internal sealed class DreamService : IHostedService, IDisposable
         return Task.CompletedTask;
     }
 
-    public Task StopAsync(CancellationToken cancellationToken)
+    public async Task StopAsync(CancellationToken cancellationToken)
     {
-        _timer?.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
-        return Task.CompletedTask;
+        // Disarm first so no new cycle starts while we are waiting for the current one.
+        try
+        {
+            _timer?.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+        }
+        catch (ObjectDisposedException)
+        {
+            // Already torn down; nothing left to disarm.
+        }
+
+        _stopping.Cancel();
+
+        Task cycle;
+        lock (_cycleLock)
+            cycle = _cycleTask;
+
+        if (cycle.IsCompleted)
+            return;
+
+        _logger.LogInformation("DreamService: waiting for the in-flight dream cycle to unwind");
+
+        try
+        {
+            // Bounded by the host's shutdown token so a pass that ignores its own
+            // cancellation cannot hang shutdown indefinitely.
+            await cycle.WaitAsync(cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogWarning(
+                "DreamService: dream cycle did not finish within the shutdown timeout; abandoning the wait");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "DreamService: dream cycle faulted during shutdown");
+        }
     }
 
-    public void Dispose() => _timer?.Dispose();
+    public void Dispose()
+    {
+        _timer?.Dispose();
+
+        Task cycle;
+        lock (_cycleLock)
+            cycle = _cycleTask;
+
+        // A cycle that outran the shutdown timeout still holds _stopping.Token.
+        // Leaking the CTS is cheaper than handing that cycle a disposed one.
+        if (cycle.IsCompleted)
+            _stopping.Dispose();
+    }
 
     /// <summary>
     /// Re-reads every dream-pass directive file from disk into the in-memory fields.
@@ -497,13 +558,22 @@ internal sealed class DreamService : IHostedService, IDisposable
 
     private async Task OnTimerTickAsync()
     {
-        var outcome = await DreamAsync();
+        // Nothing observes this task except StopAsync, so anything that escapes here
+        // would surface as an unhandled exception on the timer thread.
+        try
+        {
+            var outcome = await DreamAsync();
 
-        if (outcome == DreamCycleOutcome.Deferred && TryArmContentionRetry())
-            return;
+            if (outcome == DreamCycleOutcome.Deferred && TryArmContentionRetry())
+                return;
 
-        _contentionRetries = 0;
-        ArmNextCronTimer();
+            _contentionRetries = 0;
+            ArmNextCronTimer();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "DreamService: dream timer tick failed");
+        }
     }
 
     /// <summary>
@@ -535,6 +605,9 @@ internal sealed class DreamService : IHostedService, IDisposable
         if (!_options.DeferDreamOnContention || _timer is null)
             return false;
 
+        if (_stopping.IsCancellationRequested)
+            return false;
+
         if (_contentionRetries >= _options.DreamContentionMaxRetries)
         {
             _logger.LogWarning(
@@ -555,8 +628,17 @@ internal sealed class DreamService : IHostedService, IDisposable
         if (next is not null && next.Value <= _clock.Now + delay)
             return false;
 
+        try
+        {
+            _timer.Change(delay, Timeout.InfiniteTimeSpan);
+        }
+        catch (ObjectDisposedException)
+        {
+            // Host shut down between the check above and here.
+            return false;
+        }
+
         _contentionRetries++;
-        _timer.Change(delay, Timeout.InfiniteTimeSpan);
         _logger.LogInformation(
             "DreamService: cycle blocked by other agent work; retry {Attempt} of {Max} in {Delay:g}",
             _contentionRetries, _options.DreamContentionMaxRetries, delay);
@@ -566,6 +648,7 @@ internal sealed class DreamService : IHostedService, IDisposable
     private void ArmNextCronTimer()
     {
         if (_cron is null) return;
+        if (_stopping.IsCancellationRequested) return;
 
         var next = _cron.GetNextOccurrence(_clock.Now, _clock.Zone);
         if (next is null)
@@ -578,7 +661,16 @@ internal sealed class DreamService : IHostedService, IDisposable
         var delay = next.Value - _clock.Now;
         if (delay < TimeSpan.Zero) delay = TimeSpan.Zero;
 
-        _timer?.Change(delay, Timeout.InfiniteTimeSpan);
+        try
+        {
+            _timer?.Change(delay, Timeout.InfiniteTimeSpan);
+        }
+        catch (ObjectDisposedException)
+        {
+            // Host shut down between the check above and here.
+            return;
+        }
+
         _logger.LogInformation("DreamService: next dream cycle at {Next} (in {Delay:g})", next.Value, delay);
     }
 
@@ -588,29 +680,45 @@ internal sealed class DreamService : IHostedService, IDisposable
 
         // Acquire the work serializer slot so user messages can preempt the dream.
         // TryAcquireForScheduledAsync is non-blocking: if something else holds the slot, defer.
-        var slot = await _workSerializer.TryAcquireForScheduledAsync(CancellationToken.None);
+        // The token is _stopping rather than None so cancelling it unwinds the cycle.
+        IScheduledTaskSlot? slot;
+        try
+        {
+            slot = await _workSerializer.TryAcquireForScheduledAsync(_stopping.Token);
+        }
+        catch (Exception ex) when (ex is ObjectDisposedException or OperationCanceledException)
+        {
+            // The host tore down between the timer firing and this call.
+            _logger.LogInformation("DreamService: host shutting down, skipping dream cycle");
+            return DreamCycleOutcome.Deferred;
+        }
+
         if (slot is null)
         {
             _logger.LogInformation("DreamService: agent busy, deferring dream cycle");
             return DreamCycleOutcome.Deferred;
         }
 
-        // Re-read directives from disk so live edits to /data/agent/*-dream.md and
-        // skill-optimize.md take effect without a pod restart. Cheap (~18 small file
-        // reads) and runs once per cycle.
-        LoadDirectives(initialLoad: false);
-
-        // Read the change-gate ledger once per cycle. Passes consult it before spending an LLM
-        // call on a corpus that has not moved since they last looked at it.
-        _passLedger = await DreamPassLedger.LoadAsync(
-            ResolvePath(DreamPassLedger.FileName, _profileOptions.BasePath), _logger);
-
-        _logger.LogInformation("DreamService: dream cycle starting");
-
         var outcome = DreamCycleOutcome.Finished;
+
+        // Clear before loading so the finally below cannot re-save the previous cycle's
+        // ledger if the load itself throws.
+        _passLedger = null;
 
         try
         {
+            // Re-read directives from disk so live edits to /data/agent/*-dream.md and
+            // skill-optimize.md take effect without a pod restart. Cheap (~18 small file
+            // reads) and runs once per cycle.
+            LoadDirectives(initialLoad: false);
+
+            // Read the change-gate ledger once per cycle. Passes consult it before spending an
+            // LLM call on a corpus that has not moved since they last looked at it.
+            _passLedger = await DreamPassLedger.LoadAsync(
+                ResolvePath(DreamPassLedger.FileName, _profileOptions.BasePath), _logger);
+
+            _logger.LogInformation("DreamService: dream cycle starting");
+
             var ct = slot.Token;
 
             // Log retention runs first — append-only JSONL logs must be capped even on

--- a/tests/RockBot.Host.Tests/AgentWorkSerializerDisposalTests.cs
+++ b/tests/RockBot.Host.Tests/AgentWorkSerializerDisposalTests.cs
@@ -1,0 +1,102 @@
+namespace RockBot.Host.Tests;
+
+/// <summary>
+/// The scheduled-acquisition path runs from timer callbacks that can outlive host
+/// shutdown, so it must report "no slot" on a disposed serializer rather than throwing
+/// <see cref="ObjectDisposedException"/> out of an unobserved task (issue #494).
+/// </summary>
+[TestClass]
+public class AgentWorkSerializerDisposalTests
+{
+    [TestMethod]
+    public async Task TryAcquireForScheduled_ReturnsSlot_BeforeDisposal()
+    {
+        using var serializer = new AgentWorkSerializer();
+
+        var slot = await serializer.TryAcquireForScheduledAsync(CancellationToken.None);
+
+        Assert.IsNotNull(slot);
+        await slot.DisposeAsync();
+    }
+
+    [TestMethod]
+    public async Task TryAcquireForScheduled_AfterDispose_ReturnsNull()
+    {
+        var serializer = new AgentWorkSerializer();
+        serializer.Dispose();
+
+        var slot = await serializer.TryAcquireForScheduledAsync(CancellationToken.None);
+
+        Assert.IsNull(slot);
+    }
+
+    [TestMethod]
+    public void Dispose_IsIdempotent()
+    {
+        var serializer = new AgentWorkSerializer();
+
+        serializer.Dispose();
+        serializer.Dispose();
+    }
+
+    [TestMethod]
+    public async Task TryAcquireForScheduled_ReturnsNull_WhileSlotIsHeld()
+    {
+        using var serializer = new AgentWorkSerializer();
+
+        var held = await serializer.TryAcquireForScheduledAsync(CancellationToken.None);
+        Assert.IsNotNull(held);
+
+        // Moving the non-blocking wait inside the preemption lock must not change this:
+        // a second scheduled acquisition still sees the slot as taken.
+        var second = await serializer.TryAcquireForScheduledAsync(CancellationToken.None);
+        Assert.IsNull(second);
+
+        await held.DisposeAsync();
+
+        var third = await serializer.TryAcquireForScheduledAsync(CancellationToken.None);
+        Assert.IsNotNull(third);
+        await third.DisposeAsync();
+    }
+
+    [TestMethod]
+    public async Task ScheduledSlot_Dispose_AfterSerializerDisposed_DoesNotThrow()
+    {
+        var serializer = new AgentWorkSerializer();
+
+        // A cycle that outran the host's shutdown timeout still holds its slot when
+        // the container disposes the serializer. Handing the slot back must be a no-op,
+        // not an ObjectDisposedException out of the cycle's finally block.
+        var slot = await serializer.TryAcquireForScheduledAsync(CancellationToken.None);
+        Assert.IsNotNull(slot);
+
+        serializer.Dispose();
+
+        await slot.DisposeAsync();
+    }
+
+    [TestMethod]
+    public async Task UserSlot_Dispose_AfterSerializerDisposed_DoesNotThrow()
+    {
+        var serializer = new AgentWorkSerializer();
+
+        var user = await serializer.AcquireForUserAsync(CancellationToken.None);
+
+        serializer.Dispose();
+
+        await user.DisposeAsync();
+    }
+
+    [TestMethod]
+    public async Task TryAcquireForScheduled_ReturnsNull_WhileUserHoldsSlot()
+    {
+        using var serializer = new AgentWorkSerializer();
+
+        var user = await serializer.AcquireForUserAsync(CancellationToken.None);
+
+        var slot = await serializer.TryAcquireForScheduledAsync(CancellationToken.None);
+        Assert.IsNull(slot);
+
+        await user.DisposeAsync();
+    }
+}


### PR DESCRIPTION
Fixes #494.

A dream cycle that was scheduled or in flight when the host shut down could throw `ObjectDisposedException` out of a task nobody observes. Two independent hazards, both fixed here.

## `AgentWorkSerializer`

`Dispose()` disposed `_slot` and `_preemptCts` while timer callbacks could still be calling into them — `TryAcquireForScheduledAsync` does `_slot.Wait(0)` and reads `_preemptCts.Token`, and both throw on a disposed instance.

- Added a `_disposed` flag set under `_preemptLock`; `Dispose()` is idempotent and disposes the semaphore inside that same lock.
- `TryAcquireForScheduledAsync` takes the lock first, returns `null` when disposed, and does the non-blocking `Wait(0)` inside the lock so disposal cannot land between the check and the token read. "No slot available" is an outcome every caller already handles.
- Slot handles release through a `ReleaseQuietly` helper that tolerates a disposed semaphore, so work that outran the shutdown timeout hands the slot back as a no-op instead of throwing from its `finally`.
- `AcquireForUserAsync` still throws on a disposed serializer — returning a fake handle there would let user work run unserialized, and that path is not part of the bug.

`SchedulerService.FireTaskAsync` calls the same method and gets the fix for free.

## `DreamService`

`StopAsync` only disarmed the timer; it never waited for a callback already running, and the callback discarded its task (`_ = OnTimerTickAsync()`) so anything thrown there was unobserved. Meanwhile `ArmNextCronTimer` / `TryArmContentionRetry` could call `_timer.Change(...)` on a disposed timer.

- New `_stopping` CTS plus a kept `_cycleTask`; the timer callback assigns the task instead of discarding it.
- `OnTimerTickAsync` has a top-level catch that logs, so nothing escapes as unhandled.
- `DreamAsync` acquires the slot with `_stopping.Token` (not `CancellationToken.None`) so cancellation unwinds an in-flight cycle through the existing `catch (OperationCanceledException)` path, and the acquisition itself is guarded for `ObjectDisposedException`/`OperationCanceledException`.
- `StopAsync` disarms, cancels `_stopping`, then awaits the in-flight cycle bounded by the host's shutdown token — logging a warning rather than hanging or throwing if it does not finish in time.
- `TryArmContentionRetry` / `ArmNextCronTimer` bail once `_stopping` is cancelled and tolerate a disposed timer; the retry counter now increments only after the re-arm succeeds.
- `Dispose()` disposes `_stopping` only when the cycle task actually completed, so a cycle that outran the timeout cannot reach a disposed CTS.
- Directive loading and the pass-ledger load moved inside the guarded `try`, with `_passLedger` cleared first so a failed load cannot make the `finally` re-save the previous cycle's ledger.

## Tests

New `tests/RockBot.Host.Tests/AgentWorkSerializerDisposalTests.cs` — 7 tests covering normal acquisition, `null` instead of a throw after `Dispose()`, idempotent disposal, both held-slot cases (guarding the `Wait(0)` move into the lock), and releasing a scheduled and a user slot after the serializer is disposed.

`DreamService` is a sealed internal class with ~30 constructor dependencies and no test constructs one today, so its shutdown path is covered by build + review rather than a new unit test. The load-bearing, testable half of the fix is the serializer contract.

Full solution suite passes (1431 Host tests, all projects green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GsCZ7jPi8GLu14CoDovvP
