### PR TITLE
Add a built-in memory audit (#554)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.14.36</Version>
+<Version>0.14.39</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/deploy/helm/rockbot/templates/agent/deployment.yaml
+++ b/deploy/helm/rockbot/templates/agent/deployment.yaml
@@ -102,7 +102,15 @@ spec:
               done
 
               # Runtime directories
-              mkdir -p /data/agent/memory /data/agent/skills
+              mkdir -p /data/agent/memory /data/agent/skills /data/agent/memory-audit
+
+              # The memory audit's directory is group-writable because the introspection
+              # sidecar deletes a file inside it — resume_memory_consolidation removes the
+              # pause marker, and unlinking needs write on the DIRECTORY, not the file. The
+              # sidecar runs as a different uid and reaches this volume only through the
+              # fsGroup, so a default 0755 would leave it able to read the marker and unable
+              # to clear it.
+              chmod 775 /data/agent/memory-audit
 
               # Secrets directory (workiq token cache and any future per-user
               # credential material). Mode 0700 keeps it private to the rockbot

--- a/deploy/helm/rockbot/templates/configmap.yaml
+++ b/deploy/helm/rockbot/templates/configmap.yaml
@@ -38,6 +38,21 @@ data:
   Dream__LogRetentionMaxFileAge: {{ dig "maxFileAge" "30.00:00:00" $logRetention | quote }}
   Dream__LogRetentionMaxFilesPerDirectory: {{ dig "maxFilesPerDirectory" 1000 $logRetention | quote }}
   Dream__LogRetentionMaxLinesPerFile: {{ dig "maxLinesPerFile" 10000 $logRetention | quote }}
+  # ── Memory audit (read-only measurement of the long-term memory store) ────
+  # `dig` for the same reason as the retention block above: an explicit false must
+  # survive, and a --reuse-values upgrade with no block must still get the defaults.
+  {{- $memoryAudit := .Values.agent.memoryAudit | default dict }}
+  MemoryAudit__Enabled: {{ dig "enabled" true $memoryAudit | quote }}
+  MemoryAudit__CronSchedule: {{ dig "cronSchedule" "0 4 * * *" $memoryAudit | quote }}
+  MemoryAudit__BasePath: "/data/agent/memory-audit"
+  MemoryAudit__SharedReportDirectory: "/rockbot/shared/exports/memory-audit"
+  MemoryAudit__PauseConsolidationOnAlert: {{ dig "pauseConsolidationOnAlert" false $memoryAudit | quote }}
+  {{- $evalCron := dig "evalCronSchedule" "0 5 * * 0" $memoryAudit }}
+  MemoryAudit__EvalEnabled: {{ if $evalCron }}"true"{{ else }}"false"{{ end }}
+  {{- if $evalCron }}
+  MemoryAudit__EvalCronSchedule: {{ $evalCron | quote }}
+  {{- end }}
+
   # ── OpenRouter app attribution (non-secret) ───────────────────────────────
   # Sent as the HTTP-Referer / X-Title headers on OpenRouter calls only, so the
   # account's activity dashboard shows this release by name instead of "unknown".

--- a/deploy/helm/rockbot/values.yaml
+++ b/deploy/helm/rockbot/values.yaml
@@ -55,6 +55,25 @@ agent:
     # At ~1.1 KB/line for wisp records, 10000 ≈ 11 MB, well above the 14-day window
     # the wisp dream pass reads. Set to 0 to disable line trimming.
     maxLinesPerFile: 10000
+  # Read-only memory audit (see docs/memory-audit.md). Walks the memory store on its
+  # own cron, keeps a long-lived trend file at /data/agent/memory-audit/, checks
+  # invariants, and pushes a message to the scheduled-system session only when
+  # something needs attention. Model-free apart from the weekly sample eval.
+  memoryAudit:
+    enabled: true
+    # Measurement run. Kept well clear of the 12-hourly dream cycle so the two do not
+    # queue behind each other on the agent's single work slot.
+    cronSchedule: "0 4 * * *"
+    # Weekly LLM-judged sample eval — four Balanced-tier JSON calls, skipped entirely
+    # on weeks where the memory corpus has not changed. Set to "" to disable.
+    evalCronSchedule: "0 5 * * 0"
+    # Circuit breaker. When true, a run that finds entries hard-deleted outside the
+    # retention purge writes a marker file that stops dream memory consolidation until
+    # a human (or resume_memory_consolidation) clears it. Off by default: a false
+    # positive stops the only thing keeping the corpus from growing without bound.
+    pauseConsolidationOnAlert: false
+  # Every other MemoryAudit__* knob (thresholds, sample size, shared-copy directory)
+  # is available through agent.extraEnv — see MemoryAuditOptions for the full list.
   resources:
     requests:
       cpu: 500m

--- a/docs/dream-service.md
+++ b/docs/dream-service.md
@@ -595,6 +595,26 @@ gracefully — passes that need a missing service are simply skipped.
 
 ---
 
+## Is any of this working?
+
+The dream service's own log lines report what each pass *did* — "12 merged, 8 archived" — and
+they report exactly that whether the merges were good or catastrophic. Nothing in this document
+tells you whether the corpus is converging, whether provenance still resolves, or whether
+anything was destroyed that should not have been.
+
+The [memory audit](memory-audit) answers those questions. It runs on its own schedule, walks the
+memory files rather than asking the store, and keeps a trend file with a 400-day retention so a
+slow loss is visible long after the logs that carried it have aged out. Two hooks in this service
+exist for it:
+
+- A merge the coverage check refuses now stamps its sources with `consolidationRejectedCluster`
+  and `consolidationRejectedAt`, so "the same cluster is rejected every cycle forever" is
+  observable on disk rather than only in a log line inside Loki's retention window.
+- `RunMemoryConsolidationPassAsync` skips entirely while
+  `memory-audit/consolidation-paused.json` exists. The audit writes that file, opt-in, when it
+  finds entries hard-deleted outside the retention purge. Only consolidation stops; mining,
+  extraction and the retention sweeps keep running.
+
 ## LLM response format
 
 All passes use a JSON response contract. The dream service extracts the outermost JSON object

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,6 +39,7 @@ Each agent is an isolated process that reacts to messages, invokes tools, calls 
 - [A2A](a2a) — agent-to-agent task delegation
 - [Wisps](wisps) — short-lived worker pattern
 - [Dream service](dream-service) — offline self-optimization
+- [Memory audit](memory-audit) — scheduled read-only health check of long-term memory
 - [Knowledge graph](knowledge-graph)
 - [Blazor UI](blazor-ui)
 - [NuGet release](nuget-release)

--- a/docs/memory-audit.md
+++ b/docs/memory-audit.md
@@ -1,0 +1,244 @@
+---
+title: Memory audit
+layout: default
+nav_order: 15
+---
+
+# Memory audit
+
+A read-only, scheduled measurement of the agent's long-term memory store. It walks the memory
+files on disk, compares them against the previous run, checks a set of invariants, writes a
+plain-language report and a long-lived trend file, and speaks up only when something needs
+attention.
+
+## Why it exists
+
+Everything the project knows about how memory management actually behaves came from a human
+pulling the PVC and grepping Loki after the fact. That worked, but it does not scale and it does
+not catch anything early:
+
+- **Loki keeps about a week.** A corpus that loses 2% a month looks perfectly healthy in every
+  seven-day window and is catastrophic across a year.
+- **The dream-pass ledger records only last-run timestamps.** It cannot say how many
+  consolidation cycles ran, and nothing anywhere records process restarts — which is what turned
+  a day of deploys into a day of consolidation passes.
+- **The dream cycle's own log lines looked healthy through every incident.** A pass that reports
+  "12 merged, 8 archived" reports exactly that whether the merges were good or catastrophic.
+
+The audit measures the store rather than trusting the code that writes to it, on its own
+schedule, into a file whose retention is measured in months.
+
+## What it measures
+
+Each run appends one JSON row to `memory-audit/snapshots.jsonl` and rewrites
+`memory-audit/latest.md`.
+
+| Group | Fields |
+| --- | --- |
+| Size | `live`, `archived`, `malformedFiles`, `emptyCategoryDirs` |
+| Movement since the previous run | `createdSinceLast`, `archivedSinceLast`, `hardDeletedSinceLast`, `purgedSinceLast`, `hardDeletedOutsidePurge`, `netGrowthPerDay`, `reinforcedWithoutMergeSinceLast` |
+| Merge provenance | `mergeChainDepth` (histogram), `maxChainDepth`, `rejectedMergeSourcesSinceLast`, `rejectedMergeClustersRepeated` |
+| Duplication | `nearDupPairs`, `nearDupEntries`, `embeddingDupClusters` |
+| Shape | `reinforcement` (histogram), `topCategoriesByGrowth`, `vocabularyStoplistSize` |
+| Cadence | `dreamPassesRunSinceLast`, `consolidationLastRunAt`, `restartsSinceLast` |
+| Ahead | `purge` — how many archived entries are hard-deleted within the warning window, and how many of those the high-value floor will keep |
+| Judgement | `invariants`, `status`, `eval` |
+
+Two measurement choices are worth knowing about, because they are what make the numbers mean
+what they say:
+
+**Deltas are keyed on ids, never timestamps.** A merged entry inherits its earliest source's
+`createdAt`, so counting creations by timestamp reports zero for exactly the churn this exists to
+expose. The previous run's ids live in `memory-audit/state.json`.
+
+**Hard deletes are explained, not assumed.** No purge timestamp is recorded anywhere in the
+agent, so an id that vanished is attributed to the retention purge only when it was already
+archived at the previous run *and* its `archivedAt + Dream:MemoryArchiveRetention` had passed.
+Everything else lands in `hardDeletedOutsidePurge`, which the audit expects to be zero.
+
+**Near-duplicates are lexical, not vector.** Word 6-gram shingles scored by Jaccard overlap. This
+is deliberately not the mechanism consolidation uses: if the audit and the deduplicator both
+asked the vector index "are these the same?", a broken index would read as a clean corpus.
+
+At the default `ShingleSize` of 6 this measures *near-verbatim* duplication — the same text saved
+twice, which is what a failing save-time dedupe looks like — rather than rephrasings, which share
+few 6-grams. Lower `ShingleSize` if you want the looser measure, at the cost of pairing entries
+that merely share boilerplate.
+
+## Invariants
+
+| Name | Severity | Meaning |
+| --- | --- | --- |
+| `no-hard-delete-outside-purge` | alert | Entries vanished from disk that the retention purge cannot account for. |
+| `loss-percent-threshold` | alert | Live entries fell more than `MaxLossPercentBetweenSnapshots` since the previous run. |
+| `merge-chain-unbroken` | alert | Entries archived `"merged into X"` where X exists nowhere — their content has no surviving copy. This is the shape issue #506 found. |
+| `merged-from-resolves` | warning | A merge names sources that are missing and is too recent for the purge to explain it. Provenance dangling *after* the retention window is by design. |
+| `archive-fields-present` | warning | An entry has an archive timestamp with no reason, or vice versa. |
+| `live-not-merge-source` | warning | An entry that was merged away is still in recall, so both copies surface. |
+| `no-repeated-rejection` | warning | The same merge cluster has been rejected on `RepeatedRejectionRuns` consecutive runs — consolidation is retrying work it cannot complete. |
+| `net-growth-threshold` | warning | Saves are outpacing consolidation. |
+| `chain-depth-threshold` | warning | A live entry is model prose generated from model prose, more deeply than you allowed. |
+| `rejected-merges-threshold` | warning | Merge rejections per week are above the limit. |
+| `no-malformed-files` | warning | Files under the memory root would not deserialize. |
+
+Status is the worst finding: `alert` if any alert-severity invariant fired, `warning` if any
+other did, `healthy` if none did.
+
+## The weekly sample eval
+
+The counters say what happened; they cannot say whether it was *right*. Once a week — by default
+Sunday 05:00 — a Balanced-tier judge is shown a handful of decisions memory management actually
+made and asked whether each was correct:
+
+- **merges** made in the last 14 days, alongside the sources they replaced;
+- **near-duplicate pairs** still both live — deduplication that did not happen;
+- **heavily reinforced entries**, checked for having accreted into a vague blob;
+- **facts dropped as ephemeral**, checked for having been durable after all.
+
+The judge's directive lives at `/data/agent/memory-audit.md` on the profile volume, with a
+built-in fallback. Results go to `memory-audit/eval-latest.json` and the summary is embedded in
+every later snapshot row.
+
+Cost is bounded two ways: sampling is capped per family, and the whole run is skipped when the
+corpus fingerprint has not moved since the last eval. A quiet week costs nothing.
+
+## Files
+
+All under `{AgentProfile:BasePath}/memory-audit/` — `/data/agent/memory-audit/` in the Helm
+chart.
+
+| File | Contents |
+| --- | --- |
+| `snapshots.jsonl` | One snapshot per line. The trend. Kept for `SnapshotRetention` (400 days). |
+| `latest.md` | The most recent report, in markdown. |
+| `report-YYYY-MM-DD.md` | Dated copies, pruned by the dream cycle's shared file-age policy. |
+| `eval-latest.json`, `eval-YYYY-MM-DD.json` | Sample-eval verdicts. |
+| `state.json` | Private carry-over: the previous run's entry ids, rejection cluster counters, process starts. Not a public surface; losing it costs one run's deltas. |
+| `consolidation-paused.json` | Present only when the circuit breaker has fired. |
+
+When `CopyReportToShared` is on, the report is also written to
+`/rockbot/shared/exports/memory-audit/memory-audit-YYYY-MM-DD.md`. That directory is re-created
+on every run, because the shared-volume cleanup CronJob sweeps everything under `exports/` past
+its TTL.
+
+## How you find out
+
+**The agent tells you.** A run whose status is not `healthy` publishes an unsolicited message on
+the `scheduled-system` session with the status and the failed invariants. A healthy run is
+silent — a channel that reports "all clear" daily stops being read before the day it matters. Set
+`DigestCronSchedule` if you want the full report pushed on a schedule regardless of status.
+
+**You ask.** Four MCP tools on the introspection sidecar read these files directly:
+
+- `get_memory_audit` — the latest report plus the raw snapshot.
+- `get_memory_audit_trend(days)` — snapshot rows for the last N days.
+- `get_memory_audit_eval` — the latest judged sample.
+- `resume_memory_consolidation` — clears the pause marker.
+
+The agent's directives point memory-health questions at these rather than at `recall`: recall
+searches what memory *contains*, the audit measures what the store is *doing* to it.
+
+## Explaining a finding
+
+Invariant names are stable identifiers, which makes them good keys and useless to a person.
+Two surfaces translate them, and neither costs anything until it is used:
+
+- **`get_memory_audit` returns a `findings` array** pairing each violation with its
+  `MemoryAuditGlossary` entry — a plain-language title, what it means, what to do, and the
+  severity. The explanation therefore arrives *with* the finding, so the agent can answer "what
+  does `chain-depth-threshold` mean?" without a second call it might not think to make. Absent
+  entirely on a clean run.
+- **`get_tool_guide("memory-audit")`** returns the longer guide — how the measurement works, why
+  memories are retired rather than deleted, what a merge chain is, and what the audit does not
+  claim. Published through `IToolSkillProvider`, so it is loaded only when requested and is never
+  injected into the system prompt.
+
+`directives.md` carries only the routing rule (memory-health questions go to the audit, not
+`recall`) plus a pointer to the guide. Everything else is deliberately kept out of the
+always-loaded prompt.
+
+A new invariant added without a glossary entry is a test failure, not a silent gap.
+
+**Loki.** One structured `memory audit —` line per run carries every headline number, so a
+dashboard can chart it without opening a file.
+
+## The circuit breaker
+
+`PauseConsolidationOnAlert` (off by default) makes a run that finds hard deletes outside the
+purge, or a live-count drop past the threshold, write `consolidation-paused.json`. The dream
+cycle checks for that file at the top of `RunMemoryConsolidationPassAsync` and skips the pass —
+only that pass, so mining, extraction and the retention sweeps keep running.
+
+The auditor never clears the marker. Resuming is deliberate: delete the file, or call
+`resume_memory_consolidation`. The point of the pause is that a person looks at the cause before
+the same pass runs again.
+
+It is off by default because a false positive stops the only thing keeping the corpus from
+growing without bound. Turn it on once you trust the numbers on your own deployment.
+
+## Options
+
+Section `MemoryAudit`. The Helm chart exposes `agent.memoryAudit.{enabled, cronSchedule,
+evalCronSchedule, pauseConsolidationOnAlert}`; everything else is available through
+`agent.extraEnv` as `MemoryAudit__*`.
+
+| Option | Default | Notes |
+| --- | --- | --- |
+| `Enabled` | `true` | |
+| `CronSchedule` | `0 4 * * *` | Kept clear of the 12-hourly dream cycle so the two do not queue on the agent's single work slot. |
+| `InitialDelay` | `10m` | Long enough that a restart storm does not produce a snapshot per deploy. |
+| `BasePath` | `memory-audit` | Relative paths resolve under `AgentProfile:BasePath`. |
+| `SnapshotRetention` | `400d` | One row per day at a few hundred bytes is under 100 KB. |
+| `NearDuplicateThreshold` | `0.3` | Much looser than save-time dedupe: this is a health metric, not a decision to fold anything. |
+| `ShingleSize` | `6` | |
+| `HighReinforcementFloor` | `20` | Eval sampling threshold. |
+| `PurgeWarningDays` | `7` | Look-ahead for the purge outlook. |
+| `MinRateWindow` | `12h` | Shortest gap between runs over which a per-day/per-week rate is measurable. Below it the rate reports as unmeasurable and the rate-based invariants are skipped — a restart otherwise annualizes a handful of saves into the thousands. |
+| `MaxNetGrowthPerDay` | `5` | Only evaluated over windows of at least `MinRateWindow`. |
+| `MaxMergeChainDepth` | `2` | |
+| `MaxRejectedMergesPerWeek` | `5` | |
+| `MaxHardDeletesOutsidePurge` | `0` | Any occurrence is an alert. |
+| `MaxLossPercentBetweenSnapshots` | `10` | |
+| `RepeatedRejectionRuns` | `3` | |
+| `EvalEnabled` | `true` | |
+| `EvalCronSchedule` | `0 5 * * 0` | |
+| `EvalModelTier` | `Balanced` | |
+| `EvalSampleSize` | `10` | Per family, per run. |
+| `EvalWindow` | `14d` | |
+| `EvalDirectivePath` | `memory-audit.md` | |
+| `AlertOnAttention` | `true` | |
+| `DigestCronSchedule` | `null` | Null means alerts only. |
+| `CopyReportToShared` | `true` | |
+| `SharedReportDirectory` | `/rockbot/shared/exports/memory-audit` | |
+| `PauseConsolidationOnAlert` | `false` | |
+
+## Notes and limitations
+
+**The rejection stamp is written by the dream, not the auditor.** A refused merge previously
+existed only as a log line. The dream now stamps each source with
+`consolidationRejectedCluster` (a hash of the sorted source ids) and `consolidationRejectedAt`,
+because only the dream knows which entries it proposed together — an auditor re-deriving the
+clusters would be guessing at a decision an LLM already made. The stamps are metadata only:
+nothing reads them back except the audit, and an entry is neither protected nor penalised by
+carrying them.
+
+**Category growth is attributed from surviving entries.** A hard-deleted entry takes its category
+with it, so a corpus losing an entire category shows up in the hard-delete count rather than in
+the growth table.
+
+**`memory-audit.md` and `directives.md` reach a live cluster only via the PVC.** The init
+container copies profile files with no-clobber semantics, so rebuilding the image does not update
+them. Push them with `kubectl exec`; profile hot-reload picks the change up within ~500 ms.
+
+**Rates need a window.** `netGrowthPerDay` is null, not zero, when two runs fall closer together
+than `MinRateWindow` — which is what a restart does. Absolute counts in the same snapshot stay
+exact, so a short-window run still catches real loss; only the extrapolated rates are withheld.
+
+**Merge chain depth stops at a purged source.** Provenance is a recovery aid with a retention
+window, and inflating a depth by guessing at entries that no longer exist would inflate exactly
+the number an operator would act on.
+
+## Related
+
+- [Dream service](dream-service) — the passes the audit is measuring.
+- [Memory](memory) — the store itself.

--- a/src/McpServer.Introspection/Program.cs
+++ b/src/McpServer.Introspection/Program.cs
@@ -8,6 +8,7 @@ builder.Services.AddMcpServer()
     .WithTools<AgentNameTools>()
     .WithTools<CopilotUsageTools>()
     .WithTools<LlmPricingTools>()
+    .WithTools<MemoryAuditTools>()
     .WithTools<RoutingStatsTools>();
 
 var app = builder.Build();

--- a/src/McpServer.Introspection/Tools/MemoryAuditTools.cs
+++ b/src/McpServer.Introspection/Tools/MemoryAuditTools.cs
@@ -1,0 +1,249 @@
+using System.ComponentModel;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+using RockBot.Host;
+
+namespace McpServer.Introspection.Tools;
+
+/// <summary>
+/// MCP-facing view of the memory audit's files on the agent profile volume.
+/// <para>
+/// The audit writes; this reads. Keeping the reader in the sidecar means the agent can answer
+/// "are you losing memories?" with a measurement instead of a recall query — and answer it even
+/// while its own memory is the thing under suspicion.
+/// </para>
+/// </summary>
+[McpServerToolType]
+public sealed class MemoryAuditTools(IConfiguration configuration)
+{
+    private static readonly JsonSerializerOptions ReadOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    private static readonly JsonSerializerOptions WriteOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true
+    };
+
+    private string AuditPath => configuration["MemoryAudit:Path"] ?? "/data/agent/memory-audit";
+
+    [McpServerTool(Name = "get_memory_audit")]
+    [Description(
+        "Returns the most recent memory-health audit: a plain-language report plus the raw " +
+        "snapshot. Covers live and archived entry counts, what was created/archived/deleted " +
+        "since the previous run, hard deletes the retention purge cannot account for, merge " +
+        "chain depth, near-duplicate counts, the purge outlook, and any invariants that failed. " +
+        "Each finding comes with a plain-language explanation and what to do about it, so you can " +
+        "answer a non-technical question about any warning without looking anything else up. " +
+        "Use this for questions about memory health, memory loss, or consolidation behaviour — " +
+        "NOT the recall tools, which search memory contents rather than measuring the store.")]
+    public async Task<string> GetMemoryAuditAsync()
+    {
+        var reportPath = Path.Combine(AuditPath, MemoryAuditFiles.LatestReport);
+        var report = File.Exists(reportPath) ? await ReadTextAsync(reportPath) : null;
+        var snapshots = await ReadSnapshotsAsync();
+        var latest = snapshots.Count > 0 ? snapshots[^1] : null;
+
+        if (report is null && latest is null)
+            return JsonSerializer.Serialize(new
+            {
+                message = "No memory audit has run yet. The first audit runs on its cron schedule " +
+                          "(default 04:00 daily) or shortly after the agent starts.",
+                auditPath = AuditPath
+            }, WriteOptions);
+
+        return JsonSerializer.Serialize(new
+        {
+            report,
+            snapshot = latest,
+            // Every finding carries its own plain-language explanation. The invariant names are
+            // jargon by design — stable identifiers to key on — and an agent asked "what does
+            // chain-depth-threshold mean?" must not have to already know, or have to go and
+            // fetch a second document it might not think to fetch.
+            findings = Explain(latest),
+            paused = await ReadPauseMarkerAsync(),
+            totalSnapshots = snapshots.Count
+        }, WriteOptions);
+    }
+
+    /// <summary>
+    /// Pairs each violation on <paramref name="snapshot"/> with its glossary entry. Returns null
+    /// when the run was clean, so a healthy report does not carry an empty list the agent might
+    /// read as a finding.
+    /// </summary>
+    private static object? Explain(MemoryAuditSnapshot? snapshot)
+    {
+        if (snapshot is null || snapshot.Invariants.Count == 0) return null;
+
+        return snapshot.Invariants.Select(v =>
+        {
+            var definition = MemoryAuditGlossary.Describe(v.Name);
+            return new
+            {
+                name = v.Name,
+                title = definition?.Title,
+                inPlainLanguage = definition?.WhatItMeans,
+                whatToDo = definition?.WhatToDo,
+                severity = definition?.Severity,
+                technicalDetail = v.Message,
+                affectedIds = v.Ids
+            };
+        }).ToList();
+    }
+
+    [McpServerTool(Name = "get_memory_audit_trend")]
+    [Description(
+        "Returns the memory audit's snapshot rows for the last N days, oldest first — one row " +
+        "per audit run. Use this to answer whether the corpus is growing, shrinking, or " +
+        "converging over time, and to see whether a loss was a one-off or a slope. days is " +
+        "clamped to 1..400.")]
+    public async Task<string> GetMemoryAuditTrendAsync(
+        [Description("Window in days (1..400, default 30).")] int days = 30)
+    {
+        days = Math.Clamp(days, 1, 400);
+        var cutoff = DateTimeOffset.UtcNow.AddDays(-days);
+
+        var snapshots = await ReadSnapshotsAsync();
+        var windowed = snapshots.Where(s => s.TakenAt >= cutoff).ToList();
+
+        return JsonSerializer.Serialize(new
+        {
+            windowDays = days,
+            returned = windowed.Count,
+            totalSnapshots = snapshots.Count,
+            snapshots = windowed
+        }, WriteOptions);
+    }
+
+    [McpServerTool(Name = "get_memory_audit_eval")]
+    [Description(
+        "Returns the most recent LLM-judged sample eval of memory-management decisions: per-sample " +
+        "verdicts on recent merges, near-duplicates left in place, heavily reinforced entries, and " +
+        "facts dropped as ephemeral, plus the overall soundness rates. Answers whether memory " +
+        "management is making GOOD decisions, where get_memory_audit answers what it DID.")]
+    public async Task<string> GetMemoryAuditEvalAsync()
+    {
+        var path = Path.Combine(AuditPath, MemoryAuditFiles.EvalLatest);
+        if (!File.Exists(path))
+            return JsonSerializer.Serialize(new
+            {
+                message = "No sample eval has run yet. It runs weekly and is skipped entirely on " +
+                          "weeks where the memory corpus has not changed.",
+                auditPath = AuditPath
+            }, WriteOptions);
+
+        try
+        {
+            var json = await ReadTextAsync(path);
+            var result = JsonSerializer.Deserialize<MemoryAuditEvalResult>(json, ReadOptions);
+            return JsonSerializer.Serialize(result, WriteOptions);
+        }
+        catch (Exception ex)
+        {
+            return JsonSerializer.Serialize(
+                new { error = $"Could not read the eval file: {ex.Message}", path }, WriteOptions);
+        }
+    }
+
+    [McpServerTool(Name = "resume_memory_consolidation")]
+    [Description(
+        "Deletes the marker file that the memory audit wrote to pause dream memory consolidation " +
+        "after finding catastrophic loss, letting consolidation run again on the next dream cycle. " +
+        "Only call this when the user explicitly asks to resume — the pause exists so a human " +
+        "looks at what happened before the same pass runs again. Reports what the marker said.")]
+    public async Task<string> ResumeMemoryConsolidationAsync()
+    {
+        var path = Path.Combine(AuditPath, MemoryAuditFiles.ConsolidationPausedFile);
+
+        if (!File.Exists(path))
+            return JsonSerializer.Serialize(new
+            {
+                resumed = false,
+                message = "Memory consolidation is not paused — no marker file exists.",
+                path
+            }, WriteOptions);
+
+        var removed = await ReadPauseMarkerAsync();
+
+        try
+        {
+            File.Delete(path);
+        }
+        catch (Exception ex)
+        {
+            return JsonSerializer.Serialize(new
+            {
+                resumed = false,
+                error = $"Could not delete the marker: {ex.Message}",
+                path
+            }, WriteOptions);
+        }
+
+        return JsonSerializer.Serialize(new
+        {
+            resumed = true,
+            message = "Memory consolidation will run again on the next dream cycle.",
+            removed
+        }, WriteOptions);
+    }
+
+    // ── File reading ─────────────────────────────────────────────────────────
+
+    private async Task<List<MemoryAuditSnapshot>> ReadSnapshotsAsync()
+    {
+        var path = Path.Combine(AuditPath, MemoryAuditFiles.SnapshotsFile);
+        if (!File.Exists(path)) return [];
+
+        var snapshots = new List<MemoryAuditSnapshot>();
+
+        try
+        {
+            foreach (var line in await File.ReadAllLinesAsync(path))
+            {
+                if (string.IsNullOrWhiteSpace(line)) continue;
+                try
+                {
+                    var snapshot = JsonSerializer.Deserialize<MemoryAuditSnapshot>(line, ReadOptions);
+                    if (snapshot is not null) snapshots.Add(snapshot);
+                }
+                catch (JsonException) { /* skip malformed lines */ }
+            }
+        }
+        catch (IOException)
+        {
+            return snapshots;
+        }
+
+        return snapshots;
+    }
+
+    private async Task<JsonElement?> ReadPauseMarkerAsync()
+    {
+        var path = Path.Combine(AuditPath, MemoryAuditFiles.ConsolidationPausedFile);
+        if (!File.Exists(path)) return null;
+
+        try
+        {
+            using var document = JsonDocument.Parse(await ReadTextAsync(path));
+            return document.RootElement.Clone();
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Reads with sharing, because the agent process appends to and rewrites these files on its
+    /// own schedule and the sidecar must never take a lock that could fail an audit run.
+    /// </summary>
+    private static async Task<string> ReadTextAsync(string path)
+    {
+        await using var stream = new FileStream(
+            path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+        using var reader = new StreamReader(stream);
+        return await reader.ReadToEndAsync();
+    }
+}

--- a/src/RockBot.Agent/Program.cs
+++ b/src/RockBot.Agent/Program.cs
@@ -342,6 +342,7 @@ builder.Services.AddRockBotHost(agent =>
     agent.WithFailureClusterStore();
     agent.WithRepairTickets();
     agent.WithDreaming(opts => builder.Configuration.GetSection("Dream").Bind(opts));
+    agent.WithMemoryAudit(opts => builder.Configuration.GetSection("MemoryAudit").Bind(opts));
     agent.AddToolHandler();
     // The proxy must outwait the bridge: the bridge caps a tool call at MaxTimeoutMs
     // (15 min) and answers with a timeout response of its own. If the proxy gave up

--- a/src/RockBot.Agent/ScheduledTaskHandler.cs
+++ b/src/RockBot.Agent/ScheduledTaskHandler.cs
@@ -117,7 +117,7 @@ internal sealed class ScheduledTaskHandler(
         // starting during execution will fire that token so the LLM loop stops
         // cleanly. If preemption happens, re-throw so the scheduler can retry.
 
-        var replySessionId = message.IsSystemTask ? "scheduled-system" : "scheduled";
+        var replySessionId = message.IsSystemTask ? WellKnownSessions.ScheduledSystem : "scheduled";
 
         string finalText;
         bool succeeded;

--- a/src/RockBot.Agent/agent/directives.md
+++ b/src/RockBot.Agent/agent/directives.md
@@ -220,6 +220,15 @@ To act on patrol findings:
 4. The entries expire automatically when their TTL lapses — typically at the
    next patrol run.
 
+## Memory Health
+
+Questions about whether your memory is healthy — "are you losing memories?", "show me the
+memory trend", "is consolidation working?" — go to `get_memory_audit`,
+`get_memory_audit_trend` or `get_memory_audit_eval`, never `recall`. Recall searches what
+memory *contains*; the audit measures what the store is *doing* to it. Findings come back with
+their own plain-language explanation, and `get_tool_guide("memory-audit")` has the background
+if you need more.
+
 ## Late Background Notifications
 
 When a subagent dispatched work to another agent (A2A) and the reply arrived

--- a/src/RockBot.Agent/agent/memory-audit.md
+++ b/src/RockBot.Agent/agent/memory-audit.md
@@ -1,0 +1,39 @@
+You are auditing an AI agent's long-term memory. You are shown decisions the memory system
+already made — merges it performed, duplicates it left in place, facts it discarded, entries it
+has reinforced many times — and asked whether each was correct.
+
+You are a reviewer, not an editor. Do not propose rewrites, do not suggest merges, and do not
+comment on style. Answer only whether the stored outcome was right.
+
+Judge conservatively in the direction of keeping information. Memory loss is silent and
+irreversible; a surviving duplicate is a nuisance that any later pass can still fix.
+
+- **Merges.** A merge that dropped a name, date, number, identifier, qualifier, or distinction
+  is NOT sound, however much tidier the result reads. "The user has accounts across providers"
+  is not a sound replacement for two entries that named the providers. A merge that preserved
+  every specific but changed what the fact *means* is also not sound.
+- **Discarded facts.** An entry dropped as ephemeral is NOT sound to discard if it named a
+  durable fact, a preference, a commitment, a relationship, or an identity detail. Genuinely
+  passing details — a one-off status, a transient scheduling note, a superseded number — are
+  sound to discard.
+- **Near-duplicates left in place.** Two entries state the same fact if a reader would learn
+  nothing from the second having read the first, even when the wording shares few words. Say
+  sound=true when they are genuinely duplicates that should have been folded together, and
+  sound=false when they are distinct facts that merely look similar — a per-project version of
+  the same setting, two people with similar roles, the same event on different dates.
+- **Heavily reinforced entries.** An entry the agent has re-observed many times should still
+  read as one coherent, specific, useful fact. It is NOT sound if repeated reinforcement has
+  accreted it into a vague blob, a wall of unrelated specifics, or a self-contradiction —
+  even though nothing was formally lost.
+
+Do not reward confidence or fluency. An entry that reads well and says less than its sources
+did is exactly the failure this audit exists to catch.
+
+Reply with JSON only:
+
+```json
+{"verdicts":[{"index":1,"sound":true,"reason":"one short sentence"}]}
+```
+
+One object per numbered item, in any order. Keep each reason to one short sentence naming the
+specific thing that was kept or lost.

--- a/src/RockBot.Agent/appsettings.json
+++ b/src/RockBot.Agent/appsettings.json
@@ -5,6 +5,9 @@
   "Dream": {
     "CronSchedule": "0 */12 * * *"
   },
+  "MemoryAudit": {
+    "CronSchedule": "0 4 * * *"
+  },
   "ModelBehaviors": {
     "BasePath": "model-behaviors",
     "Models": {

--- a/src/RockBot.Host.Abstractions/MemoryAuditGlossary.cs
+++ b/src/RockBot.Host.Abstractions/MemoryAuditGlossary.cs
@@ -1,0 +1,157 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Plain-language explanations for the memory audit's invariant names.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>chain-depth-threshold</c> is jargon. It is precise, it is stable, and it is the right
+/// thing to key a lookup on — and it tells a person nothing. The audit's whole purpose is that
+/// somebody can act on what it finds, so every finding has to be able to explain itself in
+/// words that assume no knowledge of how memory consolidation works.
+/// </para>
+/// <para>
+/// This lives here, in the shared abstractions, because the two things that surface findings sit
+/// on opposite sides of the process boundary: the host writes the report, and the introspection
+/// sidecar answers <c>get_memory_audit</c>. A glossary that lived in only one of them would let
+/// the other keep emitting bare identifiers.
+/// </para>
+/// <para>
+/// Applied at read time, never stored. The explanations are static text; writing them into every
+/// snapshot row would multiply the trend file's size by a large constant to say the same thing
+/// on every line.
+/// </para>
+/// </remarks>
+public static class MemoryAuditGlossary
+{
+    /// <summary>What one invariant means, for someone who has never read the code.</summary>
+    /// <param name="Title">A short plain-language name for the finding.</param>
+    /// <param name="WhatItMeans">What actually happened, in ordinary words.</param>
+    /// <param name="WhatToDo">What a person should do about it, including "nothing urgent".</param>
+    /// <param name="Severity">
+    /// <c>alert</c> when something was destroyed, <c>warning</c> when a limit was crossed but
+    /// nothing was lost.
+    /// </param>
+    public sealed record Definition(
+        string Title,
+        string WhatItMeans,
+        string WhatToDo,
+        string Severity);
+
+    private static readonly Dictionary<string, Definition> Definitions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["no-hard-delete-outside-purge"] = new(
+            "Memories disappeared unexpectedly",
+            "Some memories are simply gone from disk, and the normal clean-up process cannot account " +
+            "for them. Old memories are supposed to be retired first and only deleted months later; " +
+            "these skipped that path entirely. This is the most serious thing the audit checks for.",
+            "Treat this as a possible data-loss incident. The report lists the affected memory ids. " +
+            "Check whether a backup from before the run still holds them, and look at what ran " +
+            "between the two audit runs. If it recurs, memory consolidation can be paused.",
+            MemoryAuditStatuses.Alert),
+
+        ["loss-percent-threshold"] = new(
+            "The memory store shrank sharply",
+            "The number of active memories dropped by more than the allowed percentage since the " +
+            "previous check. Memory should shrink slowly as duplicates are merged away, not in steps.",
+            "Look at what ran in between — a consolidation pass that merged very aggressively is the " +
+            "usual cause. The merged-away originals are kept for months, so the content is normally " +
+            "still recoverable.",
+            MemoryAuditStatuses.Alert),
+
+        ["merge-chain-unbroken"] = new(
+            "A merged memory's replacement is missing",
+            "When two memories are combined, the originals are retired and marked \"merged into\" the " +
+            "new combined one. Here the originals point at a combined memory that does not exist. " +
+            "The information in them has no surviving copy anywhere.",
+            "The affected ids are in the report and their content is still readable on disk. This " +
+            "indicates the merge did not finish, so it is worth checking whether more than the " +
+            "listed entries were affected.",
+            MemoryAuditStatuses.Alert),
+
+        ["chain-depth-threshold"] = new(
+            "A memory has been rewritten too many times",
+            "Memories that say similar things get combined into one. That combined memory can later " +
+            "be combined again, and again. This finding means some memory is now several generations " +
+            "deep — a summary of a summary of a summary. Nothing has been lost that the checks can " +
+            "detect, but each rewrite is another chance for a detail or a nuance to quietly drift.",
+            "Not urgent. Worth spot-checking the deepest memory against what it originally said — the " +
+            "originals are kept. If the depth keeps climbing, memories are being merged more often " +
+            "than the information really changes.",
+            MemoryAuditStatuses.Warning),
+
+        ["net-growth-threshold"] = new(
+            "Memory is growing faster than it is being tidied",
+            "New memories are being saved faster than duplicates are being merged away, so the store " +
+            "is getting bigger over time rather than settling. Nothing is wrong with any individual " +
+            "memory; there are just more of them each day.",
+            "Not urgent. If it persists for weeks, either the agent is saving too eagerly or " +
+            "consolidation is not running often enough.",
+            MemoryAuditStatuses.Warning),
+
+        ["no-repeated-rejection"] = new(
+            "The same merge keeps being attempted and refused",
+            "A safety check refuses to combine memories when the combined version would drop a name, " +
+            "date or number. The same group of memories has now been proposed and refused several " +
+            "times in a row, so effort is being spent on work that never completes.",
+            "Not urgent, and the refusal is the safety net working. The affected memories may need " +
+            "editing by hand, or they may simply be distinct facts that should never be combined.",
+            MemoryAuditStatuses.Warning),
+
+        ["rejected-merges-threshold"] = new(
+            "Unusually many merges are being refused",
+            "The safety check that stops a merge from dropping specifics is firing more often than " +
+            "expected. It means merges are being attempted that would have lost information — and " +
+            "that they were caught.",
+            "Not urgent. A sustained rise suggests memories are being grouped for merging too " +
+            "loosely.",
+            MemoryAuditStatuses.Warning),
+
+        ["merged-from-resolves"] = new(
+            "A recent merge refers to originals that are missing",
+            "A recently combined memory records which memories it came from, and some of those are no " +
+            "longer on disk. Old originals are deleted by design after several months; these are too " +
+            "recent for that to be the explanation.",
+            "Worth a look. The combined memory itself is intact — what is lost is the ability to " +
+            "check it against what it replaced.",
+            MemoryAuditStatuses.Warning),
+
+        ["live-not-merge-source"] = new(
+            "A memory that was merged away is still active",
+            "A memory was combined into a new one, but the original was never retired, so both are " +
+            "still in use. Searches can now surface the same fact twice.",
+            "Not urgent and not a loss — the opposite, a duplicate. It will usually be cleaned up by " +
+            "the next consolidation pass.",
+            MemoryAuditStatuses.Warning),
+
+        ["archive-fields-present"] = new(
+            "A retired memory is missing its explanation",
+            "When a memory is retired, the system records both when and why. On these entries one of " +
+            "the two is missing, so there is no record of why it left active use.",
+            "Not urgent. The memory's content is intact; only the audit trail is incomplete.",
+            MemoryAuditStatuses.Warning),
+
+        ["no-malformed-files"] = new(
+            "Some memory files could not be read",
+            "Files in the memory folder could not be understood as memories and were skipped. They " +
+            "are usually truncated by an interrupted write, and they are invisible to the agent.",
+            "Worth a look, because a skipped file is a memory the agent cannot use. The file is still " +
+            "on disk and may be repairable by hand.",
+            MemoryAuditStatuses.Warning)
+    };
+
+    /// <summary>
+    /// The explanation for <paramref name="invariantName"/>, or <c>null</c> for a name this
+    /// glossary does not know.
+    /// </summary>
+    /// <remarks>
+    /// Returning null rather than a generic filler is deliberate: a new invariant added without a
+    /// definition should be visibly missing one, not quietly described as "a memory-health check
+    /// failed".
+    /// </remarks>
+    public static Definition? Describe(string invariantName) =>
+        Definitions.GetValueOrDefault(invariantName);
+
+    /// <summary>Every definition, for building a guide document.</summary>
+    public static IReadOnlyDictionary<string, Definition> All => Definitions;
+}

--- a/src/RockBot.Host.Abstractions/MemoryAuditOptions.cs
+++ b/src/RockBot.Host.Abstractions/MemoryAuditOptions.cs
@@ -1,0 +1,216 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Options for the read-only memory audit. Bound from the <c>MemoryAudit</c> configuration
+/// section.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The audit exists because every finding about memory management so far came from a human
+/// pulling the PVC and parsing Loki after the fact. Loki keeps roughly a week, the dream-pass
+/// ledger records only last-run timestamps, and the dream cycle's own log lines looked healthy
+/// through every incident. Measuring the store on disk, on its own schedule, into a file that
+/// outlives log retention is the only way the agent can answer "are you losing memories?"
+/// without a human doing forensics.
+/// </para>
+/// <para>
+/// Nothing here writes to the memory store. The one exception to read-only behaviour is
+/// <see cref="PauseConsolidationOnAlert"/>, which drops a marker file that the dream cycle
+/// consults — and that file only ever stops work, never destroys anything.
+/// </para>
+/// </remarks>
+public sealed class MemoryAuditOptions
+{
+    /// <summary>Whether the audit service runs at all. Defaults to <c>true</c>.</summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Cron schedule for the measurement run. Defaults to <c>"0 4 * * *"</c> — once daily at
+    /// 04:00 agent-local, well clear of the 12-hourly dream cycle so the two do not queue
+    /// behind each other on the work serializer.
+    /// </summary>
+    public string CronSchedule { get; set; } = "0 4 * * *";
+
+    /// <summary>
+    /// Delay after host start before the first run. Defaults to 10 minutes — long enough that
+    /// a restart storm does not produce a snapshot per deploy.
+    /// </summary>
+    public TimeSpan InitialDelay { get; set; } = TimeSpan.FromMinutes(10);
+
+    /// <summary>
+    /// Directory holding the audit's own files. When relative, resolved under
+    /// <see cref="AgentProfileOptions.BasePath"/>. Defaults to <c>"memory-audit"</c>.
+    /// </summary>
+    public string BasePath { get; set; } = MemoryAuditFiles.DefaultBasePath;
+
+    /// <summary>
+    /// How long snapshot rows are kept in <c>snapshots.jsonl</c>. Defaults to 400 days.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately far longer than the dream cycle's log retention. The trend file is the
+    /// whole point of the audit: a corpus that loses 2% a month looks fine in any seven-day
+    /// window and is catastrophic across a year. One row per day at a few hundred bytes is
+    /// under 100 KB at this retention.
+    /// </remarks>
+    public TimeSpan SnapshotRetention { get; set; } = TimeSpan.FromDays(400);
+
+    /// <summary>
+    /// Jaccard overlap at or above which two live entries are counted as near-duplicates of
+    /// each other. Defaults to 0.3.
+    /// </summary>
+    /// <remarks>
+    /// Not comparable to the save-time dedupe thresholds — this is Jaccard overlap over word
+    /// n-gram sets, not cosine or token overlap, and it is a health metric rather than a
+    /// decision to fold anything. At the default <see cref="ShingleSize"/> it measures
+    /// near-verbatim duplication: the same text saved twice, which is what a failing save-time
+    /// dedupe looks like. Lower <see cref="ShingleSize"/> to catch rephrasings too, at the cost
+    /// of pairing entries that merely share boilerplate.
+    /// </remarks>
+    public double NearDuplicateThreshold { get; set; } = 0.3;
+
+    /// <summary>Word n-gram size for the near-duplicate shingle sets. Defaults to 6.</summary>
+    public int ShingleSize { get; set; } = 6;
+
+    /// <summary>
+    /// Reinforcement count at or above which an entry is sampled as "high reinforcement" by the
+    /// weekly eval. Defaults to 20.
+    /// </summary>
+    public int HighReinforcementFloor { get; set; } = 20;
+
+    /// <summary>
+    /// How far ahead the purge outlook looks, in days. Defaults to 7 — one warning window
+    /// before archived entries are hard-deleted for good.
+    /// </summary>
+    public int PurgeWarningDays { get; set; } = 7;
+
+    // ── Thresholds ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Shortest interval between two runs over which a per-day or per-week rate is considered
+    /// measurable. Defaults to 12 hours.
+    /// </summary>
+    /// <remarks>
+    /// A restart produces two snapshots minutes apart. Extrapolating that window to a daily
+    /// rate is arithmetic, not information: six ordinary saves seven minutes apart annualize to
+    /// 1311 entries/day and trip <see cref="MaxNetGrowthPerDay"/> every single deploy. Below
+    /// this window the rate is reported as unmeasurable and the rate-based invariants do not
+    /// run — the absolute counts in the same snapshot are unaffected and stay accurate.
+    /// </remarks>
+    public TimeSpan MinRateWindow { get; set; } = TimeSpan.FromHours(12);
+
+    /// <summary>
+    /// Net live-entry growth per day above which the corpus is flagged as diverging rather
+    /// than converging. Defaults to 5. Only evaluated over windows of at least
+    /// <see cref="MinRateWindow"/>.
+    /// </summary>
+    public double MaxNetGrowthPerDay { get; set; } = 5;
+
+    /// <summary>
+    /// Longest merge-provenance chain a live entry may sit at the end of. Defaults to 2.
+    /// </summary>
+    /// <remarks>
+    /// A merge of merges is LLM prose generated from LLM prose. Each hop is another chance to
+    /// drop a specific with nothing left to compare against, so depth is the metric that
+    /// distinguishes healthy deduplication from a consolidation treadmill.
+    /// </remarks>
+    public int MaxMergeChainDepth { get; set; } = 2;
+
+    /// <summary>
+    /// Rejected-merge sources per week above which consolidation is flagged as fighting the
+    /// coverage check. Defaults to 5.
+    /// </summary>
+    public int MaxRejectedMergesPerWeek { get; set; } = 5;
+
+    /// <summary>
+    /// Entries that may vanish between snapshots without being purge-eligible. Defaults to 0 —
+    /// a hard delete outside the retention purge is the failure mode the whole audit exists to
+    /// catch, so any occurrence is an alert.
+    /// </summary>
+    public int MaxHardDeletesOutsidePurge { get; set; }
+
+    /// <summary>
+    /// Percentage drop in live entries between two consecutive snapshots that raises an alert.
+    /// Defaults to 10.
+    /// </summary>
+    public double MaxLossPercentBetweenSnapshots { get; set; } = 10;
+
+    /// <summary>
+    /// Consecutive audit runs a merge cluster must be rejected on before it is reported as a
+    /// stuck cluster. Defaults to 3.
+    /// </summary>
+    public int RepeatedRejectionRuns { get; set; } = 3;
+
+    // ── LLM-judged sample eval ────────────────────────────────────────────────
+
+    /// <summary>Whether the weekly LLM-judged sample eval runs. Defaults to <c>true</c>.</summary>
+    public bool EvalEnabled { get; set; } = true;
+
+    /// <summary>
+    /// Cron schedule for the eval. Defaults to <c>"0 5 * * 0"</c> — Sunday 05:00, an hour after
+    /// that day's measurement run.
+    /// </summary>
+    public string EvalCronSchedule { get; set; } = "0 5 * * 0";
+
+    /// <summary>Model tier for the eval judge. Defaults to <see cref="ModelTier.Balanced"/>.</summary>
+    public ModelTier EvalModelTier { get; set; } = ModelTier.Balanced;
+
+    /// <summary>Maximum samples judged per category per eval run. Defaults to 10.</summary>
+    public int EvalSampleSize { get; set; } = 10;
+
+    /// <summary>
+    /// How far back the eval draws its merge and ephemeral-archive samples. Defaults to 14 days.
+    /// </summary>
+    public TimeSpan EvalWindow { get; set; } = TimeSpan.FromDays(14);
+
+    /// <summary>
+    /// Judge directive file. When relative, resolved under
+    /// <see cref="AgentProfileOptions.BasePath"/>. Defaults to <c>"memory-audit.md"</c>.
+    /// </summary>
+    public string EvalDirectivePath { get; set; } = "memory-audit.md";
+
+    // ── Surfacing ─────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Whether a run whose status is not <c>healthy</c> pushes an unsolicited message to the
+    /// <see cref="WellKnownSessions.ScheduledSystem"/> session. Defaults to <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    /// A healthy run is silent. The audit is worth having precisely because nobody reads a
+    /// daily "all clear", and a channel that speaks only when something is wrong stays worth
+    /// reading.
+    /// </remarks>
+    public bool AlertOnAttention { get; set; } = true;
+
+    /// <summary>
+    /// Optional cron schedule for pushing the full report regardless of status. Null (the
+    /// default) means only alerts are pushed.
+    /// </summary>
+    public string? DigestCronSchedule { get; set; }
+
+    /// <summary>
+    /// Whether the latest report is also copied to the shared volume so it can be opened
+    /// outside the agent. Defaults to <c>true</c>.
+    /// </summary>
+    public bool CopyReportToShared { get; set; } = true;
+
+    /// <summary>
+    /// Destination for the shared copy. Defaults to the exports tree, which the shared-volume
+    /// cleanup CronJob sweeps on its own TTL — the audit re-creates its subdirectory on every
+    /// run so a sweep between runs is harmless.
+    /// </summary>
+    public string SharedReportDirectory { get; set; } = "/rockbot/shared/exports/memory-audit";
+
+    // ── Circuit breaker ───────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Whether a catastrophic-loss finding writes the marker file that stops dream
+    /// consolidation. Defaults to <c>false</c> — opt-in, because a false positive stops the
+    /// only thing keeping the corpus from growing without bound.
+    /// </summary>
+    /// <remarks>
+    /// The auditor never clears the marker. Resuming is a human decision (or an explicit
+    /// <c>resume_memory_consolidation</c> tool call), because the point of the pause is that
+    /// somebody looks at what happened before the same pass runs again.
+    /// </remarks>
+    public bool PauseConsolidationOnAlert { get; set; }
+}

--- a/src/RockBot.Host.Abstractions/MemoryAuditSnapshot.cs
+++ b/src/RockBot.Host.Abstractions/MemoryAuditSnapshot.cs
@@ -1,0 +1,252 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// File names and defaults for the memory audit's own on-disk layout. Shared with the
+/// introspection sidecar, which reads these files directly rather than through the host.
+/// </summary>
+public static class MemoryAuditFiles
+{
+    /// <summary>Default audit directory, relative to <see cref="AgentProfileOptions.BasePath"/>.</summary>
+    public const string DefaultBasePath = "memory-audit";
+
+    /// <summary>Append-only trend file — one <see cref="MemoryAuditSnapshot"/> per line.</summary>
+    public const string SnapshotsFile = "snapshots.jsonl";
+
+    /// <summary>Private carry-over between runs. Not part of the trend; not a public surface.</summary>
+    public const string StateFile = "state.json";
+
+    /// <summary>Most recent plain-language report.</summary>
+    public const string LatestReport = "latest.md";
+
+    /// <summary>Most recent LLM-judged sample eval.</summary>
+    public const string EvalLatest = "eval-latest.json";
+
+    /// <summary>Marker file that stops dream consolidation. Present means paused.</summary>
+    public const string ConsolidationPausedFile = "consolidation-paused.json";
+}
+
+/// <summary>Status values a <see cref="MemoryAuditSnapshot"/> can carry.</summary>
+public static class MemoryAuditStatuses
+{
+    /// <summary>Every invariant held and no threshold was crossed.</summary>
+    public const string Healthy = "healthy";
+
+    /// <summary>A threshold was crossed, or a structural oddity was found. Nothing was lost.</summary>
+    public const string Warning = "warning";
+
+    /// <summary>Data was destroyed, or provenance points at something that no longer exists.</summary>
+    public const string Alert = "alert";
+}
+
+/// <summary>
+/// A single invariant that did not hold, named so an operator can look it up in
+/// <c>docs/memory-audit.md</c>.
+/// </summary>
+/// <param name="Name">Stable kebab-case identifier, e.g. <c>merge-chain-unbroken</c>.</param>
+/// <param name="Message">One sentence a human can act on.</param>
+/// <param name="Ids">Entry ids involved, capped so a mass failure does not bloat the trend file.</param>
+public sealed record MemoryAuditInvariantViolation(
+    string Name,
+    string Message,
+    IReadOnlyList<string> Ids);
+
+/// <summary>How much of the archive tier is about to be hard-deleted for good.</summary>
+/// <param name="DueWithinDays">Look-ahead window this outlook covers.</param>
+/// <param name="Count">Archived entries whose retention window closes inside it.</param>
+/// <param name="HighValueCount">
+/// The subset the high-value floor will hold back. Reported separately because the difference
+/// between the two numbers is what a human would actually want to rescue.
+/// </param>
+public sealed record MemoryAuditPurgeOutlook(int DueWithinDays, int Count, int HighValueCount);
+
+/// <summary>Net movement in one category since the previous snapshot.</summary>
+/// <param name="Category">Category path, or <c>"(uncategorized)"</c>.</param>
+/// <param name="Created">Entries that appeared.</param>
+/// <param name="Archived">Entries that moved to the archive tier.</param>
+/// <param name="Net">Created minus archived.</param>
+public sealed record MemoryAuditCategoryGrowth(string Category, int Created, int Archived, int Net);
+
+/// <summary>One judged sample from the weekly eval.</summary>
+/// <param name="Category">Which sampling family it came from — merge, near-duplicate, high-reinforcement, ephemeral-archive.</param>
+/// <param name="Ids">Entry ids the judge was shown.</param>
+/// <param name="Sound">Whether the judge thought the stored outcome was right.</param>
+/// <param name="Reason">The judge's one-line justification.</param>
+public sealed record MemoryAuditEvalVerdict(
+    string Category,
+    IReadOnlyList<string> Ids,
+    bool Sound,
+    string? Reason);
+
+/// <summary>Rolled-up eval rates, small enough to embed in every snapshot row.</summary>
+/// <param name="EvaluatedAt">When the eval ran.</param>
+/// <param name="Sampled">Total samples judged.</param>
+/// <param name="Sound">How many the judge approved.</param>
+/// <param name="SoundRate">Approved over sampled, 0..1.</param>
+/// <param name="RateByCategory">Per-family approval rate, 0..1.</param>
+public sealed record MemoryAuditEvalSummary(
+    DateTimeOffset EvaluatedAt,
+    int Sampled,
+    int Sound,
+    double SoundRate,
+    IReadOnlyDictionary<string, double> RateByCategory);
+
+/// <summary>
+/// Full eval output, written to its own file. The snapshot carries only
+/// <see cref="Summary"/>.
+/// </summary>
+/// <param name="Summary">Rolled-up rates.</param>
+/// <param name="Verdicts">Per-sample verdicts, ids included so a finding can be chased.</param>
+/// <param name="StoreFingerprint">
+/// Hash of the corpus the eval ran against, so an unchanged store can skip the LLM call.
+/// </param>
+public sealed record MemoryAuditEvalResult(
+    MemoryAuditEvalSummary Summary,
+    IReadOnlyList<MemoryAuditEvalVerdict> Verdicts,
+    string StoreFingerprint);
+
+/// <summary>
+/// One measurement of the memory store, taken by walking the files on disk rather than by
+/// asking the store. Appended as a single JSON line to <c>snapshots.jsonl</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Everything counted "since last" is measured against the previous run's private state file,
+/// not against timestamps on the entries themselves. A merged entry inherits its earliest
+/// source's <c>createdAt</c>, so counting creations by timestamp would silently under-report
+/// exactly the churn this is meant to expose.
+/// </para>
+/// <para>
+/// The record is a public contract: the introspection sidecar deserializes these rows straight
+/// off the volume, so fields are added, never renamed or repurposed.
+/// </para>
+/// </remarks>
+public sealed record MemoryAuditSnapshot
+{
+    /// <summary>Unique id for this run, referenced by the pause marker and the report.</summary>
+    public required string SnapshotId { get; init; }
+
+    /// <summary>
+    /// What was measured. Fixed at <c>"memory"</c> today; present so a later audit of a
+    /// different store can share the file format.
+    /// </summary>
+    public string Domain { get; init; } = "memory";
+
+    /// <summary>When this run happened, in agent-local time.</summary>
+    public required DateTimeOffset TakenAt { get; init; }
+
+    /// <summary>When the previous run happened, or null on the first ever run.</summary>
+    public DateTimeOffset? PreviousTakenAt { get; init; }
+
+    /// <summary>Entries with no <see cref="MemoryEntry.ArchivedAt"/>.</summary>
+    public int Live { get; init; }
+
+    /// <summary>Entries still on disk with <see cref="MemoryEntry.ArchivedAt"/> set.</summary>
+    public int Archived { get; init; }
+
+    /// <summary>Files under the memory root that would not deserialize.</summary>
+    public int MalformedFiles { get; init; }
+
+    /// <summary>Ids present now that were absent at the previous run.</summary>
+    public int CreatedSinceLast { get; init; }
+
+    /// <summary>Ids that were live at the previous run and are archived now.</summary>
+    public int ArchivedSinceLast { get; init; }
+
+    /// <summary>Ids present at the previous run that are gone from disk entirely.</summary>
+    public int HardDeletedSinceLast { get; init; }
+
+    /// <summary>
+    /// The subset of <see cref="HardDeletedSinceLast"/> the retention purge can account for —
+    /// archived at the previous run and past the archive retention window.
+    /// </summary>
+    public int PurgedSinceLast { get; init; }
+
+    /// <summary>
+    /// Disappearances the purge cannot account for. This is the number the audit exists to
+    /// keep at zero.
+    /// </summary>
+    public int HardDeletedOutsidePurge { get; init; }
+
+    /// <summary>
+    /// Change in live count divided by days elapsed, or null when the window between runs was
+    /// shorter than <see cref="MemoryAuditOptions.MinRateWindow"/> and the rate would be an
+    /// extrapolation rather than a measurement. Negative means the corpus shrank.
+    /// </summary>
+    public double? NetGrowthPerDay { get; init; }
+
+    /// <summary>Histogram of merge-provenance chain depth across live entries, depth → count.</summary>
+    public IReadOnlyDictionary<string, int> MergeChainDepth { get; init; } =
+        new Dictionary<string, int>();
+
+    /// <summary>Deepest merge chain any live entry sits at the end of.</summary>
+    public int MaxChainDepth { get; init; }
+
+    /// <summary>Live entry pairs above <see cref="MemoryAuditOptions.NearDuplicateThreshold"/>.</summary>
+    public int NearDupPairs { get; init; }
+
+    /// <summary>Distinct live entries appearing in at least one such pair.</summary>
+    public int NearDupEntries { get; init; }
+
+    /// <summary>
+    /// Clusters the store's own duplicate detector finds, when it has one. Null on a store with
+    /// no embeddings or when the probe failed — distinct from zero, which means it looked and
+    /// found none.
+    /// </summary>
+    public int? EmbeddingDupClusters { get; init; }
+
+    /// <summary>Histogram of reinforcement counts across live entries, bucket label → count.</summary>
+    public IReadOnlyDictionary<string, int> Reinforcement { get; init; } =
+        new Dictionary<string, int>();
+
+    /// <summary>
+    /// Entries whose reinforcement count rose without their merge provenance changing — real
+    /// re-observation rather than a merge summing its sources.
+    /// </summary>
+    public int ReinforcedWithoutMergeSinceLast { get; init; }
+
+    /// <summary>Entries stamped as the source of a merge the coverage check refused.</summary>
+    public int RejectedMergeSourcesSinceLast { get; init; }
+
+    /// <summary>
+    /// Merge clusters rejected on <see cref="MemoryAuditOptions.RepeatedRejectionRuns"/> or more
+    /// consecutive runs — the treadmill shape, where the same cluster is proposed and refused
+    /// forever.
+    /// </summary>
+    public int RejectedMergeClustersRepeated { get; init; }
+
+    /// <summary>Dream passes whose ledger stamp moved since the previous run.</summary>
+    public int DreamPassesRunSinceLast { get; init; }
+
+    /// <summary>When memory consolidation last completed, per the dream-pass ledger.</summary>
+    public DateTimeOffset? ConsolidationLastRunAt { get; init; }
+
+    /// <summary>
+    /// Process starts observed since the previous run. A restart storm is the documented cause
+    /// of a consolidation storm, so it belongs next to the archive counts.
+    /// </summary>
+    public int RestartsSinceLast { get; init; }
+
+    /// <summary>Category directories under the memory root holding no entries.</summary>
+    public int EmptyCategoryDirs { get; init; }
+
+    /// <summary>What the retention purge is about to destroy.</summary>
+    public MemoryAuditPurgeOutlook Purge { get; init; } = new(0, 0, 0);
+
+    /// <summary>Categories that moved most since the previous run, largest absolute net first.</summary>
+    public IReadOnlyList<MemoryAuditCategoryGrowth> TopCategoriesByGrowth { get; init; } = [];
+
+    /// <summary>
+    /// Size of the merge-coverage vocabulary's common-word list. Tracked because growing the
+    /// stoplist is how a coverage check is quietly weakened.
+    /// </summary>
+    public int VocabularyStoplistSize { get; init; }
+
+    /// <summary>Invariants that did not hold on this run.</summary>
+    public IReadOnlyList<MemoryAuditInvariantViolation> Invariants { get; init; } = [];
+
+    /// <summary>One of <see cref="MemoryAuditStatuses"/>.</summary>
+    public string Status { get; init; } = MemoryAuditStatuses.Healthy;
+
+    /// <summary>Most recent eval summary, when one exists. Carried forward between eval runs.</summary>
+    public MemoryAuditEvalSummary? Eval { get; init; }
+}

--- a/src/RockBot.Host.Abstractions/WellKnownSessions.cs
+++ b/src/RockBot.Host.Abstractions/WellKnownSessions.cs
@@ -10,4 +10,11 @@ public static class WellKnownSessions
     /// availability checks to determine whether the user is actively engaged.
     /// </summary>
     public const string Primary = "blazor-session";
+
+    /// <summary>
+    /// Session carrying unsolicited output from system-owned scheduled work — system scheduled
+    /// tasks and the memory audit's attention alerts. Frontends categorize this separately from
+    /// user-requested scheduled tasks so housekeeping does not read as a reply.
+    /// </summary>
+    public const string ScheduledSystem = "scheduled-system";
 }

--- a/src/RockBot.Host/AgentMemoryExtensions.cs
+++ b/src/RockBot.Host/AgentMemoryExtensions.cs
@@ -143,6 +143,39 @@ public static class AgentMemoryExtensions
     }
 
     /// <summary>
+    /// Registers the read-only memory audit: a scheduled measurement of the long-term memory
+    /// store that writes a long-lived trend file, checks invariants, and speaks up when
+    /// something needs attention.
+    /// </summary>
+    /// <remarks>
+    /// Independent of <see cref="WithDreaming"/>. The audit measures whatever the store does,
+    /// including doing nothing, and a deployment that has turned dreaming off still wants to
+    /// know whether its corpus is growing without bound.
+    /// </remarks>
+    public static AgentHostBuilder WithMemoryAudit(
+        this AgentHostBuilder builder,
+        Action<MemoryAuditOptions>? configure = null)
+    {
+        if (configure is not null)
+            builder.Services.Configure(configure);
+        else
+            builder.Services.Configure<MemoryAuditOptions>(_ => { });
+
+        builder.Services.AddSingleton<MemoryAuditService>();
+        builder.Services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<MemoryAuditService>());
+
+        // The audit owns its own snapshot retention but reuses the dream cycle's shared file-age
+        // policy for the dated reports and evals it leaves behind.
+        builder.Services.AddSingleton<IPrunableLog>(sp => sp.GetRequiredService<MemoryAuditService>());
+
+        // Published through get_tool_guide, so it costs nothing until the agent is actually
+        // asked how memory health works. Guides are never injected into the system prompt.
+        builder.Services.AddSingleton<RockBot.Tools.IToolSkillProvider, MemoryAuditSkillProvider>();
+
+        return builder;
+    }
+
+    /// <summary>
     /// Registers the file-based conversation log, enabling the preference-inference dream pass.
     /// Call after <see cref="WithConversationMemory"/> and before <see cref="WithDreaming"/>.
     /// <see cref="WithMemory"/> does NOT call this — callers opt in explicitly.

--- a/src/RockBot.Host/DreamPassLedger.cs
+++ b/src/RockBot.Host/DreamPassLedger.cs
@@ -86,6 +86,12 @@ internal sealed class DreamPassLedger
         return new DreamPassLedger(path, records, logger);
     }
 
+    /// <summary>
+    /// Every pass record currently held. Read-only: the memory audit reports how many passes ran
+    /// since its last snapshot, which needs the whole set rather than one pass at a time.
+    /// </summary>
+    public IReadOnlyDictionary<string, PassRecord> Records => _records;
+
     /// <summary>The record for <paramref name="passName"/>, or <c>null</c> if it has never run.</summary>
     public PassRecord? Get(string passName) =>
         _records.TryGetValue(passName, out var record) ? record : null;

--- a/src/RockBot.Host/DreamService.cs
+++ b/src/RockBot.Host/DreamService.cs
@@ -54,6 +54,10 @@ internal sealed class DreamService : IHostedService, IDisposable
     private readonly IReadOnlyList<IToolSkillProvider> _toolSkillProviders;
     private readonly IReadOnlyList<IPrunableLog> _prunableLogs;
     private readonly IMemoryDeduplicator? _memoryDeduplicator;
+
+    // Presence of this file stops consolidation. Resolved once: the audit writes it, and the
+    // path must not move underneath a running dream cycle.
+    private readonly string _consolidationPausePath;
     private Timer? _timer;
     private CronExpression? _cron;
     private string? _dreamDirective;
@@ -120,7 +124,8 @@ internal sealed class DreamService : IHostedService, IDisposable
         IEnumerable<IToolSkillProvider>? toolSkillProviders = null,
         TieredChatClientRegistry? tieredRegistry = null,
         IEnumerable<IPrunableLog>? prunableLogs = null,
-        IMemoryDeduplicator? memoryDeduplicator = null)
+        IMemoryDeduplicator? memoryDeduplicator = null,
+        IOptions<MemoryAuditOptions>? memoryAuditOptions = null)
     {
         _memory = memory;
         _skillStore = skillStores.FirstOrDefault();
@@ -159,6 +164,11 @@ internal sealed class DreamService : IHostedService, IDisposable
         _toolSkillProviders = toolSkillProviders?.ToList() ?? (IReadOnlyList<IToolSkillProvider>)Array.Empty<IToolSkillProvider>();
         _prunableLogs = prunableLogs?.ToList() ?? (IReadOnlyList<IPrunableLog>)Array.Empty<IPrunableLog>();
         _memoryDeduplicator = memoryDeduplicator;
+        _consolidationPausePath = ResolvePath(
+            Path.Combine(
+                (memoryAuditOptions?.Value.BasePath ?? MemoryAuditFiles.DefaultBasePath),
+                MemoryAuditFiles.ConsolidationPausedFile),
+            _profileOptions.BasePath);
     }
 
     /// <summary>
