### PR TITLE
Bump version to 0.14.41

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.14.40</Version>
+<Version>0.14.41</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->


### PR DESCRIPTION
## Summary

Bumps `<Version>` from 0.14.40 to 0.14.41.

The #308 schema migration mechanism (PR #559) was verified on the cluster as the pre-release tag `0.14.41-issue308`:

- First boot logged all four stores as pre-existing data at v1 and ran no migrations
- Markers stamped correctly in `/data/agent/{memory,skills,feedback}` and `/rockbot/shared`, each carrying its own store name
- Store data unchanged against the pre-deploy baseline (memory 2000, feedback 29, wisp log 5355; skills +1 from `StarterSkillService` writing `service-search.json`)
- Second boot was a silent no-op, with the memory store indexing normally around the marker in its root
- Zero store load warnings or errors

A released tag is needed so the running version stays observable in `kubectl describe`, and docker tags are never reused.

## Test plan

- [x] Full suite green on #559 (21 assemblies, 3147 passed, 0 failed)
- [x] Verified on the cluster at `0.14.41-issue308`
- [ ] CI green here
- [ ] Build, push and deploy `rockylhotka/rockbot-agent:0.14.41`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uf8a2Z1v9dY3YjjM42zJEj