### PR TITLE
Stop the agent narrating memory writes on longer follow-ups (#397)

### DIFF
--- a/src/RockBot.Agent/UserMessageHandler.cs
+++ b/src/RockBot.Agent/UserMessageHandler.cs
@@ -65,8 +65,10 @@ internal sealed class UserMessageHandler(
     // Heuristic for "thread is currently active" — controls whether the tier selector
     // applies the short-message-on-active-thread override. Conservative enough to leave
     // first-turn and stale-session messages on the existing routing path. See #383.
-    private const int ThreadEstablishedMinTurns = 3;
-    private static readonly TimeSpan ThreadEstablishedRecency = TimeSpan.FromMinutes(30);
+    // Shared with AgentContextBuilder's recent-window query enrichment (#397) so both
+    // read "the thread is live" the same way.
+    private const int ThreadEstablishedMinTurns = ShortMessageHeuristics.ThreadEstablishedMinTurns;
+    private static readonly TimeSpan ThreadEstablishedRecency = ShortMessageHeuristics.ThreadEstablishedRecency;
 
     // Shared with AgentLoopRunner — single source of truth for hallucinated-action detection.
     private static readonly Regex HallucinatedActionRegex = AgentLoopRunner.HallucinatedActionRegex;

--- a/src/RockBot.Agent/agent/directives.md
+++ b/src/RockBot.Agent/agent/directives.md
@@ -280,9 +280,19 @@ memory or knowledge graph entries happen to have been injected this turn.
   like "Noted, I've got that on the travel ledger" answer "what did you
   just store?" rather than the user's actual message.
 - **Short messages that DO introduce a new fact** ("My birthday is March
-  12.") are different — saving and acknowledging is the correct response.
-  The test is whether the fact came from the user's words this turn, or
-  from already-injected context.
+  12.", "Hopefully we can go this winter — my health seems better now")
+  should still be saved. But saving is not the reply. Respond to what the
+  user said as a contribution to the conversation you are already having,
+  and say nothing about the write itself. The test for whether to save is
+  whether the fact came from the user's words this turn, or from
+  already-injected context.
+
+- **Never close a reply by narrating what you stored.** Sentences like
+  "I've marked it as a winter trip goal", "I've got that on the travel
+  ledger", or "That's on the list now" report your own bookkeeping, which
+  the user did not ask about. The exception is when the user explicitly
+  asked you to remember something — then confirming the write is exactly
+  what they wanted.
 
 If the short message is genuinely ambiguous, ask one focused clarifying
 question about the active thread rather than guessing from injected memory.

--- a/src/RockBot.Host.Abstractions/ShortMessageHeuristics.cs
+++ b/src/RockBot.Host.Abstractions/ShortMessageHeuristics.cs
@@ -18,4 +18,28 @@ public static class ShortMessageHeuristics
     /// band, and the longer 67-char variant is handled as a separate concern.
     /// </summary>
     public const int UserMessageCharThreshold = 30;
+
+    /// <summary>
+    /// Maximum character length, inclusive, for a user message to be treated as a
+    /// conversational follow-up for the purposes of the memory-narration guard.
+    /// Deliberately wider than <see cref="UserMessageCharThreshold"/>: a fact-introducing
+    /// follow-up ("Hopefully we can go this coming winter. My health seems better now",
+    /// 66 chars) sits above the lexical-noise band that gates the BM25 and routing
+    /// defenses, but still exhibits the storing-and-summarising failure. Only consumed
+    /// by the AgentLoopRunner guard, which additionally requires a memory write and a
+    /// narration-shaped response — the 30-char gates are unaffected. See issue #397.
+    /// </summary>
+    public const int FollowUpMessageCharThreshold = 120;
+
+    /// <summary>
+    /// Minimum number of prior turns before a session counts as an established
+    /// conversational thread. Conservative enough to leave first-turn messages on the
+    /// unmodified path.
+    /// </summary>
+    public const int ThreadEstablishedMinTurns = 3;
+
+    /// <summary>
+    /// Maximum age of the most recent prior turn for a thread to still count as active.
+    /// </summary>
+    public static readonly TimeSpan ThreadEstablishedRecency = TimeSpan.FromMinutes(30);
 }

--- a/src/RockBot.Host/AgentContextBuilder.cs
+++ b/src/RockBot.Host/AgentContextBuilder.cs
@@ -53,6 +53,60 @@ public sealed class AgentContextBuilder(
     private readonly KnowledgeGraphOptions _graphOptions = knowledgeGraphOptions.Value;
     private readonly IEmbeddingGenerator<string, Embedding<float>>? _embeddingGenerator = embeddingGenerators.FirstOrDefault();
 
+    /// <summary>How many prior turns are folded into the enriched search query.</summary>
+    private const int RecentWindowTurns = 2;
+
+    /// <summary>Per-turn character cap when building the enriched search query.</summary>
+    private const int RecentWindowTurnChars = 200;
+
+    /// <summary>
+    /// Anchors the per-turn search query on the active conversation thread by appending
+    /// the last <see cref="RecentWindowTurns"/> turns to the incoming message. Returns the
+    /// raw message unchanged for short messages (already fully gated), on the first turns
+    /// of a session, and on a stale thread — the cases where there is no thread to anchor
+    /// to, or where the raw message is all the signal there is. See issue #397.
+    /// </summary>
+    private string BuildSearchQuery(
+        string currentUserContent,
+        IReadOnlyList<ConversationTurn> history,
+        bool isShortMessage,
+        string sessionId)
+    {
+        if (isShortMessage || string.IsNullOrWhiteSpace(currentUserContent) || history.Count == 0)
+            return currentUserContent;
+
+        // Callers add the incoming user turn to conversation memory before building
+        // context (UserMessageHandler), so drop it to leave only prior turns.
+        var prior = history;
+        if (string.Equals(history[^1].Role, "user", StringComparison.OrdinalIgnoreCase)
+            && string.Equals(history[^1].Content, currentUserContent, StringComparison.Ordinal))
+        {
+            prior = history.Take(history.Count - 1).ToList();
+        }
+
+        var threadEstablished = prior.Count >= ShortMessageHeuristics.ThreadEstablishedMinTurns
+            && (DateTimeOffset.UtcNow - prior[^1].Timestamp) <= ShortMessageHeuristics.ThreadEstablishedRecency;
+
+        if (!threadEstablished)
+            return currentUserContent;
+
+        var window = prior
+            .Skip(Math.Max(0, prior.Count - RecentWindowTurns))
+            .Select(t => t.Content.Length > RecentWindowTurnChars
+                ? t.Content[..RecentWindowTurnChars]
+                : t.Content)
+            .Where(c => !string.IsNullOrWhiteSpace(c));
+
+        var enriched = currentUserContent + "\n" + string.Join("\n", window);
+
+        logger.LogInformation(
+            "Recent-window query enrichment applied for session {SessionId} " +
+            "({Turns} prior turns folded in, query {Before} → {After} chars)",
+            sessionId, Math.Min(RecentWindowTurns, prior.Count), currentUserContent.Length, enriched.Length);
+
+        return enriched;
+    }
+
     /// <summary>
     /// Builds the full chat message list for one LLM call: system prompt, rules, history,
     /// long-term memory recall, skill index + BM25 recall, and working memory inventory.
@@ -147,6 +201,21 @@ public sealed class AgentContextBuilder(
                 "Short user message ({Len} chars ≤ {Threshold}) — skipping per-turn topic search injection",
                 currentUserContent.Length, ShortMessageHeuristics.UserMessageCharThreshold);
 
+        // ── Conversation history, read ahead of the search wave ──────────────
+        // Awaited before the other stores (rather than alongside them) so the recent
+        // window is available to anchor the per-turn search query below. This is a
+        // local store read; the remaining lookups still run concurrently.
+        var history = await conversationMemory.GetTurnsAsync(sessionId, ct);
+
+        // Recent-window query enrichment (#397). A fact-introducing follow-up on a live
+        // thread ("Hopefully we can go this coming winter. My health seems better now")
+        // carries too few distinctive terms to retrieve the memories the conversation is
+        // actually about, so BM25 answers with whatever else those words touch. Appending
+        // the last couple of turns keeps the query anchored on the thread. The raw message
+        // still leads, and the window is deliberately small so a genuine topic change is
+        // not drowned out by what came before.
+        var searchQuery = BuildSearchQuery(currentUserContent, history, isShortMessage, sessionId);
+
         // ── Wave 0: generate the query embedding once, shared across all searches ──
         // Avoids redundant calls to the embedding endpoint — each store would otherwise
         // generate its own query embedding for the same user message text. Skipped
@@ -157,7 +226,7 @@ public sealed class AgentContextBuilder(
         {
             try
             {
-                var result = await _embeddingGenerator.GenerateAsync(currentUserContent, cancellationToken: ct);
+                var result = await _embeddingGenerator.GenerateAsync(searchQuery, cancellationToken: ct);
                 sharedQueryEmbedding = result.Vector.ToArray();
                 logger.LogInformation("Shared query embedding generated ({Dimensions} dimensions)", sharedQueryEmbedding.Length);
             }
@@ -179,15 +248,14 @@ public sealed class AgentContextBuilder(
         // Evaluate skill index gate synchronously (has side effects — marks session).
         var shouldInjectSkillIndex = skillIndexTracker.TryMarkAsInjected(sessionId);
 
-        var historyTask = conversationMemory.GetTurnsAsync(sessionId, ct);
         var ltmTask = isShortMessage
             ? Task.FromResult<IReadOnlyList<MemoryEntry>>([])
             : longTermMemory.SearchAsync(
-                new MemorySearchCriteria(Query: currentUserContent, MaxResults: 8, QueryEmbedding: sharedQueryEmbedding));
+                new MemorySearchCriteria(Query: searchQuery, MaxResults: 8, QueryEmbedding: sharedQueryEmbedding));
         var episodicTask = isShortMessage
             ? Task.FromResult<IReadOnlyList<MemoryEntry>>([])
             : longTermMemory.SearchAsync(
-                new MemorySearchCriteria(Query: currentUserContent, Category: "episodic", MaxResults: 5, QueryEmbedding: sharedQueryEmbedding));
+                new MemorySearchCriteria(Query: searchQuery, Category: "episodic", MaxResults: 5, QueryEmbedding: sharedQueryEmbedding));
         var identityTask = longTermMemory.SearchAsync(
             new MemorySearchCriteria(Category: AgentIdentityCategories.Prefix, MaxResults: 20));
         var skillListTask = shouldInjectSkillIndex
@@ -195,8 +263,10 @@ public sealed class AgentContextBuilder(
             : Task.FromResult<IReadOnlyList<Skill>>([]);
         var skillSearchTask = isShortMessage
             ? Task.FromResult<IReadOnlyList<Skill>>([])
-            : skillStore.SearchAsync(currentUserContent, maxResults: 5, ct, queryEmbedding: sharedQueryEmbedding);
+            : skillStore.SearchAsync(searchQuery, maxResults: 5, ct, queryEmbedding: sharedQueryEmbedding);
         var wmTask = workingMemory.ListAsync(wmNamespace);
+        // Entity extraction wants the literal message, not the enriched window — seeding
+        // the graph from prior turns would re-traverse entities already in context.
         var graphTask = _knowledgeGraph?.FindEntitiesByNameAsync(currentUserContent);
         var patrolTask = isUserSession
             ? workingMemory.ListAsync("patrol")
@@ -211,13 +281,12 @@ public sealed class AgentContextBuilder(
 
         // Await all wave-1 tasks. graphTask may be null when no knowledge graph is configured.
         if (graphTask is not null)
-            await Task.WhenAll(historyTask, ltmTask, episodicTask, identityTask,
+            await Task.WhenAll(ltmTask, episodicTask, identityTask,
                 skillListTask, skillSearchTask, wmTask, graphTask, patrolTask, subagentTask, sharedTask);
         else
-            await Task.WhenAll(historyTask, ltmTask, episodicTask, identityTask,
+            await Task.WhenAll(ltmTask, episodicTask, identityTask,
                 skillListTask, skillSearchTask, wmTask, patrolTask, subagentTask, sharedTask);
 
-        var history = historyTask.Result;
         var recalled = ltmTask.Result;
         var episodes = episodicTask.Result;
         var identityEntries = identityTask.Result;

--- a/src/RockBot.Host/AgentLoopRunner.cs
+++ b/src/RockBot.Host/AgentLoopRunner.cs
@@ -153,6 +153,35 @@ public sealed partial class AgentLoopRunner(
         "conversational thread. Do not narrate your memory-write activity.";
 
     /// <summary>
+    /// Detects a reply whose whole body is memory-write narration, in the phrasings that
+    /// do not open with "Noted" and so slip past <see cref="MemorySummaryReplyRegex"/> —
+    /// "I've marked it as a winter trip goal…", "I've got that on the travel list."
+    /// Requires a first-person write verb, a pronoun object, and memory vocabulary, so a
+    /// reply reporting a genuine non-memory outcome does not match. Used by the guard
+    /// only for whole-response narration; the trailing-paragraph form is removed without
+    /// a re-prompt by <see cref="ResponseSanitizer.StripTrailingMemoryNarration"/>.
+    /// See issue #397.
+    /// </summary>
+    public static readonly Regex MemoryNarrationReplyRegex = new(
+        @"^\s*(?:Noted[.,!]?\s+|Done[.,!]?\s+|Okay[.,!]?\s+|Sure[.,!]?\s+)?" +
+        @"I(?:'ve|\s+have|'m|\s+am)?\s*(?:also\s+)?" +
+        @"(?:marked|logged|noted|saved|stored|got|added|put|recorded|captured|filed|keeping|kept)\s+" +
+        @"(?:it|that|this|them|(?-i:[A-Z])[\w'’-]*(?:\s+[\w'’-]+){0,3})\b" +
+        @"(?![^\n]*\b(?:todo|to-do|task list|calendar|reminder|shopping list|invite|email|draft|file)\b)" +
+        @"[^\n]*\b(?:memor(?:y|ies)|ledger|board|wishlist|list|notes?|record|on file|in mind|for later|down|goal|picture|profile)\b",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    /// <summary>
+    /// Matches a user message that explicitly asks the agent to remember something.
+    /// When the user commanded the write, confirming it is the correct reply — the
+    /// memory-narration guard and the trailing-narration strip both stand down.
+    /// </summary>
+    public static readonly Regex ExplicitMemoryCommandRegex = new(
+        @"\b(?:remember|memorize|memorise|don'?t forget|keep track|make a note|note that|" +
+        @"save (?:that|this|it)|store (?:that|this|it)|write (?:that|this|it) down|add (?:that|this|it) to (?:my )?memory)\b",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    /// <summary>
     /// Context window limit in tokens, learned from the first overflow error (text-based path only).
     /// </summary>
     private int? _knownContextLimit;
@@ -449,7 +478,7 @@ public sealed partial class AgentLoopRunner(
             {
                 HostDiagnostics.CompletionCheckSkipped.Add(1);
                 logger.LogInformation("Completion evaluator: SKIPPED (consecutive timeouts)");
-                return result.Response;
+                return FinalizeResponse(result.Response, chatMessages, originalUserRequest);
             }
 
             // Model-specific sanity checks on the output. Each is independently gated by
@@ -518,15 +547,24 @@ public sealed partial class AgentLoopRunner(
                 continue;
             }
 
-            // Memory-summary reply guard (#383). Fires when a short user message
-            // produced a turn that invoked SaveMemory AND closed with the
-            // "Noted, I saved X" pattern — the production signature for a model
-            // summarising injected long-term memory instead of replying to the
-            // actual follow-up. Logs every match for telemetry on false positives,
-            // and re-prompts at most once per RunAsync.
+            // Memory-summary reply guard (#383, widened by #397). Fires when a
+            // conversational follow-up produced a turn that invoked SaveMemory AND the
+            // whole reply is memory-write narration — either the "Noted, I saved X"
+            // opener from #383 or the "I've marked it as X" form from #397, which does
+            // not start with "Noted" and so needs its own pattern. The trailing-narration
+            // variant (a real answer followed by a narration paragraph) is handled
+            // without a re-prompt in FinalizeResponse.
+            //
+            // The length gate is FollowUpMessageCharThreshold (120), not the 30-char
+            // UserMessageCharThreshold used by the BM25 and routing defenses — the #397
+            // reproducer is 66 chars. The extra conditions (memory write happened, reply
+            // is narration-shaped, user did not ask for the write) carry the precision.
+            var userAskedToRemember = ExplicitMemoryCommandRegex.IsMatch(originalUserRequest);
             if (modelBehavior.NudgeOnMemorySummaryReply
-                && originalUserRequest.Length <= ShortMessageHeuristics.UserMessageCharThreshold
-                && MemorySummaryReplyRegex.IsMatch(result.Response)
+                && originalUserRequest.Length <= ShortMessageHeuristics.FollowUpMessageCharThreshold
+                && !userAskedToRemember
+                && (MemorySummaryReplyRegex.IsMatch(result.Response)
+                    || MemoryNarrationReplyRegex.IsMatch(result.Response))
                 && SavedMemoryThisTurn(chatMessages))
             {
                 var preview = result.Response.Length > 80
@@ -550,7 +588,7 @@ public sealed partial class AgentLoopRunner(
 
             // Skip evaluation when disabled or on the final re-prompt.
             if (!enableCompletionEval || maxReprompts == 0 || reprompt == maxReprompts)
-                return result.Response;
+                return FinalizeResponse(result.Response, chatMessages, originalUserRequest);
 
             // Skip evaluation when the agent delegated to a subagent. Spawning a
             // subagent is intentional delegation — the SubagentResultHandler will
@@ -561,7 +599,7 @@ public sealed partial class AgentLoopRunner(
             {
                 HostDiagnostics.CompletionCheckSkipped.Add(1);
                 logger.LogInformation("Completion evaluator: SKIPPED (delegated to subagent/agent)");
-                return result.Response;
+                return FinalizeResponse(result.Response, chatMessages, originalUserRequest);
             }
 
             // Heuristic short-circuit: if the model stopped naturally and the response
@@ -581,7 +619,7 @@ public sealed partial class AgentLoopRunner(
                 if (!enableFollowUp || reprompt > 0)
                 {
                     HostDiagnostics.FollowUpSkipped.Add(1);
-                    return result.Response;
+                    return FinalizeResponse(result.Response, chatMessages, originalUserRequest);
                 }
 
                 try
@@ -598,7 +636,7 @@ public sealed partial class AgentLoopRunner(
                 {
                     logger.LogWarning(ex,
                         "Follow-up pass failed; returning completed response instead of propagating error");
-                    return result.Response;
+                    return FinalizeResponse(result.Response, chatMessages, originalUserRequest);
                 }
             }
 
@@ -625,7 +663,7 @@ public sealed partial class AgentLoopRunner(
                 if (!enableFollowUp || reprompt > 0)
                 {
                     HostDiagnostics.FollowUpSkipped.Add(1);
-                    return result.Response;
+                    return FinalizeResponse(result.Response, chatMessages, originalUserRequest);
                 }
 
                 try
@@ -642,7 +680,7 @@ public sealed partial class AgentLoopRunner(
                 {
                     logger.LogWarning(ex,
                         "Follow-up pass failed; returning completed response instead of propagating error");
-                    return result.Response;
+                    return FinalizeResponse(result.Response, chatMessages, originalUserRequest);
                 }
             }
 
@@ -2684,6 +2722,36 @@ public sealed partial class AgentLoopRunner(
     /// actually wrote to long-term memory before re-prompting on the
     /// "Noted, I saved X" pattern. Internal so tests can exercise it directly.
     /// </summary>
+    /// <summary>
+    /// Final post-processing applied to every response leaving <see cref="RunAsync"/>.
+    /// Removes a trailing memory-write narration paragraph ("…\n\nI've marked it as a
+    /// winter trip goal…") when this turn actually wrote to long-term memory and the
+    /// user did not ask for the write. Issue #397: the model answers the user correctly
+    /// and then appends a sentence narrating what it stored, which reads as a
+    /// non-sequitur closing. Stripping is deterministic and costs no extra LLM turn;
+    /// replies that are *entirely* narration are left alone here and handled by the
+    /// memory-summary re-prompt guard instead.
+    /// </summary>
+    private string FinalizeResponse(string response, List<ChatMessage> chatMessages, string originalUserRequest)
+    {
+        if (string.IsNullOrEmpty(response)
+            || !modelBehavior.NudgeOnMemorySummaryReply
+            || !SavedMemoryThisTurn(chatMessages)
+            || ExplicitMemoryCommandRegex.IsMatch(originalUserRequest))
+            return response;
+
+        var stripped = ResponseSanitizer.StripTrailingMemoryNarration(response);
+        if (ReferenceEquals(stripped, response) || stripped.Length == response.Length)
+            return response;
+
+        logger.LogInformation(
+            "Stripped trailing memory narration from response ({Before} → {After} chars); " +
+            "removed=\"{Removed}\"",
+            response.Length, stripped.Length, response[stripped.Length..].Trim());
+
+        return stripped;
+    }
+
     internal static bool SavedMemoryThisTurn(List<ChatMessage> chatMessages)
     {
         foreach (var m in chatMessages)

--- a/src/RockBot.Host/AgentLoopRunner.cs
+++ b/src/RockBot.Host/AgentLoopRunner.cs
@@ -164,11 +164,22 @@ public sealed partial class AgentLoopRunner(
     /// </summary>
     public static readonly Regex MemoryNarrationReplyRegex = new(
         @"^\s*(?:Noted[.,!]?\s+|Done[.,!]?\s+|Okay[.,!]?\s+|Sure[.,!]?\s+)?" +
-        @"I(?:'ve|\s+have|'m|\s+am)?\s*(?:also\s+)?" +
-        @"(?:marked|logged|noted|saved|stored|got|added|put|recorded|captured|filed|keeping|kept)\s+" +
-        @"(?:it|that|this|them|(?-i:[A-Z])[\w'’-]*(?:\s+[\w'’-]+){0,3})\b" +
-        @"(?![^\n]*\b(?:todo|to-do|task list|calendar|reminder|shopping list|invite|email|draft|file)\b)" +
-        @"[^\n]*\b(?:memor(?:y|ies)|ledger|board|wishlist|list|notes?|record|on file|in mind|for later|down|goal|picture|profile)\b",
+        @"(?:" +
+            // "I've marked it as a winter trip goal…"
+            @"I(?:'ve|\s+have|'m|\s+am)?\s*(?:also\s+)?" +
+            @"(?:marked|logged|noted|saved|stored|got|added|put|recorded|captured|filed|keeping|kept)\s+" +
+            @"(?:it|that|this|them|(?-i:[A-Z])[\w'’-]*(?:\s+[\w'’-]+){0,3})\b" +
+            @"(?![^\n]*\b(?:todo|to-do|task list|calendar|reminder|shopping list|invite|email|draft|file)\b)" +
+            @"[^\n]*\b(?:memor(?:y|ies)|ledger|board|wishlist|list|notes?|record|on file|in mind|for later|down|goal|picture|profile)\b" +
+        @"|" +
+            // Subjectless participle form observed live: "Added to the ledger: …".
+            // The preposition is required so "Added the notes to the shared drive"
+            // — a real file action — does not match.
+            @"(?:Added|Logged|Noted|Saved|Stored|Recorded|Captured|Filed)\s+" +
+            @"(?:it\s+|that\s+|this\s+|them\s+)?(?:to|in|on|onto|under)\s+" +
+            @"(?![^\n]*\b(?:todo|to-do|task list|calendar|reminder|shopping list|invite|email|draft|file)\b)" +
+            @"[^\n]{0,40}?\b(?:memor(?:y|ies)|ledger|board|wishlist|list|notes?|record|profile)\b" +
+        @")",
         RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
     /// <summary>

--- a/src/RockBot.Host/ResponseSanitizer.cs
+++ b/src/RockBot.Host/ResponseSanitizer.cs
@@ -61,4 +61,69 @@ public static partial class ResponseSanitizer
 
         return result;
     }
+
+    // Matches a trailing paragraph that narrates a memory write — the production
+    // signature from issue #397, where the model answers the user properly and then
+    // appends a sentence reporting what it stored:
+    //
+    //   "I've marked it as a winter trip goal tied to your joints and the dry air."
+    //   "I've got Cathedral City in the travel picture now, ..."
+    //   "Noted it in memory."
+    //
+    // Three parts must all be present, which is what keeps legitimate outcome reports
+    // out of the pattern:
+    //
+    //   1. a first-person memory-write verb,
+    //   2. a pronoun or proper-noun object. "I've saved the file to /tmp/x" reports a
+    //      real outcome the user needs to hear; the lowercase determiner keeps it out,
+    //      while "I've got Cathedral City in the travel picture" — the same narration
+    //      with a named subject — stays in. The proper-noun branch is matched
+    //      case-sensitively via (?-i:…) since the pattern as a whole ignores case.
+    //   3. memory-storage vocabulary, with todo/calendar/reminder targets excluded
+    //      because those describe genuine tool actions rather than memory narration.
+    //
+    // Anchored to a trailing paragraph the same way TrailingOfferPattern is; a reply
+    // that is *entirely* narration is left to the AgentLoopRunner re-prompt guard.
+    [GeneratedRegex(
+        @"(\r?\n){1,}" +                                        // one or more newlines
+        @"(?:Also,?\s|And\s|Noted[.,]?\s)?" +                   // optional lead-in
+        @"I(?:'ve|\s+have|\s+am|'m)?\s*" +                      // "I", "I've", "I have", "I'm"
+        @"(?:also\s+)?" +
+        @"(?:marked|logged|noted|saved|stored|got|added|put|recorded|captured|filed|" +
+            @"keeping|kept|holding|held)\s+" +                  // memory-write verb
+        @"(?:it|that|this|them|(?-i:[A-Z])[\w'’-]*(?:\s+[\w'’-]+){0,3})\b" +  // object (see note 2)
+        @"(?![^\n]*\b(?:todo|to-do|task list|calendar|reminder|shopping list|" +
+            @"invite|email|draft|file|repo|branch|issue|pull request)\b)" +  // real-action exclusions
+        @"[^\n]*\b(?:memor(?:y|ies)|ledger|board|wishlist|list|notes?|record|" +
+            @"on file|in mind|for later|down|goal|picture|profile)\b" +      // memory vocabulary
+        @"[^\n]*(?:\r?\n[^\n]+)*$",                             // consume the trailing paragraph
+        RegexOptions.IgnoreCase | RegexOptions.Compiled)]
+    private static partial Regex TrailingMemoryNarrationPattern();
+
+    /// <summary>
+    /// Strips a trailing paragraph that narrates a memory write ("I've marked it as a
+    /// winter trip goal…") while leaving the substantive reply intact. Returns the
+    /// original text when nothing matches, or when stripping would remove most of the
+    /// content — a reply that is *only* narration is not silently emptied; the
+    /// AgentLoopRunner memory-summary guard re-prompts for that case instead.
+    /// </summary>
+    /// <remarks>
+    /// Callers must only apply this when a memory write actually happened this turn
+    /// (see <c>AgentLoopRunner.SavedMemoryThisTurn</c>). Without that gate a reply
+    /// legitimately reporting some other stored outcome could be trimmed. See issue #397.
+    /// </remarks>
+    public static string StripTrailingMemoryNarration(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+            return text;
+
+        var result = TrailingMemoryNarrationPattern().Replace(text, string.Empty).TrimEnd();
+
+        // Same substance guard as StripTrailingOffers: only trailing narration goes,
+        // never the answer itself.
+        if (result.Length < text.Length * 0.3)
+            return text;
+
+        return result;
+    }
 }

--- a/src/RockBot.Host/ResponseSanitizer.cs
+++ b/src/RockBot.Host/ResponseSanitizer.cs
@@ -87,15 +87,26 @@ public static partial class ResponseSanitizer
     [GeneratedRegex(
         @"(\r?\n){1,}" +                                        // one or more newlines
         @"(?:Also,?\s|And\s|Noted[.,]?\s)?" +                   // optional lead-in
-        @"I(?:'ve|\s+have|\s+am|'m)?\s*" +                      // "I", "I've", "I have", "I'm"
-        @"(?:also\s+)?" +
-        @"(?:marked|logged|noted|saved|stored|got|added|put|recorded|captured|filed|" +
-            @"keeping|kept|holding|held)\s+" +                  // memory-write verb
-        @"(?:it|that|this|them|(?-i:[A-Z])[\w'’-]*(?:\s+[\w'’-]+){0,3})\b" +  // object (see note 2)
-        @"(?![^\n]*\b(?:todo|to-do|task list|calendar|reminder|shopping list|" +
-            @"invite|email|draft|file|repo|branch|issue|pull request)\b)" +  // real-action exclusions
-        @"[^\n]*\b(?:memor(?:y|ies)|ledger|board|wishlist|list|notes?|record|" +
-            @"on file|in mind|for later|down|goal|picture|profile)\b" +      // memory vocabulary
+        @"(?:" +
+            @"I(?:'ve|\s+have|\s+am|'m)?\s*" +                  // "I", "I've", "I have", "I'm"
+            @"(?:also\s+)?" +
+            @"(?:marked|logged|noted|saved|stored|got|added|put|recorded|captured|filed|" +
+                @"keeping|kept|holding|held)\s+" +              // memory-write verb
+            @"(?:it|that|this|them|(?-i:[A-Z])[\w'’-]*(?:\s+[\w'’-]+){0,3})\b" +  // object (see note 2)
+            @"(?![^\n]*\b(?:todo|to-do|task list|calendar|reminder|shopping list|" +
+                @"invite|email|draft|file|repo|branch|issue|pull request)\b)" +   // real-action exclusions
+            @"[^\n]*\b(?:memor(?:y|ies)|ledger|board|wishlist|list|notes?|record|" +
+                @"on file|in mind|for later|down|goal|picture|profile)\b" +       // memory vocabulary
+        @"|" +
+            // Subjectless participle form observed live: "Added to the ledger: …".
+            // The preposition is required so "Added the notes to the shared drive"
+            // — a real file action — does not match.
+            @"(?:Added|Logged|Noted|Saved|Stored|Recorded|Captured|Filed)\s+" +
+            @"(?:it\s+|that\s+|this\s+|them\s+)?(?:to|in|on|onto|under)\s+" +
+            @"(?![^\n]*\b(?:todo|to-do|task list|calendar|reminder|shopping list|" +
+                @"invite|email|draft|file|repo|branch|issue|pull request)\b)" +
+            @"[^\n]{0,40}?\b(?:memor(?:y|ies)|ledger|board|wishlist|list|notes?|record|profile)\b" +
+        @")" +
         @"[^\n]*(?:\r?\n[^\n]+)*$",                             // consume the trailing paragraph
         RegexOptions.IgnoreCase | RegexOptions.Compiled)]
     private static partial Regex TrailingMemoryNarrationPattern();

--- a/tests/RockBot.Host.Tests/AgentContextBuilderRecentWindowEnrichmentTests.cs
+++ b/tests/RockBot.Host.Tests/AgentContextBuilderRecentWindowEnrichmentTests.cs
@@ -1,0 +1,336 @@
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using RockBot.Host;
+using RockBot.Llm;
+using RockBot.Memory;
+using RockBot.Skills;
+
+namespace RockBot.Host.Tests;
+
+/// <summary>
+/// Covers the recent-window query enrichment in <see cref="AgentContextBuilder"/>
+/// added under issue #397. A fact-introducing follow-up on a live thread carries too
+/// few distinctive terms to retrieve what the conversation is actually about, so the
+/// per-turn search query is anchored by appending the last couple of turns. Enrichment
+/// applies only on an established thread — first turns, stale threads, and short
+/// messages keep the existing behaviour.
+/// </summary>
+[TestClass]
+public class AgentContextBuilderRecentWindowEnrichmentTests
+{
+    // The 66-char production reproducer from #397.
+    private const string Reproducer = "Hopefully we can go this coming winter. My health seems better now";
+
+    private const string PriorUser = "The dry desert air there helps my joints more than anything else has.";
+    private const string PriorAssistant = "That tracks. Dry air can be the difference between tolerable and miserable.";
+
+    [TestMethod]
+    public async Task EstablishedThread_EnrichesQueryWithRecentWindow()
+    {
+        var ltm = new RecordingLongTermMemory();
+        var (builder, _) = BuildBuilder(
+            ltm: ltm,
+            conversationMemory: ThreadOf(DateTimeOffset.UtcNow, includeCurrentTurn: true));
+
+        await builder.BuildAsync("session-enrich", Reproducer, CancellationToken.None);
+
+        var bm25 = ltm.SearchCalls.FirstOrDefault(c => c.Category is null && c.Query is not null);
+        Assert.IsNotNull(bm25, "An LTM BM25 search should have run.");
+        StringAssert.StartsWith(bm25.Query, Reproducer,
+            "The raw user message must still lead the query.");
+        StringAssert.Contains(bm25.Query, "dry desert air",
+            "The recent window should be folded into the search query.");
+    }
+
+    [TestMethod]
+    public async Task EstablishedThread_EnrichesSkillSearchAndEmbedding()
+    {
+        var skills = new RecordingSkillStore();
+        var embeddings = new RecordingEmbeddingGenerator();
+        var (builder, _) = BuildBuilder(
+            skillStore: skills,
+            embeddingGenerator: embeddings,
+            conversationMemory: ThreadOf(DateTimeOffset.UtcNow, includeCurrentTurn: true));
+
+        await builder.BuildAsync("session-enrich-skill", Reproducer, CancellationToken.None);
+
+        Assert.AreEqual(1, skills.SearchCalls.Count);
+        StringAssert.Contains(skills.SearchCalls[0], "dry desert air",
+            "Skill recall should use the same anchored query.");
+        Assert.AreEqual(1, embeddings.Inputs.Count);
+        StringAssert.Contains(embeddings.Inputs[0], "dry desert air",
+            "The shared query embedding must be generated from the enriched query so hybrid " +
+            "deployments get the same anchoring as BM25.");
+    }
+
+    [TestMethod]
+    public async Task FirstTurn_DoesNotEnrich()
+    {
+        var ltm = new RecordingLongTermMemory();
+        // Only the current user turn exists — nothing to anchor to.
+        var (builder, _) = BuildBuilder(
+            ltm: ltm,
+            conversationMemory: new StubConversationMemory(
+                [new ConversationTurn("user", Reproducer, DateTimeOffset.UtcNow)]));
+
+        await builder.BuildAsync("session-first", Reproducer, CancellationToken.None);
+
+        var bm25 = ltm.SearchCalls.FirstOrDefault(c => c.Category is null && c.Query is not null);
+        Assert.IsNotNull(bm25);
+        Assert.AreEqual(Reproducer, bm25.Query,
+            "A first-turn message has no thread to anchor to — the query must be the raw message.");
+    }
+
+    [TestMethod]
+    public async Task StaleThread_DoesNotEnrich()
+    {
+        var ltm = new RecordingLongTermMemory();
+        var (builder, _) = BuildBuilder(
+            ltm: ltm,
+            // Last turn is well outside ThreadEstablishedRecency.
+            conversationMemory: ThreadOf(DateTimeOffset.UtcNow.AddHours(-3), includeCurrentTurn: true));
+
+        await builder.BuildAsync("session-stale", Reproducer, CancellationToken.None);
+
+        var bm25 = ltm.SearchCalls.FirstOrDefault(c => c.Category is null && c.Query is not null);
+        Assert.IsNotNull(bm25);
+        Assert.AreEqual(Reproducer, bm25.Query,
+            "A stale thread is not the conversation the user is continuing — do not anchor to it.");
+    }
+
+    [TestMethod]
+    public async Task ShortMessage_StaysFullyGated()
+    {
+        var ltm = new RecordingLongTermMemory();
+        var embeddings = new RecordingEmbeddingGenerator();
+        var (builder, _) = BuildBuilder(
+            ltm: ltm,
+            embeddingGenerator: embeddings,
+            conversationMemory: ThreadOf(DateTimeOffset.UtcNow, includeCurrentTurn: false));
+
+        await builder.BuildAsync("session-short", "ok", CancellationToken.None);
+
+        Assert.IsFalse(ltm.SearchCalls.Any(c => c.Category is null && c.Query is not null),
+            "The 30-char gate from #384 must still suppress the per-turn topic search entirely — " +
+            "enrichment must not become a way in.");
+        Assert.AreEqual(0, embeddings.Inputs.Count,
+            "Short messages must still skip embedding generation.");
+    }
+
+    [TestMethod]
+    public async Task EnrichmentDoesNotReachTheKnowledgeGraphSeed()
+    {
+        var graph = new SeedRecordingKnowledgeGraph();
+        var (builder, _) = BuildBuilder(
+            knowledgeGraph: graph,
+            conversationMemory: ThreadOf(DateTimeOffset.UtcNow, includeCurrentTurn: true));
+
+        await builder.BuildAsync("session-graph", Reproducer, CancellationToken.None);
+
+        Assert.AreEqual(1, graph.FindCalls.Count);
+        Assert.AreEqual(Reproducer, graph.FindCalls[0],
+            "Entity extraction wants the literal message — seeding from prior turns would " +
+            "re-traverse entities already in context.");
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A thread of three prior turns ending at <paramref name="lastTurnAt"/>, optionally
+    /// followed by the current user turn (which callers add to conversation memory before
+    /// building context, so the builder must discount it).
+    /// </summary>
+    private static StubConversationMemory ThreadOf(DateTimeOffset lastTurnAt, bool includeCurrentTurn)
+    {
+        var turns = new List<ConversationTurn>
+        {
+            new("user", "I've been thinking about the trip to Cathedral City again.", lastTurnAt.AddMinutes(-2)),
+            new("user", PriorUser, lastTurnAt.AddMinutes(-1)),
+            new("assistant", PriorAssistant, lastTurnAt),
+        };
+
+        if (includeCurrentTurn)
+            turns.Add(new ConversationTurn("user", Reproducer, lastTurnAt.AddSeconds(1)));
+
+        return new StubConversationMemory(turns);
+    }
+
+    private static (AgentContextBuilder Builder, KnowledgeGraphOptions Options) BuildBuilder(
+        IKnowledgeGraph? knowledgeGraph = null,
+        ILongTermMemory? ltm = null,
+        ISkillStore? skillStore = null,
+        IConversationMemory? conversationMemory = null,
+        IEmbeddingGenerator<string, Embedding<float>>? embeddingGenerator = null)
+    {
+        var profileHolder = new ProfileHolder();
+        var doc = new AgentProfileDocument("soul", null, [], "I am a test agent.");
+        profileHolder.Update(new AgentProfile(doc, doc));
+        var nameHolder = new AgentNameHolder();
+
+        var agentProfileOptions = Options.Create(new AgentProfileOptions
+        {
+            BasePath = Path.Combine(Path.GetTempPath(), "rockbot-enrich-test-" + Guid.NewGuid().ToString("N"))
+        });
+        Directory.CreateDirectory(agentProfileOptions.Value.BasePath);
+
+        var clock = new AgentClock(
+            new ConfigurationBuilder().Build(),
+            agentProfileOptions,
+            NullLoggerFactory.Instance.CreateLogger<AgentClock>());
+
+        var graphOpts = new KnowledgeGraphOptions();
+
+        var builder = new AgentContextBuilder(
+            profileHolder: profileHolder,
+            agent: new AgentIdentity("TestBot"),
+            promptBuilder: new DefaultSystemPromptBuilder(profileHolder, nameHolder, Options.Create(new AgentProfileOptions())),
+            rulesStore: new StubRulesStore(),
+            modelBehavior: ModelBehavior.Default,
+            conversationMemory: conversationMemory ?? new StubConversationMemory([]),
+            longTermMemory: ltm ?? new RecordingLongTermMemory(),
+            injectedMemoryTracker: new InjectedMemoryTracker(),
+            workingMemory: new StubWorkingMemory(),
+            skillStore: skillStore ?? new RecordingSkillStore(),
+            skillIndexTracker: new SkillIndexTracker(),
+            skillRecallTracker: new SkillRecallTracker(),
+            clock: clock,
+            serviceSearchIndexProviders: [],
+            knowledgeGraphProviders: knowledgeGraph is null ? [] : [knowledgeGraph],
+            knowledgeGraphOptions: Options.Create(graphOpts),
+            embeddingGenerators: embeddingGenerator is null ? [] : [embeddingGenerator],
+            logger: NullLogger<AgentContextBuilder>.Instance);
+
+        return (builder, graphOpts);
+    }
+
+    // ── Stubs ────────────────────────────────────────────────────────────────
+
+    private sealed class RecordingEmbeddingGenerator : IEmbeddingGenerator<string, Embedding<float>>
+    {
+        public List<string> Inputs { get; } = [];
+
+        public Task<GeneratedEmbeddings<Embedding<float>>> GenerateAsync(
+            IEnumerable<string> values,
+            EmbeddingGenerationOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            var list = new GeneratedEmbeddings<Embedding<float>>();
+            foreach (var v in values)
+            {
+                Inputs.Add(v);
+                list.Add(new Embedding<float>(new float[] { 0f, 0f, 0f }));
+            }
+            return Task.FromResult(list);
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+        public void Dispose() { }
+    }
+
+    private sealed class RecordingLongTermMemory : ILongTermMemory
+    {
+        public List<MemorySearchCriteria> SearchCalls { get; } = [];
+
+        public Task SaveAsync(MemoryEntry entry, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task<IReadOnlyList<MemoryEntry>> SearchAsync(MemorySearchCriteria criteria, CancellationToken cancellationToken = default)
+        {
+            SearchCalls.Add(criteria);
+            return Task.FromResult<IReadOnlyList<MemoryEntry>>([]);
+        }
+
+        public Task<MemoryEntry?> GetAsync(string id, CancellationToken cancellationToken = default) =>
+            Task.FromResult<MemoryEntry?>(null);
+
+        public Task DeleteAsync(string id, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task<IReadOnlyList<string>> ListTagsAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<string>>([]);
+
+        public Task<IReadOnlyList<string>> ListCategoriesAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<string>>([]);
+    }
+
+    private sealed class RecordingSkillStore : ISkillStore
+    {
+        public List<string> SearchCalls { get; } = [];
+
+        public Task SaveAsync(Skill skill) => Task.CompletedTask;
+        public Task<Skill?> GetAsync(string name) => Task.FromResult<Skill?>(null);
+        public Task<IReadOnlyList<Skill>> ListAsync() => Task.FromResult<IReadOnlyList<Skill>>([]);
+        public Task DeleteAsync(string name) => Task.CompletedTask;
+
+        public Task<IReadOnlyList<Skill>> SearchAsync(
+            string query, int maxResults, CancellationToken cancellationToken = default, float[]? queryEmbedding = null)
+        {
+            SearchCalls.Add(query);
+            return Task.FromResult<IReadOnlyList<Skill>>([]);
+        }
+    }
+
+    private sealed class StubConversationMemory(IReadOnlyList<ConversationTurn> turns) : IConversationMemory
+    {
+        public Task AddTurnAsync(string sessionId, ConversationTurn turn, CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
+
+        public Task<IReadOnlyList<ConversationTurn>> GetTurnsAsync(string sessionId, CancellationToken cancellationToken = default) =>
+            Task.FromResult(turns);
+
+        public Task ClearAsync(string sessionId, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task<IReadOnlyList<string>> ListSessionsAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<string>>([]);
+    }
+
+    private sealed class StubWorkingMemory : IWorkingMemory
+    {
+        public Task SetAsync(string key, string value, TimeSpan? ttl = null, string? category = null, IReadOnlyList<string>? tags = null) => Task.CompletedTask;
+        public Task<string?> GetAsync(string key) => Task.FromResult<string?>(null);
+        public Task<IReadOnlyList<WorkingMemoryEntry>> ListAsync(string? prefix = null) =>
+            Task.FromResult<IReadOnlyList<WorkingMemoryEntry>>([]);
+        public Task DeleteAsync(string key) => Task.CompletedTask;
+        public Task ClearAsync(string? prefix = null) => Task.CompletedTask;
+        public Task<IReadOnlyList<WorkingMemoryEntry>> SearchAsync(MemorySearchCriteria criteria, string? prefix = null) =>
+            Task.FromResult<IReadOnlyList<WorkingMemoryEntry>>([]);
+    }
+
+    private sealed class StubRulesStore : IRulesStore
+    {
+        public IReadOnlyList<string> Rules => [];
+        public Task<IReadOnlyList<string>> ListAsync() => Task.FromResult<IReadOnlyList<string>>([]);
+        public Task AddAsync(string rule) => Task.CompletedTask;
+        public Task RemoveAsync(string rule) => Task.CompletedTask;
+    }
+
+    private sealed class SeedRecordingKnowledgeGraph : IKnowledgeGraph
+    {
+        public List<string> FindCalls { get; } = [];
+
+        public Task<IReadOnlyList<KnowledgeEntity>> FindEntitiesByNameAsync(string query, CancellationToken cancellationToken = default)
+        {
+            FindCalls.Add(query);
+            return Task.FromResult<IReadOnlyList<KnowledgeEntity>>([]);
+        }
+
+        public Task<IReadOnlyList<KnowledgeTriple>> TraverseAsync(IReadOnlyList<string> seedEntityIds, int maxHops = 2, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<KnowledgeTriple>>([]);
+
+        public Task TouchEntitiesAsync(IReadOnlyList<string> entityIds, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task SaveEntityAsync(KnowledgeEntity entity, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task<KnowledgeEntity?> GetEntityAsync(string id, CancellationToken cancellationToken = default) => Task.FromResult<KnowledgeEntity?>(null);
+        public Task DeleteEntityAsync(string id, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task<IReadOnlyList<KnowledgeEntity>> ListEntitiesAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<KnowledgeEntity>>([]);
+        public Task SaveTripleAsync(KnowledgeTriple triple, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task<IReadOnlyList<KnowledgeTriple>> GetTriplesForSubjectAsync(string subjectId, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<KnowledgeTriple>>([]);
+        public Task<IReadOnlyList<KnowledgeTriple>> GetTriplesForObjectAsync(string objectId, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<KnowledgeTriple>>([]);
+        public Task DeleteTripleAsync(string id, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task<IReadOnlyList<KnowledgeTriple>> ListTriplesAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<KnowledgeTriple>>([]);
+    }
+}

--- a/tests/RockBot.Host.Tests/AgentLoopRunnerMemorySummaryGuardTests.cs
+++ b/tests/RockBot.Host.Tests/AgentLoopRunnerMemorySummaryGuardTests.cs
@@ -138,6 +138,88 @@ public class AgentLoopRunnerMemorySummaryGuardTests
             "ModelBehavior.Default should enable NudgeOnMemorySummaryReply.");
     }
 
+    // ── MemoryNarrationReplyRegex (#397) ─────────────────────────────────────
+    //
+    // The #383 pattern is anchored on a "Noted" opener. The variant tracked by #397
+    // does not open with "Noted" — it states the memory write directly — so the guard
+    // needs a second pattern to reach whole-response narration above the 30-char gate.
+
+    [TestMethod]
+    [DataRow("I've marked it as a winter trip goal tied to your joints and the dry air.")]
+    [DataRow("I've got that on the travel list now.")]
+    [DataRow("I've logged it in memory.")]
+    [DataRow("I have stored that in your profile.")]
+    [DataRow("Done. I've noted it down for later.")]
+    [DataRow("I've also added it to the wishlist.")]
+    public void MemoryNarrationReplyRegex_MatchesWholeResponseNarration(string response)
+    {
+        Assert.IsTrue(AgentLoopRunner.MemoryNarrationReplyRegex.IsMatch(response),
+            $"Expected match for: \"{response}\"");
+    }
+
+    [TestMethod]
+    [DataRow("I've saved the file to /tmp/report.csv.")]      // concrete object, real outcome
+    [DataRow("I've added it to your todo list for Thursday.")] // real tool action
+    [DataRow("I've put it on your calendar.")]                 // real tool action
+    [DataRow("That's the right window — mid-January is cheapest.")]
+    [DataRow("The dry air is doing real work there.")]
+    [DataRow("I've booked the flight.")]
+    public void MemoryNarrationReplyRegex_DoesNotMatchGenuineOutcomes(string response)
+    {
+        Assert.IsFalse(AgentLoopRunner.MemoryNarrationReplyRegex.IsMatch(response),
+            $"Expected no match for: \"{response}\"");
+    }
+
+    // ── ExplicitMemoryCommandRegex (#397) ────────────────────────────────────
+    //
+    // When the user asked for the write, confirming it is the correct reply — both
+    // the guard and the trailing-narration strip stand down.
+
+    [TestMethod]
+    [DataRow("Remember that my birthday is March 12.")]
+    [DataRow("Please save that for later.")]
+    [DataRow("Don't forget the gate code is 4417.")]
+    [DataRow("Make a note that Allen prefers Tuesdays.")]
+    [DataRow("Keep track of how often this fails.")]
+    public void ExplicitMemoryCommandRegex_MatchesUserMemoryCommands(string userMessage)
+    {
+        Assert.IsTrue(AgentLoopRunner.ExplicitMemoryCommandRegex.IsMatch(userMessage),
+            $"Expected match for: \"{userMessage}\"");
+    }
+
+    [TestMethod]
+    [DataRow("Hopefully we can go this coming winter. My health seems better now")]
+    [DataRow("The dry desert air there helps my joints more than anything else has.")]
+    [DataRow("What's on the calendar for Thursday?")]
+    public void ExplicitMemoryCommandRegex_DoesNotMatchOrdinaryFollowUps(string userMessage)
+    {
+        Assert.IsFalse(AgentLoopRunner.ExplicitMemoryCommandRegex.IsMatch(userMessage),
+            $"Expected no match for: \"{userMessage}\"");
+    }
+
+    // ── Length gates ─────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void ReproducerSitsAboveShortGateAndInsideFollowUpGate()
+    {
+        // The whole point of #397: the reproducer clears the 30-char band that gates
+        // the BM25 and routing defenses, but must fall inside the guard's wider band.
+        const string reproducer = "Hopefully we can go this coming winter. My health seems better now";
+
+        Assert.IsTrue(reproducer.Length > ShortMessageHeuristics.UserMessageCharThreshold,
+            "Reproducer must sit above the 30-char short-message gate.");
+        Assert.IsTrue(reproducer.Length <= ShortMessageHeuristics.FollowUpMessageCharThreshold,
+            "Reproducer must sit inside the follow-up gate the guard now uses.");
+    }
+
+    [TestMethod]
+    public void ShortMessageThresholdIsUnchanged()
+    {
+        // #397 is explicitly a non-goal for the #384/#395 defenses — the 30-char
+        // constant they share must not drift.
+        Assert.AreEqual(30, ShortMessageHeuristics.UserMessageCharThreshold);
+    }
+
     // ── Helpers ──────────────────────────────────────────────────────────────
 
     private static ChatMessage BuildAssistantWithFunctionCall(string name, string argumentsJson)

--- a/tests/RockBot.Host.Tests/AgentLoopRunnerMemorySummaryGuardTests.cs
+++ b/tests/RockBot.Host.Tests/AgentLoopRunnerMemorySummaryGuardTests.cs
@@ -151,6 +151,10 @@ public class AgentLoopRunnerMemorySummaryGuardTests
     [DataRow("I have stored that in your profile.")]
     [DataRow("Done. I've noted it down for later.")]
     [DataRow("I've also added it to the wishlist.")]
+    // Subjectless participle form, captured live on 2026-09-06.
+    [DataRow("Added to the ledger: your sister might drive out for a few days too.")]
+    [DataRow("Saved to your travel list.")]
+    [DataRow("Logged in memory.")]
     public void MemoryNarrationReplyRegex_MatchesWholeResponseNarration(string response)
     {
         Assert.IsTrue(AgentLoopRunner.MemoryNarrationReplyRegex.IsMatch(response),
@@ -164,6 +168,9 @@ public class AgentLoopRunnerMemorySummaryGuardTests
     [DataRow("That's the right window — mid-January is cheapest.")]
     [DataRow("The dry air is doing real work there.")]
     [DataRow("I've booked the flight.")]
+    [DataRow("Added the notes to the shared drive.")]   // real file action, not narration
+    [DataRow("Logged in to the portal.")]
+    [DataRow("Added it to your todo list for Thursday.")]
     public void MemoryNarrationReplyRegex_DoesNotMatchGenuineOutcomes(string response)
     {
         Assert.IsFalse(AgentLoopRunner.MemoryNarrationReplyRegex.IsMatch(response),

--- a/tests/RockBot.Host.Tests/ResponseSanitizerMemoryNarrationTests.cs
+++ b/tests/RockBot.Host.Tests/ResponseSanitizerMemoryNarrationTests.cs
@@ -1,0 +1,117 @@
+using RockBot.Host;
+
+namespace RockBot.Host.Tests;
+
+/// <summary>
+/// Covers <see cref="ResponseSanitizer.StripTrailingMemoryNarration"/>, added under
+/// issue #397. The production failure is a reply that answers the user correctly and
+/// then appends a sentence narrating the memory write. The strip must remove that
+/// closing without touching the answer, and must leave genuine outcome reports alone.
+/// </summary>
+[TestClass]
+public class ResponseSanitizerMemoryNarrationTests
+{
+    // ── Positive cases: captured from the live cluster on 2026-09-05 ─────────
+
+    [TestMethod]
+    public void StripsTrailingNarration_CathedralCityReproducer()
+    {
+        const string response =
+            "That's the right window. Cathedral City sounds less like a nice idea and more " +
+            "like a place that actually earns its keep for you, especially if the holidays " +
+            "are over and the rental market cools off.\n\n" +
+            "I've marked it as a winter trip goal tied to your joints and the dry air.";
+
+        var result = ResponseSanitizer.StripTrailingMemoryNarration(response);
+
+        StringAssert.StartsWith(result, "That's the right window.");
+        Assert.IsFalse(result.Contains("I've marked it", StringComparison.Ordinal),
+            "The memory-write narration closing must be removed.");
+    }
+
+    [TestMethod]
+    public void StripsTrailingNarration_TravelPictureVariant()
+    {
+        const string response =
+            "That tracks. Dry air can be the difference between tolerable and miserable with joints.\n\n" +
+            "I've got Cathedral City in the travel picture now, as a place that's physically " +
+            "easier on you, not just another dot on the map.";
+
+        var result = ResponseSanitizer.StripTrailingMemoryNarration(response);
+
+        Assert.AreEqual(
+            "That tracks. Dry air can be the difference between tolerable and miserable with joints.",
+            result);
+    }
+
+    [TestMethod]
+    public void StripsTrailingNarration_SingleNewlineSeparator()
+    {
+        const string response =
+            "The post-holiday dip is real — mid-January onward is usually the cheapest stretch, " +
+            "and the weather is still good.\n" +
+            "I've noted that in memory.";
+
+        var result = ResponseSanitizer.StripTrailingMemoryNarration(response);
+
+        Assert.IsFalse(result.Contains("noted that in memory", StringComparison.OrdinalIgnoreCase));
+        StringAssert.StartsWith(result, "The post-holiday dip is real");
+    }
+
+    // ── Negative cases: real outcomes the user needs to hear ────────────────
+
+    [TestMethod]
+    [DataRow("Done. The migration ran clean.\n\nI've saved the file to /tmp/report.csv.")]
+    [DataRow("Both conflicts are resolved.\n\nI've added it to your todo list for Thursday.")]
+    [DataRow("Thursday at 2pm works for everyone.\n\nI've put it on your calendar.")]
+    [DataRow("The build is green.\n\nI've noted the flaky test in the issue.")]
+    [DataRow("Here's the summary you asked for.\n\nLet me know if you want more detail.")]
+    public void DoesNotStripGenuineOutcomeReports(string response)
+    {
+        Assert.AreEqual(response, ResponseSanitizer.StripTrailingMemoryNarration(response),
+            $"Must not strip a real reported outcome: \"{response}\"");
+    }
+
+    [TestMethod]
+    public void DoesNotStripWholeResponseNarration()
+    {
+        // A reply that is ONLY narration would be emptied by stripping. The substance
+        // guard declines, leaving it to the AgentLoopRunner re-prompt guard.
+        const string response = "I've marked it as a winter trip goal tied to your joints and the dry air.";
+
+        Assert.AreEqual(response, ResponseSanitizer.StripTrailingMemoryNarration(response));
+    }
+
+    [TestMethod]
+    public void LeavesOrdinaryReplyUnchanged()
+    {
+        const string response =
+            "The dry air is doing real work there — that's a good reason to aim for January " +
+            "rather than pushing it to spring.";
+
+        Assert.AreEqual(response, ResponseSanitizer.StripTrailingMemoryNarration(response));
+    }
+
+    [TestMethod]
+    [DataRow("")]
+    [DataRow(null)]
+    public void HandlesEmptyInput(string? response)
+    {
+        Assert.AreEqual(response, ResponseSanitizer.StripTrailingMemoryNarration(response!));
+    }
+
+    [TestMethod]
+    public void DoesNotDisturbTrailingOfferStripping()
+    {
+        // The two sanitizers are independent; running both must not corrupt the answer.
+        const string response =
+            "Mid-January is the sweet spot for both price and weather.\n\n" +
+            "I've got that on the travel list now.\n\n" +
+            "Would you like me to check flight prices?";
+
+        var result = ResponseSanitizer.StripTrailingMemoryNarration(
+            ResponseSanitizer.StripTrailingOffers(response));
+
+        Assert.AreEqual("Mid-January is the sweet spot for both price and weather.", result);
+    }
+}

--- a/tests/RockBot.Host.Tests/ResponseSanitizerMemoryNarrationTests.cs
+++ b/tests/RockBot.Host.Tests/ResponseSanitizerMemoryNarrationTests.cs
@@ -58,6 +58,21 @@ public class ResponseSanitizerMemoryNarrationTests
         StringAssert.StartsWith(result, "The post-holiday dip is real");
     }
 
+    [TestMethod]
+    public void StripsTrailingNarration_SubjectlessParticipleForm()
+    {
+        // Captured live on 2026-09-06: the model drops the subject entirely.
+        const string response =
+            "February works — that keeps the whole trip inside the good stretch of weather.\n\n" +
+            "Added to the ledger: your sister might drive out for a few days too.";
+
+        var result = ResponseSanitizer.StripTrailingMemoryNarration(response);
+
+        Assert.AreEqual(
+            "February works — that keeps the whole trip inside the good stretch of weather.",
+            result);
+    }
+
     // ── Negative cases: real outcomes the user needs to hear ────────────────
 
     [TestMethod]
@@ -66,6 +81,8 @@ public class ResponseSanitizerMemoryNarrationTests
     [DataRow("Thursday at 2pm works for everyone.\n\nI've put it on your calendar.")]
     [DataRow("The build is green.\n\nI've noted the flaky test in the issue.")]
     [DataRow("Here's the summary you asked for.\n\nLet me know if you want more detail.")]
+    [DataRow("The upload finished.\n\nAdded the notes to the shared drive.")]
+    [DataRow("Access is working again.\n\nLogged in to the portal without trouble.")]
     public void DoesNotStripGenuineOutcomeReports(string response)
     {
         Assert.AreEqual(response, ResponseSanitizer.StripTrailingMemoryNarration(response),


### PR DESCRIPTION
## Summary

The four defenses from #395 are all gated at 30 characters, so a fact-introducing follow-up on a live thread slips past every one of them. I re-validated this against the live cluster on 2026-09-05 — Low tier is still `gpt-5.4-mini`, the model from the original incident — and the reproducer behaved exactly as #397 predicts:

```
Routing user message to tier=Low (score=0.000, threadEstablished=True)
```

`threadEstablished=True` but the tier override needs ≤30 chars; no BM25 dampening; the memory-summary guard never fired.

**The failure has changed shape since #383, and that changed the fix.** It is no longer a whole-reply memory summary — the model answers properly and then appends the narration:

> That's the right window. Cathedral City sounds less like a nice idea and more like a place that actually earns its keep for you, especially if the holidays are over and the rental market cools off.
>
> **I've marked it as a winter trip goal tied to your joints and the dry air.**

That closed the issue's proposed approach #4: `MemorySummaryReplyRegex` is anchored `^\s*Noted…`, so widening the length gate alone would have caught nothing here.

### What changed

- **`ResponseSanitizer.StripTrailingMemoryNarration`** — a trailing paragraph doesn't need a re-prompt. Reuses the existing `StripTrailingOffers` shape, including its 30%-substance guard.
- **`AgentLoopRunner.FinalizeResponse`** — applies the strip at every `RunAsync` exit, gated on `SavedMemoryThisTurn`, so only turns that actually wrote memory are touched. Genuine outcome reports ("I've saved the file to /tmp/x", "I've added it to your todo list") are excluded by the pattern and by that gate. Living in `AgentLoopRunner` also covers the text path and subagents, per the CLAUDE.md convention that cross-cutting concerns belong at the single LLM entry point.
- **Guard widened for the whole-response form** — new `MemoryNarrationReplyRegex` for the "I've marked it as X" phrasing that doesn't open with "Noted", at a new `FollowUpMessageCharThreshold` (120), with an `ExplicitMemoryCommandRegex` exemption so confirming a write the user *asked* for still works. `UserMessageCharThreshold` (30) and its three consumers are untouched — the issue's non-goal.
- **Recent-window query enrichment** (issue approach #1) — the per-turn search query folds in the last 2 turns (200 chars each) on an established thread, feeding long-term, episodic and skill recall plus the shared embedding. Conversation history moves ahead of the search wave to make it available; graph seeding keeps the literal message.
- **`directives.md`** — the carve-out said saving and acknowledging was the correct response to a fact-introducing follow-up, which sanctioned the exact reply this issue calls a bug. It now requires continuing the thread and forbids narrating the write.

### Deliberately not changed

Per discussion, the **tier-selector override stays at 30 chars**. Widening it would push every conversational follow-up on a live thread from Low to Balanced; the fixes here are deterministic and cost nothing per turn. Approaches #2/#3 (embedding-overlap gating) remain deferred as the expensive end.

## Test plan

- [x] Full suite green — 3,123 passed, 0 failed
- [x] `ResponseSanitizerMemoryNarrationTests` — both live-captured narrations strip; file/todo/calendar outcome reports and whole-response narration do not
- [x] `AgentContextBuilderRecentWindowEnrichmentTests` — enriched on an established thread (BM25, skill search and embedding), raw on first turn and stale thread, short messages still fully gated, graph seed unaffected
- [x] `AgentLoopRunnerMemorySummaryGuardTests` extended — new pattern, the command exemption, and an assertion pinning the 30-char constant
- [x] `AgentContextBuilderShortMessageGateTests` passes unmodified — the #384/#395 defenses are intact
- [ ] Live re-run of the Cathedral City reproducer after deploy: expect a thread-continuing reply with no trailing narration and a `Stripped trailing memory narration` log line, with routing still `tier=Low`

## Deployment note

`directives.md` ships on the PVC and the init container will not overwrite it, so merging this does **not** change live behaviour on its own. It needs the `cat … | kubectl exec -i` push documented in CLAUDE.md. The code changes take effect with the next agent image.

Closes #397

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uf8a2Z1v9dY3YjjM42zJEj