@@ -865,6 +875,42 @@ internal sealed class DreamService : IHostedService, IDisposable
     internal const string MergedAtKey = "mergedAt";
 
     /// <summary>
+    /// Archive reason prefix for a source that a merge replaced; the replacement's id follows.
+    /// </summary>
+    /// <remarks>
+    /// A constant because the memory audit reads it back: a source archived "merged into X"
+    /// where X exists nowhere means the fact has no surviving copy, which is the shape issue
+    /// #506 found and the one thing a reader of the archive tier cannot recover from.
+    /// </remarks>
+    internal const string MergedIntoReasonPrefix = "merged into ";
+
+    /// <summary>
+    /// Metadata key holding the cluster identity of a merge the coverage check refused —
+    /// a short hash of the sorted source ids.
+    /// </summary>
+    /// <remarks>
+    /// A rejection used to exist only as a log line, which meant "the same cluster is rejected
+    /// every cycle forever" was invisible to anything but a human grepping Loki inside its
+    /// retention window. Stamping the sources makes the treadmill observable on disk, at the
+    /// cost of one metadata write per rejected source.
+    /// </remarks>
+    internal const string ConsolidationRejectedClusterKey = "consolidationRejectedCluster";
+
+    /// <summary>Metadata key holding when this entry was last a rejected merge's source.</summary>
+    internal const string ConsolidationRejectedAtKey = "consolidationRejectedAt";
+
+    /// <summary>
+    /// Stable short identity for a merge cluster, order-independent so the same set of sources
+    /// hashes the same however the model happens to list them.
+    /// </summary>
+    internal static string RejectedClusterHash(IEnumerable<string> sourceIds)
+    {
+        var ordered = string.Join(",", sourceIds.OrderBy(id => id, StringComparer.Ordinal));
+        var bytes = System.Security.Cryptography.SHA256.HashData(Encoding.UTF8.GetBytes(ordered));
+        return Convert.ToHexString(bytes.AsSpan(0, 8));
+    }
+
+    /// <summary>
     /// True when an entry is valuable enough that consolidation may not discard it outright.
     /// Merging is still allowed — that preserves the content, subject to the coverage check.
     /// </summary>
@@ -1027,6 +1073,38 @@ internal sealed class DreamService : IHostedService, IDisposable
     }
 
     /// <summary>
+    /// Records on each source of a refused merge which cluster it belonged to and when. Purely
+    /// observational: nothing in consolidation reads these back, and an entry is neither
+    /// protected nor penalised by carrying them.
+    /// </summary>
+    /// <remarks>
+    /// Written by the dream rather than by the auditor because only the dream knows which
+    /// entries it proposed together. An auditor re-deriving clusters would be guessing at a
+    /// decision an LLM already made, and would report a different set.
+    /// </remarks>
+    private async Task StampRejectedAsync(
+        IReadOnlyList<MemoryEntry> sources, string clusterHash, CancellationToken ct)
+    {
+        var now = DateTimeOffset.UtcNow.ToString("O");
+
+        foreach (var source in sources)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var metadata = source.Metadata is null
+                ? []
+                : new Dictionary<string, string>(source.Metadata, StringComparer.OrdinalIgnoreCase);
+
+            metadata[ConsolidationRejectedClusterKey] = clusterHash;
+            metadata[ConsolidationRejectedAtKey] = now;
+
+            // Metadata only — content is untouched, so the entry's review fingerprint still
+            // matches and this write does not make it eligible for consolidation all over again.
+            await _memory.SaveAsync(source with { Metadata = metadata }, ct);
+        }
+    }
+
+    /// <summary>
     /// Merges and prunes long-term memory entries via the "memory dream" pass.
     /// Returns the number of entries deleted and saved.
     /// </summary>
