### PR TITLE
Framework-level schema migration mechanism for persisted state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,3 +72,4 @@ Topics use hierarchical dot-separated naming: `agent.task.*`, `llm.request`, `to
 - Integration tests use unique exchange names per run to avoid cross-contamination
 - **Configuration** — Use the standard .NET 10 configuration stack: `appsettings.json`, environment variables, `dotnet user-secrets` for local dev, Kubernetes Secrets for deployment. No custom config mechanisms.
 - **Console apps** — Use `Spectre.Console` for argument parsing, prompts, and CLI output in any console applications
+- **Persisted store schemas** — Adding an optional property with a default is additive and needs nothing; the tolerant deserializer absorbs it. Anything it can't absorb (renamed/removed required field, changed layout or file format) bumps the store's version constant *and* ships an `ISchemaMigration` in the same PR. See `design/schema-migrations.md`.

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -188,6 +188,7 @@ rockbot/
 ### Phase 6: Hardening
 - [x] Observability (OpenTelemetry traces and metrics)
 - [x] [WIP tracking](wip-tracking.md) for crash recovery of in-flight messages
+- [x] [Schema migrations](schema-migrations.md) for persisted store upgrades
 - [ ] Rate limiting and back-pressure
 - [ ] Azure Service Bus provider
 - [ ] Admin UI / dashboard

--- a/design/schema-migrations.md
+++ b/design/schema-migrations.md
@@ -1,0 +1,167 @@
+# Schema migrations for persisted state
+
+RockBot keeps agent state in on-disk stores — long-term memory, skills, feedback, the wisp
+execution log, and whatever a consumer adds of its own. This document is the contract for
+changing the shape of that data: when a change needs a migration, how to write one, and what
+the host does at startup.
+
+## Policy
+
+**Additive changes are normal and need no migration.** Every store deserializes with
+`PropertyNameCaseInsensitive = true` and camelCase naming, so adding an optional property with
+a default is absorbed silently: old records read back with the default, new records round-trip.
+Adding `LastSeenAt` and `ReinforcementCount` to `MemoryEntry` was exactly this. Do not bump a
+version for it, and do not write a migration.
+
+**Destructive changes ship with a migration, in the same PR.** Renaming or removing a required
+field, restructuring a directory layout, splitting one store into two, changing a file format
+— anything a tolerant deserializer cannot absorb. Bump the store's version constant and add an
+`ISchemaMigration` that bridges the step.
+
+The line between the two is whether a store written by the *previous* release still reads
+correctly under the *new* code. If it does, the change is additive.
+
+### Non-goals
+
+Migrations are **forward-only** — there is no rollback. Deploying an older build against a
+migrated store is detected and logged, not undone. They are also **startup-blocking**: the
+host does not serve messages until every enrolled store is at the expected version. Neither is
+a limitation to design around; both are deliberate for RockBot's workload.
+
+## The version marker
+
+Each enrolled store carries a `.rockbot-schema` file in its root directory:
+
+```json
+{
+  "store": "memory",
+  "version": 1,
+  "updatedAt": "2026-09-06T14:22:31.000+00:00"
+}
+```
+
+The name is dot-prefixed and deliberately has **no `.json` extension**. `FileMemoryStore` and
+`FileSkillStore` build their indexes by enumerating `*.json` recursively beneath their root,
+and `FileFeedbackStore` does the same for `*.jsonl`; a marker matching those patterns would be
+picked up and reported as a corrupt record. (`EmbeddingCache` already writes `.embeddings/`
+into the memory root for the same reason.)
+
+The `store` field is a collision check. `FileWispExecutionLog` roots itself at
+`WispOptions.SharedVolumePath` — `/rockbot/shared` on the reference deployment — which other
+things write into. If the runner finds a marker naming a different store, it logs a warning and
+skips that store rather than migrating against someone else's version number.
+
+Writes go through `AtomicFile.WriteAllTextAsync`, so an interrupted stamp leaves either the old
+marker or the new one, never a truncated file.
+
+## Startup policy
+
+`SchemaMigrationService` is registered as the first `IHostedService` in `AddRockBotHost`, so its
+`StartAsync` runs before any store that has one. For each registered `StoreSchemaDescriptor`:
+
+| On disk | Action |
+| --- | --- |
+| No marker, directory empty or absent | Stamp `CurrentVersion` — a new store |
+| No marker, directory holds data | Assume `LegacyVersion` (default 1), run pending migrations |
+| `marker.Version < CurrentVersion` | Run migrations in order, re-stamp after **each** step |
+| `marker.Version == CurrentVersion` | Nothing to do |
+| `marker.Version > CurrentVersion` | Log a warning, leave untouched, continue |
+| `marker.Store` names a different store | Log a warning, skip |
+| Marker present but unreadable | Treat as unmarked and re-derive from `LegacyVersion` |
+
+Walking the chain, the runner looks for the single migration whose `FromVersion` matches where
+the store currently is. A **gap** (no migration bridges the step) or an **ambiguity** (two
+migrations claim the same step) throws and aborts startup: a store this build cannot read
+safely is worse than a host that refuses to start, because the agent would otherwise carry on
+writing new-format records over data the migration was meant to convert.
+
+A migration that throws propagates the same way. Because the marker is stamped after *each*
+step rather than once at the end, a failure three steps in leaves the store at the last step
+that actually completed, and the restart resumes from there. Write migrations to be safe to
+re-run against partially converted data anyway.
+
+### Ordering caveat
+
+.NET constructs the entire `IEnumerable<IHostedService>` before starting any of it, so other
+hosted services' **constructors** have already run when migrations start. This is why
+`SchemaMigrationContext` hands a migration a *path* rather than the store service: a migration
+that resolved its store could observe, or cache, pre-migration data.
+
+All four framework stores index lazily (`FileMemoryStore` and `FileSkillStore` build their
+index on first use; `FileWispExecutionLog`'s constructor only creates its directory), so no
+enrolled store reads data before migrations run. A consumer that resolves a store *outside* the
+host's startup path is outside this guarantee.
+
+## Writing a migration
+
+```csharp
+internal sealed class MemoryV1ToV2 : ISchemaMigration
+{
+    public string StoreName => AgentMemoryExtensions.MemoryStoreSchemaName;
+    public int FromVersion => 1;
+    public int ToVersion => 2;
+
+    public async Task MigrateAsync(SchemaMigrationContext context, CancellationToken ct = default)
+    {
+        foreach (var file in Directory.EnumerateFiles(context.StorePath, "*.json", SearchOption.AllDirectories))
+        {
+            // Read, reshape, rewrite. Idempotent where you can manage it.
+        }
+    }
+}
+```
+
+Register it alongside the version bump:
+
+```csharp
+builder.AddSchemaMigration<MemoryV1ToV2>();
+```
+
+and bump `MemoryStoreSchemaVersion` in `AgentMemoryExtensions` from 1 to 2 in the same change.
+The two always move together — a bump without a migration fails startup on the next upgrade,
+and a migration without a bump never runs.
+
+## Enrolling a store
+
+A store is enrolled by the same extension method that registers it, so a consumer that never
+opts into a store never gets a marker for it:
+
+```csharp
+builder.AddStoreSchema(
+    storeName: "my-store",
+    currentVersion: 1,
+    resolvePath: sp => sp.GetRequiredService<IOptions<MyOptions>>().Value.BasePath);
+```
+
+`storeName` is part of the on-disk format — it is written into every marker, so changing it
+after release orphans them. `legacyVersion` (default 1) is what an unmarked store holding data
+is assumed to be at.
+
+The framework enrols four stores, all currently at version 1 with no migrations:
+
+| Store name | Registered by | Root |
+| --- | --- | --- |
+| `memory` | `WithLongTermMemory` | `MemoryOptions.BasePath` |
+| `skills` | `WithSkills` | `SkillOptions.BasePath` |
+| `feedback` | `WithFeedback` | `FeedbackOptions.BasePath` |
+| `wisp` | `AddWisps` | `WispOptions.SharedVolumePath` |
+
+## Operating
+
+`SchemaMigrationOptions` tunes the startup check:
+
+```csharp
+builder.ConfigureSchemaMigrations(o => o.DryRun = true);
+```
+
+- `DryRun` logs every migration it *would* run and writes nothing — boot a copy of a deployment
+  against it to see what an upgrade will do before committing to it.
+- `Enabled = false` skips the check entirely. Only for a host that migrates its stores by some
+  other means; the agent then reads whatever is on disk, unmigrated and unmarked.
+
+## Open
+
+- An operator CLI (`dotnet rockbot migrate --dry-run`) to inspect pending migrations without
+  booting the agent. Dry-run currently requires a host start.
+- End-to-end migration tests against committed fixtures of old on-disk state. Nothing to
+  exercise them with until the first real migration ships.

--- a/src/RockBot.Host.Abstractions/ISchemaMigration.cs
+++ b/src/RockBot.Host.Abstractions/ISchemaMigration.cs
@@ -1,0 +1,46 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// A single forward step in one store's on-disk schema history.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Migrations are forward-only and run at startup, blocking, before the host serves any
+/// message. Each one bridges exactly one version step; a store that is several versions
+/// behind runs its migrations in sequence, and the version marker is re-stamped after each
+/// step, so an interrupted upgrade resumes rather than restarting.
+/// </para>
+/// <para>
+/// Only ship a migration for a change a tolerant deserializer cannot absorb. Adding an
+/// optional property with a default is an additive change and needs no migration. See
+/// <c>design/schema-migrations.md</c>.
+/// </para>
+/// </remarks>
+public interface ISchemaMigration
+{
+    /// <summary>
+    /// The store this migration applies to, matching a registered
+    /// <see cref="StoreSchemaDescriptor.StoreName"/>.
+    /// </summary>
+    string StoreName { get; }
+
+    /// <summary>The schema version this migration reads.</summary>
+    int FromVersion { get; }
+
+    /// <summary>
+    /// The schema version this migration produces. Must be greater than
+    /// <see cref="FromVersion"/>.
+    /// </summary>
+    int ToVersion { get; }
+
+    /// <summary>
+    /// Rewrites the store's on-disk data from <see cref="FromVersion"/> to
+    /// <see cref="ToVersion"/>.
+    /// </summary>
+    /// <remarks>
+    /// Throwing aborts host startup and leaves the version marker at
+    /// <see cref="FromVersion"/>, so the next start retries this same step. Implementations
+    /// should therefore be safe to re-run against partially migrated data.
+    /// </remarks>
+    Task MigrateAsync(SchemaMigrationContext context, CancellationToken cancellationToken = default);
+}

--- a/src/RockBot.Host.Abstractions/SchemaMigrationContext.cs
+++ b/src/RockBot.Host.Abstractions/SchemaMigrationContext.cs
@@ -1,0 +1,21 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// What a migration is being asked to do: the store it belongs to, where that store's data
+/// lives on disk, and the version step it is bridging.
+/// </summary>
+/// <remarks>
+/// A migration is handed a <em>path</em>, never the store service that owns it. Migrations run
+/// from an <c>IHostedService</c>, and .NET constructs every hosted service before starting any
+/// of them, so a migration that resolved its store could observe — or cache — pre-migration
+/// data. Reading and rewriting the files directly is the only ordering-safe option.
+/// </remarks>
+/// <param name="StoreName">The store's stable name, matching <see cref="StoreSchemaDescriptor.StoreName"/>.</param>
+/// <param name="StorePath">Absolute path to the store's root directory. Created if it did not exist.</param>
+/// <param name="FromVersion">The schema version the on-disk data is currently at.</param>
+/// <param name="ToVersion">The schema version the data will be stamped at once this migration returns.</param>
+public sealed record SchemaMigrationContext(
+    string StoreName,
+    string StorePath,
+    int FromVersion,
+    int ToVersion);

--- a/src/RockBot.Host.Abstractions/SchemaMigrationOptions.cs
+++ b/src/RockBot.Host.Abstractions/SchemaMigrationOptions.cs
@@ -1,0 +1,26 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Options for the startup schema migration check.
+/// </summary>
+public sealed class SchemaMigrationOptions
+{
+    /// <summary>
+    /// Whether the check runs at all. Defaults to <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    /// Turning this off starts the host against whatever is on disk, unmigrated and unmarked.
+    /// Only useful for a host that migrates its stores by some other means.
+    /// </remarks>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Report what would happen without touching anything. Defaults to <c>false</c>.
+    /// </summary>
+    /// <remarks>
+    /// Pending migrations are logged and skipped, and no version marker is written. Lets an
+    /// operator boot a copy of a deployment to see what an upgrade would do to its data before
+    /// committing to it.
+    /// </remarks>
+    public bool DryRun { get; set; }
+}

--- a/src/RockBot.Host.Abstractions/StoreSchemaDescriptor.cs
+++ b/src/RockBot.Host.Abstractions/StoreSchemaDescriptor.cs
@@ -1,0 +1,59 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// Enrols one persisted store in the startup migration check: what it is called, what schema
+/// version the running code expects, and where its data lives.
+/// </summary>
+/// <remarks>
+/// Registered as a singleton by whichever extension method registers the store itself, so a
+/// consumer that never opts into a store never gets a version marker for it. Third-party
+/// stores enrol the same way — see <c>AddStoreSchema</c> in <c>RockBot.Host</c>.
+/// </remarks>
+public sealed class StoreSchemaDescriptor
+{
+    /// <summary>
+    /// Creates a descriptor for a store.
+    /// </summary>
+    /// <param name="storeName">
+    /// Stable name for the store, recorded in its version marker. Changing it after release
+    /// orphans existing markers, so treat it as part of the on-disk format.
+    /// </param>
+    /// <param name="currentVersion">The schema version the running code expects. Must be at least 1.</param>
+    /// <param name="resolvePath">
+    /// Resolves the store's root directory from the service provider. Deferred rather than a
+    /// plain string because store paths come from bound options that are not available at
+    /// registration time.
+    /// </param>
+    /// <param name="legacyVersion">
+    /// The version to assume for a store that already holds data but carries no marker —
+    /// a deployment that predates this mechanism. Defaults to 1.
+    /// </param>
+    public StoreSchemaDescriptor(
+        string storeName,
+        int currentVersion,
+        Func<IServiceProvider, string> resolvePath,
+        int legacyVersion = 1)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(storeName);
+        ArgumentOutOfRangeException.ThrowIfLessThan(currentVersion, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(legacyVersion, 1);
+        ArgumentNullException.ThrowIfNull(resolvePath);
+
+        StoreName = storeName;
+        CurrentVersion = currentVersion;
+        ResolvePath = resolvePath;
+        LegacyVersion = legacyVersion;
+    }
+
+    /// <summary>Stable name for the store, recorded in its version marker.</summary>
+    public string StoreName { get; }
+
+    /// <summary>The schema version the running code expects.</summary>
+    public int CurrentVersion { get; }
+
+    /// <summary>Resolves the store's root directory from the service provider.</summary>
+    public Func<IServiceProvider, string> ResolvePath { get; }
+
+    /// <summary>The version assumed for an unmarked store that already holds data.</summary>
+    public int LegacyVersion { get; }
+}

--- a/src/RockBot.Host.Abstractions/StoreSchemaMarker.cs
+++ b/src/RockBot.Host.Abstractions/StoreSchemaMarker.cs
@@ -1,0 +1,19 @@
+namespace RockBot.Host;
+
+/// <summary>
+/// The contents of a store's on-disk schema version marker.
+/// </summary>
+/// <remarks>
+/// Written to <see cref="FileName"/> in the store's root directory. The name is deliberately
+/// dot-prefixed and extension-less: several stores build their index by enumerating
+/// <c>*.json</c> or <c>*.jsonl</c> beneath their root, and a marker matching those patterns
+/// would be picked up as a corrupt record.
+/// </remarks>
+/// <param name="Store">The owning store's name. A mismatch means two stores share a directory.</param>
+/// <param name="Version">The schema version the data in this directory is at.</param>
+/// <param name="UpdatedAt">When the marker was last stamped.</param>
+public sealed record StoreSchemaMarker(string Store, int Version, DateTimeOffset UpdatedAt)
+{
+    /// <summary>File name of the marker within a store's root directory.</summary>
+    public const string FileName = ".rockbot-schema";
+}

--- a/src/RockBot.Host/AgentHostBuilderSchemaMigrationExtensions.cs
+++ b/src/RockBot.Host/AgentHostBuilderSchemaMigrationExtensions.cs
@@ -1,0 +1,80 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace RockBot.Host;
+
+/// <summary>
+/// Registration extensions for persisted-store schema versioning and migration.
+/// </summary>
+/// <remarks>
+/// The framework enrols its own stores from the extension method that registers each store.
+/// A consumer with its own persisted state uses <see cref="AddStoreSchema(AgentHostBuilder, string, int, Func{IServiceProvider, string}, int)"/>
+/// to enrol it and <see cref="AddSchemaMigration{TMigration}(AgentHostBuilder)"/> to supply the
+/// migrations. See <c>design/schema-migrations.md</c>.
+/// </remarks>
+public static class AgentHostBuilderSchemaMigrationExtensions
+{
+    /// <summary>
+    /// Registers a migration. Any number may be registered; the runner picks the one that
+    /// bridges each version step a store actually needs.
+    /// </summary>
+    public static AgentHostBuilder AddSchemaMigration<TMigration>(this AgentHostBuilder builder)
+        where TMigration : class, ISchemaMigration
+    {
+        builder.Services.AddSchemaMigration<TMigration>();
+        return builder;
+    }
+
+    /// <inheritdoc cref="AddSchemaMigration{TMigration}(AgentHostBuilder)"/>
+    public static IServiceCollection AddSchemaMigration<TMigration>(this IServiceCollection services)
+        where TMigration : class, ISchemaMigration
+    {
+        services.AddSingleton<ISchemaMigration, TMigration>();
+        return services;
+    }
+
+    /// <summary>
+    /// Enrols a store in the startup schema check.
+    /// </summary>
+    /// <param name="builder">The host builder.</param>
+    /// <param name="storeName">Stable name for the store, recorded in its version marker.</param>
+    /// <param name="currentVersion">The schema version this build expects.</param>
+    /// <param name="resolvePath">Resolves the store's root directory from the service provider.</param>
+    /// <param name="legacyVersion">
+    /// Version to assume for an unmarked store that already holds data. Defaults to 1.
+    /// </param>
+    public static AgentHostBuilder AddStoreSchema(
+        this AgentHostBuilder builder,
+        string storeName,
+        int currentVersion,
+        Func<IServiceProvider, string> resolvePath,
+        int legacyVersion = 1)
+    {
+        builder.Services.AddStoreSchema(storeName, currentVersion, resolvePath, legacyVersion);
+        return builder;
+    }
+
+    /// <inheritdoc cref="AddStoreSchema(AgentHostBuilder, string, int, Func{IServiceProvider, string}, int)"/>
+    public static IServiceCollection AddStoreSchema(
+        this IServiceCollection services,
+        string storeName,
+        int currentVersion,
+        Func<IServiceProvider, string> resolvePath,
+        int legacyVersion = 1)
+    {
+        services.AddSingleton(
+            new StoreSchemaDescriptor(storeName, currentVersion, resolvePath, legacyVersion));
+        return services;
+    }
+
+    /// <summary>
+    /// Configures the startup schema check — whether it runs, and whether it reports instead
+    /// of writing.
+    /// </summary>
+    public static AgentHostBuilder ConfigureSchemaMigrations(
+        this AgentHostBuilder builder,
+        Action<SchemaMigrationOptions> configure)
+    {
+        builder.Services.Configure(configure);
+        return builder;
+    }
+}

--- a/src/RockBot.Host/AgentMemoryExtensions.cs
+++ b/src/RockBot.Host/AgentMemoryExtensions.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 
 namespace RockBot.Host;
 
@@ -10,6 +11,21 @@ namespace RockBot.Host;
 /// </summary>
 public static class AgentMemoryExtensions
 {
+    /// <summary>Schema store name for the long-term memory store.</summary>
+    public const string MemoryStoreSchemaName = "memory";
+
+    /// <summary>Schema store name for the skill store.</summary>
+    public const string SkillStoreSchemaName = "skills";
+
+    /// <summary>Schema store name for the feedback store.</summary>
+    public const string FeedbackStoreSchemaName = "feedback";
+
+    // Bump alongside a migration that changes the store's on-disk shape. Additive changes —
+    // a new optional property with a default — leave these alone. See design/schema-migrations.md.
+    private const int MemoryStoreSchemaVersion = 1;
+    private const int SkillStoreSchemaVersion = 1;
+    private const int FeedbackStoreSchemaVersion = 1;
+
     /// <summary>
     /// Registers conversation memory, long-term memory, and working memory with default options.
     /// </summary>
@@ -56,6 +72,10 @@ public static class AgentMemoryExtensions
 
         builder.Services.TryAddSingleton<EmbeddingTextPreparer>();
         builder.Services.AddSingleton<ILongTermMemory, FileMemoryStore>();
+
+        builder.AddStoreSchema(MemoryStoreSchemaName, MemoryStoreSchemaVersion, sp => FileMemoryStore.ResolvePath(
+            sp.GetRequiredService<IOptions<MemoryOptions>>().Value.BasePath,
+            sp.GetRequiredService<IOptions<AgentProfileOptions>>().Value.BasePath));
 
         // Save-time deduplication. Callers that want it take IMemoryDeduplicator optionally and
         // fall back to SaveAsync, so registering it here changes behaviour without changing any
@@ -110,6 +130,11 @@ public static class AgentMemoryExtensions
 
         builder.Services.TryAddSingleton<EmbeddingTextPreparer>();
         builder.Services.AddSingleton<ISkillStore, FileSkillStore>();
+
+        builder.AddStoreSchema(SkillStoreSchemaName, SkillStoreSchemaVersion, sp => FileSkillStore.ResolvePath(
+            sp.GetRequiredService<IOptions<SkillOptions>>().Value.BasePath,
+            sp.GetRequiredService<IOptions<AgentProfileOptions>>().Value.BasePath));
+
         builder.Services.AddSingleton<ISkillUsageStore, FileSkillUsageStore>();
         builder.Services.AddSingleton<IPrunableLog>(sp => (IPrunableLog)sp.GetRequiredService<ISkillUsageStore>());
         builder.Services.AddSingleton<ISkillResourceUsageStore, FileSkillResourceUsageStore>();
@@ -232,6 +257,11 @@ public static class AgentMemoryExtensions
             builder.Services.Configure<FeedbackOptions>(_ => { });
 
         builder.Services.AddSingleton<IFeedbackStore, FileFeedbackStore>();
+
+        builder.AddStoreSchema(FeedbackStoreSchemaName, FeedbackStoreSchemaVersion, sp => FileFeedbackStore.ResolvePath(
+            sp.GetRequiredService<IOptions<FeedbackOptions>>().Value.BasePath,
+            sp.GetRequiredService<IOptions<AgentProfileOptions>>().Value.BasePath));
+
         builder.Services.AddSingleton<IPrunableLog>(sp => (IPrunableLog)sp.GetRequiredService<IFeedbackStore>());
         builder.Services.AddSingleton<SessionSummaryService>();
         builder.Services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<SessionSummaryService>());

--- a/src/RockBot.Host/FileFeedbackStore.cs
+++ b/src/RockBot.Host/FileFeedbackStore.cs
@@ -133,7 +133,7 @@ internal sealed class FileFeedbackStore : IFeedbackStore, IPrunableLog
         return entries;
     }
 
-    private static string ResolvePath(string path, string basePath)
+    internal static string ResolvePath(string path, string basePath)
     {
         if (Path.IsPathRooted(path))
             return path;

--- a/src/RockBot.Host/SchemaMigrationRunner.cs
+++ b/src/RockBot.Host/SchemaMigrationRunner.cs
@@ -1,0 +1,190 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace RockBot.Host;
+
+/// <summary>
+/// Brings every enrolled store's on-disk data up to the schema version the running code
+/// expects, before the host starts serving.
+/// </summary>
+/// <remarks>
+/// See <c>design/schema-migrations.md</c> for the policy this implements and for when a
+/// change needs a migration at all.
+/// </remarks>
+internal sealed class SchemaMigrationRunner
+{
+    private readonly IReadOnlyList<StoreSchemaDescriptor> _descriptors;
+    private readonly IReadOnlyList<ISchemaMigration> _migrations;
+    private readonly SchemaMigrationOptions _options;
+    private readonly IServiceProvider _services;
+    private readonly TimeProvider _time;
+    private readonly ILogger<SchemaMigrationRunner> _logger;
+
+    public SchemaMigrationRunner(
+        IEnumerable<StoreSchemaDescriptor> descriptors,
+        IEnumerable<ISchemaMigration> migrations,
+        IOptions<SchemaMigrationOptions> options,
+        IServiceProvider services,
+        ILogger<SchemaMigrationRunner> logger,
+        TimeProvider? timeProvider = null)
+    {
+        _descriptors = descriptors.ToList();
+        _migrations = migrations.ToList();
+        _options = options.Value;
+        _services = services;
+        _logger = logger;
+        _time = timeProvider ?? TimeProvider.System;
+    }
+
+    public async Task RunAsync(CancellationToken cancellationToken = default)
+    {
+        if (!_options.Enabled)
+        {
+            _logger.LogWarning(
+                "Schema migration check disabled; {Count} store(s) left unverified", _descriptors.Count);
+            return;
+        }
+
+        foreach (var descriptor in _descriptors)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await MigrateStoreAsync(descriptor, cancellationToken);
+        }
+    }
+
+    private async Task MigrateStoreAsync(StoreSchemaDescriptor descriptor, CancellationToken cancellationToken)
+    {
+        var storePath = descriptor.ResolvePath(_services);
+        var marker = await StoreSchemaMarkerFile.ReadAsync(storePath, _logger, cancellationToken);
+
+        if (marker is not null &&
+            !string.Equals(marker.Store, descriptor.StoreName, StringComparison.Ordinal))
+        {
+            // Two stores rooted at the same directory. Migrating either one against the other's
+            // marker would rewrite data the migration was never written for.
+            _logger.LogWarning(
+                "Schema marker at {Path} belongs to store '{Found}', not '{Expected}'; skipping migration",
+                StoreSchemaMarkerFile.PathFor(storePath), marker.Store, descriptor.StoreName);
+            return;
+        }
+
+        if (marker is null)
+        {
+            var isLegacy = StoreSchemaMarkerFile.HasData(storePath);
+            var assumed = isLegacy ? descriptor.LegacyVersion : descriptor.CurrentVersion;
+
+            _logger.LogInformation(
+                "Store '{Store}' at {Path} has no schema marker; treating it as {Kind} at v{Version}",
+                descriptor.StoreName, storePath, isLegacy ? "existing data" : "a new store", assumed);
+
+            await ApplyPendingAsync(descriptor, storePath, assumed, stampWhenCurrent: true, cancellationToken);
+            return;
+        }
+
+        if (marker.Version > descriptor.CurrentVersion)
+        {
+            // Written by a newer build. Downgrading is not something we can do, and refusing to
+            // start would strand a rollback, so read it as-is and say so loudly.
+            _logger.LogWarning(
+                "Store '{Store}' at {Path} is at schema v{Found}, ahead of this build's v{Expected}; " +
+                "continuing without migrating",
+                descriptor.StoreName, storePath, marker.Version, descriptor.CurrentVersion);
+            return;
+        }
+
+        await ApplyPendingAsync(descriptor, storePath, marker.Version, stampWhenCurrent: false, cancellationToken);
+    }
+
+    private async Task ApplyPendingAsync(
+        StoreSchemaDescriptor descriptor,
+        string storePath,
+        int currentVersion,
+        bool stampWhenCurrent,
+        CancellationToken cancellationToken)
+    {
+        if (currentVersion == descriptor.CurrentVersion)
+        {
+            if (!stampWhenCurrent)
+                return;
+
+            if (_options.DryRun)
+                _logger.LogInformation(
+                    "[dry run] Would stamp store '{Store}' at v{Version}",
+                    descriptor.StoreName, currentVersion);
+            else
+                await StampAsync(descriptor, storePath, currentVersion, cancellationToken);
+
+            return;
+        }
+
+        while (currentVersion < descriptor.CurrentVersion)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var migration = SelectMigration(descriptor, currentVersion);
+            var context = new SchemaMigrationContext(
+                descriptor.StoreName, storePath, currentVersion, migration.ToVersion);
+
+            if (_options.DryRun)
+            {
+                _logger.LogInformation(
+                    "[dry run] Would migrate store '{Store}' at {Path} from v{From} to v{To} using {Migration}",
+                    descriptor.StoreName, storePath, currentVersion, migration.ToVersion,
+                    migration.GetType().Name);
+                currentVersion = migration.ToVersion;
+                continue;
+            }
+
+            _logger.LogInformation(
+                "Migrating store '{Store}' at {Path} from v{From} to v{To} using {Migration}",
+                descriptor.StoreName, storePath, currentVersion, migration.ToVersion,
+                migration.GetType().Name);
+
+            Directory.CreateDirectory(storePath);
+            await migration.MigrateAsync(context, cancellationToken);
+
+            currentVersion = migration.ToVersion;
+
+            // Stamped per step, not once at the end: a migration that fails three steps in
+            // leaves the marker at the last step that actually completed, so the restart picks
+            // up where it stopped instead of replaying steps that already succeeded.
+            await StampAsync(descriptor, storePath, currentVersion, cancellationToken);
+        }
+    }
+
+    private ISchemaMigration SelectMigration(StoreSchemaDescriptor descriptor, int fromVersion)
+    {
+        var candidates = _migrations
+            .Where(m => string.Equals(m.StoreName, descriptor.StoreName, StringComparison.Ordinal)
+                        && m.FromVersion == fromVersion)
+            .ToList();
+
+        if (candidates.Count == 0)
+            throw new InvalidOperationException(
+                $"Store '{descriptor.StoreName}' is at schema v{fromVersion} and this build expects " +
+                $"v{descriptor.CurrentVersion}, but no migration from v{fromVersion} is registered. " +
+                "The store cannot be read safely; register the missing migration or roll back.");
+
+        if (candidates.Count > 1)
+            throw new InvalidOperationException(
+                $"Store '{descriptor.StoreName}' has {candidates.Count} migrations registered from " +
+                $"v{fromVersion} ({string.Join(", ", candidates.Select(c => c.GetType().Name))}). " +
+                "Exactly one migration may claim a version step.");
+
+        var migration = candidates[0];
+        if (migration.ToVersion <= fromVersion)
+            throw new InvalidOperationException(
+                $"Migration {migration.GetType().Name} for store '{descriptor.StoreName}' targets " +
+                $"v{migration.ToVersion} from v{fromVersion}. Migrations are forward-only.");
+
+        return migration;
+    }
+
+    private Task StampAsync(
+        StoreSchemaDescriptor descriptor,
+        string storePath,
+        int version,
+        CancellationToken cancellationToken) =>
+        StoreSchemaMarkerFile.WriteAsync(
+            storePath, descriptor.StoreName, version, _time.GetUtcNow(), cancellationToken);
+}

--- a/src/RockBot.Host/SchemaMigrationService.cs
+++ b/src/RockBot.Host/SchemaMigrationService.cs
@@ -1,0 +1,36 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace RockBot.Host;
+
+/// <summary>
+/// Runs the schema migration check at host startup, before any store is read.
+/// </summary>
+/// <remarks>
+/// Registered as the first <see cref="IHostedService"/> so its <see cref="StartAsync"/> runs
+/// ahead of every store that has one. Note that .NET constructs the whole hosted-service set
+/// before starting any of it, so other services' constructors have already run by this point —
+/// which is why migrations are handed a path rather than a store service.
+/// </remarks>
+internal sealed class SchemaMigrationService : IHostedService
+{
+    private readonly SchemaMigrationRunner _runner;
+    private readonly ILogger<SchemaMigrationService> _logger;
+
+    public SchemaMigrationService(SchemaMigrationRunner runner, ILogger<SchemaMigrationService> logger)
+    {
+        _runner = runner;
+        _logger = logger;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        // Deliberately not caught: a store this build cannot read is worse than a host that
+        // refuses to start, because the agent would carry on writing v-next records over data
+        // the migration was meant to convert.
+        await _runner.RunAsync(cancellationToken);
+        _logger.LogDebug("Schema migration check complete");
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/RockBot.Host/ServiceCollectionExtensions.cs
+++ b/src/RockBot.Host/ServiceCollectionExtensions.cs
@@ -23,6 +23,13 @@ public static class ServiceCollectionExtensions
     {
         var builder = new AgentHostBuilder(services);
 
+        // Registered before anything the caller configures so it is the first IHostedService in
+        // the collection, and therefore the first to start: no store gets to read its data until
+        // the schema check has brought that data up to the version this build expects.
+        services.Configure<SchemaMigrationOptions>(_ => { });
+        services.AddSingleton<SchemaMigrationRunner>();
+        services.AddSingleton<IHostedService, SchemaMigrationService>();
+
         // Register TracingMiddleware first so it's the outermost wrapper
         builder.UseMiddleware<TracingMiddleware>();
         // WIP tracking sits just inside tracing — persists the envelope to disk

--- a/src/RockBot.Host/StoreSchemaMarkerFile.cs
+++ b/src/RockBot.Host/StoreSchemaMarkerFile.cs
@@ -1,0 +1,83 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace RockBot.Host;
+
+/// <summary>
+/// Reads and writes a store's <see cref="StoreSchemaMarker"/> file.
+/// </summary>
+internal static class StoreSchemaMarkerFile
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = true
+    };
+
+    /// <summary>Full path to the marker within <paramref name="storePath"/>.</summary>
+    internal static string PathFor(string storePath) =>
+        Path.Combine(storePath, StoreSchemaMarker.FileName);
+
+    /// <summary>
+    /// Reads the marker, or returns <c>null</c> when the store has never been stamped.
+    /// </summary>
+    /// <remarks>
+    /// An unreadable marker is reported as absent rather than thrown. A store with a corrupt
+    /// marker and real data in it is indistinguishable from a pre-mechanism store, and that is
+    /// the safer of the two readings: the caller re-derives the version from
+    /// <see cref="StoreSchemaDescriptor.LegacyVersion"/> instead of refusing to start.
+    /// </remarks>
+    internal static async Task<StoreSchemaMarker?> ReadAsync(
+        string storePath,
+        ILogger logger,
+        CancellationToken cancellationToken = default)
+    {
+        var path = PathFor(storePath);
+        if (!File.Exists(path))
+            return null;
+
+        try
+        {
+            var json = await File.ReadAllTextAsync(path, cancellationToken);
+            return JsonSerializer.Deserialize<StoreSchemaMarker>(json, JsonOptions);
+        }
+        catch (Exception ex) when (ex is JsonException or IOException or UnauthorizedAccessException)
+        {
+            logger.LogWarning(ex,
+                "Unreadable schema marker at {Path}; treating the store as unmarked", path);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Stamps <paramref name="version"/> into the store's marker, creating the store
+    /// directory if it does not exist yet.
+    /// </summary>
+    internal static async Task WriteAsync(
+        string storePath,
+        string storeName,
+        int version,
+        DateTimeOffset timestamp,
+        CancellationToken cancellationToken = default)
+    {
+        Directory.CreateDirectory(storePath);
+        var marker = new StoreSchemaMarker(storeName, version, timestamp);
+        var json = JsonSerializer.Serialize(marker, JsonOptions);
+        await AtomicFile.WriteAllTextAsync(PathFor(storePath), json, cancellationToken);
+    }
+
+    /// <summary>
+    /// Whether the store directory holds anything other than its own marker — the test for
+    /// "this is an existing store from before the marker existed" rather than a fresh one.
+    /// </summary>
+    internal static bool HasData(string storePath)
+    {
+        if (!Directory.Exists(storePath))
+            return false;
+
+        return Directory.EnumerateFileSystemEntries(storePath)
+            .Any(entry => !string.Equals(
+                Path.GetFileName(entry), StoreSchemaMarker.FileName, StringComparison.Ordinal));
+    }
+}

--- a/src/RockBot.Wisp/FileWispExecutionLog.cs
+++ b/src/RockBot.Wisp/FileWispExecutionLog.cs
@@ -22,11 +22,18 @@ internal sealed class FileWispExecutionLog : IWispExecutionLog, IPrunableLog
 
     public FileWispExecutionLog(WispOptions options, ILogger<FileWispExecutionLog> logger)
     {
-        var basePath = options.SharedVolumePath ?? Path.Combine(AppContext.BaseDirectory, "wisp-log");
+        var basePath = ResolvePath(options);
         Directory.CreateDirectory(basePath);
         _filePath = Path.Combine(basePath, "wisp-executions.jsonl");
         _logger = logger;
     }
+
+    /// <summary>
+    /// The directory the execution log lives in. Shared with the schema-migration descriptor so
+    /// the marker lands beside the log rather than in a second guess at the same location.
+    /// </summary>
+    internal static string ResolvePath(WispOptions options) =>
+        options.SharedVolumePath ?? Path.Combine(AppContext.BaseDirectory, "wisp-log");
 
     public async Task AppendAsync(WispExecutionRecord record, CancellationToken ct = default)
     {

--- a/src/RockBot.Wisp/WispServiceCollectionExtensions.cs
+++ b/src/RockBot.Wisp/WispServiceCollectionExtensions.cs
@@ -9,6 +9,13 @@ namespace RockBot.Wisp;
 /// </summary>
 public static class WispServiceCollectionExtensions
 {
+    /// <summary>Schema store name for the wisp execution log.</summary>
+    public const string WispStoreSchemaName = "wisp";
+
+    // Bump alongside a migration that changes the log's on-disk shape. Additive changes —
+    // a new optional property with a default — leave this alone. See design/schema-migrations.md.
+    private const int WispStoreSchemaVersion = 1;
+
     /// <summary>
     /// Adds wisp executor support and the <c>spawn_wisps</c> tool.
     /// </summary>
@@ -23,6 +30,14 @@ public static class WispServiceCollectionExtensions
         builder.Services.AddSingleton<WispDispatchCircuitBreaker>();
         builder.Services.AddSingleton<WispExecutor>();
         builder.Services.AddSingleton<IWispExecutionLog, FileWispExecutionLog>();
+
+        // The log shares its directory with whatever else uses the shared volume, so the marker
+        // carries the store name and the runner skips on a mismatch rather than migrating blind.
+        builder.AddStoreSchema(
+            WispStoreSchemaName,
+            WispStoreSchemaVersion,
+            sp => FileWispExecutionLog.ResolvePath(sp.GetRequiredService<WispOptions>()));
+
         builder.Services.AddSingleton<IPrunableLog>(sp => (IPrunableLog)sp.GetRequiredService<IWispExecutionLog>());
         builder.Services.AddHostedService<WispToolRegistrar>();
         builder.Services.AddSingleton<IToolSkillProvider, WispToolSkillProvider>();

--- a/tests/RockBot.Host.Tests/SchemaMigrationRunnerTests.cs
+++ b/tests/RockBot.Host.Tests/SchemaMigrationRunnerTests.cs
@@ -1,0 +1,315 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace RockBot.Host.Tests;
+
+[TestClass]
+public class SchemaMigrationRunnerTests
+{
+    private const string StoreName = "test-store";
+
+    private string _tempDir = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "rockbot-schema-test-" + Guid.NewGuid().ToString("N"));
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    [TestMethod]
+    public async Task RunAsync_NewStore_StampsCurrentVersionAndRunsNoMigrations()
+    {
+        var migration = new RecordingMigration(1, 2);
+        var runner = CreateRunner(currentVersion: 2, migrations: [migration]);
+
+        await runner.RunAsync();
+
+        Assert.IsFalse(migration.Ran, "A directory with no data is a new store, not a legacy one.");
+        Assert.AreEqual(2, ReadMarker()!.Version);
+    }
+
+    [TestMethod]
+    public async Task RunAsync_UnmarkedStoreWithData_AtCurrentVersion_StampsWithoutMigrating()
+    {
+        WriteData("entry.json");
+        var migration = new RecordingMigration(1, 2);
+        var runner = CreateRunner(currentVersion: 1, migrations: [migration]);
+
+        await runner.RunAsync();
+
+        Assert.IsFalse(migration.Ran);
+        var marker = ReadMarker();
+        Assert.AreEqual(1, marker!.Version);
+        Assert.AreEqual(StoreName, marker.Store);
+    }
+
+    [TestMethod]
+    public async Task RunAsync_UnmarkedStoreWithData_BelowCurrentVersion_MigratesFromLegacyVersion()
+    {
+        WriteData("entry.json");
+        var migration = new RecordingMigration(1, 2);
+        var runner = CreateRunner(currentVersion: 2, migrations: [migration]);
+
+        await runner.RunAsync();
+
+        Assert.IsTrue(migration.Ran);
+        Assert.AreEqual(1, migration.Context!.FromVersion);
+        Assert.AreEqual(2, migration.Context.ToVersion);
+        Assert.AreEqual(StoreName, migration.Context.StoreName);
+        Assert.AreEqual(_tempDir, migration.Context.StorePath);
+        Assert.AreEqual(2, ReadMarker()!.Version);
+    }
+
+    [TestMethod]
+    public async Task RunAsync_MultipleVersionsBehind_RunsMigrationsInOrder()
+    {
+        await WriteMarkerAsync(StoreName, version: 1);
+        var order = new List<int>();
+        var first = new RecordingMigration(1, 2, onRun: () => order.Add(1));
+        var second = new RecordingMigration(2, 3, onRun: () => order.Add(2));
+
+        // Registered out of order on purpose — the chain walk, not registration order, decides.
+        var runner = CreateRunner(currentVersion: 3, migrations: [second, first]);
+
+        await runner.RunAsync();
+
+        CollectionAssert.AreEqual(new[] { 1, 2 }, order);
+        Assert.AreEqual(3, ReadMarker()!.Version);
+    }
+
+    [TestMethod]
+    public async Task RunAsync_MarkerAheadOfBuild_LeavesStoreUntouched()
+    {
+        await WriteMarkerAsync(StoreName, version: 5);
+        var migration = new RecordingMigration(1, 2);
+        var runner = CreateRunner(currentVersion: 2, migrations: [migration]);
+
+        await runner.RunAsync();
+
+        Assert.IsFalse(migration.Ran);
+        Assert.AreEqual(5, ReadMarker()!.Version, "A rollback must not rewrite a newer build's marker.");
+    }
+
+    [TestMethod]
+    public async Task RunAsync_GapInMigrationChain_Throws()
+    {
+        await WriteMarkerAsync(StoreName, version: 1);
+        var runner = CreateRunner(currentVersion: 3, migrations: [new RecordingMigration(2, 3)]);
+
+        var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => runner.RunAsync());
+        StringAssert.Contains(ex.Message, "no migration from v1");
+    }
+
+    [TestMethod]
+    public async Task RunAsync_TwoMigrationsClaimingSameStep_Throws()
+    {
+        await WriteMarkerAsync(StoreName, version: 1);
+        var runner = CreateRunner(
+            currentVersion: 2,
+            migrations: [new RecordingMigration(1, 2), new RecordingMigration(1, 2)]);
+
+        var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => runner.RunAsync());
+        StringAssert.Contains(ex.Message, "Exactly one migration may claim a version step");
+    }
+
+    [TestMethod]
+    public async Task RunAsync_DryRun_RunsNothingAndWritesNoMarker()
+    {
+        WriteData("entry.json");
+        var migration = new RecordingMigration(1, 2);
+        var runner = CreateRunner(currentVersion: 2, migrations: [migration], dryRun: true);
+
+        await runner.RunAsync();
+
+        Assert.IsFalse(migration.Ran);
+        Assert.IsFalse(File.Exists(MarkerPath));
+    }
+
+    [TestMethod]
+    public async Task RunAsync_Disabled_DoesNothing()
+    {
+        WriteData("entry.json");
+        var migration = new RecordingMigration(1, 2);
+        var runner = CreateRunner(currentVersion: 2, migrations: [migration], enabled: false);
+
+        await runner.RunAsync();
+
+        Assert.IsFalse(migration.Ran);
+        Assert.IsFalse(File.Exists(MarkerPath));
+    }
+
+    [TestMethod]
+    public async Task RunAsync_MigrationThrows_LeavesMarkerAtLastCompletedStep()
+    {
+        await WriteMarkerAsync(StoreName, version: 1);
+        var runner = CreateRunner(
+            currentVersion: 3,
+            migrations: [new RecordingMigration(1, 2), new ThrowingMigration(2, 3)]);
+
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => runner.RunAsync());
+
+        Assert.AreEqual(2, ReadMarker()!.Version,
+            "The step that succeeded should be stamped so a restart resumes rather than replaying it.");
+    }
+
+    [TestMethod]
+    public async Task RunAsync_MarkerBelongsToAnotherStore_SkipsWithoutMigrating()
+    {
+        await WriteMarkerAsync("some-other-store", version: 1);
+        var migration = new RecordingMigration(1, 2);
+        var runner = CreateRunner(currentVersion: 2, migrations: [migration]);
+
+        await runner.RunAsync();
+
+        Assert.IsFalse(migration.Ran);
+        Assert.AreEqual("some-other-store", ReadMarker()!.Store);
+        Assert.AreEqual(1, ReadMarker()!.Version);
+    }
+
+    [TestMethod]
+    public async Task RunAsync_UnreadableMarker_TreatsStoreAsUnmarked()
+    {
+        Directory.CreateDirectory(_tempDir);
+        await File.WriteAllTextAsync(MarkerPath, "{ not json");
+        WriteData("entry.json");
+        var migration = new RecordingMigration(1, 2);
+        var runner = CreateRunner(currentVersion: 2, migrations: [migration]);
+
+        await runner.RunAsync();
+
+        Assert.IsTrue(migration.Ran, "Corrupt marker plus real data reads as a pre-mechanism store.");
+        Assert.AreEqual(2, ReadMarker()!.Version);
+    }
+
+    [TestMethod]
+    public async Task RunAsync_EveryStoreIsVisited()
+    {
+        var otherDir = Path.Combine(_tempDir, "second");
+        var descriptors = new[]
+        {
+            new StoreSchemaDescriptor(StoreName, 1, _ => _tempDir),
+            new StoreSchemaDescriptor("second-store", 1, _ => otherDir)
+        };
+        var runner = CreateRunner(descriptors, migrations: []);
+
+        await runner.RunAsync();
+
+        Assert.AreEqual(StoreName, ReadMarker()!.Store);
+        Assert.AreEqual("second-store", ReadMarker(otherDir)!.Store);
+    }
+
+    [TestMethod]
+    public async Task Marker_IsInvisibleToTheMemoryStoreIndexWalk()
+    {
+        // The marker sits in the store root, which FileMemoryStore indexes by enumerating
+        // *.json recursively. A marker matching that pattern would show up as an entry.
+        await StoreSchemaMarkerFile.WriteAsync(
+            _tempDir, "memory", version: 1, DateTimeOffset.UtcNow);
+
+        var store = CreateMemoryStore();
+        await store.SaveAsync(new MemoryEntry(
+            "m1", "The marker must not be indexed", null, ["fact"], DateTimeOffset.UtcNow));
+        await store.SaveAsync(new MemoryEntry(
+            "m2", "Neither entry should be crowded out", null, ["fact"], DateTimeOffset.UtcNow));
+
+        var all = await store.SearchAsync(new MemorySearchCriteria(MaxResults: 50));
+
+        CollectionAssert.AreEquivalent(new[] { "m1", "m2" }, all.Select(e => e.Id).ToArray());
+        Assert.IsTrue(File.Exists(MarkerPath), "The store must not have deleted or rewritten the marker.");
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private string MarkerPath => Path.Combine(_tempDir, StoreSchemaMarker.FileName);
+
+    private SchemaMigrationRunner CreateRunner(
+        int currentVersion,
+        IEnumerable<ISchemaMigration> migrations,
+        bool dryRun = false,
+        bool enabled = true,
+        int legacyVersion = 1) =>
+        CreateRunner(
+            [new StoreSchemaDescriptor(StoreName, currentVersion, _ => _tempDir, legacyVersion)],
+            migrations,
+            dryRun,
+            enabled);
+
+    private static SchemaMigrationRunner CreateRunner(
+        IEnumerable<StoreSchemaDescriptor> descriptors,
+        IEnumerable<ISchemaMigration> migrations,
+        bool dryRun = false,
+        bool enabled = true) =>
+        new(descriptors,
+            migrations,
+            Options.Create(new SchemaMigrationOptions { DryRun = dryRun, Enabled = enabled }),
+            new EmptyServiceProvider(),
+            NullLogger<SchemaMigrationRunner>.Instance);
+
+    private FileMemoryStore CreateMemoryStore() =>
+        new(Options.Create(new MemoryOptions { BasePath = _tempDir }),
+            Options.Create(new AgentProfileOptions()),
+            Options.Create(new EmbeddingOptions()),
+            NullLogger<FileMemoryStore>.Instance,
+            EmbeddingTextPreparer.ForTests());
+
+    private void WriteData(string fileName)
+    {
+        Directory.CreateDirectory(_tempDir);
+        File.WriteAllText(Path.Combine(_tempDir, fileName), "{}");
+    }
+
+    private Task WriteMarkerAsync(string storeName, int version) =>
+        StoreSchemaMarkerFile.WriteAsync(_tempDir, storeName, version, DateTimeOffset.UtcNow);
+
+    private StoreSchemaMarker? ReadMarker(string? dir = null)
+    {
+        var path = Path.Combine(dir ?? _tempDir, StoreSchemaMarker.FileName);
+        if (!File.Exists(path))
+            return null;
+
+        return JsonSerializer.Deserialize<StoreSchemaMarker>(
+            File.ReadAllText(path),
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+    }
+
+    private sealed class RecordingMigration(int from, int to, Action? onRun = null) : ISchemaMigration
+    {
+        public string StoreName => SchemaMigrationRunnerTests.StoreName;
+        public int FromVersion => from;
+        public int ToVersion => to;
+
+        public bool Ran { get; private set; }
+        public SchemaMigrationContext? Context { get; private set; }
+
+        public Task MigrateAsync(SchemaMigrationContext context, CancellationToken cancellationToken = default)
+        {
+            Ran = true;
+            Context = context;
+            onRun?.Invoke();
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class ThrowingMigration(int from, int to) : ISchemaMigration
+    {
+        public string StoreName => SchemaMigrationRunnerTests.StoreName;
+        public int FromVersion => from;
+        public int ToVersion => to;
+
+        public Task MigrateAsync(SchemaMigrationContext context, CancellationToken cancellationToken = default) =>
+            throw new InvalidOperationException("migration failed");
+    }
+
+    private sealed class EmptyServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) => null;
+    }
+}


### PR DESCRIPTION
## Summary

Every schema change to RockBot's on-disk stores so far has been additive — a new optional property with a default, absorbed by the tolerant deserializer — so upgrading has never needed a data step. The next change that *can't* be expressed that way would have no answer for a deployment with accumulated memory on a PVC, and because RockBot ships as NuGet packages as well as an image, we can't gate that on an init container.

This adds the mechanism before we hit that wall.

**Contracts** (`RockBot.Host.Abstractions` — no new package; every store interface already lives there):
- `ISchemaMigration` — one forward step for one store
- `StoreSchemaDescriptor` — enrols a store: name, expected version, path resolver
- `StoreSchemaMarker` / `SchemaMigrationContext` / `SchemaMigrationOptions`

**Runtime** (`RockBot.Host`): `SchemaMigrationService` is registered as the first `IHostedService` in `AddRockBotHost`, so it runs before any store reads its data.

| On disk | Action |
| --- | --- |
| No marker, dir empty/absent | Stamp `CurrentVersion` — a new store |
| No marker, dir holds data | Assume `LegacyVersion`, run pending migrations |
| `marker < CurrentVersion` | Run migrations in order, re-stamp after **each** step |
| `marker > CurrentVersion` | Warn, leave untouched, continue |
| Marker names a different store | Warn, skip |

Forward-only. A gap or an ambiguity in the migration chain aborts startup — a store this build can't read safely is worse than one that won't boot. Stamping per step means an interrupted upgrade resumes rather than replaying.

**The marker filename is load-bearing.** `.rockbot-schema` is deliberately dot-prefixed and extension-less: `FileMemoryStore` and `FileSkillStore` build their indexes by enumerating `*.json` recursively beneath their root (and `FileFeedbackStore` does the same for `*.jsonl`), so a `_version.json` would have been picked up and reported as a corrupt entry. There's a test that proves the marker is invisible to the real `FileMemoryStore` index walk.

**Enrolled stores** — `memory`, `skills`, `feedback`, `wisp`, each from the `With*`/`Add*` extension that registers it, so a consumer who never opts into a store never gets a marker for it. All four at version 1 with **no migrations shipped**: the first boot after this change stamps four markers and changes nothing else.

**Consumer API:**
```csharp
builder.AddStoreSchema("my-store", currentVersion: 2, sp => "/data/my-store");
builder.AddSchemaMigration<MyV1ToV2>();
builder.ConfigureSchemaMigrations(o => o.DryRun = true);
```

**Docs:** `design/schema-migrations.md` — the additive-vs-destructive policy, the startup table, how to write and enrol one, and the hosted-service ordering caveat (constructors have already run, which is why migrations get a *path*, not a store service). Linked from `design/architecture.md`; short entry added to `CLAUDE.md`.

## Answers to the issue's open questions

- **Where does the registry live?** `RockBot.Host.Abstractions` — no new NuGet package to add to the release train.
- **CLI?** Not in this PR. `SchemaMigrationOptions.DryRun` lets an operator boot report-only, which covers the need without a new verb. `dotnet rockbot migrate` left open.
- **How to test end-to-end?** 14 unit tests here; fixtures of old on-disk state left open until there's a real migration to exercise them with.

## Test plan

- [x] `dotnet test RockBot.slnx` — 21 assemblies, 3147 passed, 0 failed
- [x] 14 new tests in `SchemaMigrationRunnerTests`: new store, legacy store, multi-step chain ordering, forward-compat, chain gap, ambiguous step, dry run, disabled, mid-chain failure leaves the marker at the last completed step, foreign marker, corrupt marker, multi-store
- [x] Marker invisibility verified against a real `FileMemoryStore`, not a stub
- [ ] First boot on the cluster should log four "no schema marker … a new store" lines (or "existing data" for the populated ones) and stamp v1; the second boot should be silent

Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uf8a2Z1v9dY3YjjM42zJEj