### PR TITLE
Stop generated IDs hiding repeated futile tool calls (#464)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.14.35</Version>
+<Version>0.14.36</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/src/RockBot.Host/AgentLoopRunner.cs
+++ b/src/RockBot.Host/AgentLoopRunner.cs
@@ -168,7 +168,7 @@ public sealed partial class AgentLoopRunner(
     /// times in a row the detector signals that the agent should try a different approach.
     /// Internal and sealed so it can be unit-tested directly.
     /// </summary>
-    internal sealed class RepetitiveToolCallDetector
+    internal sealed partial class RepetitiveToolCallDetector
     {
         public const int Threshold = 3;
 
@@ -182,8 +182,12 @@ public sealed partial class AgentLoopRunner(
         /// </summary>
         public bool Track(string toolName, string argsKey, string result)
         {
+            // Normalize before truncating — normalizing after the cut would leave a
+            // partial ID straddling the boundary, which still varies per call.
+            var normalized = NormalizeForKey(result);
+
             // Truncate large results so the key stays manageable.
-            var resultTrunc = result is { Length: > 500 } ? result[..500] : result;
+            var resultTrunc = normalized is { Length: > 500 } ? normalized[..500] : normalized;
             var key = $"{toolName}|{argsKey}|{resultTrunc}";
 
             if (key == _lastKey)
@@ -211,6 +215,44 @@ public sealed partial class AgentLoopRunner(
             _lastKey = null;
             _count = 0;
         }
+
+        /// <summary>
+        /// Replaces per-call entropy — generated IDs, timestamps and durations — with
+        /// placeholders so two runs of the same futile call compare equal. Without this
+        /// the detector is blind to tools like <c>spawn_wisps</c> whose result embeds a
+        /// fresh batch/wisp ID and elapsed time on every invocation.
+        /// </summary>
+        internal static string NormalizeForKey(string result)
+        {
+            if (string.IsNullOrEmpty(result)) return result;
+
+            var text = TimestampRegex().Replace(result, "<ts>");
+            text = GuidRegex().Replace(text, "<id>");
+            text = LongHexRegex().Replace(text, "<id>");
+            text = DurationRegex().Replace(text, "<dur>");
+            return text;
+        }
+
+        // ISO-8601 timestamps, with or without fractional seconds and offset.
+        [GeneratedRegex(
+            @"\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?",
+            RegexOptions.CultureInvariant)]
+        private static partial Regex TimestampRegex();
+
+        // Dashed GUIDs (8-4-4-4-12).
+        [GeneratedRegex(
+            @"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b",
+            RegexOptions.CultureInvariant)]
+        private static partial Regex GuidRegex();
+
+        // Bare hex runs of 8+ chars — catches truncated "N"-format GUIDs such as
+        // batch-{Guid:N}[..18] and wisp-{Guid:N}[..16], which are not well-formed GUIDs.
+        [GeneratedRegex(@"\b[0-9a-fA-F]{8,}\b", RegexOptions.CultureInvariant)]
+        private static partial Regex LongHexRegex();
+
+        // Elapsed times: "1234ms", "1.2s", "1.5 s".
+        [GeneratedRegex(@"\b\d+(?:\.\d+)?\s*(?:ms|s)\b", RegexOptions.CultureInvariant)]
+        private static partial Regex DurationRegex();
     }
 
     private sealed record CompletionEvalDto(bool Complete, string? Reason);

--- a/tests/RockBot.Host.Tests/RepetitiveToolCallDetectorTests.cs
+++ b/tests/RockBot.Host.Tests/RepetitiveToolCallDetectorTests.cs
@@ -142,6 +142,141 @@ public class RepetitiveToolCallDetectorTests
         }
     }
 
+    // ── Entropy normalization (issue #464) ───────────────────────────────────
+
+    /// <summary>
+    /// Builds a realistic spawn_wisps batch summary: a fresh batch/wisp ID and a
+    /// different elapsed time on every call, but substantively the same outcome.
+    /// </summary>
+    private static string SpawnWispsResult(string batchId, string wispId, int ms, double totalSeconds) =>
+        $"""
+        1 wisp(s) completed (0 succeeded, 1 failed, {totalSeconds:F1}s total):
+
+        - `{wispId}`: "check inbox" [failed] ({ms}ms)
+          Error (ToolNotFound): Tool 'email_search' is not registered
+          Tool: email_search
+
+        Batch ID: `{batchId}`
+        Batch summary: `wisp/batch-{batchId}/summary`
+        """;
+
+    [TestMethod]
+    public void Track_SpawnWispsStyleResultWithGuids_StillTriggers()
+    {
+        var detector = new AgentLoopRunner.RepetitiveToolCallDetector();
+
+        var batchIds = new[] { "batch-3f2a1b9c4d5e", "batch-a17c05e9b3d4", "batch-99f4c2a8e1b0" };
+        var wispIds = new[] { "wisp-1a2b3c4d5e6f", "wisp-0f9e8d7c6b5a", "wisp-c4d3e2f1a0b9" };
+        var durations = new[] { 812, 1043, 977 };
+        var totals = new[] { 0.9, 1.1, 1.0 };
+
+        bool triggered = false;
+        for (var i = 0; i < AgentLoopRunner.RepetitiveToolCallDetector.Threshold; i++)
+        {
+            triggered = detector.Track(
+                "spawn_wisps",
+                "wisps=[check inbox]",
+                SpawnWispsResult(batchIds[i], wispIds[i], durations[i], totals[i]));
+        }
+
+        Assert.IsTrue(triggered, "Per-call batch/wisp IDs and durations should not hide the repetition");
+    }
+
+    [TestMethod]
+    public void Track_ResultDifferingOnlyByGuid_StillTriggers()
+    {
+        var detector = new AgentLoopRunner.RepetitiveToolCallDetector();
+
+        var guids = new[]
+        {
+            "6f9619ff-8b86-d011-b42d-00cf4fc964ff",
+            "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "0e1d2c3b-4a59-4687-9f10-abcdef012345",
+        };
+
+        bool triggered = false;
+        for (var i = 0; i < AgentLoopRunner.RepetitiveToolCallDetector.Threshold; i++)
+            triggered = detector.Track("start_job", "name=triage", $"Job accepted. Correlation ID: {guids[i]}");
+
+        Assert.IsTrue(triggered, "A varying GUID should not hide the repetition");
+    }
+
+    [TestMethod]
+    public void Track_ResultDifferingOnlyByTimestamp_StillTriggers()
+    {
+        var detector = new AgentLoopRunner.RepetitiveToolCallDetector();
+
+        var timestamps = new[]
+        {
+            "2026-06-05T14:03:22.123Z",
+            "2026-06-05T14:03:25.907Z",
+            "2026-06-05T14:03:31+02:00",
+        };
+
+        bool triggered = false;
+        for (var i = 0; i < AgentLoopRunner.RepetitiveToolCallDetector.Threshold; i++)
+            triggered = detector.Track("check_status", "id=42", $"[{timestamps[i]}] still pending");
+
+        Assert.IsTrue(triggered, "A varying timestamp should not hide the repetition");
+    }
+
+    [TestMethod]
+    public void Track_ResultDifferingOnlyByDuration_StillTriggers()
+    {
+        var detector = new AgentLoopRunner.RepetitiveToolCallDetector();
+
+        var durations = new[] { "1234ms", "1.2s", "1.5 s" };
+
+        bool triggered = false;
+        for (var i = 0; i < AgentLoopRunner.RepetitiveToolCallDetector.Threshold; i++)
+            triggered = detector.Track("run_query", "sql=select 1", $"Query timed out after {durations[i]}");
+
+        Assert.IsTrue(triggered, "A varying duration should not hide the repetition");
+    }
+
+    [TestMethod]
+    public void Track_EntropyBeyondTruncationBoundary_StillTriggers()
+    {
+        var detector = new AgentLoopRunner.RepetitiveToolCallDetector();
+
+        // "{prefix} id=" is 498 chars, so the ID straddles the 500-char truncation
+        // boundary: only two of its hex digits survive the cut. Normalizing after
+        // truncation would leave that varying fragment in the key.
+        var prefix = new string('x', 494);
+        var ids = new[] { "1a2b3c4d5e6f7081", "90afbecd12345678", "fedcba9876543210" };
+
+        bool triggered = false;
+        for (var i = 0; i < AgentLoopRunner.RepetitiveToolCallDetector.Threshold; i++)
+            triggered = detector.Track("big_tool", "a=1", $"{prefix} id={ids[i]}");
+
+        Assert.IsTrue(triggered, "Normalization must run before truncation so IDs past the cut are neutralized");
+    }
+
+    [TestMethod]
+    public void Track_SubstantivelyDifferentResult_StillResets()
+    {
+        var detector = new AgentLoopRunner.RepetitiveToolCallDetector();
+
+        detector.Track("spawn_wisps", "wisps=[check inbox]", SpawnWispsResult("batch-3f2a1b9c4d5e", "wisp-1a2b3c4d5e6f", 812, 0.9));
+        detector.Track("spawn_wisps", "wisps=[check inbox]", SpawnWispsResult("batch-a17c05e9b3d4", "wisp-0f9e8d7c6b5a", 1043, 1.1));
+
+        // Same shape, but the wisp actually succeeded this time — a real difference.
+        var triggered = detector.Track(
+            "spawn_wisps",
+            "wisps=[check inbox]",
+            """
+            1 wisp(s) completed (1 succeeded, 0 failed, 1.0s total):
+
+            - `wisp-c4d3e2f1a0b9`: "check inbox" [ok] (977ms)
+              Output: 3 unread messages
+
+            Batch ID: `batch-99f4c2a8e1b0`
+            Batch summary: `wisp/batch-batch-99f4c2a8e1b0/summary`
+            """);
+
+        Assert.IsFalse(triggered, "Normalization must not flatten genuinely different results");
+    }
+
     [TestMethod]
     public void Threshold_IsThree()
     {


### PR DESCRIPTION
Fixes #464.

## Problem

`RepetitiveToolCallDetector` builds its key from the raw `(tool, args, result)`
triple. Any tool whose result embeds per-call entropy therefore never produces
two consecutive identical keys, so the detector silently no-ops — for exactly
the tools most likely to be called in a futile loop:

- `spawn_wisps` — `batch-{Guid:N}[..18]`, `wisp-{Guid:N}[..16]`, and a fresh
  `{ms}ms` / `{s}s total` on every invocation
- anything returning a correlation GUID or an ISO-8601 timestamp

## Fix

`NormalizeForKey` replaces the entropy before the text becomes part of the key:

| pattern | placeholder |
| --- | --- |
| ISO-8601 timestamps (optional fractional seconds / offset) | `<ts>` |
| dashed GUIDs (8-4-4-4-12) | `<id>` |
| bare hex runs of 8+ chars — catches truncated `Guid:N` IDs | `<id>` |
| elapsed times (`1234ms`, `1.2s`, `1.5 s`) | `<dur>` |

Normalization runs **before** the existing 500-char truncation — normalizing
after the cut would leave a partial ID straddling the boundary, which still
varies per call.

`Track`'s signature and `Threshold` are unchanged, so both `AgentLoopRunner`
paths and `RockBotFunctionInvokingChatClient` pick the fix up for free.

## Tests

Six new cases in `RepetitiveToolCallDetectorTests`, including a realistic
`spawn_wisps` batch summary with fresh IDs and durations per call, and a
truncation-boundary case where only two hex digits of the ID survive the cut.
Five of them fail without the fix (verified); the sixth is a guard asserting
normalization does **not** flatten a genuinely different result.

Full suite green (`dotnet test RockBot.slnx`).

## Out of scope

The cross-loop wisp dispatch circuit breaker (#463) and the trim-loop fix (#462).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GsCZ7jPi8GLu14CoDovvP