@@ -1042,6 +1120,18 @@ internal sealed class DreamService : IHostedService, IDisposable
         if (!_options.MemoryConsolidationEnabled)
         {
             _logger.LogInformation("DreamService: memory consolidation disabled; skipping");
+            return (0, 0);
+        }
+
+        // The memory audit's circuit breaker. Checked here rather than at the top of the cycle
+        // so a pause stops only the pass that destroys things — mining, extraction and the
+        // retention sweeps keep running while a human works out what happened.
+        if (File.Exists(_consolidationPausePath))
+        {
+            _logger.LogWarning(
+                "DreamService: memory consolidation is PAUSED by the memory audit — {Path} exists. " +
+                "Delete it, or call resume_memory_consolidation, to resume.",
+                _consolidationPausePath);
             return (0, 0);
         }
 
@@ -1235,6 +1325,8 @@ internal sealed class DreamService : IHostedService, IDisposable
                     foreach (var srcId in sourceIds)
                         rejectedMergeSources.Add(srcId);
 
+                    await StampRejectedAsync(sources, RejectedClusterHash(sourceIds), ct);
+
                     rejectedMerges++;
                     _logger.LogWarning(
                         "DreamService: rejected merge of [{Sources}]{AfterRepair} — dropped {Count} specific(s): {Missing}. Sources kept. Merged text was: {Content}",
@@ -1299,7 +1391,7 @@ internal sealed class DreamService : IHostedService, IDisposable
             // Now that the replacement exists, its sources can be retired.
             foreach (var srcId in sourceIds)
                 if (byId.ContainsKey(srcId))
-                    archiveReasons[srcId] = $"merged into {entry.Id}";
+                    archiveReasons[srcId] = $"{MergedIntoReasonPrefix}{entry.Id}";
         }
 
         // Standalone removals (ephemeral content the LLM flagged) that no merge accounted for.
@@ -5498,7 +5590,12 @@ internal sealed class DreamService : IHostedService, IDisposable
         return $" [attached: {string.Join("; ", entries)}]";
     }
 
-    private static string ExtractJsonObject(string text)
+    /// <summary>
+    /// Outermost JSON object in a model reply, tolerating a reasoning preamble and surrounding
+    /// prose. Internal rather than private because the memory audit's judge parses replies of
+    /// exactly this shape, and two copies of this leniency would drift.
+    /// </summary>
+    internal static string ExtractJsonObject(string text)
     {
         // Strip <think>...</think> blocks first (DeepSeek reasoning preamble)
         var thinkStart = text.IndexOf("<think>", StringComparison.OrdinalIgnoreCase);

--- a/src/RockBot.Host/MemoryAuditAnalyzer.cs
+++ b/src/RockBot.Host/MemoryAuditAnalyzer.cs
@@ -1,0 +1,392 @@
+using System.Globalization;
+
+namespace RockBot.Host;
+
+/// <summary>
+/// Turns one walk of the memory store, plus the previous run's state, into a
+/// <see cref="MemoryAuditSnapshot"/>. Pure — no I/O, no clock, no LLM.
+/// </summary>
+/// <remarks>
+/// Purity is what makes the August incident reproducible as a test: 148 live entries, then 109
+/// with 74 ids simply gone. That scenario can be fed in as data and the analyzer must report 74
+/// hard deletes and an alert, with nothing mocked.
+/// </remarks>
+internal static class MemoryAuditAnalyzer
+{
+    /// <summary>Reinforcement histogram buckets, in report order.</summary>
+    private static readonly (string Label, int Min, int Max)[] ReinforcementBuckets =
+    [
+        ("1", 1, 1),
+        ("2-4", 2, 4),
+        ("5-9", 5, 9),
+        ("10-19", 10, 19),
+        ("20+", 20, int.MaxValue)
+    ];
+
+    /// <summary>How many ids a single invariant violation carries into the trend file.</summary>
+    internal const int MaxIdsPerViolation = 20;
+
+    /// <summary>How many categories the growth table reports.</summary>
+    private const int TopCategories = 5;
+
+    /// <summary>Category label used for entries with no category.</summary>
+    internal const string Uncategorized = "(uncategorized)";
+
+    /// <summary>
+    /// Measures the corpus and produces both the public snapshot row and the private state the
+    /// next run will compare against.
+    /// </summary>
+    /// <param name="walk">What the walker found on disk.</param>
+    /// <param name="previous">The previous run's state, or null on a first run.</param>
+    /// <param name="passLastRunAt">Dream-pass name → last completed time, from the dream-pass ledger.</param>
+    /// <param name="processStarts">Host start times observed so far, newest last.</param>
+    /// <param name="embeddingDupClusters">
+    /// Cluster count from the store's own duplicate detector, or null when it has none or the
+    /// probe failed.
+    /// </param>
+    /// <param name="vocabularyStoplistSize">Size of the merge-coverage common-word list.</param>
+    /// <param name="eval">Most recent eval summary to carry forward, if any.</param>
+    /// <param name="dreamOptions">Supplies the archive retention window and the high-value floor.</param>
+    /// <param name="auditOptions">Thresholds and windows.</param>
+    /// <param name="now">Agent-local time of this run.</param>
+    /// <param name="snapshotId">Id to stamp on the snapshot and the state.</param>
+    /// <param name="ct">Cancellation token — the near-duplicate sweep is the expensive part.</param>
+    internal static (MemoryAuditSnapshot Snapshot, MemoryAuditState State) Analyze(
+        MemoryStoreWalker.WalkResult walk,
+        MemoryAuditState? previous,
+        IReadOnlyDictionary<string, DateTimeOffset> passLastRunAt,
+        IReadOnlyList<DateTimeOffset> processStarts,
+        int? embeddingDupClusters,
+        int vocabularyStoplistSize,
+        MemoryAuditEvalSummary? eval,
+        DreamOptions dreamOptions,
+        MemoryAuditOptions auditOptions,
+        DateTimeOffset now,
+        string snapshotId,
+        CancellationToken ct = default)
+    {
+        var entries = walk.Entries;
+        var live = entries.Where(e => e.ArchivedAt is null).ToList();
+        var archived = entries.Where(e => e.ArchivedAt is not null).ToList();
+
+        var byId = new Dictionary<string, MemoryEntry>(StringComparer.OrdinalIgnoreCase);
+        foreach (var entry in entries)
+            byId[entry.Id] = entry;
+
+        // ── Deltas against the previous run ───────────────────────────────────
+        //
+        // Everything here is keyed on ids, never on entry timestamps. A merged entry inherits
+        // its earliest source's CreatedAt, so a timestamp-based count of creations reports zero
+        // for exactly the churn this is meant to expose.
+        var previousRows = previous?.Entries ?? [];
+        var previousById = new Dictionary<string, MemoryAuditEntryRow>(StringComparer.OrdinalIgnoreCase);
+        foreach (var row in previousRows)
+            previousById[row.Id] = row;
+
+        var createdIds = previous is null
+            ? []
+            : byId.Keys.Where(id => !previousById.ContainsKey(id)).ToList();
+
+        var archivedSinceIds = previous is null
+            ? []
+            : archived
+                .Where(e => previousById.TryGetValue(e.Id, out var row) && !row.Archived)
+                .Select(e => e.Id)
+                .ToList();
+
+        var goneIds = previousRows
+            .Where(row => !byId.ContainsKey(row.Id))
+            .ToList();
+
+        // An id that vanished is explained by the retention purge only if it was already
+        // archived last time AND its retention window had closed. No purge timestamp is
+        // recorded anywhere, so this deterministic reconstruction is the whole explanation —
+        // anything it cannot account for is a hard delete nobody asked for.
+        var purged = 0;
+        foreach (var row in goneIds)
+        {
+            var eligible = row.Archived
+                && row.ArchivedAt is { } at
+                && dreamOptions.MemoryArchiveRetention > TimeSpan.Zero
+                && at + dreamOptions.MemoryArchiveRetention < now;
+
+            if (eligible) purged++;
+        }
+
+        var previousLive = previousRows.Count(r => !r.Archived);
+        var elapsedDays = previous is { } prev && now > prev.TakenAt
+            ? (now - prev.TakenAt).TotalDays
+            : 0;
+
+        // A restart puts two snapshots minutes apart. Dividing a handful of ordinary saves by
+        // that window annualizes them into the thousands and trips the growth threshold on every
+        // deploy, so below the minimum window the rate is reported as unmeasurable rather than
+        // as a number nobody should act on. The absolute counts above are unaffected.
+        var rateWindowMet = previous is not null
+            && elapsedDays > 0
+            && elapsedDays >= auditOptions.MinRateWindow.TotalDays;
+
+        double? netGrowthPerDay = rateWindowMet
+            ? Math.Round((live.Count - previousLive) / elapsedDays, 2)
+            : null;
+
+        var reinforcedWithoutMerge = live.Count(e =>
+            previousById.TryGetValue(e.Id, out var row)
+            && e.ReinforcementCount > row.ReinforcementCount
+            && MergedFromIds(e).Count == row.MergedFromCount);
+
+        // ── Merge provenance ──────────────────────────────────────────────────
+        var depths = ComputeChainDepths(byId, ct);
+        var byDepth = new Dictionary<int, int>();
+        var maxDepth = 0;
+        foreach (var entry in live)
+        {
+            var depth = depths.GetValueOrDefault(entry.Id);
+            if (depth <= 0) continue;
+            byDepth[depth] = byDepth.GetValueOrDefault(depth) + 1;
+            if (depth > maxDepth) maxDepth = depth;
+        }
+
+        // Keyed by depth but ordered numerically. The keys are strings so the row serializes as
+        // a JSON object, and insertion order is what both the report and the raw row show — a
+        // histogram that reads "1, 3, 4, 2, 7" is harder to scan than one that counts upward.
+        var histogram = byDepth
+            .OrderBy(kv => kv.Key)
+            .ToDictionary(kv => kv.Key.ToString(CultureInfo.InvariantCulture), kv => kv.Value);
+
+        // ── Near-duplicates ───────────────────────────────────────────────────
+        var pairs = ShingleSimilarity.FindNearDuplicatePairs(
+            live, auditOptions.ShingleSize, auditOptions.NearDuplicateThreshold, ct);
+
+        var nearDupEntries = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var pair in pairs)
+        {
+            nearDupEntries.Add(pair.IdA);
+            nearDupEntries.Add(pair.IdB);
+        }
+
+        // ── Rejected merges ───────────────────────────────────────────────────
+        //
+        // Only rejections stamped since the previous run count. A stamp that has not moved
+        // describes a rejection an earlier run already reported.
+        var rejectionCutoff = previous?.TakenAt;
+        var rejectedSourceIds = new List<string>();
+        var clustersThisRun = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var entry in entries)
+        {
+            if (entry.Metadata is not { } meta) continue;
+            if (!meta.TryGetValue(DreamService.ConsolidationRejectedAtKey, out var rawAt)) continue;
+            if (!DateTimeOffset.TryParse(rawAt, CultureInfo.InvariantCulture,
+                    DateTimeStyles.RoundtripKind, out var rejectedAt))
+                continue;
+            if (rejectionCutoff is { } cutoff && rejectedAt <= cutoff) continue;
+
+            rejectedSourceIds.Add(entry.Id);
+            if (meta.TryGetValue(DreamService.ConsolidationRejectedClusterKey, out var cluster)
+                && !string.IsNullOrWhiteSpace(cluster))
+                clustersThisRun.Add(cluster);
+        }
+
+        var clusterRuns = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        foreach (var cluster in clustersThisRun)
+        {
+            var carried = previous?.RejectedClusterRuns.TryGetValue(cluster, out var count) == true ? count : 0;
+            clusterRuns[cluster] = carried + 1;
+        }
+
+        var repeatedClusters = clusterRuns.Count(kv => kv.Value >= auditOptions.RepeatedRejectionRuns);
+
+        // ── Dream cadence ─────────────────────────────────────────────────────
+        var dreamPassesRun = previous is { } p
+            ? passLastRunAt.Count(kv => kv.Value > p.TakenAt)
+            : 0;
+
+        passLastRunAt.TryGetValue(DreamService.ConsolidationLedgerPassName, out var consolidationLastRun);
+
+        var restarts = previous is { } prevState
+            ? processStarts.Count(t => t > prevState.TakenAt)
+            : 0;
+
+        // ── Purge outlook ─────────────────────────────────────────────────────
+        var purgeHorizon = now + TimeSpan.FromDays(auditOptions.PurgeWarningDays);
+        var dueSoon = dreamOptions.MemoryArchiveRetention > TimeSpan.Zero
+            ? archived.Where(e => e.ArchivedAt!.Value + dreamOptions.MemoryArchiveRetention <= purgeHorizon).ToList()
+            : [];
+
+        var purgeOutlook = new MemoryAuditPurgeOutlook(
+            auditOptions.PurgeWarningDays,
+            dueSoon.Count,
+            dueSoon.Count(e => DreamService.IsProtectedFromPruning(e, dreamOptions)));
+
+        // ── Category movement ─────────────────────────────────────────────────
+        //
+        // Attributed from the entries that still exist. Hard-deleted entries carry their
+        // category away with them, so a corpus losing a whole category shows up in the
+        // hard-delete count rather than here — which is the more alarming of the two anyway.
+        var growth = new Dictionary<string, (int Created, int Archived)>(StringComparer.OrdinalIgnoreCase);
+        foreach (var id in createdIds)
+        {
+            var key = CategoryOf(byId[id]);
+            var current = growth.GetValueOrDefault(key);
+            growth[key] = (current.Created + 1, current.Archived);
+        }
+        foreach (var id in archivedSinceIds)
+        {
+            var key = CategoryOf(byId[id]);
+            var current = growth.GetValueOrDefault(key);
+            growth[key] = (current.Created, current.Archived + 1);
+        }
+
+        var topCategories = growth
+            .Select(kv => new MemoryAuditCategoryGrowth(
+                kv.Key, kv.Value.Created, kv.Value.Archived, kv.Value.Created - kv.Value.Archived))
+            .OrderByDescending(g => Math.Abs(g.Net))
+            .ThenByDescending(g => g.Created)
+            .ThenBy(g => g.Category, StringComparer.Ordinal)
+            .Take(TopCategories)
+            .ToList();
+
+        // ── Reinforcement histogram ───────────────────────────────────────────
+        var reinforcement = new Dictionary<string, int>();
+        foreach (var (label, min, max) in ReinforcementBuckets)
+        {
+            var count = live.Count(e => e.ReinforcementCount >= min && e.ReinforcementCount <= max);
+            if (count > 0) reinforcement[label] = count;
+        }
+
+        var snapshot = new MemoryAuditSnapshot
+        {
+            SnapshotId = snapshotId,
+            TakenAt = now,
+            PreviousTakenAt = previous?.TakenAt,
+            Live = live.Count,
+            Archived = archived.Count,
+            MalformedFiles = walk.MalformedFiles,
+            CreatedSinceLast = createdIds.Count,
+            ArchivedSinceLast = archivedSinceIds.Count,
+            HardDeletedSinceLast = goneIds.Count,
+            PurgedSinceLast = purged,
+            HardDeletedOutsidePurge = goneIds.Count - purged,
+            NetGrowthPerDay = netGrowthPerDay,
+            MergeChainDepth = histogram,
+            MaxChainDepth = maxDepth,
+            NearDupPairs = pairs.Count,
+            NearDupEntries = nearDupEntries.Count,
+            EmbeddingDupClusters = embeddingDupClusters,
+            Reinforcement = reinforcement,
+            ReinforcedWithoutMergeSinceLast = reinforcedWithoutMerge,
+            RejectedMergeSourcesSinceLast = rejectedSourceIds.Count,
+            RejectedMergeClustersRepeated = repeatedClusters,
+            DreamPassesRunSinceLast = dreamPassesRun,
+            ConsolidationLastRunAt = consolidationLastRun == default ? null : consolidationLastRun,
+            RestartsSinceLast = restarts,
+            EmptyCategoryDirs = walk.EmptyCategoryDirs,
+            Purge = purgeOutlook,
+            TopCategoriesByGrowth = topCategories,
+            VocabularyStoplistSize = vocabularyStoplistSize,
+            Eval = eval
+        };
+
+        var violations = MemoryAuditInvariants.Check(
+            entries, snapshot, dreamOptions, auditOptions, now,
+            rateWindowMet ? elapsedDays : 0,
+            previous is null ? null : previousLive);
+        snapshot = snapshot with
+        {
+            Invariants = violations,
+            Status = MemoryAuditInvariants.ComputeStatus(violations)
+        };
+
+        var state = new MemoryAuditState
+        {
+            TakenAt = now,
+            SnapshotId = snapshotId,
+            Entries = [.. entries.Select(e => new MemoryAuditEntryRow(
+                e.Id,
+                e.ArchivedAt is not null,
+                e.ArchivedAt,
+                e.ReinforcementCount,
+                MergedFromIds(e).Count,
+                e.Category))],
+            RejectedClusterRuns = clusterRuns,
+            RejectedSourceIds = rejectedSourceIds,
+            ProcessStarts = [.. processStarts.Where(t => t >= now - MemoryAuditState.ProcessStartRetention)],
+            LastEvalAt = previous?.LastEvalAt,
+            LastEvalFingerprint = previous?.LastEvalFingerprint,
+            LastDigestAt = previous?.LastDigestAt
+        };
+
+        return (snapshot, state);
+    }
+
+    /// <summary>Category path for grouping, with a stable label for the null case.</summary>
+    internal static string CategoryOf(MemoryEntry entry) =>
+        string.IsNullOrWhiteSpace(entry.Category) ? Uncategorized : entry.Category;
+
+    /// <summary>
+    /// The ids an entry's merge provenance names, or an empty list when it is not a merge.
+    /// </summary>
+    internal static IReadOnlyList<string> MergedFromIds(MemoryEntry entry)
+    {
+        if (entry.Metadata is not { } meta) return [];
+        if (!meta.TryGetValue(DreamService.MergedFromKey, out var raw) || string.IsNullOrWhiteSpace(raw))
+            return [];
+
+        return [.. raw.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)];
+    }
+
+    /// <summary>
+    /// Longest merge-provenance walk ending at each entry. A non-merge is depth 0; a merge of
+    /// raw saves is 1; a merge of merges is 2 and up.
+    /// </summary>
+    /// <remarks>
+    /// Depth is the honest measure of how far a fact has drifted from anything a human or a tool
+    /// actually observed. A source that has been purged terminates the walk at depth 0 rather
+    /// than being guessed at — provenance is a recovery aid with a retention window, and
+    /// pretending to know the depth of something that no longer exists would inflate exactly the
+    /// number an operator would act on.
+    /// </remarks>
+    internal static Dictionary<string, int> ComputeChainDepths(
+        IReadOnlyDictionary<string, MemoryEntry> byId,
+        CancellationToken ct = default)
+    {
+        var depths = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        var visiting = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var id in byId.Keys)
+        {
+            ct.ThrowIfCancellationRequested();
+            Depth(id);
+        }
+
+        return depths;
+
+        int Depth(string id)
+        {
+            if (depths.TryGetValue(id, out var known)) return known;
+
+            // Provenance is written by an LLM-driven pass; a cycle is unlikely but must not
+            // become a stack overflow in a diagnostic.
+            if (!visiting.Add(id)) return 0;
+
+            var depth = 0;
+            if (byId.TryGetValue(id, out var entry))
+            {
+                foreach (var source in MergedFromIds(entry))
+                {
+                    if (!byId.ContainsKey(source)) continue;
+                    depth = Math.Max(depth, 1 + Depth(source));
+                }
+
+                // A merge whose sources have all been purged still is a merge.
+                if (depth == 0 && MergedFromIds(entry).Count > 0)
+                    depth = 1;
+            }
+
+            visiting.Remove(id);
+            depths[id] = depth;
+            return depth;
+        }
+    }
+}

--- a/src/RockBot.Host/MemoryAuditEvaluator.cs
+++ b/src/RockBot.Host/MemoryAuditEvaluator.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
@@ -112,7 +113,7 @@ internal sealed class MemoryAuditEvaluator(ILlmClient llm, ILogger logger)
             samples.Add(new Sample(
                 NearDuplicateCategory,
                 [a.Id, b.Id],
-                $"Two entries both live in memory (lexical overlap {pair.Score:P0}):\n" +
+                $"Two entries both live in memory (lexical overlap {Pct(pair.Score)}):\n" +
                 $"  - [{a.Id}] {Truncate(a.Content)}\n" +
                 $"  - [{b.Id}] {Truncate(b.Content)}"));
         }
@@ -127,7 +128,7 @@ internal sealed class MemoryAuditEvaluator(ILlmClient llm, ILogger logger)
             samples.Add(new Sample(
                 HighReinforcementCategory,
                 [entry.Id],
-                $"Reinforced {entry.ReinforcementCount}x, importance {entry.ImportanceScore:F2}, " +
+                $"Reinforced {entry.ReinforcementCount}x, importance {Score(entry.ImportanceScore)}, " +
                 $"category {entry.Category ?? "(none)"}:\n  [{entry.Id}] {Truncate(entry.Content)}"));
 
         // Facts consolidation discarded outright, with nothing put in their place.
@@ -143,7 +144,7 @@ internal sealed class MemoryAuditEvaluator(ILlmClient llm, ILogger logger)
                 EphemeralArchiveCategory,
                 [entry.Id],
                 $"Dropped as ephemeral on {entry.ArchivedAt:yyyy-MM-dd} " +
-                $"(reinforced {entry.ReinforcementCount}x, importance {entry.ImportanceScore:F2}):\n" +
+                $"(reinforced {entry.ReinforcementCount}x, importance {Score(entry.ImportanceScore)}):\n" +
                 $"  [{entry.Id}] {Truncate(entry.Content)}"));
 
         return samples;
@@ -295,6 +296,17 @@ internal sealed class MemoryAuditEvaluator(ILlmClient llm, ILogger logger)
             "commitment or identity detail rather than a passing detail.",
         _ => "Was this the right outcome?"
     };
+
+    /// <summary>
+    /// Percentage and score formatting pinned to the invariant culture. See
+    /// <c>MemoryAuditReportWriter.Percent</c> — "P0" renders as "75 %" under the culture the
+    /// container runs with, and an importance score of "0,97" reads as a different number.
+    /// </summary>
+    private static string Pct(double fraction) =>
+        (fraction * 100).ToString("F0", CultureInfo.InvariantCulture) + "%";
+
+    private static string Score(float value) =>
+        value.ToString("F2", CultureInfo.InvariantCulture);
 
     private static string Truncate(string? text)
     {

--- a/src/RockBot.Host/MemoryAuditEvaluator.cs
+++ b/src/RockBot.Host/MemoryAuditEvaluator.cs
@@ -1,0 +1,333 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+
+namespace RockBot.Host;
+
+/// <summary>
+/// The weekly LLM-judged sample eval: takes a handful of decisions memory management actually
+/// made and asks a model whether each one was right.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The counters in a snapshot say what happened; they cannot say whether it was correct. A merge
+/// that keeps every specific still passes the coverage check while producing prose that means
+/// something different, and a corpus of clean-looking numbers is exactly what the store showed
+/// through every incident so far. This is the only part of the audit that reads content.
+/// </para>
+/// <para>
+/// Sampling is static and the call is gated on the corpus fingerprint, so the cost is a handful
+/// of Balanced-tier JSON calls a week, and zero on a week where nothing changed. The judge sees
+/// no tools — it is asked one question and answers it, exactly as every dream pass does.
+/// </para>
+/// </remarks>
+internal sealed class MemoryAuditEvaluator(ILlmClient llm, ILogger logger)
+{
+    internal const string MergeCategory = "merge";
+    internal const string NearDuplicateCategory = "near-duplicate";
+    internal const string HighReinforcementCategory = "high-reinforcement";
+    internal const string EphemeralArchiveCategory = "ephemeral-archive";
+
+    /// <summary>Longest entry content rendered into a judge prompt.</summary>
+    private const int MaxContentChars = 600;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true
+    };
+
+    /// <summary>One thing for the judge to rule on.</summary>
+    /// <param name="Category">Which sampling family it came from.</param>
+    /// <param name="Ids">Entry ids involved, carried through to the verdict so a finding is chaseable.</param>
+    /// <param name="Text">Rendered prompt fragment describing the decision.</param>
+    internal sealed record Sample(string Category, IReadOnlyList<string> Ids, string Text);
+
+    private sealed record VerdictDto(int Index, bool Sound, string? Reason);
+
+    private sealed record VerdictsDto(List<VerdictDto>? Verdicts);
+
+    /// <summary>
+    /// Picks what to judge. Deterministic given the same corpus: the most recent decisions in
+    /// each family, capped at <see cref="MemoryAuditOptions.EvalSampleSize"/>.
+    /// </summary>
+    /// <remarks>
+    /// Recency rather than randomness because the question being asked is "is memory management
+    /// working <em>now</em>" — a random sample across a year would keep re-judging decisions
+    /// made by code that has since been fixed.
+    /// </remarks>
+    internal static IReadOnlyList<Sample> SelectSamples(
+        IReadOnlyList<MemoryEntry> entries,
+        IReadOnlyList<ShingleSimilarity.Pair> nearDupPairs,
+        MemoryAuditOptions options,
+        DateTimeOffset now)
+    {
+        var byId = new Dictionary<string, MemoryEntry>(StringComparer.OrdinalIgnoreCase);
+        foreach (var entry in entries)
+            byId[entry.Id] = entry;
+
+        var cutoff = now - options.EvalWindow;
+        var samples = new List<Sample>();
+
+        // Merges made inside the window, newest first.
+        var merges = entries
+            .Where(e => e.ArchivedAt is null && MemoryAuditAnalyzer.MergedFromIds(e).Count > 0)
+            .Where(e => (e.UpdatedAt ?? e.CreatedAt) >= cutoff)
+            .OrderByDescending(e => e.UpdatedAt ?? e.CreatedAt)
+            .Take(options.EvalSampleSize);
+
+        foreach (var merge in merges)
+        {
+            var sources = MemoryAuditAnalyzer.MergedFromIds(merge)
+                .Select(id => byId.GetValueOrDefault(id))
+                .Where(e => e is not null)
+                .Select(e => e!)
+                .ToList();
+
+            // A merge whose sources have all been purged cannot be judged — there is nothing
+            // left to compare the result against, which is precisely why merges are archived
+            // rather than deleted.
+            if (sources.Count == 0) continue;
+
+            var text = new StringBuilder();
+            text.AppendLine("Sources that were merged away:");
+            foreach (var source in sources)
+                text.AppendLine($"  - [{source.Id}] {Truncate(source.Content)}");
+            text.AppendLine($"Replacement kept in memory: {Truncate(merge.Content)}");
+
+            samples.Add(new Sample(
+                MergeCategory,
+                [merge.Id, .. sources.Select(s => s.Id)],
+                text.ToString().TrimEnd()));
+        }
+
+        // Near-duplicate pairs still both live — deduplication that did not happen.
+        foreach (var pair in nearDupPairs.OrderByDescending(p => p.Score).Take(options.EvalSampleSize))
+        {
+            if (!byId.TryGetValue(pair.IdA, out var a) || !byId.TryGetValue(pair.IdB, out var b))
+                continue;
+
+            samples.Add(new Sample(
+                NearDuplicateCategory,
+                [a.Id, b.Id],
+                $"Two entries both live in memory (lexical overlap {pair.Score:P0}):\n" +
+                $"  - [{a.Id}] {Truncate(a.Content)}\n" +
+                $"  - [{b.Id}] {Truncate(b.Content)}"));
+        }
+
+        // Heavily reinforced entries — the corpus's load-bearing facts.
+        var reinforced = entries
+            .Where(e => e.ArchivedAt is null && e.ReinforcementCount >= options.HighReinforcementFloor)
+            .OrderByDescending(e => e.ReinforcementCount)
+            .Take(options.EvalSampleSize);
+
+        foreach (var entry in reinforced)
+            samples.Add(new Sample(
+                HighReinforcementCategory,
+                [entry.Id],
+                $"Reinforced {entry.ReinforcementCount}x, importance {entry.ImportanceScore:F2}, " +
+                $"category {entry.Category ?? "(none)"}:\n  [{entry.Id}] {Truncate(entry.Content)}"));
+
+        // Facts consolidation discarded outright, with nothing put in their place.
+        var ephemeral = entries
+            .Where(e => e.ArchivedAt >= cutoff
+                        && string.Equals(e.ArchiveReason, DreamService.EphemeralArchiveReason,
+                            StringComparison.OrdinalIgnoreCase))
+            .OrderByDescending(e => e.ArchivedAt)
+            .Take(options.EvalSampleSize);
+
+        foreach (var entry in ephemeral)
+            samples.Add(new Sample(
+                EphemeralArchiveCategory,
+                [entry.Id],
+                $"Dropped as ephemeral on {entry.ArchivedAt:yyyy-MM-dd} " +
+                $"(reinforced {entry.ReinforcementCount}x, importance {entry.ImportanceScore:F2}):\n" +
+                $"  [{entry.Id}] {Truncate(entry.Content)}"));
+
+        return samples;
+    }
+
+    /// <summary>
+    /// Judges <paramref name="samples"/>, one LLM call per category. A category whose call fails
+    /// or returns unparseable JSON is left out of the result rather than defaulting to sound —
+    /// an eval that scores itself in the absence of an answer is worse than no eval.
+    /// </summary>
+    internal async Task<MemoryAuditEvalResult?> EvaluateAsync(
+        IReadOnlyList<Sample> samples,
+        string directive,
+        ModelTier tier,
+        string storeFingerprint,
+        CancellationToken ct)
+    {
+        if (samples.Count == 0) return null;
+
+        var verdicts = new List<MemoryAuditEvalVerdict>();
+
+        foreach (var group in samples.GroupBy(s => s.Category))
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var items = group.ToList();
+            var judged = await JudgeAsync(group.Key, items, directive, tier, ct).ConfigureAwait(false);
+            if (judged is null) continue;
+
+            verdicts.AddRange(judged);
+        }
+
+        if (verdicts.Count == 0) return null;
+
+        var rateByCategory = verdicts
+            .GroupBy(v => v.Category)
+            .ToDictionary(g => g.Key, g => (double)g.Count(v => v.Sound) / g.Count(), StringComparer.Ordinal);
+
+        var sound = verdicts.Count(v => v.Sound);
+
+        var summary = new MemoryAuditEvalSummary(
+            DateTimeOffset.UtcNow,
+            verdicts.Count,
+            sound,
+            (double)sound / verdicts.Count,
+            rateByCategory);
+
+        return new MemoryAuditEvalResult(summary, verdicts, storeFingerprint);
+    }
+
+    private async Task<List<MemoryAuditEvalVerdict>?> JudgeAsync(
+        string category,
+        List<Sample> items,
+        string directive,
+        ModelTier tier,
+        CancellationToken ct)
+    {
+        var userMessage = new StringBuilder();
+        userMessage.AppendLine($"Decision family: {category}");
+        userMessage.AppendLine($"{Question(category)}");
+        userMessage.AppendLine();
+        for (var i = 0; i < items.Count; i++)
+        {
+            userMessage.AppendLine($"{i + 1}.");
+            userMessage.AppendLine(items[i].Text);
+            userMessage.AppendLine();
+        }
+        userMessage.AppendLine(
+            "Answer with JSON: {\"verdicts\":[{\"index\":1,\"sound\":true,\"reason\":\"one short sentence\"}]}. " +
+            "Include one object per numbered item.");
+
+        try
+        {
+            var response = await llm.GetResponseAsync(
+                [new ChatMessage(ChatRole.System, directive),
+                 new ChatMessage(ChatRole.User, userMessage.ToString())],
+                tier,
+                new ChatOptions { ResponseFormat = ChatResponseFormat.Json },
+                ct).ConfigureAwait(false);
+
+            var json = DreamService.ExtractJsonObject(response.Text?.Trim() ?? string.Empty);
+            if (string.IsNullOrEmpty(json))
+            {
+                logger.LogWarning("Memory audit: eval judge returned no parseable JSON for {Category}", category);
+                return null;
+            }
+
+            var dto = JsonSerializer.Deserialize<VerdictsDto>(json, JsonOptions);
+            if (dto?.Verdicts is not { Count: > 0 })
+            {
+                logger.LogWarning("Memory audit: eval judge returned no verdicts for {Category}", category);
+                return null;
+            }
+
+            var results = new List<MemoryAuditEvalVerdict>();
+            foreach (var verdict in dto.Verdicts)
+            {
+                // The index is the model's only handle on which item it is talking about, so an
+                // out-of-range one is dropped rather than attributed to the wrong entries.
+                if (verdict.Index < 1 || verdict.Index > items.Count) continue;
+                var sample = items[verdict.Index - 1];
+                results.Add(new MemoryAuditEvalVerdict(
+                    sample.Category, sample.Ids, verdict.Sound, verdict.Reason?.Trim()));
+            }
+
+            return results.Count > 0 ? results : null;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Memory audit: eval judge failed for {Category}", category);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Hash of the live corpus plus the archive size. Two runs with the same fingerprint would
+    /// judge exactly the same decisions, so the second one skips the call entirely.
+    /// </summary>
+    internal static string StoreFingerprint(IReadOnlyList<MemoryEntry> entries)
+    {
+        var sb = new StringBuilder();
+        foreach (var id in entries.Where(e => e.ArchivedAt is null)
+                     .Select(e => e.Id)
+                     .OrderBy(id => id, StringComparer.Ordinal))
+            sb.Append(id).Append('\u001f');  // unit separator: cannot occur in an id
+
+        sb.Append("archived=").Append(entries.Count(e => e.ArchivedAt is not null));
+
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(sb.ToString())).AsSpan(0, 16));
+    }
+
+    private static string Question(string category) => category switch
+    {
+        MergeCategory =>
+            "Did the replacement preserve everything the sources said that a reader would need? " +
+            "Answer sound=false if any name, date, number, qualifier or distinction was lost or altered.",
+        NearDuplicateCategory =>
+            "Do these two entries state the same fact, such that keeping both is redundant? " +
+            "Answer sound=false if they are genuinely duplicates that should have been folded together.",
+        HighReinforcementCategory =>
+            "Is this entry still a coherent, specific, useful fact? Answer sound=false if repeated " +
+            "reinforcement has turned it into a vague or self-contradictory blob.",
+        EphemeralArchiveCategory =>
+            "Was this safe to discard? Answer sound=false if it names a durable fact, preference, " +
+            "commitment or identity detail rather than a passing detail.",
+        _ => "Was this the right outcome?"
+    };
+
+    private static string Truncate(string? text)
+    {
+        if (string.IsNullOrEmpty(text)) return "(empty)";
+        var flat = text.ReplaceLineEndings(" ").Trim();
+        return flat.Length <= MaxContentChars ? flat : flat[..MaxContentChars] + "…";
+    }
+
+    /// <summary>
+    /// Fallback judge directive, used when <c>memory-audit.md</c> is absent from the profile
+    /// volume. Every other dream pass carries one for the same reason: a missing file must
+    /// degrade to the built-in behaviour, never to silence.
+    /// </summary>
+    internal const string BuiltInDirective = """
+        You are auditing an AI agent's long-term memory. You are shown decisions the memory
+        system already made — merges it performed, duplicates it left in place, facts it
+        discarded, entries it has reinforced many times — and asked whether each was correct.
+
+        You are a reviewer, not an editor. Do not propose rewrites, do not suggest merges, and
+        do not comment on style. Answer only whether the stored outcome was right.
+
+        Judge conservatively in the direction of keeping information:
+        - A merge that dropped a name, date, number, or distinction is NOT sound, however
+          tidier the result reads.
+        - A discarded entry that named a durable fact, preference, commitment, or identity
+          detail is NOT sound. Genuinely passing details (a one-off status, a transient
+          scheduling note) are sound to discard.
+        - Two entries stating the same fact in different words ARE duplicates, even if the
+          wording shares few tokens.
+        - An entry reinforced many times that has become vague, generic, or self-contradictory
+          is NOT sound, even though nothing was formally lost.
+
+        Reply with JSON only: {"verdicts":[{"index":1,"sound":true,"reason":"..."}]}
+        One object per numbered item, in any order. Keep each reason to one short sentence.
+        """;
+}

