### PR TITLE
Bump version to 0.14.40

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.14.39</Version>
+<Version>0.14.40</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->


### PR DESCRIPTION
## Summary

Bumps `<Version>` to 0.14.40.

The #397 fix (#557) was verified on the live cluster as the pre-release tag `rockbot-agent:0.14.40-issue397`. A released tag is needed so the running version stays observable in `kubectl describe`, and pushed docker tags are never reused.

This is a version bump only — no code changes, and not a full release (NuGet `release/v*` branch and the other 10 docker images are untouched).

## Test plan

- [x] No code changes; full suite was green on #557 before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uf8a2Z1v9dY3YjjM42zJEj