### PR TITLE
Bump version to 0.14.42

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.14.41</Version>
+<Version>0.14.42</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->


### PR DESCRIPTION
Ships the #556 routing-log fix (PR #561) to the cluster.

The running agent is on `0.14.41`, which is the current version in `Directory.Build.props`, and docker tags are never reused — a new released tag keeps the running version observable in `kubectl describe`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uf8a2Z1v9dY3YjjM42zJEj