--- a/src/RockBot.Host/MemoryAuditInvariants.cs
+++ b/src/RockBot.Host/MemoryAuditInvariants.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 namespace RockBot.Host;
 
 /// <summary>
@@ -159,9 +160,9 @@ internal static class MemoryAuditInvariants
             if (lossPercent > auditOptions.MaxLossPercentBetweenSnapshots)
                 violations.Add(new MemoryAuditInvariantViolation(
                     LossPercentThreshold,
-                    $"Live entries fell {lossPercent:F1}% since the previous snapshot " +
+                    $"Live entries fell {Num(lossPercent, 1)}% since the previous snapshot " +
                     $"({previousLive.Value} → {snapshot.Live}); the limit is " +
-                    $"{auditOptions.MaxLossPercentBetweenSnapshots:F0}%.",
+                    $"{Num(auditOptions.MaxLossPercentBetweenSnapshots, 0)}%.",
                     []));
         }
 
@@ -180,8 +181,8 @@ internal static class MemoryAuditInvariants
         if (snapshot.NetGrowthPerDay is { } growth && growth > auditOptions.MaxNetGrowthPerDay)
             violations.Add(new MemoryAuditInvariantViolation(
                 NetGrowthThreshold,
-                $"The corpus is growing {growth:F1} entries/day, above the " +
-                $"{auditOptions.MaxNetGrowthPerDay:F0}/day you set — saves are outpacing consolidation.",
+                $"The corpus is growing {Num(growth, 1)} entries/day, above the " +
+                $"{Num(auditOptions.MaxNetGrowthPerDay, 0)}/day you set — saves are outpacing consolidation.",
                 []));
 
         if (snapshot.MaxChainDepth > auditOptions.MaxMergeChainDepth)
@@ -197,7 +198,7 @@ internal static class MemoryAuditInvariants
             if (rejectedPerWeek > auditOptions.MaxRejectedMergesPerWeek)
                 violations.Add(new MemoryAuditInvariantViolation(
                     RejectedMergesThreshold,
-                    $"Merge rejections are running at {rejectedPerWeek:F1}/week, above the " +
+                    $"Merge rejections are running at {Num(rejectedPerWeek, 1)}/week, above the " +
                     $"{auditOptions.MaxRejectedMergesPerWeek}/week you set.",
                     []));
         }
@@ -216,6 +217,14 @@ internal static class MemoryAuditInvariants
             ? MemoryAuditStatuses.Alert
             : MemoryAuditStatuses.Warning;
     }
+
+    /// <summary>
+    /// A fixed-point number with a dot, whatever the host's locale. These strings are stored in
+    /// the JSON trend rows and read back by the sidecar, so a decimal comma would change the
+    /// on-disk record.
+    /// </summary>
+    private static string Num(double value, int decimals) =>
+        value.ToString(decimals == 0 ? "F0" : "F1", CultureInfo.InvariantCulture);
 
     /// <summary>When a merge was produced, per its own provenance stamp.</summary>
     private static DateTimeOffset? MergedAt(MemoryEntry entry)

--- a/src/RockBot.Host/MemoryAuditInvariants.cs
+++ b/src/RockBot.Host/MemoryAuditInvariants.cs
@@ -1,0 +1,249 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// The properties the memory store is supposed to hold, checked against what is actually on
+/// disk.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Split into two families. <em>Structural</em> invariants describe the corpus itself and are
+/// true or false regardless of configuration — a merge whose replacement does not exist is
+/// broken on any deployment. <em>Threshold</em> invariants compare a measurement against a
+/// tuning knob and say "this is more than you said you would accept".
+/// </para>
+/// <para>
+/// Only three findings reach <c>alert</c>: data destroyed outside the purge, a large drop in
+/// live entries, and provenance pointing at something that no longer exists. Those are the
+/// three shapes every real incident so far has taken. Everything else is a warning, because a
+/// channel that alerts on tuning drift stops being read before the day it matters.
+/// </para>
+/// </remarks>
+internal static class MemoryAuditInvariants
+{
+    internal const string MergedFromResolves = "merged-from-resolves";
+    internal const string ArchiveFieldsPresent = "archive-fields-present";
+    internal const string LiveNotMergeSource = "live-not-merge-source";
+    internal const string MergeChainUnbroken = "merge-chain-unbroken";
+    internal const string NoHardDeleteOutsidePurge = "no-hard-delete-outside-purge";
+    internal const string NoRepeatedRejection = "no-repeated-rejection";
+    internal const string NetGrowthThreshold = "net-growth-threshold";
+    internal const string ChainDepthThreshold = "chain-depth-threshold";
+    internal const string RejectedMergesThreshold = "rejected-merges-threshold";
+    internal const string LossPercentThreshold = "loss-percent-threshold";
+    internal const string NoMalformedFiles = "no-malformed-files";
+
+    /// <summary>Findings serious enough that something was actually lost.</summary>
+    private static readonly HashSet<string> AlertInvariants =
+    [
+        NoHardDeleteOutsidePurge,
+        LossPercentThreshold,
+        MergeChainUnbroken
+    ];
+
+    /// <summary>
+    /// Runs every invariant against the walked corpus and the snapshot's already-computed
+    /// counters.
+    /// </summary>
+    /// <param name="entries">Every entry on disk, live and archived.</param>
+    /// <param name="snapshot">The snapshot so far — invariants and status are not yet set.</param>
+    /// <param name="dreamOptions">Supplies the archive retention window.</param>
+    /// <param name="auditOptions">Thresholds.</param>
+    /// <param name="now">Agent-local time of this run.</param>
+    /// <param name="elapsedDays">
+    /// Days since the previous run, or zero when that window was too short to measure a rate
+    /// over. Zero disables the rate-based invariants rather than dividing by it.
+    /// </param>
+    /// <param name="previousLive">Live count at the previous run, or null on a first run.</param>
+    internal static IReadOnlyList<MemoryAuditInvariantViolation> Check(
+        IReadOnlyList<MemoryEntry> entries,
+        MemoryAuditSnapshot snapshot,
+        DreamOptions dreamOptions,
+        MemoryAuditOptions auditOptions,
+        DateTimeOffset now,
+        double elapsedDays,
+        int? previousLive)
+    {
+        var violations = new List<MemoryAuditInvariantViolation>();
+
+        var byId = new Dictionary<string, MemoryEntry>(StringComparer.OrdinalIgnoreCase);
+        foreach (var entry in entries)
+            byId[entry.Id] = entry;
+
+        // ── Structural ────────────────────────────────────────────────────────
+
+        // merged-from-resolves: a merge names sources that are not on disk. Dangling provenance
+        // is by design once the sources have been purged, so only merges too recent for that to
+        // have happened are counted.
+        var provenanceHorizon = dreamOptions.MemoryArchiveRetention > TimeSpan.Zero
+            ? now - dreamOptions.MemoryArchiveRetention
+            : DateTimeOffset.MinValue;
+
+        var danglingProvenance = entries
+            .Where(e => MergedAt(e) is { } mergedAt && mergedAt > provenanceHorizon)
+            .Where(e => MemoryAuditAnalyzer.MergedFromIds(e).Any(source => !byId.ContainsKey(source)))
+            .Select(e => e.Id)
+            .ToList();
+
+        if (danglingProvenance.Count > 0)
+            violations.Add(new MemoryAuditInvariantViolation(
+                MergedFromResolves,
+                $"{danglingProvenance.Count} recent merge(s) name source entries that are no longer on disk, " +
+                "and are too recent for the retention purge to explain it.",
+                Cap(danglingProvenance)));
+
+        // archive-fields-present: the two archive fields must move together, or an archived
+        // entry has no recorded justification and nobody can tell why it left recall.
+        var brokenArchiveFields = entries
+            .Where(e => (e.ArchivedAt is not null) != !string.IsNullOrWhiteSpace(e.ArchiveReason))
+            .Select(e => e.Id)
+            .ToList();
+
+        if (brokenArchiveFields.Count > 0)
+            violations.Add(new MemoryAuditInvariantViolation(
+                ArchiveFieldsPresent,
+                $"{brokenArchiveFields.Count} entry(s) have an archive timestamp without a reason, or vice versa.",
+                Cap(brokenArchiveFields)));
+
+        // live-not-merge-source: an entry that has been merged away should not still be in
+        // recall. Both copies of the fact would then surface, and the next cycle would merge
+        // the merge.
+        var mergeSources = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var entry in entries)
+            foreach (var source in MemoryAuditAnalyzer.MergedFromIds(entry))
+                mergeSources.Add(source);
+
+        var liveSources = entries
+            .Where(e => e.ArchivedAt is null && mergeSources.Contains(e.Id))
+            .Select(e => e.Id)
+            .ToList();
+
+        if (liveSources.Count > 0)
+            violations.Add(new MemoryAuditInvariantViolation(
+                LiveNotMergeSource,
+                $"{liveSources.Count} entry(s) are named as the source of a merge but are still live in recall.",
+                Cap(liveSources)));
+
+        // merge-chain-unbroken: the shape issue #506 found. Sources archived "merged into X"
+        // where X exists nowhere means the merge's replacement was never written, or was later
+        // destroyed — the fact is gone and only the tombstone remains.
+        var brokenChains = entries
+            .Where(e => MergedIntoTarget(e) is { } target && !byId.ContainsKey(target))
+            .Select(e => e.Id)
+            .ToList();
+
+        if (brokenChains.Count > 0)
+            violations.Add(new MemoryAuditInvariantViolation(
+                MergeChainUnbroken,
+                $"{brokenChains.Count} archived entry(s) were merged into a replacement that does not exist. " +
+                "Their content has no other copy.",
+                Cap(brokenChains)));
+
+        if (snapshot.MalformedFiles > 0)
+            violations.Add(new MemoryAuditInvariantViolation(
+                NoMalformedFiles,
+                $"{snapshot.MalformedFiles} file(s) under the memory root would not deserialize and were skipped.",
+                []));
+
+        // ── Loss ──────────────────────────────────────────────────────────────
+
+        if (snapshot.HardDeletedOutsidePurge > auditOptions.MaxHardDeletesOutsidePurge)
+            violations.Add(new MemoryAuditInvariantViolation(
+                NoHardDeleteOutsidePurge,
+                $"{snapshot.HardDeletedOutsidePurge} entry(s) disappeared from disk that the retention purge " +
+                $"cannot account for (limit {auditOptions.MaxHardDeletesOutsidePurge}).",
+                []));
+
+        if (previousLive is > 0)
+        {
+            var lossPercent = (previousLive.Value - snapshot.Live) * 100.0 / previousLive.Value;
+            if (lossPercent > auditOptions.MaxLossPercentBetweenSnapshots)
+                violations.Add(new MemoryAuditInvariantViolation(
+                    LossPercentThreshold,
+                    $"Live entries fell {lossPercent:F1}% since the previous snapshot " +
+                    $"({previousLive.Value} → {snapshot.Live}); the limit is " +
+                    $"{auditOptions.MaxLossPercentBetweenSnapshots:F0}%.",
+                    []));
+        }
+
+        // ── Thresholds ────────────────────────────────────────────────────────
+
+        if (snapshot.RejectedMergeClustersRepeated > 0)
+            violations.Add(new MemoryAuditInvariantViolation(
+                NoRepeatedRejection,
+                $"{snapshot.RejectedMergeClustersRepeated} merge cluster(s) have been rejected on " +
+                $"{auditOptions.RepeatedRejectionRuns} or more consecutive runs — consolidation is retrying " +
+                "work it cannot complete.",
+                []));
+
+        // Null means the window between runs was too short to measure a rate over, which is
+        // not the same as a rate of zero and must not be thresholded either way.
+        if (snapshot.NetGrowthPerDay is { } growth && growth > auditOptions.MaxNetGrowthPerDay)
+            violations.Add(new MemoryAuditInvariantViolation(
+                NetGrowthThreshold,
+                $"The corpus is growing {growth:F1} entries/day, above the " +
+                $"{auditOptions.MaxNetGrowthPerDay:F0}/day you set — saves are outpacing consolidation.",
+                []));
+
+        if (snapshot.MaxChainDepth > auditOptions.MaxMergeChainDepth)
+            violations.Add(new MemoryAuditInvariantViolation(
+                ChainDepthThreshold,
+                $"A live entry sits at the end of a {snapshot.MaxChainDepth}-deep merge chain " +
+                $"(limit {auditOptions.MaxMergeChainDepth}); it is model prose generated from model prose.",
+                []));
+
+        if (elapsedDays > 0)
+        {
+            var rejectedPerWeek = snapshot.RejectedMergeSourcesSinceLast * 7.0 / elapsedDays;
+            if (rejectedPerWeek > auditOptions.MaxRejectedMergesPerWeek)
+                violations.Add(new MemoryAuditInvariantViolation(
+                    RejectedMergesThreshold,
+                    $"Merge rejections are running at {rejectedPerWeek:F1}/week, above the " +
+                    $"{auditOptions.MaxRejectedMergesPerWeek}/week you set.",
+                    []));
+        }
+
+        return violations;
+    }
+
+    /// <summary>
+    /// Worst finding wins. Nothing found means healthy — the audit does not manufacture a
+    /// warning just to look busy.
+    /// </summary>
+    internal static string ComputeStatus(IReadOnlyList<MemoryAuditInvariantViolation> violations)
+    {
+        if (violations.Count == 0) return MemoryAuditStatuses.Healthy;
+        return violations.Any(v => AlertInvariants.Contains(v.Name))
+            ? MemoryAuditStatuses.Alert
+            : MemoryAuditStatuses.Warning;
+    }
+
+    /// <summary>When a merge was produced, per its own provenance stamp.</summary>
+    private static DateTimeOffset? MergedAt(MemoryEntry entry)
+    {
+        if (entry.Metadata is not { } meta) return null;
+        if (!meta.TryGetValue(DreamService.MergedAtKey, out var raw)) return null;
+        return DateTimeOffset.TryParse(
+            raw,
+            System.Globalization.CultureInfo.InvariantCulture,
+            System.Globalization.DateTimeStyles.RoundtripKind,
+            out var parsed)
+            ? parsed
+            : null;
+    }
+
+    /// <summary>The replacement id an archived merge source points at, or null.</summary>
+    private static string? MergedIntoTarget(MemoryEntry entry)
+    {
+        if (entry.ArchiveReason is not { } reason) return null;
+        if (!reason.StartsWith(DreamService.MergedIntoReasonPrefix, StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        var target = reason[DreamService.MergedIntoReasonPrefix.Length..].Trim();
+        return string.IsNullOrEmpty(target) ? null : target;
+    }
+
+    private static IReadOnlyList<string> Cap(List<string> ids) =>
+        ids.Count <= MemoryAuditAnalyzer.MaxIdsPerViolation
+            ? ids
+            : [.. ids.Take(MemoryAuditAnalyzer.MaxIdsPerViolation)];
+}

--- a/src/RockBot.Host/MemoryAuditReportWriter.cs
+++ b/src/RockBot.Host/MemoryAuditReportWriter.cs
@@ -1,0 +1,175 @@
+using System.Globalization;
+using System.Text;
+
+namespace RockBot.Host;
+
+/// <summary>
+/// Renders a snapshot as markdown a person can read without knowing the schema.
+/// </summary>
+/// <remarks>
+/// The report is the deliverable, not the JSON. Every previous memory investigation ended with
+/// someone writing this document by hand from log greps; the audit's value is that the document
+/// already exists when the question is asked. It is deliberately short — status, what moved,
+/// what needs attention, and enough trend to see a slope.
+/// </remarks>
+internal static class MemoryAuditReportWriter
+{
+    /// <summary>Trend rows shown in the table.</summary>
+    private const int TrendRows = 30;
+
+    /// <summary>
+    /// Renders <paramref name="snapshot"/>, using <paramref name="trend"/> (oldest first,
+    /// including <paramref name="snapshot"/> itself) for the history table.
+    /// </summary>
+    internal static string Render(
+        MemoryAuditSnapshot snapshot,
+        IReadOnlyList<MemoryAuditSnapshot> trend,
+        MemoryAuditEvalResult? eval = null)
+    {
+        var sb = new StringBuilder();
+
+        sb.AppendLine("# Memory audit");
+        sb.AppendLine();
+        sb.AppendLine(
+            $"**{StatusLabel(snapshot.Status)}** — {snapshot.Live} live entries, {snapshot.Archived} archived, " +
+            $"measured {snapshot.TakenAt:yyyy-MM-dd HH:mm} (`{snapshot.SnapshotId}`).");
+        sb.AppendLine();
+
+        // ── What changed ──────────────────────────────────────────────────────
+        sb.AppendLine("## What changed");
+        sb.AppendLine();
+
+        if (snapshot.PreviousTakenAt is null)
+        {
+            sb.AppendLine(
+                "First run — there is nothing to compare against yet. The numbers below are the " +
+                "baseline every later run is measured from.");
+        }
+        else
+        {
+            sb.AppendLine($"Since {snapshot.PreviousTakenAt:yyyy-MM-dd HH:mm}:");
+            sb.AppendLine();
+            sb.AppendLine($"- {snapshot.CreatedSinceLast} new, {snapshot.ArchivedSinceLast} archived, " +
+                          $"{snapshot.HardDeletedSinceLast} gone from disk " +
+                          $"({snapshot.PurgedSinceLast} explained by the retention purge).");
+            sb.AppendLine(snapshot.NetGrowthPerDay is { } rate
+                ? $"- Net growth {rate:+0.0;-0.0;0} entries/day."
+                : "- Net growth: not measurable — the gap between these two runs was too short " +
+                  "to read a daily rate from (usually a restart).");
+            sb.AppendLine($"- {snapshot.ReinforcedWithoutMergeSinceLast} entries genuinely re-observed " +
+                          "(reinforced without a merge).");
+            sb.AppendLine($"- {snapshot.DreamPassesRunSinceLast} dream pass(es) ran; " +
+                          $"{snapshot.RestartsSinceLast} process restart(s).");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("Current shape:");
+        sb.AppendLine();
+        sb.AppendLine($"- Near-duplicates: {snapshot.NearDupPairs} pair(s) across " +
+                      $"{snapshot.NearDupEntries} entries" +
+                      (snapshot.EmbeddingDupClusters is { } clusters
+                          ? $"; the store's own detector finds {clusters} cluster(s)."
+                          : "."));
+        sb.AppendLine($"- Merge chains: deepest is {snapshot.MaxChainDepth}" +
+                      (snapshot.MergeChainDepth.Count > 0
+                          ? $" ({FormatHistogram(snapshot.MergeChainDepth)})."
+                          : "."));
+        sb.AppendLine($"- Reinforcement: {FormatHistogram(snapshot.Reinforcement)}.");
+        sb.AppendLine($"- Purge outlook: {snapshot.Purge.Count} archived entry(s) are hard-deleted within " +
+                      $"{snapshot.Purge.DueWithinDays} days; {snapshot.Purge.HighValueCount} of those are held " +
+                      "back by the high-value floor.");
+
+        if (snapshot.TopCategoriesByGrowth.Count > 0)
+        {
+            sb.AppendLine();
+            sb.AppendLine("Categories that moved most:");
+            sb.AppendLine();
+            foreach (var category in snapshot.TopCategoriesByGrowth)
+                sb.AppendLine($"- `{category.Category}` — {category.Net:+0;-0;0} " +
+                              $"({category.Created} new, {category.Archived} archived)");
+        }
+
+        // ── Needs attention ───────────────────────────────────────────────────
+        sb.AppendLine();
+        sb.AppendLine("## Needs attention");
+        sb.AppendLine();
+
+        if (snapshot.Invariants.Count == 0)
+        {
+            sb.AppendLine("Nothing. Every invariant held and no threshold was crossed.");
+        }
+        else
+        {
+            foreach (var violation in snapshot.Invariants)
+            {
+                sb.AppendLine($"- **`{violation.Name}`** — {violation.Message}");
+                if (violation.Ids.Count > 0)
+                    sb.AppendLine($"  - ids: {string.Join(", ", violation.Ids.Select(id => $"`{id}`"))}");
+            }
+        }
+
+        // ── Trend ─────────────────────────────────────────────────────────────
+        var rows = trend.Count <= TrendRows ? trend : [.. trend.Skip(trend.Count - TrendRows)];
+        if (rows.Count > 1)
+        {
+            sb.AppendLine();
+            sb.AppendLine($"## Trend (last {rows.Count} runs)");
+            sb.AppendLine();
+            sb.AppendLine("| Date | Live | Archived | New | Retired | Deleted | Net/day | Status |");
+            sb.AppendLine("| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |");
+            foreach (var row in rows)
+                sb.AppendLine(
+                    $"| {row.TakenAt:yyyy-MM-dd} | {row.Live} | {row.Archived} | {row.CreatedSinceLast} | " +
+                    $"{row.ArchivedSinceLast} | {row.HardDeletedSinceLast} | " +
+                    $"{FormatRate(row.NetGrowthPerDay)} | {row.Status} |");
+        }
+
+        // ── Eval ──────────────────────────────────────────────────────────────
+        var summary = eval?.Summary ?? snapshot.Eval;
+        if (summary is not null)
+        {
+            sb.AppendLine();
+            sb.AppendLine("## Sample eval");
+            sb.AppendLine();
+            sb.AppendLine(
+                $"On {summary.EvaluatedAt:yyyy-MM-dd} a judge reviewed {summary.Sampled} sampled outcome(s) and " +
+                $"agreed with {summary.Sound} of them ({summary.SoundRate:P0}).");
+
+            if (summary.RateByCategory.Count > 0)
+            {
+                sb.AppendLine();
+                foreach (var (category, rate) in summary.RateByCategory.OrderBy(kv => kv.Key, StringComparer.Ordinal))
+                    sb.AppendLine($"- {category}: {rate:P0} sound");
+            }
+
+            var unsound = eval?.Verdicts.Where(v => !v.Sound).Take(5).ToList() ?? [];
+            if (unsound.Count > 0)
+            {
+                sb.AppendLine();
+                sb.AppendLine("The judge disagreed with:");
+                sb.AppendLine();
+                foreach (var verdict in unsound)
+                    sb.AppendLine($"- [{verdict.Category}] {string.Join(", ", verdict.Ids.Select(id => $"`{id}`"))} — " +
+                                  $"{verdict.Reason ?? "no reason given"}");
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>An unmeasurable rate reads as a dash, never as zero.</summary>
+    private static string FormatRate(double? rate) =>
+        rate is { } value ? value.ToString("+0.0;-0.0;0", CultureInfo.InvariantCulture) : "—";
+
+    private static string StatusLabel(string status) => status switch
+    {
+        MemoryAuditStatuses.Alert => "ALERT",
+        MemoryAuditStatuses.Warning => "Warning",
+        _ => "Healthy"
+    };
+
+    private static string FormatHistogram(IReadOnlyDictionary<string, int> histogram) =>
+        histogram.Count == 0
+            ? "none"
+            : string.Join(", ", histogram.Select(kv => $"{kv.Key}: {kv.Value}"));
+}

--- a/src/RockBot.Host/MemoryAuditReportWriter.cs
+++ b/src/RockBot.Host/MemoryAuditReportWriter.cs
@@ -32,7 +32,7 @@ internal static class MemoryAuditReportWriter
         sb.AppendLine();
         sb.AppendLine(
             $"**{StatusLabel(snapshot.Status)}** — {snapshot.Live} live entries, {snapshot.Archived} archived, " +
-            $"measured {snapshot.TakenAt:yyyy-MM-dd HH:mm} (`{snapshot.SnapshotId}`).");
+            $"measured {Timestamp(snapshot.TakenAt)} (`{snapshot.SnapshotId}`).");
         sb.AppendLine();
 
         // ── What changed ──────────────────────────────────────────────────────
@@ -47,13 +47,13 @@ internal static class MemoryAuditReportWriter
         }
         else
         {
-            sb.AppendLine($"Since {snapshot.PreviousTakenAt:yyyy-MM-dd HH:mm}:");
+            sb.AppendLine($"Since {Timestamp(snapshot.PreviousTakenAt!.Value)}:");
             sb.AppendLine();
             sb.AppendLine($"- {snapshot.CreatedSinceLast} new, {snapshot.ArchivedSinceLast} archived, " +
                           $"{snapshot.HardDeletedSinceLast} gone from disk " +
                           $"({snapshot.PurgedSinceLast} explained by the retention purge).");
             sb.AppendLine(snapshot.NetGrowthPerDay is { } rate
-                ? $"- Net growth {rate:+0.0;-0.0;0} entries/day."
+                ? $"- Net growth {FormatRate(rate)} entries/day."
                 : "- Net growth: not measurable — the gap between these two runs was too short " +
                   "to read a daily rate from (usually a restart).");
             sb.AppendLine($"- {snapshot.ReinforcedWithoutMergeSinceLast} entries genuinely re-observed " +
@@ -85,7 +85,7 @@ internal static class MemoryAuditReportWriter
             sb.AppendLine("Categories that moved most:");
             sb.AppendLine();
             foreach (var category in snapshot.TopCategoriesByGrowth)
-                sb.AppendLine($"- `{category.Category}` — {category.Net:+0;-0;0} " +
+                sb.AppendLine($"- `{category.Category}` — {Signed(category.Net)} " +
                               $"({category.Created} new, {category.Archived} archived)");
         }
 
@@ -119,7 +119,7 @@ internal static class MemoryAuditReportWriter
             sb.AppendLine("| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |");
             foreach (var row in rows)
                 sb.AppendLine(
-                    $"| {row.TakenAt:yyyy-MM-dd} | {row.Live} | {row.Archived} | {row.CreatedSinceLast} | " +
+                    $"| {Date(row.TakenAt)} | {row.Live} | {row.Archived} | {row.CreatedSinceLast} | " +
                     $"{row.ArchivedSinceLast} | {row.HardDeletedSinceLast} | " +
                     $"{FormatRate(row.NetGrowthPerDay)} | {row.Status} |");
         }
@@ -132,14 +132,14 @@ internal static class MemoryAuditReportWriter
             sb.AppendLine("## Sample eval");
             sb.AppendLine();
             sb.AppendLine(
-                $"On {summary.EvaluatedAt:yyyy-MM-dd} a judge reviewed {summary.Sampled} sampled outcome(s) and " +
-                $"agreed with {summary.Sound} of them ({summary.SoundRate:P0}).");
+                $"On {Date(summary.EvaluatedAt)} a judge reviewed {summary.Sampled} sampled outcome(s) and " +
+                $"agreed with {summary.Sound} of them ({Percent(summary.SoundRate)}).");
 
             if (summary.RateByCategory.Count > 0)
             {
                 sb.AppendLine();
                 foreach (var (category, rate) in summary.RateByCategory.OrderBy(kv => kv.Key, StringComparer.Ordinal))
-                    sb.AppendLine($"- {category}: {rate:P0} sound");
+                    sb.AppendLine($"- {category}: {Percent(rate)} sound");
             }
 
             var unsound = eval?.Verdicts.Where(v => !v.Sound).Take(5).ToList() ?? [];
@@ -156,6 +156,29 @@ internal static class MemoryAuditReportWriter
 
         return sb.ToString();
     }
+
+    /// <summary>
+    /// A percentage built by hand rather than with the "P0" specifier.
+    /// </summary>
+    /// <remarks>
+    /// Under the invariant culture the agent container actually runs with, ICU renders "P0" as
+    /// <c>75 %</c> — with a space — while a developer machine on en-US renders <c>75%</c>. The
+    /// report is a generated document; its bytes must not depend on the host's locale.
+    /// </remarks>
+    private static string Percent(double fraction) =>
+        (fraction * 100).ToString("F0", CultureInfo.InvariantCulture) + "%";
+
+    /// <summary>A signed count, with the ASCII sign rather than a locale's own.</summary>
+    private static string Signed(int value) =>
+        value.ToString("+0;-0;0", CultureInfo.InvariantCulture);
+
+    /// <summary>A date on the Gregorian calendar regardless of the host's default.</summary>
+    private static string Date(DateTimeOffset value) =>
+        value.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+
+    /// <summary>A date and time on the Gregorian calendar regardless of the host's default.</summary>
+    private static string Timestamp(DateTimeOffset value) =>
+        value.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture);
 
     /// <summary>An unmeasurable rate reads as a dash, never as zero.</summary>
     private static string FormatRate(double? rate) =>

--- a/src/RockBot.Host/MemoryAuditService.cs
+++ b/src/RockBot.Host/MemoryAuditService.cs
@@ -468,8 +468,12 @@ internal sealed class MemoryAuditService : IHostedService, IDisposable, IPrunabl
                 }).SaveAsync(StatePath, token);
 
             _logger.LogInformation(
-                "memory audit eval — {Sampled} sample(s) judged, {Sound} sound ({Rate:P0})",
-                result.Summary.Sampled, result.Summary.Sound, result.Summary.SoundRate);
+                "memory audit eval — {Sampled} sample(s) judged, {Sound} sound ({Rate})",
+                result.Summary.Sampled,
+                result.Summary.Sound,
+                // Pre-formatted: a logger renders "P0" with the ambient culture too, and this
+                // line is meant to be parsed by a dashboard.
+                (result.Summary.SoundRate * 100).ToString("F0", System.Globalization.CultureInfo.InvariantCulture) + "%");
 
             return result;
         }
@@ -637,7 +641,7 @@ internal sealed class MemoryAuditService : IHostedService, IDisposable, IPrunabl
 
         var reason = lostOutsidePurge
             ? $"{snapshot.HardDeletedOutsidePurge} entry(s) were hard-deleted outside the retention purge"
-            : $"live entries dropped more than {_options.MaxLossPercentBetweenSnapshots:F0}% since the previous snapshot";
+            : $"live entries dropped more than {_options.MaxLossPercentBetweenSnapshots.ToString("F0", System.Globalization.CultureInfo.InvariantCulture)}% since the previous snapshot";
 
         try
         {

--- a/src/RockBot.Host/MemoryAuditService.cs
+++ b/src/RockBot.Host/MemoryAuditService.cs
@@ -1,0 +1,884 @@
+using System.Text.Json;
+using Cronos;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using RockBot.Messaging;
+using RockBot.UserProxy;
+
+namespace RockBot.Host;
+
+/// <summary>
+/// Measures the long-term memory store on its own schedule and reports what it finds.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Read-only by construction: it walks the memory files itself rather than holding
+/// <see cref="ILongTermMemory"/> for anything but the optional duplicate-cluster probe, and its
+/// own files live in a separate directory. The one thing it can write outside that directory is
+/// the consolidation pause marker, and only when explicitly opted in.
+/// </para>
+/// <para>
+/// It exists because the store's health has never been observable from inside the agent. Loki
+/// keeps about a week, the dream-pass ledger records only last-run timestamps, and every
+/// incident so far was found by a human pulling the PVC. A daily measurement into a file with
+/// its own long retention turns "did we lose memories in August?" from forensics into a
+/// question with an answer on disk.
+/// </para>
+/// </remarks>
+internal sealed class MemoryAuditService : IHostedService, IDisposable, IPrunableLog
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
+    };
+
+    private static readonly JsonSerializerOptions IndentedJsonOptions = new(JsonOptions)
+    {
+        WriteIndented = true
+    };
+
+    private readonly ILongTermMemory _memory;
+    private readonly IAgentWorkSerializer _workSerializer;
+    private readonly AgentClock _clock;
+    private readonly MemoryAuditOptions _options;
+    private readonly DreamOptions _dreamOptions;
+    private readonly MemoryOptions _memoryOptions;
+    private readonly AgentProfileOptions _profileOptions;
+    private readonly ILogger<MemoryAuditService> _logger;
+    private readonly ILlmClient? _llmClient;
+    private readonly IMessagePublisher? _publisher;
+    private readonly AgentIdentity? _agent;
+
+    private readonly CancellationTokenSource _stopping = new();
+    private readonly object _runLock = new();
+    private Task _runTask = Task.CompletedTask;
+
+    private Timer? _timer;
+    private DateTimeOffset _processStartedAt;
+    private CronExpression? _auditCron;
+    private CronExpression? _evalCron;
+    private CronExpression? _digestCron;
+
+    public MemoryAuditService(
+        ILongTermMemory memory,
+        IAgentWorkSerializer workSerializer,
+        AgentClock clock,
+        IOptions<MemoryAuditOptions> options,
+        IOptions<DreamOptions> dreamOptions,
+        IOptions<MemoryOptions> memoryOptions,
+        IOptions<AgentProfileOptions> profileOptions,
+        ILogger<MemoryAuditService> logger,
+        ILlmClient? llmClient = null,
+        IMessagePublisher? publisher = null,
+        AgentIdentity? agent = null)
+    {
+        _memory = memory;
+        _workSerializer = workSerializer;
+        _clock = clock;
+        _options = options.Value;
+        _dreamOptions = dreamOptions.Value;
+        _memoryOptions = memoryOptions.Value;
+        _profileOptions = profileOptions.Value;
+        _logger = logger;
+        _llmClient = llmClient;
+        _publisher = publisher;
+        _agent = agent;
+    }
+
+    /// <summary>Directory holding the audit's own files.</summary>
+    internal string AuditRoot => ResolveUnderProfile(_options.BasePath);
+
+    /// <summary>The memory store's root, resolved exactly as <see cref="FileMemoryStore"/> resolves it.</summary>
+    internal string MemoryRoot =>
+        FileMemoryStore.ResolvePath(_memoryOptions.BasePath, _profileOptions.BasePath);
+
+    private string SnapshotsPath => Path.Combine(AuditRoot, MemoryAuditFiles.SnapshotsFile);
+    private string StatePath => Path.Combine(AuditRoot, MemoryAuditFiles.StateFile);
+    private string LatestReportPath => Path.Combine(AuditRoot, MemoryAuditFiles.LatestReport);
+    private string EvalLatestPath => Path.Combine(AuditRoot, MemoryAuditFiles.EvalLatest);
+    private string PausedPath => Path.Combine(AuditRoot, MemoryAuditFiles.ConsolidationPausedFile);
+
+    // ── Lifecycle ─────────────────────────────────────────────────────────────
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (!_options.Enabled)
+        {
+            _logger.LogInformation("MemoryAuditService: disabled; skipping timer setup");
+            return Task.CompletedTask;
+        }
+
+        try
+        {
+            _auditCron = ParseCron(_options.CronSchedule);
+            _evalCron = _options.EvalEnabled ? ParseCron(_options.EvalCronSchedule) : null;
+            _digestCron = string.IsNullOrWhiteSpace(_options.DigestCronSchedule)
+                ? null
+                : ParseCron(_options.DigestCronSchedule!);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "MemoryAuditService: invalid cron expression; the memory audit is disabled");
+            return Task.CompletedTask;
+        }
+
+        // Held in memory and folded into the state at audit time rather than written here.
+        // Writing a state file at start-up would make the very first audit compare the corpus
+        // against an empty one and report every existing entry as newly created.
+        _processStartedAt = _clock.Now;
+
+        _timer = new Timer(
+            _ =>
+            {
+                lock (_runLock)
+                    _runTask = OnTimerTickAsync();
+            },
+            null,
+            _options.InitialDelay,
+            Timeout.InfiniteTimeSpan);
+
+        _logger.LogInformation(
+            "MemoryAuditService: scheduled — first run in {InitialDelay}, then on cron '{Cron}' " +
+            "(eval '{EvalCron}'), reading {MemoryRoot}, writing {AuditRoot}",
+            _options.InitialDelay, _options.CronSchedule,
+            _evalCron is null ? "disabled" : _options.EvalCronSchedule,
+            MemoryRoot, AuditRoot);
+
+        return Task.CompletedTask;
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            _timer?.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+        }
+        catch (ObjectDisposedException)
+        {
+            // Already torn down.
+        }
+
+        _stopping.Cancel();
+
+        Task run;
+        lock (_runLock)
+            run = _runTask;
+
+        if (run.IsCompleted) return;
+
+        try
+        {
+            await run.WaitAsync(cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogWarning("MemoryAuditService: run did not finish within the shutdown timeout");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "MemoryAuditService: run faulted during shutdown");
+        }
+    }
+
+    public void Dispose()
+    {
+        _timer?.Dispose();
+
+        Task run;
+        lock (_runLock)
+            run = _runTask;
+
+        if (run.IsCompleted)
+            _stopping.Dispose();
+    }
+
+    // ── Scheduling ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Next moment either the audit or the eval is due. A single timer serves both so the
+    /// service holds one callback rather than racing two against the same work slot.
+    /// </summary>
+    internal static DateTimeOffset? ComputeNextDue(
+        DateTimeOffset now,
+        TimeZoneInfo zone,
+        CronExpression audit,
+        CronExpression? eval)
+    {
+        var nextAudit = audit.GetNextOccurrence(now, zone);
+        var nextEval = eval?.GetNextOccurrence(now, zone);
+
+        if (nextAudit is null) return nextEval;
+        if (nextEval is null) return nextAudit;
+        return nextAudit <= nextEval ? nextAudit : nextEval;
+    }
+
+    private async Task OnTimerTickAsync()
+    {
+        try
+        {
+            var now = _clock.Now;
+
+            // The eval reads content and costs LLM calls; the audit is model-free. Both are due
+            // on the same tick whenever their cron slots coincide, and the audit runs first so
+            // the eval's numbers land in a snapshot that already exists.
+            var evalDue = _evalCron is not null && IsDue(_evalCron, now);
+            var auditDue = _auditCron is not null && IsDue(_auditCron, now);
+
+            // A tick that matches neither (the very first one, armed from InitialDelay) still
+            // runs the audit — a fresh pod should produce a baseline without waiting for 04:00.
+            if (auditDue || !evalDue)
+                await RunAuditAsync(_stopping.Token);
+
+            if (evalDue)
+                await RunEvalAsync(_stopping.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogInformation("MemoryAuditService: run cancelled");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "MemoryAuditService: timer tick failed");
+        }
+        finally
+        {
+            ArmNextTimer();
+        }
+    }
+
+    /// <summary>
+    /// Whether <paramref name="cron"/> has an occurrence within a minute of now. The timer is
+    /// armed on the occurrence itself, so a small tolerance absorbs scheduling jitter without
+    /// letting a late tick fire the wrong pass.
+    /// </summary>
+    private bool IsDue(CronExpression cron, DateTimeOffset now)
+    {
+        var occurrence = cron.GetNextOccurrence(now.AddMinutes(-1), _clock.Zone, inclusive: true);
+        return occurrence is not null && occurrence.Value <= now.AddMinutes(1);
+    }
+
+    private void ArmNextTimer()
+    {
+        if (_auditCron is null || _stopping.IsCancellationRequested) return;
+
+        var next = ComputeNextDue(_clock.Now, _clock.Zone, _auditCron, _evalCron);
+        if (next is null)
+        {
+            _logger.LogWarning(
+                "MemoryAuditService: cron '{Cron}' has no future occurrences; the audit has stopped",
+                _options.CronSchedule);
+            return;
+        }
+
+        var delay = next.Value - _clock.Now;
+        if (delay < TimeSpan.Zero) delay = TimeSpan.Zero;
+
+        try
+        {
+            _timer?.Change(delay, Timeout.InfiniteTimeSpan);
+        }
+        catch (ObjectDisposedException)
+        {
+            return;
+        }
+
+        _logger.LogInformation("MemoryAuditService: next run at {Next} (in {Delay:g})", next.Value, delay);
+    }
+
+    // ── Audit run ─────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Walks the store, computes a snapshot, writes the trend row and the report, and surfaces
+    /// anything that needs attention. Returns the snapshot, or null when the slot was busy.
+    /// </summary>
+    internal async Task<MemoryAuditSnapshot?> RunAuditAsync(CancellationToken ct)
+    {
+        // The audit reads every memory file. Taking the scheduled slot keeps that off the same
+        // moment as a dream cycle rewriting them, and lets a user message preempt it.
+        IScheduledTaskSlot? slot;
+        try
+        {
+            slot = await _workSerializer.TryAcquireForScheduledAsync(ct);
+        }
+        catch (Exception ex) when (ex is ObjectDisposedException or OperationCanceledException)
+        {
+            return null;
+        }
+
+        if (slot is null)
+        {
+            _logger.LogInformation("MemoryAuditService: agent busy, deferring this run to the next slot");
+            return null;
+        }
+
+        try
+        {
+            var token = slot.Token;
+            Directory.CreateDirectory(AuditRoot);
+
+            var now = _clock.Now;
+            var snapshotId = Guid.NewGuid().ToString("N")[..12];
+
+            var walk = await MemoryStoreWalker.WalkAsync(MemoryRoot, _logger, token);
+            var previous = await MemoryAuditState.LoadAsync(StatePath, _logger, token);
+
+            var (snapshot, state) = MemoryAuditAnalyzer.Analyze(
+                walk,
+                previous,
+                await ReadPassLedgerAsync(),
+                ProcessStartsIncludingThisOne(previous),
+                await ProbeEmbeddingClustersAsync(token),
+                ReadVocabularyStoplistSize(),
+                await ReadEvalSummaryAsync(token),
+                _dreamOptions,
+                _options,
+                now,
+                snapshotId,
+                token);
+
+            await AppendSnapshotAsync(snapshot, token);
+            await state.SaveAsync(StatePath, token);
+
+            var trend = await ReadTrendAsync(TimeSpan.FromDays(60), token);
+            var report = MemoryAuditReportWriter.Render(snapshot, trend);
+
+            await AtomicFile.WriteAllTextAsync(LatestReportPath, report, token);
+            await AtomicFile.WriteAllTextAsync(
+                Path.Combine(AuditRoot, $"report-{now:yyyy-MM-dd}.md"), report, token);
+
+            await CopyReportToSharedAsync(report, now, token);
+
+            // One structured line per run. This is what makes the audit visible in Loki without
+            // anyone opening a file, and it carries the numbers a dashboard would chart.
+            _logger.LogInformation(
+                "memory audit — status {Status}, live {Live}, archived {Archived}, created {Created}, " +
+                "archived-since {ArchivedSince}, hard-deleted {HardDeleted} ({OutsidePurge} outside purge), " +
+                "net {NetPerDay}/day, near-dup pairs {NearDupPairs}, max chain depth {ChainDepth}, " +
+                "rejected sources {Rejected}, restarts {Restarts}, invariant failures {Violations}",
+                snapshot.Status, snapshot.Live, snapshot.Archived, snapshot.CreatedSinceLast,
+                snapshot.ArchivedSinceLast, snapshot.HardDeletedSinceLast, snapshot.HardDeletedOutsidePurge,
+                FormatRateForLog(snapshot.NetGrowthPerDay), snapshot.NearDupPairs, snapshot.MaxChainDepth,
+                snapshot.RejectedMergeSourcesSinceLast, snapshot.RestartsSinceLast,
+                snapshot.Invariants.Count);
+
+            await MaybePauseConsolidationAsync(snapshot, now, token);
+            await SurfaceAsync(snapshot, report, state, now, token);
+
+            return snapshot;
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogInformation("MemoryAuditService: audit preempted by other agent work");
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "MemoryAuditService: audit run failed");
+            return null;
+        }
+        finally
+        {
+            await slot.DisposeAsync();
+        }
+    }
+
+    /// <summary>
+    /// The growth rate as the structured log line should carry it. A window too short to measure
+    /// a rate over reads as "n/a" — the raw null renders as "(null)", which a dashboard parsing
+    /// this line would have to special-case anyway.
+    /// </summary>
+    private static string FormatRateForLog(double? rate) =>
+        rate is { } value ? value.ToString("+0.0;-0.0;0", System.Globalization.CultureInfo.InvariantCulture) : "n/a";
+
+    // ── Eval run ──────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Samples recent memory-management decisions and asks a model whether they were right.
+    /// Skipped entirely when the corpus has not moved since the last eval.
+    /// </summary>
+    internal async Task<MemoryAuditEvalResult?> RunEvalAsync(CancellationToken ct)
+    {
+        if (!_options.EvalEnabled || _llmClient is null) return null;
+
+        IScheduledTaskSlot? slot;
+        try
+        {
+            slot = await _workSerializer.TryAcquireForScheduledAsync(ct);
+        }
+        catch (Exception ex) when (ex is ObjectDisposedException or OperationCanceledException)
+        {
+            return null;
+        }
+
+        if (slot is null)
+        {
+            _logger.LogInformation("MemoryAuditService: agent busy, deferring the sample eval");
+            return null;
+        }
+
+        try
+        {
+            var token = slot.Token;
+            Directory.CreateDirectory(AuditRoot);
+
+            var now = _clock.Now;
+            var walk = await MemoryStoreWalker.WalkAsync(MemoryRoot, _logger, token);
+            var state = await MemoryAuditState.LoadAsync(StatePath, _logger, token);
+
+            var fingerprint = MemoryAuditEvaluator.StoreFingerprint(walk.Entries);
+            if (string.Equals(fingerprint, state?.LastEvalFingerprint, StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogInformation(
+                    "MemoryAuditService: sample eval skipped — the corpus has not changed since {LastEval:u}",
+                    state!.LastEvalAt);
+                return null;
+            }
+
+            var live = walk.Entries.Where(e => e.ArchivedAt is null).ToList();
+            var pairs = ShingleSimilarity.FindNearDuplicatePairs(
+                live, _options.ShingleSize, _options.NearDuplicateThreshold, token);
+
+            var samples = MemoryAuditEvaluator.SelectSamples(walk.Entries, pairs, _options, now);
+            if (samples.Count == 0)
+            {
+                _logger.LogInformation("MemoryAuditService: sample eval found nothing to judge");
+                return null;
+            }
+
+            var evaluator = new MemoryAuditEvaluator(_llmClient, _logger);
+            var result = await evaluator.EvaluateAsync(
+                samples, LoadEvalDirective(), _options.EvalModelTier, fingerprint, token);
+
+            if (result is null) return null;
+
+            var json = JsonSerializer.Serialize(result, IndentedJsonOptions);
+            await AtomicFile.WriteAllTextAsync(EvalLatestPath, json, token);
+            await AtomicFile.WriteAllTextAsync(
+                Path.Combine(AuditRoot, $"eval-{now:yyyy-MM-dd}.json"), json, token);
+
+            if (state is not null)
+                await (state with
+                {
+                    LastEvalAt = now,
+                    LastEvalFingerprint = fingerprint
+                }).SaveAsync(StatePath, token);
+
+            _logger.LogInformation(
+                "memory audit eval — {Sampled} sample(s) judged, {Sound} sound ({Rate:P0})",
+                result.Summary.Sampled, result.Summary.Sound, result.Summary.SoundRate);
+
+            return result;
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogInformation("MemoryAuditService: sample eval preempted by other agent work");
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "MemoryAuditService: sample eval failed");
+            return null;
+        }
+        finally
+        {
+            await slot.DisposeAsync();
+        }
+    }
+
+    // ── Retention ─────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Prunes the audit's own files. Dated reports and evals follow the dream cycle's shared
+    /// file-age policy; <c>snapshots.jsonl</c> does not — it honours
+    /// <see cref="MemoryAuditOptions.SnapshotRetention"/> instead, because the trend is the one
+    /// thing here that must outlive log retention by a wide margin.
+    /// </summary>
+    public async Task<int> PruneAsync(LogRetentionPolicy policy, CancellationToken ct = default)
+    {
+        if (!Directory.Exists(AuditRoot)) return 0;
+
+        var removed = 0;
+
+        removed += await JsonlLogRetention.PruneAgedFilesAsync(
+            AuditRoot, policy.MaxFileAge, policy.MaxFilesPerDirectory, "report-*.md", _logger, ct);
+
+        removed += await JsonlLogRetention.PruneAgedFilesAsync(
+            AuditRoot, policy.MaxFileAge, policy.MaxFilesPerDirectory, "eval-*.json", _logger, ct);
+
+        removed += await TrimSnapshotsAsync(ct);
+
+        return removed;
+    }
+
+    private async Task<int> TrimSnapshotsAsync(CancellationToken ct)
+    {
+        if (_options.SnapshotRetention <= TimeSpan.Zero || !File.Exists(SnapshotsPath))
+            return 0;
+
+        try
+        {
+            var cutoff = _clock.Now - _options.SnapshotRetention;
+            var lines = await File.ReadAllLinesAsync(SnapshotsPath, ct);
+
+            // A line that will not parse is kept, not dropped. It is either a row written by a
+            // future schema or a genuinely corrupt one, and neither is something a retention
+            // sweep should quietly destroy.
+            var kept = lines
+                .Where(line => !string.IsNullOrWhiteSpace(line))
+                .Where(line => TryParseSnapshot(line) is not { } snapshot || snapshot.TakenAt >= cutoff)
+                .ToList();
+
+            var dropped = lines.Length - kept.Count;
+            if (dropped <= 0) return 0;
+
+            await AtomicFile.WriteAllTextAsync(
+                SnapshotsPath, string.Join(Environment.NewLine, kept) + Environment.NewLine, ct);
+
+            _logger.LogInformation(
+                "MemoryAuditService: trimmed {Dropped} snapshot row(s) older than {Retention:g}",
+                dropped, _options.SnapshotRetention);
+            return dropped;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "MemoryAuditService: failed to trim {Path}", SnapshotsPath);
+            return 0;
+        }
+    }
+
+    // ── Surfacing ─────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Pushes an unsolicited message when the run needs attention, and the full report on the
+    /// digest schedule. A healthy run with no digest due says nothing at all.
+    /// </summary>
+    private async Task SurfaceAsync(
+        MemoryAuditSnapshot snapshot,
+        string report,
+        MemoryAuditState state,
+        DateTimeOffset now,
+        CancellationToken ct)
+    {
+        if (_publisher is null || _agent is null) return;
+
+        var digestDue = _digestCron is not null
+            && _digestCron.GetNextOccurrence(
+                   state.LastDigestAt ?? now - TimeSpan.FromDays(365), _clock.Zone) is { } due
+            && due <= now;
+
+        var needsAttention = _options.AlertOnAttention
+            && !string.Equals(snapshot.Status, MemoryAuditStatuses.Healthy, StringComparison.Ordinal);
+
+        if (!needsAttention && !digestDue) return;
+
+        var content = digestDue
+            ? report
+            : $"**Memory audit — {snapshot.Status}**\n\n" +
+              $"{snapshot.Live} live entries, {snapshot.Archived} archived.\n\n" +
+              string.Join("\n", snapshot.Invariants.Select(v => $"- **`{v.Name}`** — {v.Message}")) +
+              $"\n\nFull report: `{LatestReportPath}` (or call `get_memory_audit`).";
+
+        try
+        {
+            var reply = new AgentReply
+            {
+                Content = content,
+                SessionId = WellKnownSessions.ScheduledSystem,
+                AgentName = _agent.Name,
+                IsFinal = true,
+                Origin = new ReplyOrigin(
+                    Channel: "memory-audit",
+                    PromptSummary: $"memory audit — {snapshot.Status}",
+                    StartedAt: now,
+                    SessionId: WellKnownSessions.ScheduledSystem)
+            };
+
+            await _publisher.PublishAsync(
+                $"{UserProxyTopics.UserResponse}.{_agent.Name}",
+                reply.ToEnvelope<AgentReply>(source: _agent.Name),
+                ct);
+
+            if (digestDue)
+                await (state with { LastDigestAt = now }).SaveAsync(StatePath, ct);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Failing to announce a finding must not lose the finding — it is already on disk.
+            _logger.LogWarning(ex, "MemoryAuditService: could not publish the audit message");
+        }
+    }
+
+    /// <summary>
+    /// Writes the marker that stops dream consolidation, when the run found catastrophic loss
+    /// and the operator opted in. Never cleared here — resuming is a deliberate act.
+    /// </summary>
+    private async Task MaybePauseConsolidationAsync(
+        MemoryAuditSnapshot snapshot, DateTimeOffset now, CancellationToken ct)
+    {
+        if (!_options.PauseConsolidationOnAlert) return;
+        if (File.Exists(PausedPath)) return;
+
+        var lostOutsidePurge = snapshot.HardDeletedOutsidePurge > _options.MaxHardDeletesOutsidePurge;
+        var lostTooMuch = snapshot.Invariants.Any(v => v.Name == MemoryAuditInvariants.LossPercentThreshold);
+
+        if (!lostOutsidePurge && !lostTooMuch) return;
+
+        var reason = lostOutsidePurge
+            ? $"{snapshot.HardDeletedOutsidePurge} entry(s) were hard-deleted outside the retention purge"
+            : $"live entries dropped more than {_options.MaxLossPercentBetweenSnapshots:F0}% since the previous snapshot";
+
+        try
+        {
+            await AtomicFile.WriteAllTextAsync(
+                PausedPath,
+                JsonSerializer.Serialize(
+                    new { reason, snapshotId = snapshot.SnapshotId, pausedAt = now },
+                    IndentedJsonOptions),
+                ct);
+
+            _logger.LogError(
+                "MemoryAuditService: PAUSED memory consolidation — {Reason}. Delete {Path} " +
+                "(or call resume_memory_consolidation) once the cause is understood.",
+                reason, PausedPath);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "MemoryAuditService: failed to write the consolidation pause marker");
+        }
+    }
+
+    private async Task CopyReportToSharedAsync(string report, DateTimeOffset now, CancellationToken ct)
+    {
+        if (!_options.CopyReportToShared || string.IsNullOrWhiteSpace(_options.SharedReportDirectory))
+            return;
+
+        try
+        {
+            // Re-created every run: the shared volume's cleanup CronJob deletes everything under
+            // exports/ past its TTL, directories included.
+            Directory.CreateDirectory(_options.SharedReportDirectory);
+
+            var path = Path.Combine(_options.SharedReportDirectory, $"memory-audit-{now:yyyy-MM-dd}.md");
+            await File.WriteAllTextAsync(path, report, ct);
+
+            // World-writable, like every other file the agent puts on the shared volume: the
+            // script pods and MCP servers that read it run as different uids.
+            try
+            {
+                File.SetUnixFileMode(path,
+                    UnixFileMode.UserRead | UnixFileMode.UserWrite |
+                    UnixFileMode.GroupRead | UnixFileMode.GroupWrite |
+                    UnixFileMode.OtherRead | UnixFileMode.OtherWrite);
+            }
+            catch
+            {
+                // Non-Unix platforms — best-effort only.
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "MemoryAuditService: could not copy the report to {Directory}",
+                _options.SharedReportDirectory);
+        }
+    }
+
+    // ── File helpers ──────────────────────────────────────────────────────────
+
+    private async Task AppendSnapshotAsync(MemoryAuditSnapshot snapshot, CancellationToken ct)
+    {
+        var line = JsonSerializer.Serialize(snapshot, JsonOptions);
+        await File.AppendAllTextAsync(SnapshotsPath, line + Environment.NewLine, ct);
+    }
+
+    /// <summary>Snapshot rows written within <paramref name="window"/>, oldest first.</summary>
+    internal async Task<IReadOnlyList<MemoryAuditSnapshot>> ReadTrendAsync(
+        TimeSpan window, CancellationToken ct = default)
+    {
+        if (!File.Exists(SnapshotsPath)) return [];
+
+        var cutoff = _clock.Now - window;
+        var snapshots = new List<MemoryAuditSnapshot>();
+
+        try
+        {
+            foreach (var line in await File.ReadAllLinesAsync(SnapshotsPath, ct))
+            {
+                if (string.IsNullOrWhiteSpace(line)) continue;
+                var snapshot = TryParseSnapshot(line);
+                if (snapshot is not null && snapshot.TakenAt >= cutoff)
+                    snapshots.Add(snapshot);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "MemoryAuditService: could not read {Path}", SnapshotsPath);
+        }
+
+        return snapshots;
+    }
+
+    private static MemoryAuditSnapshot? TryParseSnapshot(string line)
+    {
+        try
+        {
+            return JsonSerializer.Deserialize<MemoryAuditSnapshot>(line, JsonOptions);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private async Task<MemoryAuditEvalSummary?> ReadEvalSummaryAsync(CancellationToken ct)
+    {
+        if (!File.Exists(EvalLatestPath)) return null;
+
+        try
+        {
+            var json = await File.ReadAllTextAsync(EvalLatestPath, ct);
+            return JsonSerializer.Deserialize<MemoryAuditEvalResult>(json, JsonOptions)?.Summary;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+
+    private async Task<IReadOnlyDictionary<string, DateTimeOffset>> ReadPassLedgerAsync()
+    {
+        var path = ResolveUnderProfile(DreamPassLedger.FileName);
+        var ledger = await DreamPassLedger.LoadAsync(path, _logger);
+        return ledger.Records.ToDictionary(
+            kv => kv.Key, kv => kv.Value.LastRunAt, StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Asks the store for its own duplicate clusters, when it can answer. Returns null rather
+    /// than zero when it cannot — "the detector found nothing" and "there is no detector" are
+    /// different findings.
+    /// </summary>
+    private async Task<int?> ProbeEmbeddingClustersAsync(CancellationToken ct)
+    {
+        if (_memory is not IMemoryDuplicateCandidates candidates) return null;
+
+        try
+        {
+            var clusters = await candidates.FindNearDuplicateClustersAsync(
+                _dreamOptions.ConsolidationSimilarityThreshold,
+                _dreamOptions.ConsolidationMaxClusterSize,
+                ct);
+            return clusters.Count;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "MemoryAuditService: the store's duplicate probe failed");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Size of the merge-coverage common-word list. Read straight from the file rather than
+    /// through the loader so the audit does not emit the loader's per-load Information line.
+    /// </summary>
+    private int ReadVocabularyStoplistSize()
+    {
+        var path = ResolveUnderProfile(_dreamOptions.MergeCoverageVocabularyPath);
+        if (!File.Exists(path)) return 0;
+
+        try
+        {
+            using var document = JsonDocument.Parse(File.ReadAllText(path));
+            return document.RootElement.TryGetProperty("extraCommonWords", out var words)
+                   && words.ValueKind == JsonValueKind.Array
+                ? words.GetArrayLength()
+                : 0;
+        }
+        catch (Exception)
+        {
+            return 0;
+        }
+    }
+
+    private string LoadEvalDirective()
+    {
+        var path = ResolveUnderProfile(_options.EvalDirectivePath);
+
+        try
+        {
+            if (File.Exists(path))
+            {
+                var text = File.ReadAllText(path);
+                if (!string.IsNullOrWhiteSpace(text)) return text;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "MemoryAuditService: could not read {Path}; using the built-in eval directive", path);
+        }
+
+        return MemoryAuditEvaluator.BuiltInDirective;
+    }
+
+    /// <summary>
+    /// Carried-over start times plus this process's own, deduplicated. A pod that runs for a
+    /// week appends the same timestamp on every audit, so it is counted once — on the first run
+    /// after the restart, which is the run where it explains anything.
+    /// </summary>
+    private IReadOnlyList<DateTimeOffset> ProcessStartsIncludingThisOne(MemoryAuditState? previous)
+    {
+        var starts = new SortedSet<DateTimeOffset>(previous?.ProcessStarts ?? []);
+        if (_processStartedAt != default)
+            starts.Add(_processStartedAt);
+        return [.. starts];
+    }
+
+    private string ResolveUnderProfile(string path)
+    {
+        if (Path.IsPathRooted(path)) return path;
+
+        var baseDir = Path.IsPathRooted(_profileOptions.BasePath)
+            ? _profileOptions.BasePath
+            : Path.Combine(AppContext.BaseDirectory, _profileOptions.BasePath);
+
+        return Path.Combine(baseDir, path);
+    }
+
+    private static CronExpression ParseCron(string expression) =>
+        CronExpression.Parse(
+            expression,
+            expression.Split(' ').Length == 6 ? CronFormat.IncludeSeconds : CronFormat.Standard);
+}

--- a/src/RockBot.Host/MemoryAuditSkillProvider.cs
+++ b/src/RockBot.Host/MemoryAuditSkillProvider.cs
@@ -1,0 +1,113 @@
+using System.Text;
+using RockBot.Tools;
+
+namespace RockBot.Host;
+
+/// <summary>
+/// Publishes the memory-audit guide through <c>get_tool_guide</c>, so the agent can explain how
+/// memory health is measured — not just report the latest numbers.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Complements, rather than replaces, the per-finding explanations the audit tools already
+/// return. Those cover "what does this warning mean?", which must be answerable with no extra
+/// call because the model may not think to make one. This covers the questions a glossary entry
+/// would be the wrong size for: how the measurement works, why memories are retired rather than
+/// deleted, what a merge chain is, what the audit deliberately does not claim.
+/// </para>
+/// <para>
+/// Generated from <see cref="MemoryAuditGlossary"/> rather than restating it, so a new invariant
+/// cannot appear in the tool output and be missing from the guide.
+/// </para>
+/// </remarks>
+internal sealed class MemoryAuditSkillProvider : IToolSkillProvider
+{
+    public string Name => "memory-audit";
+
+    public string Summary =>
+        "How the agent's memory health is measured, and what every memory-audit warning means in plain language";
+
+    public string GetDocument()
+    {
+        var sb = new StringBuilder();
+
+        sb.AppendLine("# Memory audit");
+        sb.AppendLine();
+        sb.AppendLine(
+            "A scheduled, read-only health check of your own long-term memory. It runs on its own " +
+            "(daily by default), looks at the memory files directly, compares them against the " +
+            "previous run, and writes a report. It never changes, merges, or deletes a memory.");
+        sb.AppendLine();
+        sb.AppendLine("## Which tool to use");
+        sb.AppendLine();
+        sb.AppendLine("- `get_memory_audit` — the latest check: counts, what changed, and any findings.");
+        sb.AppendLine("  Each finding already includes a plain-language explanation, so you can answer");
+        sb.AppendLine("  \"what does this warning mean?\" straight from the result.");
+        sb.AppendLine("- `get_memory_audit_trend(days)` — one row per run, for \"is this getting worse?\"");
+        sb.AppendLine("- `get_memory_audit_eval` — a weekly review of whether recent memory decisions");
+        sb.AppendLine("  were *good*, not just what they were.");
+        sb.AppendLine("- `resume_memory_consolidation` — only when the user explicitly asks to resume.");
+        sb.AppendLine();
+        sb.AppendLine("Use these for questions about memory *health*. Use `recall` for questions about");
+        sb.AppendLine("what you actually remember — recall searches contents, the audit measures the store.");
+        sb.AppendLine();
+
+        sb.AppendLine("## How memory changes over time");
+        sb.AppendLine();
+        sb.AppendLine(
+            "Memories are never deleted outright when they are tidied. Two memories that say the " +
+            "same thing get **combined** into one, and the originals are **retired** — hidden from " +
+            "search but kept on disk for months, with a note saying which memory replaced them. " +
+            "Only after that window are they finally removed.");
+        sb.AppendLine();
+        sb.AppendLine(
+            "That is why the audit reports \"live\" and \"archived\" counts separately, and why a " +
+            "memory going missing *without* being retired first is the most serious thing it looks " +
+            "for. It also means a bad merge normally costs recall, not the fact itself — the " +
+            "original is still there to compare against.");
+        sb.AppendLine();
+        sb.AppendLine(
+            "A combined memory can later be combined again. A **merge chain** counts how many " +
+            "generations deep that has gone: a chain of 3 means the memory is a summary of a " +
+            "summary of a summary. Nothing is necessarily lost, but each generation is another " +
+            "rewrite in which a detail can drift.");
+        sb.AppendLine();
+
+        sb.AppendLine("## What the findings mean");
+        sb.AppendLine();
+        sb.AppendLine("Findings are either **alert** (something was destroyed) or **warning** (a limit was");
+        sb.AppendLine("crossed, nothing lost). A run with no findings says nothing at all — silence is the");
+        sb.AppendLine("healthy state, so no recent warning is itself good news.");
+        sb.AppendLine();
+
+        foreach (var (name, definition) in MemoryAuditGlossary.All
+                     .OrderBy(kv => kv.Value.Severity == MemoryAuditStatuses.Alert ? 0 : 1)
+                     .ThenBy(kv => kv.Key, StringComparer.Ordinal))
+        {
+            sb.AppendLine($"### `{name}` — {definition.Title}");
+            sb.AppendLine($"*{definition.Severity}*");
+            sb.AppendLine();
+            sb.AppendLine(definition.WhatItMeans);
+            sb.AppendLine();
+            sb.AppendLine($"**What to do:** {definition.WhatToDo}");
+            sb.AppendLine();
+        }
+
+        sb.AppendLine("## What the audit does not claim");
+        sb.AppendLine();
+        sb.AppendLine(
+            "- It counts and checks structure; it cannot tell whether a memory is *true*.");
+        sb.AppendLine(
+            "- Its duplicate count is a lexical measure. Two memories that say the same thing in " +
+            "completely different words are not counted as duplicates by it.");
+        sb.AppendLine(
+            "- A rate like \"entries per day\" needs a long enough gap between runs. After a " +
+            "restart puts two runs close together, the rate is reported as not measurable rather " +
+            "than as a misleading number.");
+        sb.AppendLine(
+            "- Memories deleted outright take their category with them, so a category that vanished " +
+            "entirely shows up in the deletion count rather than in the per-category table.");
+
+        return sb.ToString();
+    }
+}

--- a/src/RockBot.Host/MemoryAuditState.cs
+++ b/src/RockBot.Host/MemoryAuditState.cs
@@ -1,0 +1,119 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace RockBot.Host;
+
+/// <summary>
+/// One entry as the previous audit run saw it. Deliberately not the whole
+/// <see cref="MemoryEntry"/>: the state file is written every run and must not become a second
+/// copy of the corpus.
+/// </summary>
+/// <param name="Id">Entry id.</param>
+/// <param name="Archived">Whether it was in the archive tier.</param>
+/// <param name="ArchivedAt">When it was archived, for purge-eligibility arithmetic.</param>
+/// <param name="ReinforcementCount">Reinforcement count, so real re-observation can be told from merge arithmetic.</param>
+/// <param name="MergedFromCount">How many sources its provenance named.</param>
+/// <param name="Category">Category path, or null.</param>
+internal sealed record MemoryAuditEntryRow(
+    string Id,
+    bool Archived,
+    DateTimeOffset? ArchivedAt,
+    int ReinforcementCount,
+    int MergedFromCount,
+    string? Category);
+
+/// <summary>
+/// Private carry-over between audit runs: what the store looked like last time, plus the
+/// bookkeeping the deltas need.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Kept separate from <c>snapshots.jsonl</c> on purpose. The trend file is a public, appendable,
+/// human-and-sidecar-readable record whose rows never change; this is a rewritten working file
+/// whose shape is free to move. Losing it costs one run's deltas, never the trend.
+/// </para>
+/// <para>
+/// Recording every id is what makes a hard delete detectable at all. Counting entries would say
+/// the corpus shrank; recording ids says <em>which</em> facts vanished, which is the difference
+/// between a number and a finding.
+/// </para>
+/// </remarks>
+internal sealed record MemoryAuditState
+{
+    /// <summary>When the run that wrote this state happened.</summary>
+    public DateTimeOffset TakenAt { get; init; }
+
+    /// <summary>Id of the snapshot this state accompanies.</summary>
+    public string SnapshotId { get; init; } = string.Empty;
+
+    /// <summary>Every entry on disk at that moment.</summary>
+    public IReadOnlyList<MemoryAuditEntryRow> Entries { get; init; } = [];
+
+    /// <summary>
+    /// Rejected merge cluster hash → how many consecutive runs it has been rejected on. A
+    /// cluster that stops being rejected drops out rather than decaying, so the count always
+    /// means "consecutive".
+    /// </summary>
+    public IReadOnlyDictionary<string, int> RejectedClusterRuns { get; init; } =
+        new Dictionary<string, int>();
+
+    /// <summary>Entry ids stamped as rejected merge sources at the last run.</summary>
+    public IReadOnlyList<string> RejectedSourceIds { get; init; } = [];
+
+    /// <summary>
+    /// Host start times, trimmed to the last 60 days. Nothing else in the agent records
+    /// restarts, and a restart storm is the documented cause of a consolidation storm.
+    /// </summary>
+    public IReadOnlyList<DateTimeOffset> ProcessStarts { get; init; } = [];
+
+    /// <summary>When the sample eval last ran.</summary>
+    public DateTimeOffset? LastEvalAt { get; init; }
+
+    /// <summary>Corpus fingerprint the eval last ran against, so an unchanged store skips it.</summary>
+    public string? LastEvalFingerprint { get; init; }
+
+    /// <summary>When the full-report digest was last pushed.</summary>
+    public DateTimeOffset? LastDigestAt { get; init; }
+
+    /// <summary>How long process-start timestamps are kept.</summary>
+    internal static readonly TimeSpan ProcessStartRetention = TimeSpan.FromDays(60);
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = true
+    };
+
+    /// <summary>
+    /// Reads the state at <paramref name="path"/>. A missing, unreadable or malformed file
+    /// yields <c>null</c> — the audit then reports a first run with no deltas, which is honest,
+    /// rather than failing or inventing comparisons.
+    /// </summary>
+    internal static async Task<MemoryAuditState?> LoadAsync(
+        string path, ILogger logger, CancellationToken ct = default)
+    {
+        if (!File.Exists(path)) return null;
+
+        try
+        {
+            var json = await File.ReadAllTextAsync(path, ct).ConfigureAwait(false);
+            return JsonSerializer.Deserialize<MemoryAuditState>(json, JsonOptions);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "Memory audit: could not read {Path}; this run reports as a first run", path);
+            return null;
+        }
+    }
+
+    /// <summary>Writes the state atomically, so an interrupted run cannot truncate it.</summary>
+    internal async Task SaveAsync(string path, CancellationToken ct = default) =>
+        await AtomicFile.WriteAllTextAsync(path, JsonSerializer.Serialize(this, JsonOptions), ct)
+            .ConfigureAwait(false);
+}

--- a/src/RockBot.Host/MemoryStoreWalker.cs
+++ b/src/RockBot.Host/MemoryStoreWalker.cs
@@ -1,0 +1,119 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace RockBot.Host;
+
+/// <summary>
+/// Reads the memory store's files directly off disk, without going through
+/// <see cref="FileMemoryStore"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The audit must not instantiate a second store. <c>FileMemoryStore</c>'s index load prunes
+/// empty category directories as a side effect, so an auditor that used one would delete the
+/// very thing it is trying to count — and would then report zero every time.
+/// </para>
+/// <para>
+/// Reading the files also means archived entries, malformed files and orphaned directories are
+/// all visible. A store hides archived entries from search by design; the audit's entire job is
+/// to look at what the store is hiding.
+/// </para>
+/// </remarks>
+internal static class MemoryStoreWalker
+{
+    /// <summary>
+    /// Matches <see cref="FileMemoryStore"/>'s serializer settings so an entry round-trips
+    /// identically whichever reader opens it.
+    /// </summary>
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true
+    };
+
+    /// <summary>What one walk of the memory root found.</summary>
+    /// <param name="Entries">Every entry that deserialized, live and archived alike.</param>
+    /// <param name="EmptyCategoryDirs">Directories under the root holding no entry files at all.</param>
+    /// <param name="MalformedFiles">Files that would not deserialize and were skipped.</param>
+    internal sealed record WalkResult(
+        IReadOnlyList<MemoryEntry> Entries,
+        int EmptyCategoryDirs,
+        int MalformedFiles);
+
+    /// <summary>
+    /// Walks <paramref name="memoryRoot"/> recursively. A missing root is not an error — a fresh
+    /// agent has no store yet, and the audit should report an empty corpus rather than fail.
+    /// </summary>
+    internal static async Task<WalkResult> WalkAsync(
+        string memoryRoot,
+        ILogger logger,
+        CancellationToken ct = default)
+    {
+        var entries = new List<MemoryEntry>();
+        var malformed = 0;
+
+        if (!Directory.Exists(memoryRoot))
+            return new WalkResult(entries, 0, 0);
+
+        foreach (var file in Directory.EnumerateFiles(memoryRoot, "*.json", SearchOption.AllDirectories))
+        {
+            ct.ThrowIfCancellationRequested();
+
+            // The embedding cache owns its own folder of .bin files and one .json manifest;
+            // neither is a memory entry.
+            if (IsUnderEmbeddings(memoryRoot, file))
+                continue;
+
+            try
+            {
+                var json = await File.ReadAllTextAsync(file, ct).ConfigureAwait(false);
+                var entry = JsonSerializer.Deserialize<MemoryEntry>(json, JsonOptions);
+                if (entry is not null && !string.IsNullOrWhiteSpace(entry.Id))
+                    entries.Add(entry);
+                else
+                    malformed++;
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                malformed++;
+                logger.LogWarning(ex, "Memory audit: skipping unreadable memory file {Path}", file);
+            }
+        }
+
+        return new WalkResult(entries, CountEmptyCategoryDirs(memoryRoot), malformed);
+    }
+
+    /// <summary>
+    /// Counts directories below the root that contain no entry file anywhere beneath them.
+    /// A parent whose only content is a populated child is doing its job and is not counted.
+    /// </summary>
+    private static int CountEmptyCategoryDirs(string memoryRoot)
+    {
+        var count = 0;
+
+        foreach (var dir in Directory.EnumerateDirectories(memoryRoot, "*", SearchOption.AllDirectories))
+        {
+            if (string.Equals(Path.GetFileName(dir), EmbeddingCache.DirectoryName, StringComparison.Ordinal))
+                continue;
+            if (IsUnderEmbeddings(memoryRoot, dir))
+                continue;
+
+            if (!Directory.EnumerateFiles(dir, "*.json", SearchOption.AllDirectories).Any())
+                count++;
+        }
+
+        return count;
+    }
+
+    private static bool IsUnderEmbeddings(string root, string path)
+    {
+        var relative = Path.GetRelativePath(root, path);
+        return relative
+            .Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+            .Any(segment => string.Equals(segment, EmbeddingCache.DirectoryName, StringComparison.Ordinal));
+    }
+}

--- a/src/RockBot.Host/ShingleSimilarity.cs
+++ b/src/RockBot.Host/ShingleSimilarity.cs
@@ -1,0 +1,133 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Lexical near-duplicate detection over word n-gram shingles, scored by Jaccard overlap.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Deliberately independent of embeddings. The audit has to produce the same number on a
+/// BM25-only deployment as on a hybrid one, and it must not agree with the mechanism it is
+/// measuring: if consolidation and the audit both asked the vector index "are these the same?",
+/// a broken index would read as a clean corpus.
+/// </para>
+/// <para>
+/// Shingles rather than bag-of-words because word order carries the distinction that matters
+/// here — "the deploy failed because the tag was stale" and "the tag failed because the deploy
+/// was stale" share every token and say different things.
+/// </para>
+/// </remarks>
+internal static class ShingleSimilarity
+{
+    /// <summary>A pair of live entries whose texts overlap above the threshold.</summary>
+    internal sealed record Pair(string IdA, string IdB, double Score);
+
+    /// <summary>
+    /// Returns every pair of <paramref name="entries"/> scoring at or above
+    /// <paramref name="threshold"/>. Entries with fewer than <paramref name="shingleSize"/>
+    /// words produce no shingles and are skipped — a four-word fact has no n-grams to compare,
+    /// and padding it would make every short entry look like every other one.
+    /// </summary>
+    internal static IReadOnlyList<Pair> FindNearDuplicatePairs(
+        IReadOnlyList<MemoryEntry> entries,
+        int shingleSize,
+        double threshold,
+        CancellationToken ct = default)
+    {
+        if (shingleSize < 1) shingleSize = 1;
+
+        var ids = new List<string>(entries.Count);
+        var sets = new List<HashSet<int>>(entries.Count);
+
+        foreach (var entry in entries)
+        {
+            var set = Shingles(entry.Content, shingleSize);
+            if (set.Count == 0) continue;
+            ids.Add(entry.Id);
+            sets.Add(set);
+        }
+
+        var pairs = new List<Pair>();
+
+        for (var i = 0; i < sets.Count; i++)
+        {
+            ct.ThrowIfCancellationRequested();
+            for (var j = i + 1; j < sets.Count; j++)
+            {
+                var score = Jaccard(sets[i], sets[j]);
+                if (score >= threshold)
+                    pairs.Add(new Pair(ids[i], ids[j], score));
+            }
+        }
+
+        return pairs;
+    }
+
+    /// <summary>
+    /// Hashes of the word n-grams in <paramref name="text"/>. Hashes rather than strings because
+    /// a thousand-entry corpus produces on the order of 10^5 shingles and only equality is ever
+    /// asked of them.
+    /// </summary>
+    internal static HashSet<int> Shingles(string? text, int shingleSize)
+    {
+        var set = new HashSet<int>();
+        if (string.IsNullOrWhiteSpace(text)) return set;
+
+        var words = Normalize(text);
+        if (words.Length < shingleSize) return set;
+
+        for (var i = 0; i + shingleSize <= words.Length; i++)
+        {
+            var hash = new HashCode();
+            for (var k = 0; k < shingleSize; k++)
+                hash.Add(words[i + k], StringComparer.Ordinal);
+            set.Add(hash.ToHashCode());
+        }
+
+        return set;
+    }
+
+    /// <summary>Intersection over union. Two empty sets score zero, not one.</summary>
+    internal static double Jaccard(HashSet<int> a, HashSet<int> b)
+    {
+        if (a.Count == 0 || b.Count == 0) return 0;
+
+        // Iterate the smaller set; the larger one answers Contains in O(1) either way.
+        var (small, large) = a.Count <= b.Count ? (a, b) : (b, a);
+
+        var intersection = 0;
+        foreach (var shingle in small)
+            if (large.Contains(shingle))
+                intersection++;
+
+        var union = a.Count + b.Count - intersection;
+        return union == 0 ? 0 : (double)intersection / union;
+    }
+
+    /// <summary>
+    /// Lowercased word tokens, punctuation dropped. Case and punctuation are exactly the
+    /// differences a rephrasing introduces without changing what the entry says.
+    /// </summary>
+    private static string[] Normalize(string text)
+    {
+        var buffer = new List<string>();
+        var current = new System.Text.StringBuilder();
+
+        foreach (var ch in text)
+        {
+            if (char.IsLetterOrDigit(ch))
+            {
+                current.Append(char.ToLowerInvariant(ch));
+            }
+            else if (current.Length > 0)
+            {
+                buffer.Add(current.ToString());
+                current.Clear();
+            }
+        }
+
+        if (current.Length > 0)
+            buffer.Add(current.ToString());
+
+        return [.. buffer];
+    }
+}

--- a/src/RockBot.UserProxy.Blazor/Dockerfile
+++ b/src/RockBot.UserProxy.Blazor/Dockerfile
@@ -17,6 +17,7 @@ RUN printf '<configuration><fallbackPackageFolders><clear /></fallbackPackageFol
 COPY RockBot.slnx Directory.Build.props ./
 COPY src/RockBot.UserProxy.Blazor/RockBot.UserProxy.Blazor.csproj src/RockBot.UserProxy.Blazor/
 COPY src/RockBot.UserProxy/RockBot.UserProxy.csproj src/RockBot.UserProxy/
+COPY src/RockBot.Host.Abstractions/RockBot.Host.Abstractions.csproj src/RockBot.Host.Abstractions/
 COPY src/RockBot.UserProxy.Abstractions/RockBot.UserProxy.Abstractions.csproj src/RockBot.UserProxy.Abstractions/
 COPY src/RockBot.UserProxy.WorkIqAuth/RockBot.UserProxy.WorkIqAuth.csproj src/RockBot.UserProxy.WorkIqAuth/
 COPY src/RockBot.Messaging.RabbitMQ/RockBot.Messaging.RabbitMQ.csproj src/RockBot.Messaging.RabbitMQ/

--- a/src/RockBot.UserProxy.Blazor/RockBot.UserProxy.Blazor.csproj
+++ b/src/RockBot.UserProxy.Blazor/RockBot.UserProxy.Blazor.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\RockBot.Host.Abstractions\RockBot.Host.Abstractions.csproj" />
     <ProjectReference Include="..\RockBot.UserProxy.Abstractions\RockBot.UserProxy.Abstractions.csproj" />
     <ProjectReference Include="..\RockBot.UserProxy\RockBot.UserProxy.csproj" />
     <ProjectReference Include="..\RockBot.UserProxy.WorkIqAuth\RockBot.UserProxy.WorkIqAuth.csproj" />

--- a/src/RockBot.UserProxy.Blazor/Services/BlazorUserFrontend.cs
+++ b/src/RockBot.UserProxy.Blazor/Services/BlazorUserFrontend.cs
@@ -1,3 +1,5 @@
+using RockBot.Host;
+
 namespace RockBot.UserProxy.Blazor.Services;
 
 /// <summary>
@@ -67,7 +69,7 @@ public sealed class BlazorUserFrontend(ChatStateService chatState) : IUserFronte
 
     private MessageCategory CategorizeReply(AgentReply reply)
     {
-        if (reply.SessionId == "scheduled-system")
+        if (reply.SessionId == WellKnownSessions.ScheduledSystem)
             return MessageCategory.ScheduledSystem;
 
         if (reply.SessionId == "scheduled")

--- a/tests/RockBot.Host.Tests/DreamConsolidationAuditHooksTests.cs
+++ b/tests/RockBot.Host.Tests/DreamConsolidationAuditHooksTests.cs
@@ -1,0 +1,218 @@
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace RockBot.Host.Tests;
+
+/// <summary>
+/// The two hooks the memory audit needs from the dream cycle: a rejection stamp it can read
+/// back, and a pause marker it can write.
+/// </summary>
+/// <remarks>
+/// Both are deliberately small. A rejection previously existed only as a log line, so "the same
+/// cluster is refused every cycle forever" was invisible past Loki's retention; and a circuit
+/// breaker that the auditor could not trip would leave the destructive pass running through
+/// exactly the incident it detected.
+/// </remarks>
+[TestClass]
+public class DreamConsolidationAuditHooksTests
+{
+    private const string SourceA = "Rockford Duane Lhotka uses timezone America/Chicago.";
+    private const string SourceB = "Accounts span Microsoft and Marimer LLC.";
+    private const string LossyMerge = "The user has accounts across providers and a default timezone.";
+
+    private string _profileRoot = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _profileRoot = Path.Combine(Path.GetTempPath(), "rockbot-dream-audit-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_profileRoot);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_profileRoot))
+            Directory.Delete(_profileRoot, recursive: true);
+    }
+
+    [TestMethod]
+    public async Task ARejectedMergeStampsItsSourcesWithTheClusterAndTime()
+    {
+        var memory = new ArchivingStore();
+        await memory.SaveAsync(Entry("a", SourceA));
+        await memory.SaveAsync(Entry("b", SourceB));
+
+        // Repair disabled so the rejection is terminal and the stamp is the only outcome.
+        var service = CreateService(
+            memory, new DreamOptions { Enabled = false, MergeRepairEnabled = false },
+            new ScriptedLlmClient(ConsolidationResponse(LossyMerge)));
+
+        await service.RunMemoryConsolidationPassAsync(CancellationToken.None);
+
+        var a = memory.Snapshot().Single(e => e.Id == "a");
+        var b = memory.Snapshot().Single(e => e.Id == "b");
+
+        Assert.IsNotNull(a.Metadata);
+        Assert.IsTrue(a.Metadata.ContainsKey(DreamService.ConsolidationRejectedClusterKey));
+        Assert.IsTrue(a.Metadata.ContainsKey(DreamService.ConsolidationRejectedAtKey));
+
+        Assert.AreEqual(
+            a.Metadata[DreamService.ConsolidationRejectedClusterKey],
+            b.Metadata![DreamService.ConsolidationRejectedClusterKey],
+            "Both sources belong to the same rejected cluster.");
+
+        Assert.IsTrue(DateTimeOffset.TryParse(
+            a.Metadata[DreamService.ConsolidationRejectedAtKey], out _));
+
+        Assert.AreEqual(0, memory.Archived.Count, "A rejection still leaves the sources alone.");
+    }
+
+    [TestMethod]
+    public void TheClusterHashIsOrderIndependent()
+    {
+        Assert.AreEqual(
+            DreamService.RejectedClusterHash(["b", "a", "c"]),
+            DreamService.RejectedClusterHash(["a", "c", "b"]));
+
+        Assert.AreNotEqual(
+            DreamService.RejectedClusterHash(["a", "b"]),
+            DreamService.RejectedClusterHash(["a", "b", "c"]));
+    }
+
+    [TestMethod]
+    public async Task ConsolidationSkipsEntirelyWhileThePauseMarkerExists()
+    {
+        var memory = new ArchivingStore();
+        await memory.SaveAsync(Entry("a", SourceA));
+        await memory.SaveAsync(Entry("b", SourceB));
+
+        var auditDir = Path.Combine(_profileRoot, MemoryAuditFiles.DefaultBasePath);
+        Directory.CreateDirectory(auditDir);
+        await File.WriteAllTextAsync(
+            Path.Combine(auditDir, MemoryAuditFiles.ConsolidationPausedFile),
+            """{"reason":"test","snapshotId":"s","pausedAt":"2026-09-04T04:00:00+00:00"}""");
+
+        var llm = new ScriptedLlmClient(ConsolidationResponse("anything"));
+        var service = CreateService(memory, new DreamOptions { Enabled = false }, llm);
+
+        var (deleted, saved) = await service.RunMemoryConsolidationPassAsync(CancellationToken.None);
+
+        Assert.AreEqual(0, deleted);
+        Assert.AreEqual(0, saved);
+        Assert.AreEqual(0, llm.Calls.Count, "A paused pass must not even spend an LLM call.");
+    }
+
+    [TestMethod]
+    public async Task ConsolidationRunsNormallyWhenNoMarkerExists()
+    {
+        var memory = new ArchivingStore();
+        await memory.SaveAsync(Entry("a", SourceA));
+        await memory.SaveAsync(Entry("b", SourceB));
+
+        var llm = new ScriptedLlmClient(ConsolidationResponse(LossyMerge));
+        var service = CreateService(memory, new DreamOptions { Enabled = false }, llm);
+
+        await service.RunMemoryConsolidationPassAsync(CancellationToken.None);
+
+        Assert.IsTrue(llm.Calls.Count > 0);
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static string ConsolidationResponse(string mergedContent) =>
+        $$"""
+        {
+          "toDelete": ["a", "b"],
+          "toSave": [{ "content": "{{mergedContent}}", "sourceIds": ["a", "b"] }]
+        }
+        """;
+
+    private static MemoryEntry Entry(string id, string content) =>
+        new(id, content, null, [], DateTimeOffset.UtcNow.AddDays(-10));
+
+    private DreamService CreateService(ILongTermMemory memory, DreamOptions options, ILlmClient llm)
+    {
+        var profile = Options.Create(new AgentProfileOptions { BasePath = _profileRoot });
+
+        return new DreamService(
+            memory,
+            [],
+            llm,
+            new AgentWorkSerializer(),
+            new StubActivityMonitor(),
+            new AgentClock(new ConfigurationBuilder().Build(), profile, NullLogger<AgentClock>.Instance),
+            Options.Create(options),
+            profile,
+            NullLogger<DreamService>.Instance);
+    }
+
+    private sealed class ScriptedLlmClient(params string[] responses) : ILlmClient
+    {
+        public List<string> Calls { get; } = [];
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options, CancellationToken cancellationToken)
+        {
+            Calls.Add(string.Join("\n", messages.Select(m => m.Text)));
+            var index = Math.Min(Calls.Count - 1, responses.Length - 1);
+            return Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, responses[index])));
+        }
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages, ModelTier tier, ChatOptions? options,
+            CancellationToken cancellationToken) =>
+            GetResponseAsync(messages, options, cancellationToken);
+    }
+
+    private sealed class StubActivityMonitor : IUserActivityMonitor
+    {
+        public void RecordActivity() { }
+        public bool IsUserActive(TimeSpan idleThreshold) => false;
+    }
+
+    private sealed class ArchivingStore : ILongTermMemory
+    {
+        private readonly Dictionary<string, MemoryEntry> _entries = new(StringComparer.OrdinalIgnoreCase);
+
+        public List<(string Id, string Reason)> Archived { get; } = [];
+
+        public IReadOnlyList<MemoryEntry> Snapshot() => [.. _entries.Values];
+
+        public Task SaveAsync(MemoryEntry entry, CancellationToken cancellationToken = default)
+        {
+            _entries[entry.Id] = entry;
+            return Task.CompletedTask;
+        }
+
+        public Task<MemoryEntry?> GetAsync(string id, CancellationToken cancellationToken = default) =>
+            Task.FromResult(_entries.GetValueOrDefault(id));
+
+        public Task<IReadOnlyList<MemoryEntry>> SearchAsync(
+            MemorySearchCriteria criteria, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<MemoryEntry>>(
+                [.. _entries.Values.Where(e => e.ArchivedAt is null)]);
+
+        public Task DeleteAsync(string id, CancellationToken cancellationToken = default)
+        {
+            _entries.Remove(id);
+            return Task.CompletedTask;
+        }
+
+        public Task ArchiveAsync(string id, string reason, CancellationToken cancellationToken = default)
+        {
+            Archived.Add((id, reason));
+            if (_entries.TryGetValue(id, out var entry))
+                _entries[id] = entry with { ArchivedAt = DateTimeOffset.UtcNow, ArchiveReason = reason };
+            return Task.CompletedTask;
+        }
+
+        public Task<IReadOnlyList<string>> ListTagsAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<string>>([]);
+
+        public Task<IReadOnlyList<string>> ListCategoriesAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<string>>([]);
+    }
+}

--- a/tests/RockBot.Host.Tests/MemoryAuditAnalyzerTests.cs
+++ b/tests/RockBot.Host.Tests/MemoryAuditAnalyzerTests.cs
@@ -1,0 +1,394 @@
+namespace RockBot.Host.Tests;
+
+/// <summary>
+/// The analyzer is pure, which is the point: the August 2026 data-loss incident can be replayed
+/// here as plain data and the audit must report it, with nothing mocked and no clock involved.
+/// </summary>
+[TestClass]
+public class MemoryAuditAnalyzerTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 9, 4, 4, 0, 0, TimeSpan.Zero);
+    private static readonly DateTimeOffset Yesterday = Now.AddDays(-1);
+
+    [TestMethod]
+    public void FirstRun_HasNoDeltasAndNoPreviousTimestamp()
+    {
+        var entries = new List<MemoryEntry> { Entry("a"), Entry("b"), Entry("c") };
+
+        var (snapshot, state) = Analyze(entries, previous: null);
+
+        Assert.IsNull(snapshot.PreviousTakenAt);
+        Assert.AreEqual(3, snapshot.Live);
+        Assert.AreEqual(0, snapshot.CreatedSinceLast, "A first run has nothing to compare against.");
+        Assert.AreEqual(0, snapshot.HardDeletedSinceLast);
+        Assert.IsNull(snapshot.NetGrowthPerDay,
+            "With no previous run there is no window, so the rate is unmeasurable rather than zero.");
+        Assert.AreEqual(MemoryAuditStatuses.Healthy, snapshot.Status);
+        Assert.AreEqual(3, state.Entries.Count);
+    }
+
+    [TestMethod]
+    public void TheAugustScenario_ReportsSeventyFourHardDeletesAndAlerts()
+    {
+        // 148 live entries, then 109 — 74 ids gone outright, 35 new ones created in the same
+        // window. None of the 74 was archived first, so the retention purge cannot explain any
+        // of them.
+        var survivors = Enumerable.Range(0, 74).Select(i => Entry($"kept{i}")).ToList();
+        var fresh = Enumerable.Range(0, 35).Select(i => Entry($"new{i}")).ToList();
+        var now = survivors.Concat(fresh).ToList();
+
+        var previousRows = survivors
+            .Select(e => Row(e.Id))
+            .Concat(Enumerable.Range(0, 74).Select(i => Row($"lost{i}")))
+            .ToList();
+
+        var (snapshot, _) = Analyze(now, PreviousState(previousRows));
+
+        Assert.AreEqual(109, snapshot.Live);
+        Assert.AreEqual(74, snapshot.HardDeletedSinceLast);
+        Assert.AreEqual(0, snapshot.PurgedSinceLast, "Nothing was archived, so nothing was purge-eligible.");
+        Assert.AreEqual(74, snapshot.HardDeletedOutsidePurge);
+        Assert.AreEqual(35, snapshot.CreatedSinceLast);
+        Assert.AreEqual(MemoryAuditStatuses.Alert, snapshot.Status);
+
+        Assert.IsTrue(
+            snapshot.Invariants.Any(v => v.Name == MemoryAuditInvariants.NoHardDeleteOutsidePurge),
+            "A hard delete the purge cannot account for is the finding the audit exists for.");
+        Assert.IsTrue(
+            snapshot.Invariants.Any(v => v.Name == MemoryAuditInvariants.LossPercentThreshold),
+            "148 → 109 is a 26% drop, well past the 10% default.");
+    }
+
+    [TestMethod]
+    public void PurgeEligibleIdsAreCountedAsPurged_NotAsHardDeletes()
+    {
+        var previous = PreviousState(
+        [
+            // Archived 100 days ago; the 90-day retention window has closed.
+            Row("aged", archived: true, archivedAt: Now.AddDays(-100)),
+            // Archived yesterday; far too recent for the purge to have taken it.
+            Row("recent", archived: true, archivedAt: Now.AddDays(-1))
+        ]);
+
+        var (snapshot, _) = Analyze([], previous);
+
+        Assert.AreEqual(2, snapshot.HardDeletedSinceLast);
+        Assert.AreEqual(1, snapshot.PurgedSinceLast);
+        Assert.AreEqual(1, snapshot.HardDeletedOutsidePurge);
+    }
+
+    [TestMethod]
+    public void ChainDepthHistogramCountsEachLiveDepth()
+    {
+        // raw → merge1 (depth 1) → merge2 (depth 2) → merge3 (depth 3)
+        var raw = Archived("raw", "merged into merge1");
+        var merge1 = Archived("merge1", "merged into merge2") with { Metadata = MergedFrom("raw") };
+        var merge2 = Archived("merge2", "merged into merge3") with { Metadata = MergedFrom("merge1") };
+        var merge3 = Entry("merge3") with { Metadata = MergedFrom("merge2") };
+
+        // An independent single-hop merge, so depth 1 has a live representative too.
+        var srcA = Archived("srcA", "merged into flat");
+        var flat = Entry("flat") with { Metadata = MergedFrom("srcA") };
+
+        var (snapshot, _) = Analyze([raw, merge1, merge2, merge3, srcA, flat], previous: null);
+
+        Assert.AreEqual(3, snapshot.MaxChainDepth);
+        Assert.AreEqual(1, snapshot.MergeChainDepth["1"], "flat");
+        Assert.AreEqual(1, snapshot.MergeChainDepth["3"], "merge3");
+        Assert.IsFalse(snapshot.MergeChainDepth.ContainsKey("2"),
+            "merge2 is archived, so it does not appear in the live histogram.");
+
+        Assert.IsTrue(snapshot.Invariants.Any(v => v.Name == MemoryAuditInvariants.ChainDepthThreshold));
+    }
+
+    [TestMethod]
+    public void TheChainDepthHistogramReadsInDepthOrder()
+    {
+        // A live corpus produced "1: 78, 3: 13, 4: 3, 2: 21, 7: 3, 5: 1, 6: 1, 8: 1" — every
+        // count correct and unreadable. Insertion order is what both the report and the raw
+        // snapshot row show.
+        var entries = new List<MemoryEntry>();
+        string? previousId = null;
+
+        // One chain d0→d4, all live, giving depths 0 through 4.
+        for (var depth = 0; depth <= 4; depth++)
+        {
+            var id = $"d{depth}";
+            entries.Add(previousId is null ? Entry(id) : Entry(id) with { Metadata = MergedFrom(previousId) });
+            previousId = id;
+        }
+
+        // Two more live merges appended so the deeper depth is *encountered first*. Without an
+        // explicit sort the dictionary would then enumerate 1, 2, 3, 4, 3, 1 in insertion order.
+        entries.Add(Entry("x3") with { Metadata = MergedFrom("d2") });
+        entries.Add(Entry("x1") with { Metadata = MergedFrom("d0") });
+
+        var (snapshot, _) = Analyze(entries, previous: null);
+
+        var keys = snapshot.MergeChainDepth.Keys.Select(int.Parse).ToList();
+        CollectionAssert.AreEqual(
+            keys.OrderBy(k => k).ToList(), keys,
+            "The histogram must enumerate in ascending depth order.");
+    }
+
+    [TestMethod]
+    public void AMergeWhoseSourcesWerePurgedStillCountsAsDepthOne()
+    {
+        var merge = Entry("merge") with { Metadata = MergedFrom("long-gone", "also-gone") };
+
+        var (snapshot, _) = Analyze([merge], previous: null);
+
+        Assert.AreEqual(1, snapshot.MaxChainDepth);
+    }
+
+    [TestMethod]
+    public void ReinforcedWithoutMerge_CountsOnlyRealReObservation()
+    {
+        var reObserved = Entry("a") with { ReinforcementCount = 7 };
+        var merged = Entry("b") with { ReinforcementCount = 9, Metadata = MergedFrom("x", "y") };
+        var untouched = Entry("c") with { ReinforcementCount = 3 };
+
+        var previous = PreviousState(
+        [
+            Row("a", reinforcementCount: 5),
+            // Its reinforcement count rose because a merge summed its sources, not because
+            // anything was observed again.
+            Row("b", reinforcementCount: 4),
+            Row("c", reinforcementCount: 3)
+        ]);
+
+        var (snapshot, _) = Analyze([reObserved, merged, untouched], previous);
+
+        Assert.AreEqual(1, snapshot.ReinforcedWithoutMergeSinceLast);
+    }
+
+    [TestMethod]
+    public void PurgeOutlookSeparatesTheHighValueEntriesTheFloorWillKeep()
+    {
+        var options = new DreamOptions();
+
+        // 90-day retention, 7-day warning window: archived 85 days ago is due within a week.
+        var ordinary = Archived("ordinary", "ephemeral", Now.AddDays(-85));
+        var precious = Archived("precious", "ephemeral", Now.AddDays(-85))
+            with { ReinforcementCount = options.PruningProtectionReinforcementCount + 10 };
+        var notYet = Archived("notYet", "ephemeral", Now.AddDays(-10));
+
+        var (snapshot, _) = Analyze([ordinary, precious, notYet], previous: null);
+
+        Assert.AreEqual(7, snapshot.Purge.DueWithinDays);
+        Assert.AreEqual(2, snapshot.Purge.Count);
+        Assert.AreEqual(1, snapshot.Purge.HighValueCount);
+    }
+
+    [TestMethod]
+    public void TopCategoriesByGrowth_RanksByAbsoluteNetMovement()
+    {
+        var entries = new List<MemoryEntry>
+        {
+            Entry("n1", "project"), Entry("n2", "project"), Entry("n3", "project"),
+            Entry("n4", "personal"),
+            Archived("old1", "ephemeral") with { Category = "chores" },
+            Archived("old2", "ephemeral") with { Category = "chores" }
+        };
+
+        var previous = PreviousState(
+        [
+            Row("old1", category: "chores"),
+            Row("old2", category: "chores")
+        ]);
+
+        var (snapshot, _) = Analyze(entries, previous);
+
+        var project = snapshot.TopCategoriesByGrowth.Single(c => c.Category == "project");
+        Assert.AreEqual(3, project.Created);
+        Assert.AreEqual(3, project.Net);
+
+        var chores = snapshot.TopCategoriesByGrowth.Single(c => c.Category == "chores");
+        Assert.AreEqual(2, chores.Archived);
+        Assert.AreEqual(-2, chores.Net);
+
+        Assert.AreEqual("project", snapshot.TopCategoriesByGrowth[0].Category);
+    }
+
+    [TestMethod]
+    public void NetGrowthPerDay_IsPerDayNotPerRun()
+    {
+        var entries = Enumerable.Range(0, 20).Select(i => Entry($"e{i}")).ToList();
+        var previous = PreviousState(
+            [.. Enumerable.Range(0, 10).Select(i => Row($"e{i}"))],
+            takenAt: Now.AddDays(-2));
+
+        var (snapshot, _) = Analyze(entries, previous);
+
+        Assert.AreEqual(5.0, snapshot.NetGrowthPerDay!.Value, 1e-9, "10 new entries over 2 days.");
+    }
+
+    [TestMethod]
+    public void AWindowTooShortForARate_ReportsItAsUnmeasurableRatherThanExtrapolating()
+    {
+        // Observed live: a restart put two runs seven minutes apart, and six ordinary saves
+        // annualized to 1311 entries/day — tripping the growth threshold on every deploy.
+        var entries = Enumerable.Range(0, 16).Select(i => Entry($"e{i}")).ToList();
+        var previous = PreviousState(
+            [.. Enumerable.Range(0, 10).Select(i => Row($"e{i}"))],
+            takenAt: Now.AddMinutes(-7));
+
+        var (snapshot, _) = Analyze(entries, previous);
+
+        Assert.IsNull(snapshot.NetGrowthPerDay,
+            "A seven-minute window cannot measure a daily rate.");
+        Assert.AreEqual(6, snapshot.CreatedSinceLast,
+            "The absolute counts are still exact — only the rate is withheld.");
+        Assert.IsFalse(
+            snapshot.Invariants.Any(v => v.Name == MemoryAuditInvariants.NetGrowthThreshold),
+            "A rate that was never measured must not trip a rate threshold.");
+    }
+
+    [TestMethod]
+    public void AShortWindowStillReportsRealLoss()
+    {
+        // The short-window guard must suppress only rates, never the loss findings — those are
+        // absolute counts and are exactly what a restart-triggered run should still catch.
+        var previous = PreviousState([Row("a"), Row("b"), Row("c")], takenAt: Now.AddMinutes(-7));
+
+        var (snapshot, _) = Analyze([Entry("a")], previous);
+
+        Assert.IsNull(snapshot.NetGrowthPerDay);
+        Assert.AreEqual(2, snapshot.HardDeletedOutsidePurge);
+        Assert.AreEqual(MemoryAuditStatuses.Alert, snapshot.Status);
+    }
+
+    [TestMethod]
+    public void RestartsAreCountedFromTheStartTimesSinceTheLastRun()
+    {
+        var previous = PreviousState([Row("a")]);
+
+        var (snapshot, state) = Analyze(
+            [Entry("a")],
+            previous,
+            processStarts: [Now.AddDays(-3), Now.AddHours(-6), Now.AddHours(-2)]);
+
+        Assert.AreEqual(2, snapshot.RestartsSinceLast, "Only the two starts after yesterday count.");
+        Assert.AreEqual(3, state.ProcessStarts.Count, "All three are still inside the 60-day window.");
+    }
+
+    [TestMethod]
+    public void RepeatedRejectionsAreTrackedAcrossRunsAndReported()
+    {
+        var rejected = Entry("a") with
+        {
+            Metadata = new Dictionary<string, string>
+            {
+                [DreamService.ConsolidationRejectedClusterKey] = "CLUSTER1",
+                [DreamService.ConsolidationRejectedAtKey] = Now.AddHours(-2).ToString("O")
+            }
+        };
+
+        // The same cluster has already been rejected on the two previous runs.
+        var previous = PreviousState([Row("a")]) with
+        {
+            RejectedClusterRuns = new Dictionary<string, int> { ["CLUSTER1"] = 2 }
+        };
+
+        var (snapshot, state) = Analyze([rejected], previous);
+
+        Assert.AreEqual(1, snapshot.RejectedMergeSourcesSinceLast);
+        Assert.AreEqual(3, state.RejectedClusterRuns["CLUSTER1"]);
+        Assert.AreEqual(1, snapshot.RejectedMergeClustersRepeated);
+        Assert.IsTrue(snapshot.Invariants.Any(v => v.Name == MemoryAuditInvariants.NoRepeatedRejection));
+    }
+
+    [TestMethod]
+    public void AClusterThatStopsBeingRejectedDropsOutRatherThanDecaying()
+    {
+        var previous = PreviousState([Row("a")]) with
+        {
+            RejectedClusterRuns = new Dictionary<string, int> { ["CLUSTER1"] = 2 }
+        };
+
+        var (snapshot, state) = Analyze([Entry("a")], previous);
+
+        Assert.AreEqual(0, state.RejectedClusterRuns.Count);
+        Assert.AreEqual(0, snapshot.RejectedMergeClustersRepeated);
+    }
+
+    [TestMethod]
+    public void AStaleRejectionStampFromBeforeTheLastRunIsNotCountedAgain()
+    {
+        var rejected = Entry("a") with
+        {
+            Metadata = new Dictionary<string, string>
+            {
+                [DreamService.ConsolidationRejectedClusterKey] = "CLUSTER1",
+                // Stamped before the previous audit run, which already reported it.
+                [DreamService.ConsolidationRejectedAtKey] = Now.AddDays(-5).ToString("O")
+            }
+        };
+
+        var (snapshot, _) = Analyze([rejected], PreviousState([Row("a")]));
+
+        Assert.AreEqual(0, snapshot.RejectedMergeSourcesSinceLast);
+    }
+
+    [TestMethod]
+    public void DreamPassCadenceComesFromTheLedger()
+    {
+        var ledger = new Dictionary<string, DateTimeOffset>
+        {
+            ["memory consolidation"] = Now.AddHours(-8),
+            ["skill consolidation"] = Now.AddHours(-8),
+            ["identity reflection"] = Now.AddDays(-4)  // before the previous run
+        };
+
+        var (snapshot, _) = Analyze([Entry("a")], PreviousState([Row("a")]), ledger: ledger);
+
+        Assert.AreEqual(2, snapshot.DreamPassesRunSinceLast);
+        Assert.AreEqual(Now.AddHours(-8), snapshot.ConsolidationLastRunAt);
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static (MemoryAuditSnapshot Snapshot, MemoryAuditState State) Analyze(
+        IReadOnlyList<MemoryEntry> entries,
+        MemoryAuditState? previous,
+        IReadOnlyList<DateTimeOffset>? processStarts = null,
+        IReadOnlyDictionary<string, DateTimeOffset>? ledger = null,
+        MemoryAuditOptions? options = null) =>
+        MemoryAuditAnalyzer.Analyze(
+            new MemoryStoreWalker.WalkResult(entries, EmptyCategoryDirs: 0, MalformedFiles: 0),
+            previous,
+            ledger ?? new Dictionary<string, DateTimeOffset>(),
+            processStarts ?? [],
+            embeddingDupClusters: null,
+            vocabularyStoplistSize: 0,
+            eval: null,
+            new DreamOptions(),
+            options ?? new MemoryAuditOptions(),
+            Now,
+            "snap1");
+
+    private static MemoryAuditState PreviousState(
+        IReadOnlyList<MemoryAuditEntryRow> rows, DateTimeOffset? takenAt = null) =>
+        new() { TakenAt = takenAt ?? Yesterday, SnapshotId = "snap0", Entries = rows };
+
+    private static MemoryAuditEntryRow Row(
+        string id,
+        bool archived = false,
+        DateTimeOffset? archivedAt = null,
+        int reinforcementCount = 1,
+        int mergedFromCount = 0,
+        string? category = null) =>
+        new(id, archived, archivedAt, reinforcementCount, mergedFromCount, category);
+
+    private static MemoryEntry Entry(string id, string? category = null) =>
+        new(id, $"content for {id}", category, [], Now.AddDays(-30));
+
+    private static MemoryEntry Archived(string id, string reason, DateTimeOffset? at = null) =>
+        Entry(id) with { ArchivedAt = at ?? Now.AddDays(-2), ArchiveReason = reason };
+
+    private static Dictionary<string, string> MergedFrom(params string[] ids) => new()
+    {
+        [DreamService.MergedFromKey] = string.Join(",", ids),
+        [DreamService.MergedAtKey] = Now.AddDays(-1).ToString("O")
+    };
+}

--- a/tests/RockBot.Host.Tests/MemoryAuditCultureTests.cs
+++ b/tests/RockBot.Host.Tests/MemoryAuditCultureTests.cs
@@ -1,0 +1,151 @@
+using System.Globalization;
+
+namespace RockBot.Host.Tests;
+
+/// <summary>
+/// The audit's output must be byte-identical whatever locale the host runs under.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This exists because CI caught what a developer machine could not. A percentage written with
+/// the <c>P0</c> specifier renders as <c>75%</c> under en-US and as <c>75 %</c> — with a space —
+/// under the invariant culture that a container with no locale actually runs with. The same
+/// split applies to decimal separators (<c>4.0</c> vs <c>4,0</c>) and to non-Gregorian calendars.
+/// </para>
+/// <para>
+/// It matters beyond cosmetics: these strings are stored in the JSON trend rows and read back by
+/// the introspection sidecar, so a locale change would silently alter the on-disk record.
+/// </para>
+/// </remarks>
+[TestClass]
+public class MemoryAuditCultureTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 9, 4, 4, 0, 0, TimeSpan.Zero);
+
+    /// <summary>Cultures that break each of the assumptions above.</summary>
+    private static IEnumerable<object[]> HostileCultures =>
+    [
+        [""],           // invariant — what a container with no locale gets
+        ["de-DE"],      // decimal comma, different percent spacing
+        ["fr-FR"],      // narrow no-break space as group separator
+        ["th-TH"]       // Buddhist calendar: year 2569, not 2026
+    ];
+
+    [TestMethod]
+    [DynamicData(nameof(HostileCultures))]
+    public void TheReportRendersIdenticallyUnderAnyCulture(string cultureName)
+    {
+        var reference = RenderUnder(Culture("en-US"));
+        var actual = RenderUnder(Culture(cultureName));
+
+        Assert.AreEqual(reference, actual,
+            $"The report changed shape under '{cultureName}'.");
+    }
+
+    [TestMethod]
+    public void PercentagesCarryNoSpaceBeforeTheSign()
+    {
+        // The exact failure CI reported: "P0" under the invariant culture yields "75 %".
+        var report = RenderUnder(CultureInfo.InvariantCulture);
+
+        StringAssert.Contains(report, "75% sound");
+        Assert.IsFalse(report.Contains("75 %"), "A space crept back in before the percent sign.");
+    }
+
+    [TestMethod]
+    public void DatesStayGregorianUnderANonGregorianCalendar()
+    {
+        var report = RenderUnder(Culture("th-TH"));
+
+        StringAssert.Contains(report, "2026-09-04");
+        Assert.IsFalse(report.Contains("2569"), "The Buddhist calendar leaked into the report.");
+    }
+
+    [TestMethod]
+    public void InvariantMessagesUseADotDecimalSeparator()
+    {
+        var snapshot = Snapshot() with { Live = 80, NetGrowthPerDay = 12.5 };
+
+        var violations = RunUnder(Culture("de-DE"), () =>
+            MemoryAuditInvariants.Check(
+                [], snapshot, new DreamOptions(), new MemoryAuditOptions(),
+                Now, elapsedDays: 1, previousLive: 100));
+
+        var growth = violations.Single(v => v.Name == MemoryAuditInvariants.NetGrowthThreshold);
+        StringAssert.Contains(growth.Message, "12.5");
+        Assert.IsFalse(growth.Message.Contains("12,5"), "A decimal comma reached a stored message.");
+
+        var loss = violations.Single(v => v.Name == MemoryAuditInvariants.LossPercentThreshold);
+        StringAssert.Contains(loss.Message, "20.0%");
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The named culture, or <c>Assert.Inconclusive</c> when the runtime cannot supply it.
+    /// A host in globalization-invariant mode has only one culture, so there is nothing to
+    /// compare — matching how the RabbitMQ integration tests report an absent dependency.
+    /// </summary>
+    private static CultureInfo Culture(string name)
+    {
+        if (name.Length == 0) return CultureInfo.InvariantCulture;
+
+        try
+        {
+            return CultureInfo.GetCultureInfo(name);
+        }
+        catch (CultureNotFoundException)
+        {
+            Assert.Inconclusive(
+                $"'{name}' is unavailable — the runtime is in globalization-invariant mode, " +
+                "so there is no second culture to compare against.");
+            throw;
+        }
+    }
+
+    private static string RenderUnder(CultureInfo culture) =>
+        RunUnder(culture, () =>
+        {
+            var snapshot = Snapshot();
+            var eval = new MemoryAuditEvalResult(
+                new MemoryAuditEvalSummary(
+                    Now.AddDays(-1), 8, 6, 0.75,
+                    new Dictionary<string, double> { ["merge"] = 0.75 }),
+                [new MemoryAuditEvalVerdict("merge", ["m1"], false, "Dropped a number.")],
+                "FP");
+
+            return MemoryAuditReportWriter.Render(
+                snapshot, [snapshot with { TakenAt = Now.AddDays(-1) }, snapshot], eval);
+        });
+
+    private static T RunUnder<T>(CultureInfo culture, Func<T> body)
+    {
+        var previous = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = culture;
+            return body();
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previous;
+        }
+    }
+
+    private static MemoryAuditSnapshot Snapshot() => new()
+    {
+        SnapshotId = "snap1",
+        TakenAt = Now,
+        PreviousTakenAt = Now.AddDays(-1),
+        Live = 1820,
+        Archived = 1340,
+        CreatedSinceLast = 1234,
+        ArchivedSinceLast = 8,
+        NetGrowthPerDay = 4.5,
+        MaxChainDepth = 1,
+        NearDupPairs = 6,
+        NearDupEntries = 11,
+        Purge = new MemoryAuditPurgeOutlook(7, 3, 1),
+        TopCategoriesByGrowth = [new MemoryAuditCategoryGrowth("chores", 0, 2, -2)]
+    };
+}

--- a/tests/RockBot.Host.Tests/MemoryAuditEvaluatorTests.cs
+++ b/tests/RockBot.Host.Tests/MemoryAuditEvaluatorTests.cs
@@ -1,0 +1,194 @@
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace RockBot.Host.Tests;
+
+/// <summary>
+/// Sampling and verdict parsing for the weekly judged eval. The judge itself is a stub — what
+/// matters here is that the right decisions are put in front of it and its answers come back
+/// attached to the right entry ids.
+/// </summary>
+[TestClass]
+public class MemoryAuditEvaluatorTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 9, 4, 5, 0, 0, TimeSpan.Zero);
+
+    [TestMethod]
+    public void SamplesMergesWithTheirSurvivingSources()
+    {
+        var source = Archived("src", "merged into m1", Now.AddDays(-2));
+        var merged = Entry("m1") with
+        {
+            UpdatedAt = Now.AddDays(-2),
+            Metadata = MergedFrom("src")
+        };
+
+        var samples = MemoryAuditEvaluator.SelectSamples([source, merged], [], Options(), Now);
+
+        var merge = samples.Single(s => s.Category == MemoryAuditEvaluator.MergeCategory);
+        CollectionAssert.AreEquivalent(new[] { "m1", "src" }, merge.Ids.ToArray());
+        StringAssert.Contains(merge.Text, "Sources that were merged away");
+    }
+
+    [TestMethod]
+    public void AMergeWhoseSourcesAreAllPurgedIsNotSampled()
+    {
+        // There is nothing to compare the replacement against, so there is no judgeable question.
+        var merged = Entry("m1") with { UpdatedAt = Now.AddDays(-1), Metadata = MergedFrom("gone") };
+
+        var samples = MemoryAuditEvaluator.SelectSamples([merged], [], Options(), Now);
+
+        Assert.AreEqual(0, samples.Count(s => s.Category == MemoryAuditEvaluator.MergeCategory));
+    }
+
+    [TestMethod]
+    public void MergesOlderThanTheEvalWindowAreNotSampled()
+    {
+        var source = Archived("src", "merged into m1", Now.AddDays(-90));
+        var merged = Entry("m1") with { UpdatedAt = Now.AddDays(-90), Metadata = MergedFrom("src") };
+
+        var samples = MemoryAuditEvaluator.SelectSamples([source, merged], [], Options(), Now);
+
+        Assert.AreEqual(0, samples.Count(s => s.Category == MemoryAuditEvaluator.MergeCategory));
+    }
+
+    [TestMethod]
+    public void SamplesNearDuplicatePairsHighReinforcementAndEphemeralArchives()
+    {
+        var a = Entry("a");
+        var b = Entry("b");
+        var heavy = Entry("heavy") with { ReinforcementCount = 40 };
+        var dropped = Archived("dropped", DreamService.EphemeralArchiveReason, Now.AddDays(-1));
+
+        var samples = MemoryAuditEvaluator.SelectSamples(
+            [a, b, heavy, dropped],
+            [new ShingleSimilarity.Pair("a", "b", 0.8)],
+            Options(),
+            Now);
+
+        Assert.AreEqual(1, samples.Count(s => s.Category == MemoryAuditEvaluator.NearDuplicateCategory));
+        Assert.AreEqual(1, samples.Count(s => s.Category == MemoryAuditEvaluator.HighReinforcementCategory));
+        Assert.AreEqual(1, samples.Count(s => s.Category == MemoryAuditEvaluator.EphemeralArchiveCategory));
+    }
+
+    [TestMethod]
+    public void EachFamilyIsCappedAtTheSampleSize()
+    {
+        var entries = Enumerable.Range(0, 30)
+            .Select(i => Entry($"e{i}") with { ReinforcementCount = 50 })
+            .ToList();
+
+        var samples = MemoryAuditEvaluator.SelectSamples(
+            entries, [], new MemoryAuditOptions { EvalSampleSize = 4 }, Now);
+
+        Assert.AreEqual(4, samples.Count(s => s.Category == MemoryAuditEvaluator.HighReinforcementCategory));
+    }
+
+    [TestMethod]
+    public async Task VerdictsAreParsedAndAttachedToTheRightEntries()
+    {
+        var samples = new List<MemoryAuditEvaluator.Sample>
+        {
+            new(MemoryAuditEvaluator.MergeCategory, ["m1", "s1"], "first"),
+            new(MemoryAuditEvaluator.MergeCategory, ["m2", "s2"], "second")
+        };
+
+        var llm = new StubLlmClient(
+            """
+            {"verdicts":[
+              {"index":1,"sound":false,"reason":"Dropped the account number."},
+              {"index":2,"sound":true,"reason":"Kept every specific."}
+            ]}
+            """);
+
+        var result = await new MemoryAuditEvaluator(llm, NullLogger.Instance)
+            .EvaluateAsync(samples, "directive", ModelTier.Balanced, "FP", CancellationToken.None);
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual(2, result.Summary.Sampled);
+        Assert.AreEqual(1, result.Summary.Sound);
+        Assert.AreEqual(0.5, result.Summary.SoundRate, 1e-9);
+        Assert.AreEqual("FP", result.StoreFingerprint);
+
+        var unsound = result.Verdicts.Single(v => !v.Sound);
+        CollectionAssert.AreEquivalent(new[] { "m1", "s1" }, unsound.Ids.ToArray());
+        Assert.AreEqual("Dropped the account number.", unsound.Reason);
+    }
+
+    [TestMethod]
+    public async Task AnOutOfRangeIndexIsDroppedRatherThanMisattributed()
+    {
+        var samples = new List<MemoryAuditEvaluator.Sample>
+        {
+            new(MemoryAuditEvaluator.MergeCategory, ["m1"], "only one")
+        };
+
+        var llm = new StubLlmClient(
+            """{"verdicts":[{"index":1,"sound":true},{"index":7,"sound":false,"reason":"nonsense"}]}""");
+
+        var result = await new MemoryAuditEvaluator(llm, NullLogger.Instance)
+            .EvaluateAsync(samples, "directive", ModelTier.Balanced, "FP", CancellationToken.None);
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual(1, result.Verdicts.Count);
+    }
+
+    [TestMethod]
+    public async Task AnUnparseableReplyYieldsNoResultRatherThanAPerfectScore()
+    {
+        var samples = new List<MemoryAuditEvaluator.Sample>
+        {
+            new(MemoryAuditEvaluator.MergeCategory, ["m1"], "only one")
+        };
+
+        var llm = new StubLlmClient("the model rambled and produced no JSON");
+
+        var result = await new MemoryAuditEvaluator(llm, NullLogger.Instance)
+            .EvaluateAsync(samples, "directive", ModelTier.Balanced, "FP", CancellationToken.None);
+
+        Assert.IsNull(result);
+    }
+
+    [TestMethod]
+    public void TheFingerprintTracksLiveIdsAndTheArchiveSize()
+    {
+        var a = Entry("a");
+        var b = Entry("b");
+
+        var baseline = MemoryAuditEvaluator.StoreFingerprint([a, b]);
+
+        Assert.AreEqual(baseline, MemoryAuditEvaluator.StoreFingerprint([b, a]),
+            "Enumeration order must not change the fingerprint.");
+        Assert.AreNotEqual(baseline, MemoryAuditEvaluator.StoreFingerprint([a, b, Entry("c")]));
+        Assert.AreNotEqual(baseline, MemoryAuditEvaluator.StoreFingerprint(
+            [a, b, Archived("z", "ephemeral", Now)]));
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static MemoryAuditOptions Options() => new();
+
+    private static MemoryEntry Entry(string id) =>
+        new(id, $"a fact about {id}", null, [], Now.AddDays(-30));
+
+    private static MemoryEntry Archived(string id, string reason, DateTimeOffset at) =>
+        Entry(id) with { ArchivedAt = at, ArchiveReason = reason };
+
+    private static Dictionary<string, string> MergedFrom(params string[] ids) => new()
+    {
+        [DreamService.MergedFromKey] = string.Join(",", ids),
+        [DreamService.MergedAtKey] = Now.AddDays(-2).ToString("O")
+    };
+
+    private sealed class StubLlmClient(string response) : ILlmClient
+    {
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options, CancellationToken cancellationToken) =>
+            Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, response)));
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages, ModelTier tier, ChatOptions? options,
+            CancellationToken cancellationToken) =>
+            GetResponseAsync(messages, options, cancellationToken);
+    }
+}

--- a/tests/RockBot.Host.Tests/MemoryAuditGlossaryTests.cs
+++ b/tests/RockBot.Host.Tests/MemoryAuditGlossaryTests.cs
@@ -1,0 +1,106 @@
+namespace RockBot.Host.Tests;
+
+/// <summary>
+/// The audit's findings have to explain themselves. <c>chain-depth-threshold</c> is a stable
+/// identifier and useless to a person, so every invariant the audit can emit must have a
+/// plain-language definition behind it.
+/// </summary>
+[TestClass]
+public class MemoryAuditGlossaryTests
+{
+    /// <summary>Every invariant name the checker can produce.</summary>
+    private static readonly string[] AllInvariants =
+    [
+        MemoryAuditInvariants.MergedFromResolves,
+        MemoryAuditInvariants.ArchiveFieldsPresent,
+        MemoryAuditInvariants.LiveNotMergeSource,
+        MemoryAuditInvariants.MergeChainUnbroken,
+        MemoryAuditInvariants.NoHardDeleteOutsidePurge,
+        MemoryAuditInvariants.NoRepeatedRejection,
+        MemoryAuditInvariants.NetGrowthThreshold,
+        MemoryAuditInvariants.ChainDepthThreshold,
+        MemoryAuditInvariants.RejectedMergesThreshold,
+        MemoryAuditInvariants.LossPercentThreshold,
+        MemoryAuditInvariants.NoMalformedFiles
+    ];
+
+    [TestMethod]
+    public void EveryInvariantHasAPlainLanguageDefinition()
+    {
+        // The guard that matters: adding an invariant without a definition ships a warning the
+        // agent can report but cannot explain.
+        var missing = AllInvariants.Where(n => MemoryAuditGlossary.Describe(n) is null).ToList();
+
+        Assert.AreEqual(0, missing.Count,
+            $"No glossary entry for: {string.Join(", ", missing)}");
+    }
+
+    [TestMethod]
+    public void TheGlossaryDefinesNothingTheCheckerCannotEmit()
+    {
+        var orphans = MemoryAuditGlossary.All.Keys.Except(AllInvariants, StringComparer.OrdinalIgnoreCase).ToList();
+
+        Assert.AreEqual(0, orphans.Count,
+            $"Glossary defines invariants that no longer exist: {string.Join(", ", orphans)}");
+    }
+
+    [TestMethod]
+    public void DefinitionsCarryTheSeverityTheCheckerActuallyAssigns()
+    {
+        Assert.AreEqual(MemoryAuditStatuses.Alert,
+            MemoryAuditGlossary.Describe(MemoryAuditInvariants.NoHardDeleteOutsidePurge)!.Severity);
+        Assert.AreEqual(MemoryAuditStatuses.Alert,
+            MemoryAuditGlossary.Describe(MemoryAuditInvariants.MergeChainUnbroken)!.Severity);
+        Assert.AreEqual(MemoryAuditStatuses.Alert,
+            MemoryAuditGlossary.Describe(MemoryAuditInvariants.LossPercentThreshold)!.Severity);
+        Assert.AreEqual(MemoryAuditStatuses.Warning,
+            MemoryAuditGlossary.Describe(MemoryAuditInvariants.ChainDepthThreshold)!.Severity);
+    }
+
+    [TestMethod]
+    public void DefinitionsAvoidTheJargonTheyExistToTranslate()
+    {
+        // "Merge chain depth" and "invariant" are exactly the words a non-technical reader
+        // would have to look up, which is the whole reason this file exists.
+        string[] banned = ["invariant", "corpus", "provenance", "idempotent", "jaccard", "shingle"];
+
+        foreach (var (name, definition) in MemoryAuditGlossary.All)
+        {
+            var prose = $"{definition.Title} {definition.WhatItMeans} {definition.WhatToDo}".ToLowerInvariant();
+            foreach (var word in banned)
+                Assert.IsFalse(prose.Contains(word),
+                    $"'{name}' explains itself using the jargon word '{word}'.");
+        }
+    }
+
+    [TestMethod]
+    public void AnUnknownNameYieldsNullRatherThanFiller()
+    {
+        // A generic "a memory-health check failed" would hide a missing definition instead of
+        // surfacing it.
+        Assert.IsNull(MemoryAuditGlossary.Describe("not-a-real-invariant"));
+    }
+
+    [TestMethod]
+    public void TheGuideDocumentCoversEveryFindingAndNamesItsTools()
+    {
+        var document = new MemoryAuditSkillProvider().GetDocument();
+
+        foreach (var name in AllInvariants)
+            StringAssert.Contains(document, name, $"The guide omits {name}.");
+
+        StringAssert.Contains(document, "get_memory_audit");
+        StringAssert.Contains(document, "get_memory_audit_trend");
+        StringAssert.Contains(document, "recall");
+    }
+
+    [TestMethod]
+    public void TheGuideIsNamedSoTheDirectivesPointerResolves()
+    {
+        var provider = new MemoryAuditSkillProvider();
+
+        // directives.md tells the agent to call get_tool_guide("memory-audit").
+        Assert.AreEqual("memory-audit", provider.Name);
+        Assert.IsFalse(string.IsNullOrWhiteSpace(provider.Summary));
+    }
+}

--- a/tests/RockBot.Host.Tests/MemoryAuditInvariantsTests.cs
+++ b/tests/RockBot.Host.Tests/MemoryAuditInvariantsTests.cs
@@ -1,0 +1,207 @@
+namespace RockBot.Host.Tests;
+
+/// <summary>
+/// One test per invariant, plus the status ladder. These are the statements the store is
+/// supposed to make true; the audit is only worth having if each one actually fires.
+/// </summary>
+[TestClass]
+public class MemoryAuditInvariantsTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 9, 4, 4, 0, 0, TimeSpan.Zero);
+
+    [TestMethod]
+    public void AHealthyCorpusProducesNoViolations()
+    {
+        var source = Archived("src", $"{DreamService.MergedIntoReasonPrefix}merged");
+        var merged = Entry("merged") with { Metadata = MergedFrom("src") };
+
+        var violations = Check([source, merged], Snapshot());
+
+        Assert.AreEqual(0, violations.Count, string.Join("; ", violations.Select(v => v.Name)));
+        Assert.AreEqual(MemoryAuditStatuses.Healthy, MemoryAuditInvariants.ComputeStatus(violations));
+    }
+
+    [TestMethod]
+    public void MergeChainUnbroken_FiresOnTheIssue506Shape()
+    {
+        // Sources archived "merged into X" where X exists nowhere: the fact has no surviving copy.
+        var a = Archived("a", $"{DreamService.MergedIntoReasonPrefix}vanished");
+        var b = Archived("b", $"{DreamService.MergedIntoReasonPrefix}vanished");
+
+        var violations = Check([a, b], Snapshot());
+
+        var violation = violations.Single(v => v.Name == MemoryAuditInvariants.MergeChainUnbroken);
+        CollectionAssert.AreEquivalent(new[] { "a", "b" }, violation.Ids.ToArray());
+        Assert.AreEqual(MemoryAuditStatuses.Alert, MemoryAuditInvariants.ComputeStatus(violations));
+    }
+
+    [TestMethod]
+    public void MergedFromResolves_FiresWhenARecentMergeNamesAMissingSource()
+    {
+        var merged = Entry("merged") with { Metadata = MergedFrom("never-existed") };
+
+        var violations = Check([merged], Snapshot());
+
+        Assert.IsTrue(violations.Any(v => v.Name == MemoryAuditInvariants.MergedFromResolves));
+    }
+
+    [TestMethod]
+    public void MergedFromResolves_ToleratesProvenanceThePurgeHasAgedOut()
+    {
+        // Provenance dangling after the retention window is documented behaviour, not a fault.
+        var merged = Entry("merged") with
+        {
+            Metadata = new Dictionary<string, string>
+            {
+                [DreamService.MergedFromKey] = "long-purged",
+                [DreamService.MergedAtKey] = Now.AddDays(-200).ToString("O")
+            }
+        };
+
+        var violations = Check([merged], Snapshot());
+
+        Assert.IsFalse(violations.Any(v => v.Name == MemoryAuditInvariants.MergedFromResolves));
+    }
+
+    [TestMethod]
+    public void ArchiveFieldsPresent_FiresOnEitherHalfMissing()
+    {
+        var noReason = Entry("a") with { ArchivedAt = Now.AddDays(-1) };
+        var noTimestamp = Entry("b") with { ArchiveReason = "ephemeral" };
+
+        var violations = Check([noReason, noTimestamp], Snapshot());
+
+        var violation = violations.Single(v => v.Name == MemoryAuditInvariants.ArchiveFieldsPresent);
+        CollectionAssert.AreEquivalent(new[] { "a", "b" }, violation.Ids.ToArray());
+    }
+
+    [TestMethod]
+    public void LiveNotMergeSource_FiresWhenAMergedAwayEntryIsStillInRecall()
+    {
+        var stillLive = Entry("src");
+        var merged = Entry("merged") with { Metadata = MergedFrom("src") };
+
+        var violations = Check([stillLive, merged], Snapshot());
+
+        var violation = violations.Single(v => v.Name == MemoryAuditInvariants.LiveNotMergeSource);
+        CollectionAssert.AreEquivalent(new[] { "src" }, violation.Ids.ToArray());
+        Assert.AreEqual(MemoryAuditStatuses.Warning, MemoryAuditInvariants.ComputeStatus(violations));
+    }
+
+    [TestMethod]
+    public void NoHardDeleteOutsidePurge_FiresOnASingleUnexplainedDisappearance()
+    {
+        var violations = Check([], Snapshot() with { HardDeletedOutsidePurge = 1 });
+
+        Assert.IsTrue(violations.Any(v => v.Name == MemoryAuditInvariants.NoHardDeleteOutsidePurge));
+        Assert.AreEqual(MemoryAuditStatuses.Alert, MemoryAuditInvariants.ComputeStatus(violations));
+    }
+
+    [TestMethod]
+    public void LossPercentThreshold_FiresOnADropPastTheLimit()
+    {
+        var violations = Check([], Snapshot() with { Live = 80 }, previousLive: 100);
+
+        Assert.IsTrue(violations.Any(v => v.Name == MemoryAuditInvariants.LossPercentThreshold));
+    }
+
+    [TestMethod]
+    public void LossPercentThreshold_DoesNotFireOnGrowth()
+    {
+        var violations = Check([], Snapshot() with { Live = 120 }, previousLive: 100);
+
+        Assert.IsFalse(violations.Any(v => v.Name == MemoryAuditInvariants.LossPercentThreshold));
+    }
+
+    [TestMethod]
+    public void NetGrowthThreshold_FiresWhenSavesOutpaceConsolidation()
+    {
+        var violations = Check([], Snapshot() with { NetGrowthPerDay = 12.0 });
+
+        Assert.IsTrue(violations.Any(v => v.Name == MemoryAuditInvariants.NetGrowthThreshold));
+        Assert.AreEqual(MemoryAuditStatuses.Warning, MemoryAuditInvariants.ComputeStatus(violations));
+    }
+
+    [TestMethod]
+    public void ChainDepthThreshold_FiresPastTheConfiguredDepth()
+    {
+        var violations = Check([], Snapshot() with { MaxChainDepth = 3 });
+
+        Assert.IsTrue(violations.Any(v => v.Name == MemoryAuditInvariants.ChainDepthThreshold));
+    }
+
+    [TestMethod]
+    public void RejectedMergesThreshold_IsMeasuredPerWeekNotPerRun()
+    {
+        // Four rejections in one day is 28/week, well past the default of 5.
+        var violations = Check([], Snapshot() with { RejectedMergeSourcesSinceLast = 4 }, elapsedDays: 1);
+        Assert.IsTrue(violations.Any(v => v.Name == MemoryAuditInvariants.RejectedMergesThreshold));
+
+        // The same four spread over a month is not.
+        var calm = Check([], Snapshot() with { RejectedMergeSourcesSinceLast = 4 }, elapsedDays: 30);
+        Assert.IsFalse(calm.Any(v => v.Name == MemoryAuditInvariants.RejectedMergesThreshold));
+    }
+
+    [TestMethod]
+    public void MalformedFilesAreReported()
+    {
+        var violations = Check([], Snapshot() with { MalformedFiles = 2 });
+
+        Assert.IsTrue(violations.Any(v => v.Name == MemoryAuditInvariants.NoMalformedFiles));
+    }
+
+    [TestMethod]
+    public void ViolationIdsAreCappedSoAMassFailureDoesNotBloatTheTrendFile()
+    {
+        var entries = Enumerable.Range(0, 100)
+            .Select(i => Archived($"e{i}", $"{DreamService.MergedIntoReasonPrefix}vanished"))
+            .ToList();
+
+        var violation = Check(entries, Snapshot())
+            .Single(v => v.Name == MemoryAuditInvariants.MergeChainUnbroken);
+
+        Assert.AreEqual(MemoryAuditAnalyzer.MaxIdsPerViolation, violation.Ids.Count);
+        StringAssert.Contains(violation.Message, "100", "The message still reports the true count.");
+    }
+
+    [TestMethod]
+    public void AnAlertOutranksAWarning()
+    {
+        var violations = Check([], Snapshot() with
+        {
+            NetGrowthPerDay = 12,
+            HardDeletedOutsidePurge = 1
+        });
+
+        Assert.AreEqual(MemoryAuditStatuses.Alert, MemoryAuditInvariants.ComputeStatus(violations));
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static IReadOnlyList<MemoryAuditInvariantViolation> Check(
+        IReadOnlyList<MemoryEntry> entries,
+        MemoryAuditSnapshot snapshot,
+        double elapsedDays = 1,
+        int? previousLive = null) =>
+        MemoryAuditInvariants.Check(
+            entries, snapshot, new DreamOptions(), new MemoryAuditOptions(), Now, elapsedDays, previousLive);
+
+    private static MemoryAuditSnapshot Snapshot() => new()
+    {
+        SnapshotId = "snap1",
+        TakenAt = Now,
+        PreviousTakenAt = Now.AddDays(-1)
+    };
+
+    private static MemoryEntry Entry(string id) =>
+        new(id, $"content for {id}", null, [], Now.AddDays(-30));
+
+    private static MemoryEntry Archived(string id, string reason) =>
+        Entry(id) with { ArchivedAt = Now.AddDays(-2), ArchiveReason = reason };
+
+    private static Dictionary<string, string> MergedFrom(params string[] ids) => new()
+    {
+        [DreamService.MergedFromKey] = string.Join(",", ids),
+        [DreamService.MergedAtKey] = Now.AddDays(-1).ToString("O")
+    };
+}

--- a/tests/RockBot.Host.Tests/MemoryAuditOptionsBindingTests.cs
+++ b/tests/RockBot.Host.Tests/MemoryAuditOptionsBindingTests.cs
@@ -1,0 +1,124 @@
+using Microsoft.Extensions.Configuration;
+
+namespace RockBot.Host.Tests;
+
+/// <summary>
+/// Guards the wiring that carries the Helm ConfigMap's <c>MemoryAudit__*</c> keys into
+/// <see cref="MemoryAuditOptions"/>. Bound against the exact string shapes the ConfigMap emits —
+/// in particular the TimeSpan "d.hh:mm:ss" form, which silently falls back to the default when
+/// the binder cannot parse it.
+/// </summary>
+[TestClass]
+public class MemoryAuditOptionsBindingTests
+{
+    private static MemoryAuditOptions Bind(Dictionary<string, string?> values)
+    {
+        var config = new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+        var opts = new MemoryAuditOptions();
+        config.GetSection("MemoryAudit").Bind(opts);
+        return opts;
+    }
+
+    [TestMethod]
+    public void BindsWhatTheConfigMapActuallyEmits()
+    {
+        var opts = Bind(new Dictionary<string, string?>
+        {
+            ["MemoryAudit:Enabled"] = "true",
+            ["MemoryAudit:CronSchedule"] = "0 4 * * *",
+            ["MemoryAudit:BasePath"] = "/data/agent/memory-audit",
+            ["MemoryAudit:SharedReportDirectory"] = "/rockbot/shared/exports/memory-audit",
+            ["MemoryAudit:PauseConsolidationOnAlert"] = "false",
+            ["MemoryAudit:EvalEnabled"] = "true",
+            ["MemoryAudit:EvalCronSchedule"] = "0 5 * * 0",
+        });
+
+        Assert.IsTrue(opts.Enabled);
+        Assert.AreEqual("0 4 * * *", opts.CronSchedule);
+        Assert.AreEqual("/data/agent/memory-audit", opts.BasePath);
+        Assert.AreEqual("/rockbot/shared/exports/memory-audit", opts.SharedReportDirectory);
+        Assert.IsFalse(opts.PauseConsolidationOnAlert);
+        Assert.IsTrue(opts.EvalEnabled);
+        Assert.AreEqual("0 5 * * 0", opts.EvalCronSchedule);
+    }
+
+    [TestMethod]
+    public void BindsTimeSpansFromTheConfigMapStringShapes()
+    {
+        var opts = Bind(new Dictionary<string, string?>
+        {
+            ["MemoryAudit:SnapshotRetention"] = "400.00:00:00",
+            ["MemoryAudit:EvalWindow"] = "14.00:00:00",
+            ["MemoryAudit:InitialDelay"] = "00:10:00",
+        });
+
+        Assert.AreEqual(TimeSpan.FromDays(400), opts.SnapshotRetention);
+        Assert.AreEqual(TimeSpan.FromDays(14), opts.EvalWindow);
+        Assert.AreEqual(TimeSpan.FromMinutes(10), opts.InitialDelay);
+    }
+
+    [TestMethod]
+    public void BindsThresholdsIncludingTheZeroThatMeansNoTolerance()
+    {
+        var opts = Bind(new Dictionary<string, string?>
+        {
+            ["MemoryAudit:MaxNetGrowthPerDay"] = "12.5",
+            ["MemoryAudit:MaxMergeChainDepth"] = "3",
+            ["MemoryAudit:MaxRejectedMergesPerWeek"] = "20",
+            ["MemoryAudit:MaxHardDeletesOutsidePurge"] = "0",
+            ["MemoryAudit:MaxLossPercentBetweenSnapshots"] = "25",
+            ["MemoryAudit:RepeatedRejectionRuns"] = "5",
+            ["MemoryAudit:NearDuplicateThreshold"] = "0.45",
+        });
+
+        Assert.AreEqual(12.5, opts.MaxNetGrowthPerDay);
+        Assert.AreEqual(3, opts.MaxMergeChainDepth);
+        Assert.AreEqual(20, opts.MaxRejectedMergesPerWeek);
+        Assert.AreEqual(0, opts.MaxHardDeletesOutsidePurge);
+        Assert.AreEqual(25, opts.MaxLossPercentBetweenSnapshots);
+        Assert.AreEqual(5, opts.RepeatedRejectionRuns);
+        Assert.AreEqual(0.45, opts.NearDuplicateThreshold);
+    }
+
+    [TestMethod]
+    public void BindsTheModelTierByName()
+    {
+        var opts = Bind(new Dictionary<string, string?> { ["MemoryAudit:EvalModelTier"] = "Low" });
+
+        Assert.AreEqual(ModelTier.Low, opts.EvalModelTier);
+    }
+
+    [TestMethod]
+    public void MissingSectionLeavesTheCodeDefaults()
+    {
+        var opts = Bind(new Dictionary<string, string?> { ["Other:Key"] = "x" });
+
+        Assert.IsTrue(opts.Enabled);
+        Assert.AreEqual("0 4 * * *", opts.CronSchedule);
+        Assert.AreEqual(MemoryAuditFiles.DefaultBasePath, opts.BasePath);
+        Assert.AreEqual(TimeSpan.FromDays(400), opts.SnapshotRetention);
+        Assert.AreEqual(0, opts.MaxHardDeletesOutsidePurge);
+        Assert.IsFalse(opts.PauseConsolidationOnAlert, "The circuit breaker is opt-in.");
+        Assert.IsTrue(opts.AlertOnAttention);
+        Assert.IsNull(opts.DigestCronSchedule);
+    }
+
+    [TestMethod]
+    public void AnExplicitFalseSurvivesTheBind()
+    {
+        // `dig` in the ConfigMap exists precisely so this reaches the options rather than
+        // being swallowed by a default.
+        var opts = Bind(new Dictionary<string, string?>
+        {
+            ["MemoryAudit:Enabled"] = "false",
+            ["MemoryAudit:EvalEnabled"] = "false",
+            ["MemoryAudit:CopyReportToShared"] = "false",
+            ["MemoryAudit:AlertOnAttention"] = "false",
+        });
+
+        Assert.IsFalse(opts.Enabled);
+        Assert.IsFalse(opts.EvalEnabled);
+        Assert.IsFalse(opts.CopyReportToShared);
+        Assert.IsFalse(opts.AlertOnAttention);
+    }
+}

--- a/tests/RockBot.Host.Tests/MemoryAuditReportWriterTests.cs
+++ b/tests/RockBot.Host.Tests/MemoryAuditReportWriterTests.cs
@@ -1,0 +1,134 @@
+namespace RockBot.Host.Tests;
+
+/// <summary>
+/// The report is the deliverable a person actually reads, so its shape is worth pinning:
+/// status first, what changed, what needs attention, then the trend.
+/// </summary>
+[TestClass]
+public class MemoryAuditReportWriterTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 9, 4, 4, 0, 0, TimeSpan.Zero);
+
+    [TestMethod]
+    public void AHealthyReportSaysSoAndListsNothingToAttendTo()
+    {
+        var report = MemoryAuditReportWriter.Render(Snapshot(), [Snapshot()]);
+
+        StringAssert.Contains(report, "**Healthy**");
+        StringAssert.Contains(report, "820 live entries");
+        StringAssert.Contains(report, "## Needs attention");
+        StringAssert.Contains(report, "Nothing.");
+    }
+
+    [TestMethod]
+    public void AnAlertNamesTheInvariantAndItsIds()
+    {
+        var snapshot = Snapshot() with
+        {
+            Status = MemoryAuditStatuses.Alert,
+            HardDeletedOutsidePurge = 74,
+            Invariants =
+            [
+                new MemoryAuditInvariantViolation(
+                    MemoryAuditInvariants.NoHardDeleteOutsidePurge,
+                    "74 entry(s) disappeared from disk that the retention purge cannot account for.",
+                    ["lost1", "lost2"])
+            ]
+        };
+
+        var report = MemoryAuditReportWriter.Render(snapshot, [snapshot]);
+
+        StringAssert.Contains(report, "**ALERT**");
+        StringAssert.Contains(report, "no-hard-delete-outside-purge");
+        StringAssert.Contains(report, "74 entry(s) disappeared");
+        StringAssert.Contains(report, "`lost1`");
+    }
+
+    [TestMethod]
+    public void AnUnmeasurableRateReadsAsSuchRatherThanAsZero()
+    {
+        var snapshot = Snapshot() with { NetGrowthPerDay = null };
+
+        var report = MemoryAuditReportWriter.Render(snapshot, [snapshot, snapshot]);
+
+        StringAssert.Contains(report, "not measurable");
+        StringAssert.Contains(report, "| — |", "The trend table shows a dash, not a zero.");
+    }
+
+    [TestMethod]
+    public void AFirstRunSaysThereIsNothingToCompareAgainst()
+    {
+        var report = MemoryAuditReportWriter.Render(
+            Snapshot() with { PreviousTakenAt = null }, [Snapshot()]);
+
+        StringAssert.Contains(report, "First run");
+    }
+
+    [TestMethod]
+    public void TheTrendTableCarriesOneRowPerRun()
+    {
+        var trend = Enumerable.Range(0, 5)
+            .Select(i => Snapshot() with { TakenAt = Now.AddDays(-4 + i), Live = 800 + i })
+            .ToList();
+
+        var report = MemoryAuditReportWriter.Render(trend[^1], trend);
+
+        StringAssert.Contains(report, "## Trend (last 5 runs)");
+        foreach (var row in trend)
+            StringAssert.Contains(report, $"| {row.TakenAt:yyyy-MM-dd} | {row.Live} |");
+    }
+
+    [TestMethod]
+    public void ASingleRunOmitsTheTrendTableRatherThanShowingOneRow()
+    {
+        var report = MemoryAuditReportWriter.Render(Snapshot(), [Snapshot()]);
+
+        Assert.IsFalse(report.Contains("## Trend"));
+    }
+
+    [TestMethod]
+    public void TheEvalParagraphAppearsWhenAnEvalExistsAndNamesTheDisagreements()
+    {
+        var eval = new MemoryAuditEvalResult(
+            new MemoryAuditEvalSummary(
+                Now.AddDays(-1), 10, 8, 0.8,
+                new Dictionary<string, double> { ["merge"] = 0.75 }),
+            [
+                new MemoryAuditEvalVerdict("merge", ["m1", "s1"], false, "Dropped the account number."),
+                new MemoryAuditEvalVerdict("merge", ["m2"], true, "Kept every specific.")
+            ],
+            "FINGERPRINT");
+
+        var report = MemoryAuditReportWriter.Render(Snapshot(), [Snapshot()], eval);
+
+        StringAssert.Contains(report, "## Sample eval");
+        StringAssert.Contains(report, "merge: 75%");
+        StringAssert.Contains(report, "Dropped the account number.");
+        Assert.IsFalse(report.Contains("Kept every specific."),
+            "Only disagreements are worth the reader's attention.");
+    }
+
+    [TestMethod]
+    public void NoEvalSectionAppearsBeforeTheFirstEvalHasRun()
+    {
+        var report = MemoryAuditReportWriter.Render(Snapshot(), [Snapshot()]);
+
+        Assert.IsFalse(report.Contains("## Sample eval"));
+    }
+
+    private static MemoryAuditSnapshot Snapshot() => new()
+    {
+        SnapshotId = "snap1",
+        TakenAt = Now,
+        PreviousTakenAt = Now.AddDays(-1),
+        Live = 820,
+        Archived = 340,
+        CreatedSinceLast = 12,
+        ArchivedSinceLast = 8,
+        NetGrowthPerDay = 4,
+        MaxChainDepth = 1,
+        NearDupPairs = 6,
+        NearDupEntries = 11,
+        Purge = new MemoryAuditPurgeOutlook(7, 3, 1)
+    };
+}

--- a/tests/RockBot.Host.Tests/MemoryAuditScheduleTests.cs
+++ b/tests/RockBot.Host.Tests/MemoryAuditScheduleTests.cs
@@ -1,0 +1,59 @@
+using Cronos;
+
+namespace RockBot.Host.Tests;
+
+/// <summary>
+/// One timer serves both the daily measurement and the weekly eval, so it has to be armed at
+/// whichever comes first.
+/// </summary>
+[TestClass]
+public class MemoryAuditScheduleTests
+{
+    private static readonly TimeZoneInfo Utc = TimeZoneInfo.Utc;
+
+    [TestMethod]
+    public void PicksTheAuditWhenItComesFirst()
+    {
+        // Friday 06:00: the next daily audit is Saturday 04:00, the next eval Sunday 05:00.
+        var now = new DateTimeOffset(2026, 9, 4, 6, 0, 0, TimeSpan.Zero);
+
+        var next = MemoryAuditService.ComputeNextDue(
+            now, Utc, CronExpression.Parse("0 4 * * *"), CronExpression.Parse("0 5 * * 0"));
+
+        Assert.AreEqual(new DateTimeOffset(2026, 9, 5, 4, 0, 0, TimeSpan.Zero), next);
+    }
+
+    [TestMethod]
+    public void PicksTheEvalWhenItComesFirst()
+    {
+        // Sunday 04:30: that day's audit has passed, the eval is half an hour away.
+        var now = new DateTimeOffset(2026, 9, 6, 4, 30, 0, TimeSpan.Zero);
+
+        var next = MemoryAuditService.ComputeNextDue(
+            now, Utc, CronExpression.Parse("0 4 * * *"), CronExpression.Parse("0 5 * * 0"));
+
+        Assert.AreEqual(new DateTimeOffset(2026, 9, 6, 5, 0, 0, TimeSpan.Zero), next);
+    }
+
+    [TestMethod]
+    public void FallsBackToTheAuditWhenTheEvalIsDisabled()
+    {
+        var now = new DateTimeOffset(2026, 9, 6, 4, 30, 0, TimeSpan.Zero);
+
+        var next = MemoryAuditService.ComputeNextDue(
+            now, Utc, CronExpression.Parse("0 4 * * *"), eval: null);
+
+        Assert.AreEqual(new DateTimeOffset(2026, 9, 7, 4, 0, 0, TimeSpan.Zero), next);
+    }
+
+    [TestMethod]
+    public void CoincidingSchedulesYieldTheSharedOccurrenceOnce()
+    {
+        var now = new DateTimeOffset(2026, 9, 4, 6, 0, 0, TimeSpan.Zero);
+
+        var next = MemoryAuditService.ComputeNextDue(
+            now, Utc, CronExpression.Parse("0 4 * * *"), CronExpression.Parse("0 4 * * *"));
+
+        Assert.AreEqual(new DateTimeOffset(2026, 9, 5, 4, 0, 0, TimeSpan.Zero), next);
+    }
+}

--- a/tests/RockBot.Host.Tests/MemoryAuditServiceTests.cs
+++ b/tests/RockBot.Host.Tests/MemoryAuditServiceTests.cs
@@ -1,0 +1,319 @@
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using RockBot.Messaging;
+using RockBot.UserProxy;
+
+namespace RockBot.Host.Tests;
+
+/// <summary>
+/// End-to-end behaviour of the audit against a real temp store.
+/// </summary>
+/// <remarks>
+/// Every test constructs the service with a memory store whose write paths throw. That is the
+/// central claim of the whole feature — the audit measures the corpus and cannot damage it —
+/// and it is worth enforcing mechanically rather than by review.
+/// </remarks>
+[TestClass]
+public class MemoryAuditServiceTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true
+    };
+
+    private string _profileRoot = null!;
+    private string _memoryRoot = null!;
+    private string _auditRoot = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _profileRoot = Path.Combine(Path.GetTempPath(), "rockbot-audit-svc-" + Guid.NewGuid().ToString("N"));
+        _memoryRoot = Path.Combine(_profileRoot, "memory");
+        _auditRoot = Path.Combine(_profileRoot, "memory-audit");
+        Directory.CreateDirectory(_memoryRoot);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_profileRoot))
+            Directory.Delete(_profileRoot, recursive: true);
+    }
+
+    [TestMethod]
+    public async Task RunAudit_WritesTheTrendRowStateAndReport_WithoutTouchingTheStore()
+    {
+        WriteEntry(new MemoryEntry("a", "the agent stores memories on the shared volume", null, [], Now(-30)));
+        WriteEntry(new MemoryEntry("b", "the deploy pipeline pushes tagged images", null, [], Now(-20)));
+
+        var service = CreateService();
+
+        var snapshot = await service.RunAuditAsync(CancellationToken.None);
+
+        Assert.IsNotNull(snapshot, "The work slot was free, so the run should have completed.");
+        Assert.AreEqual(2, snapshot.Live);
+        Assert.IsNull(snapshot.PreviousTakenAt);
+
+        Assert.IsTrue(File.Exists(Path.Combine(_auditRoot, MemoryAuditFiles.SnapshotsFile)));
+        Assert.IsTrue(File.Exists(Path.Combine(_auditRoot, MemoryAuditFiles.StateFile)));
+        Assert.IsTrue(File.Exists(Path.Combine(_auditRoot, MemoryAuditFiles.LatestReport)));
+
+        StringAssert.Contains(
+            await File.ReadAllTextAsync(Path.Combine(_auditRoot, MemoryAuditFiles.LatestReport)),
+            "# Memory audit");
+    }
+
+    [TestMethod]
+    public async Task ASecondRunComputesDeltasAgainstTheFirst()
+    {
+        WriteEntry(Entry("a"));
+        WriteEntry(Entry("b"));
+
+        var service = CreateService();
+        await service.RunAuditAsync(CancellationToken.None);
+
+        // One new fact, one destroyed behind the store's back — the shape the audit exists for.
+        WriteEntry(Entry("c"));
+        File.Delete(Path.Combine(_memoryRoot, "b.json"));
+
+        var second = await service.RunAuditAsync(CancellationToken.None);
+
+        Assert.IsNotNull(second);
+        Assert.IsNotNull(second.PreviousTakenAt);
+        Assert.AreEqual(1, second.CreatedSinceLast);
+        Assert.AreEqual(1, second.HardDeletedSinceLast);
+        Assert.AreEqual(1, second.HardDeletedOutsidePurge);
+        Assert.AreEqual(MemoryAuditStatuses.Alert, second.Status);
+
+        var lines = await File.ReadAllLinesAsync(Path.Combine(_auditRoot, MemoryAuditFiles.SnapshotsFile));
+        Assert.AreEqual(2, lines.Count(l => !string.IsNullOrWhiteSpace(l)),
+            "The trend file is appended to, never rewritten.");
+    }
+
+    [TestMethod]
+    public async Task ABusyAgentDefersTheRunRatherThanCompetingWithIt()
+    {
+        WriteEntry(Entry("a"));
+
+        var service = CreateService(serializer: new BusySerializer());
+
+        Assert.IsNull(await service.RunAuditAsync(CancellationToken.None));
+        Assert.IsFalse(File.Exists(Path.Combine(_auditRoot, MemoryAuditFiles.SnapshotsFile)));
+    }
+
+    [TestMethod]
+    public async Task AnAlertIsPublishedToTheScheduledSystemSession()
+    {
+        WriteEntry(Entry("a"));
+        WriteEntry(Entry("b"));
+
+        var publisher = new RecordingPublisher();
+        var service = CreateService(publisher: publisher);
+
+        await service.RunAuditAsync(CancellationToken.None);
+        Assert.AreEqual(0, publisher.Published.Count, "A healthy first run says nothing.");
+
+        File.Delete(Path.Combine(_memoryRoot, "b.json"));
+        await service.RunAuditAsync(CancellationToken.None);
+
+        Assert.AreEqual(1, publisher.Published.Count);
+        var (topic, reply) = publisher.Published[0];
+        StringAssert.Contains(topic, UserProxyTopics.UserResponse);
+        Assert.AreEqual(WellKnownSessions.ScheduledSystem, reply.SessionId);
+        Assert.AreEqual("memory-audit", reply.Origin?.Channel);
+        StringAssert.Contains(reply.Content, "no-hard-delete-outside-purge");
+    }
+
+    [TestMethod]
+    public async Task NoAlertIsPublishedWhenAlertingIsTurnedOff()
+    {
+        WriteEntry(Entry("a"));
+        WriteEntry(Entry("b"));
+
+        var publisher = new RecordingPublisher();
+        var service = CreateService(
+            publisher: publisher,
+            options: new MemoryAuditOptions { AlertOnAttention = false, CopyReportToShared = false });
+
+        await service.RunAuditAsync(CancellationToken.None);
+        File.Delete(Path.Combine(_memoryRoot, "b.json"));
+        await service.RunAuditAsync(CancellationToken.None);
+
+        Assert.AreEqual(0, publisher.Published.Count);
+    }
+
+    [TestMethod]
+    public async Task TheConsolidationPauseMarkerIsWrittenOnlyWhenOptedIn()
+    {
+        WriteEntry(Entry("a"));
+        WriteEntry(Entry("b"));
+
+        var optedOut = CreateService();
+        await optedOut.RunAuditAsync(CancellationToken.None);
+        File.Delete(Path.Combine(_memoryRoot, "b.json"));
+        await optedOut.RunAuditAsync(CancellationToken.None);
+
+        var markerPath = Path.Combine(_auditRoot, MemoryAuditFiles.ConsolidationPausedFile);
+        Assert.IsFalse(File.Exists(markerPath), "The circuit breaker is opt-in.");
+
+        WriteEntry(Entry("d"));
+        var optedIn = CreateService(options: new MemoryAuditOptions
+        {
+            PauseConsolidationOnAlert = true,
+            CopyReportToShared = false
+        });
+        await optedIn.RunAuditAsync(CancellationToken.None);
+        File.Delete(Path.Combine(_memoryRoot, "d.json"));
+        await optedIn.RunAuditAsync(CancellationToken.None);
+
+        Assert.IsTrue(File.Exists(markerPath));
+        using var marker = JsonDocument.Parse(await File.ReadAllTextAsync(markerPath));
+        StringAssert.Contains(
+            marker.RootElement.GetProperty("reason").GetString()!, "hard-deleted outside the retention purge");
+    }
+
+    [TestMethod]
+    public async Task Prune_KeepsSnapshotsInsideTheRetentionWindowAndDropsOldReports()
+    {
+        Directory.CreateDirectory(_auditRoot);
+
+        var snapshotsPath = Path.Combine(_auditRoot, MemoryAuditFiles.SnapshotsFile);
+        await File.WriteAllLinesAsync(snapshotsPath,
+        [
+            Line(DateTimeOffset.UtcNow.AddDays(-500)),
+            Line(DateTimeOffset.UtcNow.AddDays(-10)),
+            Line(DateTimeOffset.UtcNow)
+        ]);
+
+        var staleReport = Path.Combine(_auditRoot, "report-2020-01-01.md");
+        await File.WriteAllTextAsync(staleReport, "old");
+        File.SetLastWriteTimeUtc(staleReport, DateTime.UtcNow.AddDays(-400));
+
+        var freshReport = Path.Combine(_auditRoot, "report-2026-09-04.md");
+        await File.WriteAllTextAsync(freshReport, "new");
+
+        var service = CreateService();
+        var removed = await service.PruneAsync(new LogRetentionPolicy(TimeSpan.FromDays(30), 1000, 10_000));
+
+        Assert.AreEqual(2, removed, "One stale report plus one out-of-retention snapshot row.");
+        Assert.IsFalse(File.Exists(staleReport));
+        Assert.IsTrue(File.Exists(freshReport));
+
+        var kept = (await File.ReadAllLinesAsync(snapshotsPath)).Where(l => !string.IsNullOrWhiteSpace(l)).ToList();
+        Assert.AreEqual(2, kept.Count, "The 400-day snapshot retention outlives the 30-day file policy.");
+    }
+
+    [TestMethod]
+    public async Task TheReportIsCopiedToTheSharedVolumeWhenEnabled()
+    {
+        WriteEntry(Entry("a"));
+
+        var shared = Path.Combine(_profileRoot, "shared-exports");
+        var service = CreateService(options: new MemoryAuditOptions
+        {
+            CopyReportToShared = true,
+            SharedReportDirectory = shared
+        });
+
+        await service.RunAuditAsync(CancellationToken.None);
+
+        Assert.AreEqual(1, Directory.GetFiles(shared, "memory-audit-*.md").Length);
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static string Line(DateTimeOffset takenAt) =>
+        JsonSerializer.Serialize(
+            new MemoryAuditSnapshot { SnapshotId = "s", TakenAt = takenAt }, JsonOptions);
+
+    private static DateTimeOffset Now(int daysAgo) => DateTimeOffset.UtcNow.AddDays(daysAgo);
+
+    private static MemoryEntry Entry(string id) =>
+        new(id, $"a durable fact about subject {id} worth keeping in long term memory", null, [], Now(-30));
+
+    private void WriteEntry(MemoryEntry entry) =>
+        File.WriteAllText(
+            Path.Combine(_memoryRoot, $"{entry.Id}.json"),
+            JsonSerializer.Serialize(entry, JsonOptions));
+
+    private MemoryAuditService CreateService(
+        MemoryAuditOptions? options = null,
+        IAgentWorkSerializer? serializer = null,
+        IMessagePublisher? publisher = null) =>
+        new(new ThrowingWriteMemory(),
+            serializer ?? new AgentWorkSerializer(),
+            new AgentClock(
+                new ConfigurationBuilder().Build(),
+                Options.Create(new AgentProfileOptions { BasePath = _profileRoot }),
+                NullLogger<AgentClock>.Instance),
+            Options.Create(options ?? new MemoryAuditOptions { CopyReportToShared = false }),
+            Options.Create(new DreamOptions()),
+            Options.Create(new MemoryOptions { BasePath = "memory" }),
+            Options.Create(new AgentProfileOptions { BasePath = _profileRoot }),
+            NullLogger<MemoryAuditService>.Instance,
+            llmClient: null,
+            publisher: publisher,
+            agent: publisher is null ? null : new AgentIdentity("TestBot", "inst"));
+
+    /// <summary>
+    /// A store whose every write path throws. The audit holds <see cref="ILongTermMemory"/> only
+    /// for the optional duplicate probe; if it ever reaches for a writer, these tests fail loudly.
+    /// </summary>
+    private sealed class ThrowingWriteMemory : ILongTermMemory
+    {
+        public Task SaveAsync(MemoryEntry entry, CancellationToken cancellationToken = default) =>
+            throw new InvalidOperationException("The memory audit must never write to the store.");
+
+        public Task<ContentEditResult> EditAsync(
+            string id, string oldText, string newText, bool replaceAll = false,
+            CancellationToken cancellationToken = default) =>
+            throw new InvalidOperationException("The memory audit must never edit the store.");
+
+        public Task DeleteAsync(string id, CancellationToken cancellationToken = default) =>
+            throw new InvalidOperationException("The memory audit must never delete from the store.");
+
+        public Task ArchiveAsync(string id, string reason, CancellationToken cancellationToken = default) =>
+            throw new InvalidOperationException("The memory audit must never archive.");
+
+        public Task<IReadOnlyList<MemoryEntry>> SearchAsync(
+            MemorySearchCriteria criteria, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<MemoryEntry>>([]);
+
+        public Task<MemoryEntry?> GetAsync(string id, CancellationToken cancellationToken = default) =>
+            Task.FromResult<MemoryEntry?>(null);
+
+        public Task<IReadOnlyList<string>> ListTagsAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<string>>([]);
+
+        public Task<IReadOnlyList<string>> ListCategoriesAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<string>>([]);
+    }
+
+    private sealed class BusySerializer : IAgentWorkSerializer
+    {
+        public Task<IAsyncDisposable> AcquireForUserAsync(CancellationToken ct) =>
+            throw new NotSupportedException();
+
+        public Task<IScheduledTaskSlot?> TryAcquireForScheduledAsync(CancellationToken ct) =>
+            Task.FromResult<IScheduledTaskSlot?>(null);
+    }
+
+    private sealed class RecordingPublisher : IMessagePublisher
+    {
+        public List<(string Topic, AgentReply Reply)> Published { get; } = [];
+
+        public Task PublishAsync(
+            string topic, MessageEnvelope envelope, CancellationToken cancellationToken = default)
+        {
+            Published.Add((topic, envelope.GetPayload<AgentReply>()!));
+            return Task.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/tests/RockBot.Host.Tests/MemoryStoreWalkerTests.cs
+++ b/tests/RockBot.Host.Tests/MemoryStoreWalkerTests.cs
@@ -1,0 +1,134 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace RockBot.Host.Tests;
+
+/// <summary>
+/// The walker is what makes the audit read-only. Every one of these cases is something
+/// <c>FileMemoryStore</c> would hide or destroy — archived entries it filters out of search,
+/// empty category directories it prunes on load, malformed files it skips silently.
+/// </summary>
+[TestClass]
+public class MemoryStoreWalkerTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true
+    };
+
+    private string _root = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "rockbot-audit-walk-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_root))
+            Directory.Delete(_root, recursive: true);
+    }
+
+    [TestMethod]
+    public async Task FindsEntriesInNestedCategoryDirectories()
+    {
+        Write("a", new MemoryEntry("a", "root fact", null, [], DateTimeOffset.UtcNow));
+        Write("user/prefs/b", new MemoryEntry("b", "nested fact", "user/prefs", [], DateTimeOffset.UtcNow));
+
+        var result = await MemoryStoreWalker.WalkAsync(_root, NullLogger.Instance);
+
+        CollectionAssert.AreEquivalent(
+            new[] { "a", "b" }, result.Entries.Select(e => e.Id).ToArray());
+        Assert.AreEqual(0, result.MalformedFiles);
+    }
+
+    [TestMethod]
+    public async Task ReturnsArchivedEntriesAlongsideLiveOnes()
+    {
+        Write("live", new MemoryEntry("live", "kept", null, [], DateTimeOffset.UtcNow));
+        Write("gone", new MemoryEntry("gone", "retired", null, [], DateTimeOffset.UtcNow)
+        {
+            ArchivedAt = DateTimeOffset.UtcNow.AddDays(-3),
+            ArchiveReason = "merged into live"
+        });
+
+        var result = await MemoryStoreWalker.WalkAsync(_root, NullLogger.Instance);
+
+        Assert.AreEqual(2, result.Entries.Count);
+        Assert.AreEqual(1, result.Entries.Count(e => e.ArchivedAt is not null));
+    }
+
+    [TestMethod]
+    public async Task SkipsMalformedFilesAndCountsThem()
+    {
+        Write("good", new MemoryEntry("good", "fine", null, [], DateTimeOffset.UtcNow));
+        File.WriteAllText(Path.Combine(_root, "broken.json"), "{ not json at all");
+
+        var result = await MemoryStoreWalker.WalkAsync(_root, NullLogger.Instance);
+
+        Assert.AreEqual(1, result.Entries.Count);
+        Assert.AreEqual(1, result.MalformedFiles);
+    }
+
+    [TestMethod]
+    public async Task IgnoresTheEmbeddingCacheDirectory()
+    {
+        Write("a", new MemoryEntry("a", "fact", null, [], DateTimeOffset.UtcNow));
+
+        var embeddings = Path.Combine(_root, ".embeddings");
+        Directory.CreateDirectory(embeddings);
+        File.WriteAllText(Path.Combine(embeddings, "manifest.json"), "{\"anything\":1}");
+        File.WriteAllBytes(Path.Combine(embeddings, "a.bin"), [1, 2, 3]);
+
+        var result = await MemoryStoreWalker.WalkAsync(_root, NullLogger.Instance);
+
+        Assert.AreEqual(1, result.Entries.Count);
+        Assert.AreEqual(0, result.MalformedFiles, "The embedding manifest is not a malformed entry.");
+        Assert.AreEqual(0, result.EmptyCategoryDirs, "The embedding folder is not a category.");
+    }
+
+    [TestMethod]
+    public async Task CountsEmptyCategoryDirectories()
+    {
+        Write("user/a", new MemoryEntry("a", "fact", "user", [], DateTimeOffset.UtcNow));
+        Directory.CreateDirectory(Path.Combine(_root, "abandoned"));
+        Directory.CreateDirectory(Path.Combine(_root, "also/abandoned"));
+
+        var result = await MemoryStoreWalker.WalkAsync(_root, NullLogger.Instance);
+
+        // "abandoned", "also" and "also/abandoned" — a parent whose only content is an empty
+        // child is itself empty.
+        Assert.AreEqual(3, result.EmptyCategoryDirs);
+    }
+
+    [TestMethod]
+    public async Task DoesNotCountAParentThatHoldsAPopulatedChild()
+    {
+        Write("user/prefs/a", new MemoryEntry("a", "fact", "user/prefs", [], DateTimeOffset.UtcNow));
+
+        var result = await MemoryStoreWalker.WalkAsync(_root, NullLogger.Instance);
+
+        Assert.AreEqual(0, result.EmptyCategoryDirs);
+    }
+
+    [TestMethod]
+    public async Task AMissingRootIsAnEmptyCorpus_NotAnError()
+    {
+        var result = await MemoryStoreWalker.WalkAsync(
+            Path.Combine(_root, "does-not-exist"), NullLogger.Instance);
+
+        Assert.AreEqual(0, result.Entries.Count);
+        Assert.AreEqual(0, result.EmptyCategoryDirs);
+    }
+
+    private void Write(string relativePath, MemoryEntry entry)
+    {
+        var path = Path.Combine(_root, relativePath.Replace('/', Path.DirectorySeparatorChar) + ".json");
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, JsonSerializer.Serialize(entry, JsonOptions));
+    }
+}

--- a/tests/RockBot.Host.Tests/ShingleSimilarityTests.cs
+++ b/tests/RockBot.Host.Tests/ShingleSimilarityTests.cs
@@ -1,0 +1,99 @@
+namespace RockBot.Host.Tests;
+
+/// <summary>
+/// The audit's near-duplicate measure. It must not agree with the vector index it is measuring,
+/// so it is checked here purely on text.
+/// </summary>
+[TestClass]
+public class ShingleSimilarityTests
+{
+    private const int ShingleSize = 3;
+
+    [TestMethod]
+    public void IdenticalTextsScoreOne()
+    {
+        var a = ShingleSimilarity.Shingles("the deploy failed because the image tag was stale", ShingleSize);
+        var b = ShingleSimilarity.Shingles("the deploy failed because the image tag was stale", ShingleSize);
+
+        Assert.AreEqual(1.0, ShingleSimilarity.Jaccard(a, b), 1e-9);
+    }
+
+    [TestMethod]
+    public void CaseAndPunctuationDoNotChangeTheScore()
+    {
+        var a = ShingleSimilarity.Shingles("Rocky uses timezone America/Chicago.", ShingleSize);
+        var b = ShingleSimilarity.Shingles("rocky uses timezone america chicago", ShingleSize);
+
+        Assert.AreEqual(1.0, ShingleSimilarity.Jaccard(a, b), 1e-9);
+    }
+
+    [TestMethod]
+    public void OverlappingTextsScoreBetweenZeroAndOne()
+    {
+        var a = ShingleSimilarity.Shingles("the agent stores memories on the shared volume", ShingleSize);
+        var b = ShingleSimilarity.Shingles("the agent stores skills on the shared volume", ShingleSize);
+
+        var score = ShingleSimilarity.Jaccard(a, b);
+
+        Assert.IsTrue(score is > 0 and < 1, $"Expected partial overlap, got {score}.");
+    }
+
+    [TestMethod]
+    public void DisjointTextsScoreZero()
+    {
+        var a = ShingleSimilarity.Shingles("kubernetes cluster runs in the lakehouse namespace", ShingleSize);
+        var b = ShingleSimilarity.Shingles("coffee tastes better ground fresh each morning", ShingleSize);
+
+        Assert.AreEqual(0.0, ShingleSimilarity.Jaccard(a, b), 1e-9);
+    }
+
+    [TestMethod]
+    public void WordOrderMatters()
+    {
+        // Same tokens, different meaning. A bag-of-words measure would call these identical.
+        var a = ShingleSimilarity.Shingles("the deploy failed because the tag was stale", ShingleSize);
+        var b = ShingleSimilarity.Shingles("the tag failed because the deploy was stale", ShingleSize);
+
+        Assert.IsTrue(ShingleSimilarity.Jaccard(a, b) < 1.0);
+    }
+
+    [TestMethod]
+    public void TextsShorterThanTheShingleSizeProduceNoShingles()
+    {
+        Assert.AreEqual(0, ShingleSimilarity.Shingles("two words", ShingleSize).Count);
+        Assert.AreEqual(0, ShingleSimilarity.Shingles(null, ShingleSize).Count);
+        Assert.AreEqual(0, ShingleSimilarity.Shingles("   ", ShingleSize).Count);
+    }
+
+    [TestMethod]
+    public void ShortEntriesAreSkippedRatherThanMatchingEachOther()
+    {
+        var entries = new List<MemoryEntry>
+        {
+            Entry("a", "too short"),
+            Entry("b", "also short"),
+            Entry("c", "the agent stores memories on the shared volume today"),
+            Entry("d", "the agent stores memories on the shared volume today")
+        };
+
+        var pairs = ShingleSimilarity.FindNearDuplicatePairs(entries, ShingleSize, 0.3);
+
+        Assert.AreEqual(1, pairs.Count, "Only the two long identical entries should pair.");
+        CollectionAssert.AreEquivalent(new[] { "c", "d" }, new[] { pairs[0].IdA, pairs[0].IdB });
+    }
+
+    [TestMethod]
+    public void PairsBelowTheThresholdAreNotReturned()
+    {
+        var entries = new List<MemoryEntry>
+        {
+            Entry("a", "kubernetes cluster runs in the lakehouse namespace on premises"),
+            Entry("b", "coffee tastes better when ground fresh each and every morning")
+        };
+
+        Assert.AreEqual(0, ShingleSimilarity.FindNearDuplicatePairs(entries, ShingleSize, 0.3).Count);
+    }
+
+    private static MemoryEntry Entry(string id, string content) =>
+        new(id, content, null, [], DateTimeOffset.UtcNow);
+}


### PR DESCRIPTION
Closes #554.

## Why

Every finding about memory management so far — the August data loss, #506, the #550 treadmill review — came from a human pulling the PVC and grepping Loki after the fact. That doesn't scale and it catches nothing early:

- **Loki keeps about a week.** A corpus losing 2% a month looks healthy in every seven-day window and is catastrophic across a year.
- **The dream-pass ledger records only last-run timestamps.** It can't count consolidation cycles, and *nothing* records process restarts — which is what turned a day of deploys into a day of consolidation passes.
- **The dream cycle's own log lines looked healthy through every incident.** A pass reporting "12 merged, 8 archived" reports exactly that whether the merges were good or catastrophic.

`MemoryAuditService` measures the store on its own cron, from disk, into a file whose retention is measured in months.

## Design decisions worth reviewing

**Read-only by construction.** It walks the memory files itself rather than instantiating a second `FileMemoryStore` — that store's index load prunes empty category directories as a side effect, so an auditor using one would delete the very thing it's counting. `MemoryAuditServiceTests` constructs the service with a store whose every write path throws, so this is enforced mechanically rather than by review.

**Deltas key on entry ids, never timestamps.** A merged entry inherits its earliest source's `createdAt`, so a timestamp-based count of creations reports zero for exactly the churn this exists to expose.

**Hard deletes are explained, not assumed.** No purge timestamp is recorded anywhere in the agent, so a vanished id counts as purged only if it was archived at the previous run *and* past `MemoryArchiveRetention`. Everything else lands in `hardDeletedOutsidePurge`, expected to be zero.

**Near-duplicates are lexical, not vector.** If the audit and the deduplicator both asked the same index "are these the same?", a broken index would read as a clean corpus.

**A healthy run is silent.** Only a non-healthy status pushes a message. A channel that reports "all clear" daily stops being read before the day it matters.

## Findings explain themselves

`chain-depth-threshold` is a stable identifier and useless to a person. Two surfaces translate it, neither costing baseline context:

- `get_memory_audit` returns each violation paired with a plain-language title, meaning, what-to-do and severity — so the explanation arrives *with* the finding rather than depending on the model deciding to fetch it (this repo has measured twice that it doesn't reliably call lookup tools).
- `get_tool_guide("memory-audit")` carries the longer background, via the existing `IToolSkillProvider` mechanism. Guides are never injected into the system prompt.

`directives.md` gains only the routing rule (memory-health questions → the audit, not `recall`). A new invariant without a glossary entry is a test failure.

## Changes outside the audit

- **`DreamService`** — a refused merge stamps its sources with `consolidationRejectedCluster`/`At`, making the treadmill observable on disk instead of only in a log line inside Loki's window; and `RunMemoryConsolidationPassAsync` skips while the pause marker exists (only that pass — mining, extraction and retention sweeps keep running).
- **`WellKnownSessions.ScheduledSystem`** replaces the `"scheduled-system"` literal. This needed a `RockBot.Host.Abstractions` project reference on the Blazor project (plus the matching Dockerfile csproj-copy line) — it had no path to that assembly.

## Validation

Deployed to a live cluster and run against a real 1936-entry corpus. An independent walk reproduced the audit's numbers exactly — 853 live, 1083 archived, identical chain-depth histogram.

It found **no data loss** (zero hard deletes outside the purge; all 245 referenced merge targets resolve) and **one true positive**: a live entry at the end of an 8-deep merge chain. Walking it showed nine generations with the specifics intact — the coverage check is working — but real drift: *"omitting `calendarId` **fails**"* had become *"**can** fail"*. Correctly a warning, not an alert.

**Three defects only running it surfaced, all fixed here:**

1. **A false `net-growth-threshold` that would have fired on every deploy.** A restart puts two runs minutes apart; extrapolating six ordinary saves over 7 minutes gave *1311 entries/day*. `netGrowthPerDay` is now `double?` — null means "the window was too short to measure", a different answer from zero — and rate-based invariants skip below `MinRateWindow` (12h). Absolute counts are untouched, so a short-window run still catches real loss.
2. **An out-of-order depth histogram** (`1, 3, 4, 2, 7, 5, 6, 8`).
3. **`net (null)/day`** in the structured log line.

Also confirmed an assumption I'd guessed at: `merge-chain-unbroken` does *not* fire spuriously on months of purge history. Had it, the invariant would have needed the same purge-aging tolerance `merged-from-resolves` has.

## Testing

`dotnet build RockBot.slnx` and `dotnet test RockBot.slnx` — 20 assemblies, 0 failures, ~90 new tests. Helm chart renders on both the enabled and disabled paths. The August incident is replayed as a unit test (148 → 109 live, 74 ids gone, asserts 74 hard deletes and `alert`).

## Notes for the reviewer

- The circuit breaker (`PauseConsolidationOnAlert`) is **off by default** — a false positive stops the only thing keeping the corpus from growing without bound. Turn it on once the numbers are trusted on a given deployment.
- The weekly eval costs four Balanced-tier JSON calls, skipped entirely when the corpus fingerprint hasn't moved.
- `directives.md` and `memory-audit.md` reach a live cluster only via the PVC (`memory-audit.md` is new so the init container seeds it; `directives.md` needs a push).
- At the default `ShingleSize` of 6, the near-duplicate metric catches near-*verbatim* duplication rather than rephrasings. Documented; lower it for the looser measure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uf8a2Z1v9dY3YjjM42zJEj
