### PR TITLE
Multimodal input: analyze_file, MCP binary capture, and a fixture server (#513)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.14.45</Version>
+<Version>0.14.47</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.14.42</Version>
+<Version>0.14.43</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.14.47</Version>
+<Version>0.15.0</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.14.43</Version>
+<Version>0.14.44</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Version can be overridden from the command line: -p:Version=0.3.1
          AssemblyVersion and FileVersion are derived automatically by the SDK
          (prerelease suffixes like -beta001 are stripped for assembly versions). -->
-<Version>0.14.44</Version>
+<Version>0.14.45</Version>
   </PropertyGroup>
 
   <!-- NuGet package metadata (shared across all packable projects) -->

--- a/RockBot.slnx
+++ b/RockBot.slnx
@@ -5,6 +5,7 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/mcp-servers/">
+    <Project Path="src/McpServer.BinaryFixture/McpServer.BinaryFixture.csproj" />
     <Project Path="src/McpServer.Introspection/McpServer.Introspection.csproj" />
     <Project Path="src/McpServer.OpenRouter/McpServer.OpenRouter.csproj" />
 <Project Path="src/McpServer.TodoApp/McpServer.TodoApp.csproj" />

--- a/deploy/helm/rockbot/Chart.yaml
+++ b/deploy/helm/rockbot/Chart.yaml
@@ -4,8 +4,8 @@ description: >
   RockBot — an event-driven autonomous agent framework built on .NET.
   Deploys the RockBot agent and the Blazor Server web UI.
 type: application
-version: 0.10.21
-appVersion: "0.10.21"
+version: 0.15.0
+appVersion: "0.15.0"
 home: https://github.com/rockylhotka/rockbot
 keywords:
   - ai

--- a/deploy/helm/rockbot/templates/secret.yaml
+++ b/deploy/helm/rockbot/templates/secret.yaml
@@ -31,6 +31,9 @@ stringData:
   {{- if ((.Values.secrets.llm.balanced).reasoningEffort) }}
   LLM__Balanced__ReasoningEffort: {{ .Values.secrets.llm.balanced.reasoningEffort | quote }}
   {{- end }}
+  {{- if ((.Values.secrets.llm.balanced).supportsImageInput) }}
+  LLM__Balanced__SupportsImageInput: "true"
+  {{- end }}
   {{- range $i, $m := .Values.secrets.llm.balancedModels }}
   {{- if $m.provider }}
   LLM__BalancedModels__{{ $i }}__Provider: {{ $m.provider | quote }}
@@ -60,6 +63,9 @@ stringData:
   {{- if ((.Values.secrets.llm.low).reasoningEffort) }}
   LLM__Low__ReasoningEffort: {{ .Values.secrets.llm.low.reasoningEffort | quote }}
   {{- end }}
+  {{- if ((.Values.secrets.llm.low).supportsImageInput) }}
+  LLM__Low__SupportsImageInput: "true"
+  {{- end }}
   {{- end }}
   {{- if ((.Values.secrets.llm.high).modelId) }}
   # High tier — falls back to Balanced when not configured
@@ -75,6 +81,9 @@ stringData:
   LLM__High__ModelId: {{ .Values.secrets.llm.high.modelId | quote }}
   {{- if ((.Values.secrets.llm.high).reasoningEffort) }}
   LLM__High__ReasoningEffort: {{ .Values.secrets.llm.high.reasoningEffort | quote }}
+  {{- end }}
+  {{- if ((.Values.secrets.llm.high).supportsImageInput) }}
+  LLM__High__SupportsImageInput: "true"
   {{- end }}
   {{- end }}
   {{- if ((.Values.secrets.llm).endpoint) }}

--- a/deploy/helm/rockbot/values.yaml
+++ b/deploy/helm/rockbot/values.yaml
@@ -424,25 +424,37 @@ secrets:
     # GitHub token for Copilot provider (needs copilot scope):
     gitHubToken: ""
 
+    # supportsImageInput declares that a tier's model accepts images alongside text.
+    # It gates the analyze_file tool: with no tier set to true the tool is not registered
+    # at all, and a call that needs eyes is routed to a tier that has them. A vision request
+    # reaching a blind model fails with an opaque provider error, so this is declared rather
+    # than guessed from the model id. See design/multimodal-input.md.
     balanced:
       provider: ""          # Per-tier override: "" inherits global, "Copilot" or "OpenAI"
       endpoint: ""          # REQUIRED for OpenAI-compatible — base URL of the API
       apiKey: ""            # REQUIRED for OpenAI-compatible — API key
       modelId: ""           # REQUIRED — model ID (e.g. anthropic/claude-haiku-4.5 or gpt-4.1)
+      supportsImageInput: false   # true only if this model reads images
     # Ordered fallback chain for balanced tier. First entry is preferred; subsequent
     # entries are tried in order on failure. Takes precedence over single 'balanced'
     # when populated. Each entry has: provider, endpoint, apiKey, modelId.
+    #
+    # Entries take no supportsImageInput of their own — the flag is read per tier, not per
+    # fallback model. So if balanced.supportsImageInput is true, every model in this chain
+    # must read images: a fallback that cannot would be handed one and fail.
     balancedModels: []
     low:                    # Optional — fast/cheap model for simple factual questions
       provider: ""
       endpoint: ""
       apiKey: ""
       modelId: ""
+      supportsImageInput: false
     high:                   # Optional — powerful model for dream/research/complex tasks
       provider: ""
       endpoint: ""
       apiKey: ""
       modelId: ""           # leave empty to fall back to balanced
+      supportsImageInput: false
 
     # Legacy flat keys — kept for backward compatibility; remove after all deployments migrated
     endpoint: ""

--- a/deploy/k8s/mcp-binary-fixture.yaml
+++ b/deploy/k8s/mcp-binary-fixture.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
         - name: fixture
-          image: rockylhotka/rockbot-binary-fixture-mcp:0.14.47
+          image: rockylhotka/rockbot-binary-fixture-mcp:0.15.0
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/deploy/k8s/mcp-binary-fixture.yaml
+++ b/deploy/k8s/mcp-binary-fixture.yaml
@@ -1,0 +1,60 @@
+# Fixture MCP server for exercising the bridge's binary-content paths against a live agent.
+#
+# NOT part of a normal deployment. It is deliberately outside the Helm chart: it exists to be
+# applied when someone is testing binary capture or analyze_file, and deleted afterwards.
+#
+#   kubectl apply -f deploy/k8s/mcp-binary-fixture.yaml
+#   # register it in the agent's mcp.json (see src/McpServer.BinaryFixture/README.md)
+#   kubectl delete -f deploy/k8s/mcp-binary-fixture.yaml
+#
+# It serves generated fixtures only — no credentials, no external calls, no state.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mcp-binary-fixture
+  namespace: rockbot
+  labels:
+    app: mcp-binary-fixture
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mcp-binary-fixture
+  template:
+    metadata:
+      labels:
+        app: mcp-binary-fixture
+    spec:
+      containers:
+        - name: fixture
+          image: rockylhotka/rockbot-binary-fixture-mcp:0.14.47
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              memory: 192Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mcp-binary-fixture
+  namespace: rockbot
+  labels:
+    app: mcp-binary-fixture
+spec:
+  selector:
+    app: mcp-binary-fixture
+  ports:
+    - port: 80
+      targetPort: 8080
+      name: http

--- a/design/mcp-attachments.md
+++ b/design/mcp-attachments.md
@@ -180,6 +180,27 @@ rule only fires when the payload really is binary:
 The response object survives the rewrite. Only the content field is removed; `sha`, `url`, and
 whatever else the server sent stay, with `path`, `name`, `size`, `mime`, and a short note added.
 
+### When the bytes were already destroyed
+
+Not every server base64s its binary. One repository server in the reference deployment decodes
+file bytes as UTF-8 before returning them, so a 345 KB PNG arrives with its leading `0x89`
+replaced by U+FFFD and the rest studded with the same — 1,366,356 characters that chunk into 22
+working-memory entries and 22 embedding calls, for content no consumer can recover.
+
+Capture declines to save those bytes, correctly: they are not base64 and there is nothing to
+write. But declining used to mean passing the whole payload through, so the flood happened
+anyway and the agent, reading mojibake, would often retry the same call.
+
+So a content field that fails base64 decoding is checked for the signature of lossy
+binary-to-text decoding — eight or more U+FFFD in at least a kilobyte, thresholds set so a
+document with a couple of encoding glitches is still a document. On a match the field is dropped
+and replaced with a note saying the bytes were corrupted, that retrying returns the same
+corrupted text, and to fetch the file by a route that preserves bytes. `name`, `sha`, `size` and
+`html_url` survive, which is usually enough to do exactly that.
+
+Measured on the same call before and after: **1,366,356 characters and 22 chunks → 588
+characters and none.**
+
 ### Capture never fails a call
 
 A bad rule, an unwritable volume, or a payload that isn't what the rule claimed logs a warning

--- a/design/mcp-attachments.md
+++ b/design/mcp-attachments.md
@@ -123,6 +123,77 @@ gateway GETs → gateway DELETEs.
 Configurable per-server response shapes are a small follow-up if a server insists on a
 different envelope. v1 keeps it simple.
 
+## Binary capture — the fallback for servers that never heard of us
+
+Everything above requires a cooperating server. Most don't cooperate. Issue #513 arrived
+with the consequence: the official Gitea MCP server returns a repository PNG through its
+ordinary `get_file_contents` tool, as base64 inside a JSON response. That lands in context as
+~167K characters of unusable text, gets chunked into working memory, and still never reaches
+the model as an image.
+
+Capture is the response-side answer. It runs on **every** MCP response, for every server,
+manifest or not — `BinaryResponseCapture`, wired at the same
+`McpBridgeService.HandleToolInvokeAsync` seam as the gateway, just after it.
+
+### Two rules, deliberately unequal in what they ask of an operator
+
+**Typed content blocks need no configuration.** An `ImageContentBlock` or `AudioContentBlock`
+is already labelled by MCP itself, so there is nothing to guess: the bytes are written to the
+attachments directory and the block is replaced by `{path, name, size, mime, note}`. Other
+blocks in the same response are left alone.
+
+**Base64 inside JSON needs a declared rule.** Sniffing for "a field that looks like base64" is
+exactly the fragile heuristic the manifest design rejected, so this half stays declarative:
+
+```json
+{
+  "attachments": {
+    "capture": {
+      "rules": [
+        {
+          "tools": ["get_file_contents"],
+          "contentField": "content",
+          "nameField": "name",
+          "encodingField": "encoding"
+        }
+      ]
+    }
+  }
+}
+```
+
+No server change is needed — only a description of the response the server already sends.
+`capture.enabled: false` turns the whole thing off for a server, typed blocks included.
+
+### Deciding what is actually binary
+
+A repository server returns a README and a PNG through the same tool and the same field.
+Capturing the README to disk would take away content the model could simply have read, so the
+rule only fires when the payload really is binary:
+
+1. If a name or MIME field identifies the type, that decides it (`image/*`, `audio/*`,
+   `video/*`, PDF, zip, Office formats). SVG is explicitly *not* binary — it is an image by
+   MIME and text by nature, and the model can read and edit it.
+2. With no usable name, the bytes decide: a NUL byte in the first 8 KB, or a strict UTF-8
+   decode failure.
+
+The response object survives the rewrite. Only the content field is removed; `sha`, `url`, and
+whatever else the server sent stay, with `path`, `name`, `size`, `mime`, and a short note added.
+
+### Capture never fails a call
+
+A bad rule, an unwritable volume, or a payload that isn't what the rule claimed logs a warning
+and returns the server's original response. A tool that worked before capture existed still
+works. This is the opposite of the outbound gateway's stance, and deliberately so: outbound, a
+failure means the model's file never got attached and silence would be a lie; inbound, capture
+is an optimisation on top of a response that is already complete.
+
+### Why this and `analyze_file` are separate
+
+Capture puts bytes on the volume. It does not show them to a model — on OpenAI-compatible
+APIs a tool result cannot carry an image at all. `analyze_file` is the other half of that
+story; see [`multimodal-input.md`](multimodal-input.md).
+
 ## Verified calendar-mcp REST shape
 
 - `POST /attachments` (multipart, field `file` by default) → **201 Created** with

--- a/design/multimodal-input.md
+++ b/design/multimodal-input.md
@@ -1,0 +1,202 @@
+# Multimodal input
+
+## Why
+
+RockBot has been text-only end to end. Every model it talks to can see, but nothing in the
+framework could put a non-text byte in front of one. Issue #513 arrived at this from the
+outside: an agent asked an MCP server for an image, got 167K characters of textual
+representation back, chunked it into working memory, and never showed the model an image.
+
+The model was vision-capable. The image never reached it *as an image*.
+
+This document is the contract for closing that gap: what was missing, what the wire formats
+actually permit, and the order the pieces land in.
+
+## What was missing
+
+Five separate things, verified in the tree before any of this was written:
+
+1. **Every internal contract is text-only.** `UserMessage.Content`, `ConversationTurn.Content`,
+   and `LlmChatMessage.Content` are all `string`. `LlmMessageMapper.ToChatMessages` can only
+   build `TextContent`, `FunctionCallContent`, and `FunctionResultContent`. The one exception
+   is `ILlmClient.GetResponseAsync`, which takes M.E.AI `ChatMessage` — and `ChatMessage` has
+   supported `DataContent` all along. The capability exists at the boundary that matters;
+   nothing upstream could reach it.
+
+2. **`file_read` is `File.ReadAllTextAsync`.** A PNG comes back as mojibake. No MIME
+   awareness, no binary detection, no size guard.
+
+3. **The tool-result image path is half-built** — and on the wire format RockBot speaks, it
+   cannot be finished. See below.
+
+4. **No model capability declaration.** `ModelBehavior` carries a dozen behavioural flags and
+   not one modality flag, so nothing could tell a seeing tier from a blind one.
+
+5. **The context-budget machinery is blind to bytes.** `EstimateMessageChars` counts
+   `TextContent` and `FunctionResultContent`; a `DataContent` scores zero. Images are
+   invisible to the watermark trim and to every stash decision.
+
+## The constraint: images cannot ride in a tool result
+
+`RegistryToolFunction.ToAIContent` already maps MCP image and audio blocks to `DataContent`,
+and `McpToolExecutor.MapContentBlocks` already carries `ImageContentBlock` across the bus.
+That looks like a working path. It is not, for two independent reasons.
+
+**On the text-based tool-calling path**, `AgentLoopRunner` reduces the result with
+`result?.ToString()`. A `List<AIContent>` stringifies to a bare type name. The image isn't
+degraded, it's annihilated.
+
+**On the FICC path** the list survives — `ChunkingAIFunction` returns the object unchanged
+when its `ToString()` is under the threshold — and reaches M.E.AI intact. But every provider
+RockBot talks to is reached through `OpenAIClient(...).GetChatClient(...).AsIChatClient()`,
+and the OpenAI Chat Completions wire format accepts **only text in tool-role messages**. A
+`DataContent` there is JSON-serialised into a data-URI string: the full base64 token cost,
+and no image.
+
+So: **on OpenAI-compatible APIs, bytes can only enter as content parts on a user or system
+message.** Any design that hands the agent loop an image *as a tool return value* is dead on
+arrival regardless of the model's vision. This is the single most important fact in this
+document, and it is what shapes the ordering below.
+
+## Architecture
+
+Two concerns, kept separate — the issue's own framing, and it is the right one:
+
+```
+1.  External system (repo, mailbox, MCP server, script)
+              |  materialise
+              v
+        /rockbot/shared/...          <- mostly solved: attachment gateway, scripts, file tools
+
+2.  /rockbot/shared/file.png
+              |  hand to a model AS BYTES
+              v
+        configured RockBot LLM tier  <- this document
+```
+
+Concern (2) is served by a **side call**, not by enriching the main loop's tool results:
+
+```
+Agent: analyze_file({ path: "diagrams/arch.png", prompt: "Describe the components.", tier: "High" })
+    |
+    v
+AnalyzeFileToolExecutor
+    |   SafeResolvePath containment check under FileSystemOptions.BasePath
+    |   extension -> MIME, checked against the allowlist
+    |   size checked against AnalyzeFileMaxBytes
+    |   File.ReadAllBytesAsync
+    |
+    v
+ILlmClient.GetResponseAsync(
+    [ ChatMessage(User, [ TextContent(prompt), DataContent(bytes, mime) ]) ],
+    tier, options: null, ct)
+    |
+    v
+ToolInvokeResponse { Content = response.Text }    <- text only; bytes never enter the agent loop
+```
+
+The agent reasons in paths. Bytes never cross the message bus, never enter the conversation
+history, and never count against the context budget — which is why gap (5) can wait.
+
+## Key design decisions
+
+### A side call, not a richer tool result
+
+The obvious-looking fix — let a tool return an image and let the loop forward it — cannot
+work on OpenAI-compatible APIs, as above. A side call also gets three things for free that
+the inline design would have had to solve: the bytes never touch context, the budget
+machinery needs no changes, and the failure mode when a model cannot see is a sentence from
+one tool rather than a 400 from the middle of a loop.
+
+The cost is that the analysis is one-shot: the main model sees a description, not the image,
+and cannot go back and look again without another call. That is the correct trade for now.
+Inline images belong to concern (D) below, where a user attaches one to a message.
+
+### The modality flag lives on the tier config, not on `ModelBehavior`
+
+`ModelBehavior` describes how a model *behaves* — whether it hallucinates tool calls, whether
+it needs text-based tool calling. Whether a model can see is a property of the configured
+model itself, which is `LlmTierConfig`. It is a `bool SupportsImageInput` rather than a
+modality set: audio and PDF differ per provider in ways we cannot usefully model yet, and a
+second bool is cheap to add when a deployment actually needs one.
+
+It defaults to `false`. A tool that silently sends bytes to a blind model produces an opaque
+provider error deep in the stack; making the operator say "this model can see" is one config
+line and removes an entire class of confusing failure.
+
+### `analyze_file` is not registered unless a tier declares vision
+
+Registering a tool the deployment cannot execute teaches the model a capability it will then
+try to use. When no tier sets `SupportsImageInput`, the registrar logs at startup and
+registers nothing.
+
+### Tier selection prefers a seeing tier over the requested one
+
+`LlmClient` falls back to Balanced whenever a Low or High call throws. If the requested tier
+can see but Balanced cannot, that fallback lands a vision request on a blind model. So the
+executor resolves the requested tier against the vision-capable set first and substitutes the
+nearest capable tier (High → Balanced → Low) with a warning, rather than sending the call
+somewhere it will fail. When *no* tier can see, the tool is never registered in the first
+place.
+
+### It lives in `RockBot.Tools.FileSystem`
+
+That package already references `RockBot.Host` (so `ILlmClient` is in scope), already owns
+`SafeResolvePath` containment against the shared volume, and already defaults its base path
+to `/rockbot/shared` — which means the MCP attachment gateway's output directory is *already*
+inside its reachable scope. A file materialised by the gateway can be analysed with no
+further plumbing.
+
+### `LlmTierOptions` becomes a registered service
+
+It was previously a local in each host's `Program.cs`, bound and then handed to client
+factories. The executor needs to know which tiers can see, so the agent registers the bound
+instance as a singleton. Consumers that do not register it get an `analyze_file` that never
+registers — the dependency is optional, and its absence reads the same as "no tier declares
+vision".
+
+## Configuration
+
+```json
+{
+  "LLM": {
+    "High": {
+      "ModelId": "openai/gpt-5.5",
+      "SupportsImageInput": true
+    }
+  }
+}
+```
+
+Or as an environment variable: `LLM__High__SupportsImageInput=true`.
+
+`FileSystemOptions` gains two knobs, both with defaults that need no attention:
+
+- `AnalyzeFileMaxBytes` (default 8 MiB) — refused above this, before any bytes are read into
+  a request. Providers cap the encoded request well above this; the limit exists to keep a
+  mistake cheap.
+- `AnalyzeFileMimeTypes` — the allowlist, defaulting to PNG, JPEG, GIF, and WebP: the four
+  formats every vision-capable provider accepts. Adding `application/pdf` or an audio type is
+  a deployment decision, because whether it works depends on the provider.
+
+## Sequencing
+
+- **(A) `analyze_file` + (B) the modality flag** — this PR. Unblocks #513's actual use case
+  with no persisted-schema churn.
+- **(C) Generic binary capture in the MCP bridge** — next. Any non-text MCP content block is
+  stashed to the attachments directory and replaced with `{path, name, size, mime}`; the
+  per-server `attachments` manifest gains declarative *response* extraction (which field holds
+  the base64, which holds the name) so a server returning `{content, encoding: "base64"}` —
+  Gitea's shape — is adapted without server cooperation. This is the direct fix for the
+  167K-character chunk storm, and it feeds (A).
+- **(D) Inbound user attachments** — `UserMessage.Attachments` as path references mirroring
+  `AgentAttachment`, a Blazor upload writing into the shared directory, `ConversationTurn`
+  extended, and the loop injecting `DataContent` onto the user message. This one touches bus
+  contracts, the UI, and a persisted store, so it ships with a store version bump and an
+  `ISchemaMigration` (see `schema-migrations.md`), and it needs gap (5) fixed first or the
+  trim logic silently miscounts every image.
+
+Video is out of scope. Only Gemini-family models accept it natively and RockBot is
+OpenAI-compatible end to end. Audio and PDF are not separate features — they are entries in
+the same MIME allowlist on the same `DataContent` path, and become available as soon as a
+tier declares support for them.

--- a/design/multimodal-input.md
+++ b/design/multimodal-input.md
@@ -33,8 +33,9 @@ Five separate things, verified in the tree before any of this was written:
    not one modality flag, so nothing could tell a seeing tier from a blind one.
 
 5. **The context-budget machinery is blind to bytes.** `EstimateMessageChars` counts
-   `TextContent` and `FunctionResultContent`; a `DataContent` scores zero. Images are
-   invisible to the watermark trim and to every stash decision.
+   `TextContent` and `FunctionResultContent` by length and everything else at a flat 50 —
+   so a `DataContent` carrying a 1.8 MB image counts as 50 characters, roughly 35,000× under.
+   Images are effectively invisible to the watermark trim and to every stash decision.
 
 ## The constraint: images cannot ride in a tool result
 
@@ -191,12 +192,14 @@ Or as an environment variable: `LLM__High__SupportsImageInput=true`.
   without server cooperation. A binary test keeps text files from being captured out of the
   response. This was the direct fix for the 167K-character chunk storm, and it feeds (A). See
   [`mcp-attachments.md`](mcp-attachments.md#binary-capture--the-fallback-for-servers-that-never-heard-of-us).
-- **(D) Inbound user attachments** — `UserMessage.Attachments` as path references mirroring
+- **(D) Inbound user attachments** (issue #565, blocked on #564) — `UserMessage.Attachments` as path references mirroring
   `AgentAttachment`, a Blazor upload writing into the shared directory, `ConversationTurn`
   extended, and the loop injecting `DataContent` onto the user message. This one touches bus
-  contracts, the UI, and a persisted store, so it ships with a store version bump and an
-  `ISchemaMigration` (see `schema-migrations.md`), and it needs gap (5) fixed first or the
-  trim logic silently miscounts every image.
+  contracts, the UI, and the conversation store. Adding an optional `Attachments` property to
+  `ConversationTurn` is additive, so by the policy in `schema-migrations.md` it needs no
+  migration — and the conversation store is not enrolled in schema migrations at all, unlike
+  memory, skills, feedback and wisp. What it does need is gap (5) — issue #564 — fixed
+  first, or the trim logic silently miscounts every image.
 
 Video is out of scope. Only Gemini-family models accept it natively and RockBot is
 OpenAI-compatible end to end. Audio and PDF are not separate features — they are entries in

--- a/design/multimodal-input.md
+++ b/design/multimodal-input.md
@@ -183,12 +183,14 @@ Or as an environment variable: `LLM__High__SupportsImageInput=true`.
 
 - **(A) `analyze_file` + (B) the modality flag** — this PR. Unblocks #513's actual use case
   with no persisted-schema churn.
-- **(C) Generic binary capture in the MCP bridge** — next. Any non-text MCP content block is
-  stashed to the attachments directory and replaced with `{path, name, size, mime}`; the
-  per-server `attachments` manifest gains declarative *response* extraction (which field holds
-  the base64, which holds the name) so a server returning `{content, encoding: "base64"}` —
-  Gitea's shape — is adapted without server cooperation. This is the direct fix for the
-  167K-character chunk storm, and it feeds (A).
+- **(C) Generic binary capture in the MCP bridge** — done, as `BinaryResponseCapture`. Typed
+  image and audio content blocks are stashed to the attachments directory and replaced with
+  `{path, name, size, mime}` with no configuration at all; the per-server `attachments`
+  manifest gained declarative *response* extraction (which field holds the base64, which holds
+  the name) so a server returning `{content, encoding: "base64"}` — Gitea's shape — is adapted
+  without server cooperation. A binary test keeps text files from being captured out of the
+  response. This was the direct fix for the 167K-character chunk storm, and it feeds (A). See
+  [`mcp-attachments.md`](mcp-attachments.md#binary-capture--the-fallback-for-servers-that-never-heard-of-us).
 - **(D) Inbound user attachments** — `UserMessage.Attachments` as path references mirroring
   `AgentAttachment`, a Blazor upload writing into the shared directory, `ConversationTurn`
   extended, and the loop injecting `DataContent` onto the user message. This one touches bus

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -365,6 +365,14 @@ is one (`image/*`, `audio/*`, `video/*`, PDF, zip, Office — but not SVG, which
 can read), and otherwise the bytes do, via a NUL byte or a strict UTF-8 decode failure. A README
 returned through the same base64 field as a PNG stays in the response as content.
 
+Some servers don't base64 their binary at all — they decode the bytes as UTF-8 first, which
+destroys them at the source. Under a declared rule, a content field that fails base64 decoding is
+checked for that signature (eight or more U+FFFD in at least a kilobyte) and dropped with a note
+explaining that the bytes are unrecoverable and that retrying returns the same corrupted text.
+The response's `name`, `sha`, `size` and `html_url` survive. On the reference deployment this
+took one such call from 1,366,356 characters and 22 working-memory chunks to 588 characters and
+none.
+
 Set `capture.enabled: false` to disable it for a server. Capture never fails a tool call — any
 error logs and passes the server's original response through untouched.
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -387,6 +387,71 @@ See `design/mcp-arg-guards.md` for the security rationale.
 
 ---
 
+## Multimodal input: `analyze_file`
+
+Attachment passthrough gets a file *onto the shared volume*. `analyze_file` is the other half:
+it gets that file *in front of a model* as real image content.
+
+```
+analyze_file({ path: "attachments/architecture.png",
+               prompt: "Describe the components and how they connect.",
+               tier: "high" })
+    │
+    ▼
+AnalyzeFileToolExecutor  (RockBot.Tools.FileSystem)
+    │   SafeResolvePath containment under FileSystemOptions.BasePath
+    │   extension → MIME, checked against AnalyzeFileMimeTypes
+    │   size checked against AnalyzeFileMaxBytes
+    │
+    ▼
+ILlmClient.GetResponseAsync(
+    [ ChatMessage(User, [ TextContent(prompt), DataContent(bytes, mime) ]) ], tier, …)
+    │
+    ▼
+ToolInvokeResponse { Content = "Three services arranged left to right. …" }
+```
+
+The analysis runs as its own LLM call rather than as content in the agent's own loop. That is
+not an implementation shortcut — on OpenAI-compatible APIs, which is every provider RockBot
+talks to, tool-role messages accept text only, so bytes can enter a conversation solely as
+content parts on a user message. Running the look-up as a side call sidesteps that and keeps
+the agent's context free of bytes: a path goes in, prose comes out. The full reasoning, and the
+sequencing of the remaining multimodal work, is in `design/multimodal-input.md`.
+
+### Enabling it
+
+`analyze_file` is registered only when a configured tier declares that its model accepts image
+input:
+
+```json
+{
+  "LLM": {
+    "High": {
+      "ModelId": "openai/gpt-5.5",
+      "SupportsImageInput": true
+    }
+  }
+}
+```
+
+Or `LLM__High__SupportsImageInput=true` as an environment variable. With no such tier the tool
+is not registered and the file-tools skill guide omits it — an agent is never taught a
+capability its deployment does not have.
+
+When the requested `tier` is not one that can see, the executor substitutes the nearest tier
+that can (High → Balanced → Low). This matters because `ILlmClient` retries a failed Low/High
+call on Balanced: sending a vision request to a blind tier would fail twice and report the
+second, less informative error.
+
+### Limits
+
+| Option | Default | Purpose |
+|---|---|---|
+| `FileSystemOptions.AnalyzeFileMaxBytes` | 8 MiB | Refused above this, before any bytes are read. Providers cap the encoded request well above it; the limit keeps a mistake cheap. |
+| `FileSystemOptions.AnalyzeFileMimeTypes` | PNG, JPEG, GIF, WebP | The formats every vision-capable provider accepts. Adding `application/pdf` or an audio type is a deployment decision — whether it works depends on the provider behind the tier. |
+
+---
+
 ## Service search (`RockBot.ServiceSearch`)
 
 `search_known_services` is a unified BM25 keyword search over all known A2A agents **and**

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -328,6 +328,46 @@ guide instructs the model to pass `{ path: "/rockbot/shared/attachments/<file>" 
 base64 whenever a tool's parameter takes attachments — operators don't need to do anything more
 than enable the manifest.
 
+### Binary capture (response side, no manifest required)
+
+Passthrough needs a cooperating server. Capture handles the ones that don't: every MCP response
+passes through `BinaryResponseCapture` on its way back to the agent.
+
+**Typed `image`/`audio` content blocks are captured with no configuration** — MCP already
+labels them, so the bytes are written to the attachments directory and the block is replaced
+with `{path, name, size, mime, note}`. Other blocks in the response are untouched.
+
+**Base64 inside an ordinary JSON response needs a declared rule**, because sniffing for
+"a field that looks like base64" is the fragile heuristic the manifest design avoids:
+
+```json
+{
+  "attachments": {
+    "capture": {
+      "rules": [
+        {
+          "tools": ["get_file_contents"],
+          "contentField": "content",
+          "nameField": "name",
+          "encodingField": "encoding"
+        }
+      ]
+    }
+  }
+}
+```
+
+That is the shape of the official Gitea server's file tool, and it needs no change on the
+server side — only a description of the response it already sends.
+
+A rule only fires when the payload really is binary: the name or MIME field decides when there
+is one (`image/*`, `audio/*`, `video/*`, PDF, zip, Office — but not SVG, which is text the model
+can read), and otherwise the bytes do, via a NUL byte or a strict UTF-8 decode failure. A README
+returned through the same base64 field as a PNG stays in the response as content.
+
+Set `capture.enabled: false` to disable it for a server. Capture never fails a tool call — any
+error logs and passes the server's original response through untouched.
+
 ### Argument guards
 
 Some third-party MCP servers resolve path arguments inside their *own* pod: a

--- a/src/McpServer.BinaryFixture/Dockerfile
+++ b/src/McpServer.BinaryFixture/Dockerfile
@@ -1,0 +1,34 @@
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
+USER $APP_UID
+WORKDIR /app
+EXPOSE 8080
+ENV ASPNETCORE_URLS=http://+:8080
+ENV ASPNETCORE_ENVIRONMENT=Production
+
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+ARG BUILD_CONFIGURATION=Release
+WORKDIR /src
+
+# Clear Windows-specific NuGet fallback folders that break Linux builds
+RUN printf '<configuration><fallbackPackageFolders><clear /></fallbackPackageFolders></configuration>' \
+    > /src/NuGet.config
+
+# Copy project file and build props for layer-cached restore
+COPY Directory.Build.props .
+COPY src/McpServer.BinaryFixture/McpServer.BinaryFixture.csproj src/McpServer.BinaryFixture/
+
+RUN dotnet restore src/McpServer.BinaryFixture/McpServer.BinaryFixture.csproj
+
+COPY src/McpServer.BinaryFixture/ src/McpServer.BinaryFixture/
+
+WORKDIR /src/src/McpServer.BinaryFixture
+RUN dotnet build McpServer.BinaryFixture.csproj -c $BUILD_CONFIGURATION -o /app/build --no-restore
+
+FROM build AS publish
+ARG BUILD_CONFIGURATION=Release
+RUN dotnet publish McpServer.BinaryFixture.csproj -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "McpServer.BinaryFixture.dll"]

--- a/src/McpServer.BinaryFixture/Fixtures/TestMedia.cs
+++ b/src/McpServer.BinaryFixture/Fixtures/TestMedia.cs
@@ -1,0 +1,227 @@
+using System.IO.Compression;
+using System.Text;
+
+namespace McpServer.BinaryFixture.Fixtures;
+
+/// <summary>
+/// Generates the fixture payloads in code rather than shipping binary assets.
+/// </summary>
+/// <remarks>
+/// Generated media keeps the repository free of binary blobs, but the real reason is that the
+/// content is <em>known</em>: the image is a bar chart whose colours and relative heights are
+/// stated here, so an assertion about what a vision model saw can be checked against this file
+/// instead of against someone's recollection of a photo.
+/// </remarks>
+public static class TestMedia
+{
+    /// <summary>
+    /// What <see cref="BarChartPng"/> depicts, in the words a correct description would use.
+    /// Kept next to the generator so the two cannot drift apart.
+    /// </summary>
+    public const string BarChartDescription =
+        "Three vertical bars on a light background, left to right: red (medium height), " +
+        "green (tallest), blue (shortest), sitting on a dark horizontal baseline.";
+
+    private const int Width = 240;
+    private const int Height = 120;
+
+    private static readonly Lazy<byte[]> LazyBarChart = new(BuildBarChartPng);
+    private static readonly Lazy<byte[]> LazyTone = new(BuildToneWav);
+    private static readonly Lazy<byte[]> LazyNoise = new(BuildNoisePng);
+
+    /// <summary>A 240×120 PNG bar chart. See <see cref="BarChartDescription"/>.</summary>
+    public static byte[] BarChartPng => LazyBarChart.Value;
+
+    /// <summary>A short mono WAV tone — enough to be a real audio file with a real header.</summary>
+    public static byte[] ToneWav => LazyTone.Value;
+
+    /// <summary>
+    /// A deliberately incompressible PNG, for the mangled-binary fixture.
+    /// </summary>
+    /// <remarks>
+    /// Size is the point. The mangled-binary guard only fires above a length floor, because its
+    /// job is to stop a context flood and a few hundred characters of mojibake is not one. The bar
+    /// chart is flat colour and compresses to under a kilobyte, which lands below that floor and
+    /// makes the fixture prove nothing. Pixel noise gives a payload the size of a real repository
+    /// image, which is what the guard exists for.
+    /// </remarks>
+    public static byte[] NoisePng => LazyNoise.Value;
+
+    /// <summary>Plain UTF-8 text, used as the control case that must never be captured.</summary>
+    public static byte[] ReadmeText { get; } = Encoding.UTF8.GetBytes(
+        "# Fixture README\n\nThis file is text. Binary capture must leave it in the response.\n");
+
+    private static byte[] BuildBarChartPng()
+    {
+        var background = new byte[] { 250, 250, 250 };
+        var baseline = new byte[] { 40, 40, 40 };
+        (int X, int BarHeight, byte[] Colour)[] bars =
+        [
+            (20, 60, [210, 60, 60]),   // red, medium
+            (95, 95, [70, 150, 90]),   // green, tallest
+            (170, 40, [70, 110, 200])  // blue, shortest
+        ];
+
+        // Raw scanlines: one filter byte (0 = None) then RGB triples.
+        var raw = new byte[Height * (1 + Width * 3)];
+        var pos = 0;
+        for (var y = 0; y < Height; y++)
+        {
+            raw[pos++] = 0;
+            for (var x = 0; x < Width; x++)
+            {
+                var colour = background;
+                if (y == Height - 10 && x >= 10 && x < Width - 10)
+                {
+                    colour = baseline;
+                }
+                else
+                {
+                    foreach (var (barX, barHeight, barColour) in bars)
+                    {
+                        if (x >= barX && x < barX + 50 && y >= Height - 10 - barHeight && y < Height - 10)
+                        {
+                            colour = barColour;
+                            break;
+                        }
+                    }
+                }
+
+                raw[pos++] = colour[0];
+                raw[pos++] = colour[1];
+                raw[pos++] = colour[2];
+            }
+        }
+
+        using var output = new MemoryStream();
+        output.Write([0x89, (byte)'P', (byte)'N', (byte)'G', 0x0D, 0x0A, 0x1A, 0x0A]);
+
+        var ihdr = new byte[13];
+        WriteBigEndian(ihdr, 0, Width);
+        WriteBigEndian(ihdr, 4, Height);
+        ihdr[8] = 8;  // bit depth
+        ihdr[9] = 2;  // colour type: truecolour
+        WriteChunk(output, "IHDR", ihdr);
+        WriteChunk(output, "IDAT", Deflate(raw));
+        WriteChunk(output, "IEND", []);
+
+        return output.ToArray();
+    }
+
+    private static byte[] BuildNoisePng()
+    {
+        const int width = 320;
+        const int height = 240;
+
+        // A fixed seed keeps the fixture byte-identical between runs, so a size quoted in a test
+        // report stays true.
+        var rng = new Random(20260906);
+        var raw = new byte[height * (1 + width * 3)];
+        var pos = 0;
+        for (var y = 0; y < height; y++)
+        {
+            raw[pos++] = 0;
+            for (var x = 0; x < width * 3; x++)
+                raw[pos++] = (byte)rng.Next(256);
+        }
+
+        using var output = new MemoryStream();
+        output.Write([0x89, (byte)'P', (byte)'N', (byte)'G', 0x0D, 0x0A, 0x1A, 0x0A]);
+        var ihdr = new byte[13];
+        WriteBigEndian(ihdr, 0, width);
+        WriteBigEndian(ihdr, 4, height);
+        ihdr[8] = 8;
+        ihdr[9] = 2;
+        WriteChunk(output, "IHDR", ihdr);
+        WriteChunk(output, "IDAT", Deflate(raw));
+        WriteChunk(output, "IEND", []);
+        return output.ToArray();
+    }
+
+    private static byte[] BuildToneWav()
+    {
+        const int sampleRate = 8000;
+        const int samples = sampleRate / 4;   // 250 ms
+        const double frequency = 440.0;
+
+        using var output = new MemoryStream();
+        using var writer = new BinaryWriter(output, Encoding.ASCII, leaveOpen: true);
+
+        var dataBytes = samples * 2;
+        writer.Write("RIFF"u8);
+        writer.Write(36 + dataBytes);
+        writer.Write("WAVE"u8);
+        writer.Write("fmt "u8);
+        writer.Write(16);                       // PCM header size
+        writer.Write((short)1);                 // PCM
+        writer.Write((short)1);                 // mono
+        writer.Write(sampleRate);
+        writer.Write(sampleRate * 2);           // byte rate
+        writer.Write((short)2);                 // block align
+        writer.Write((short)16);                // bits per sample
+        writer.Write("data"u8);
+        writer.Write(dataBytes);
+
+        for (var i = 0; i < samples; i++)
+            writer.Write((short)(Math.Sin(2 * Math.PI * frequency * i / sampleRate) * 12000));
+
+        writer.Flush();
+        return output.ToArray();
+    }
+
+    private static byte[] Deflate(byte[] data)
+    {
+        using var buffer = new MemoryStream();
+        using (var zlib = new ZLibStream(buffer, CompressionLevel.Optimal, leaveOpen: true))
+            zlib.Write(data);
+        return buffer.ToArray();
+    }
+
+    private static void WriteChunk(Stream stream, string type, byte[] data)
+    {
+        var typeBytes = Encoding.ASCII.GetBytes(type);
+        var length = new byte[4];
+        WriteBigEndian(length, 0, data.Length);
+        stream.Write(length);
+        stream.Write(typeBytes);
+        stream.Write(data);
+
+        var crcInput = new byte[typeBytes.Length + data.Length];
+        typeBytes.CopyTo(crcInput, 0);
+        data.CopyTo(crcInput, typeBytes.Length);
+        var crc = new byte[4];
+        WriteBigEndian(crc, 0, unchecked((int)Crc32(crcInput)));
+        stream.Write(crc);
+    }
+
+    private static void WriteBigEndian(byte[] target, int offset, int value)
+    {
+        target[offset] = (byte)(value >> 24);
+        target[offset + 1] = (byte)(value >> 16);
+        target[offset + 2] = (byte)(value >> 8);
+        target[offset + 3] = (byte)value;
+    }
+
+    private static readonly uint[] CrcTable = BuildCrcTable();
+
+    private static uint[] BuildCrcTable()
+    {
+        var table = new uint[256];
+        for (uint n = 0; n < 256; n++)
+        {
+            var c = n;
+            for (var k = 0; k < 8; k++)
+                c = (c & 1) != 0 ? 0xEDB88320u ^ (c >> 1) : c >> 1;
+            table[n] = c;
+        }
+        return table;
+    }
+
+    private static uint Crc32(byte[] data)
+    {
+        var crc = 0xFFFFFFFFu;
+        foreach (var b in data)
+            crc = CrcTable[(crc ^ b) & 0xFF] ^ (crc >> 8);
+        return crc ^ 0xFFFFFFFFu;
+    }
+}

--- a/src/McpServer.BinaryFixture/McpServer.BinaryFixture.csproj
+++ b/src/McpServer.BinaryFixture/McpServer.BinaryFixture.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>McpServer.BinaryFixture</RootNamespace>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.4.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/McpServer.BinaryFixture/Program.cs
+++ b/src/McpServer.BinaryFixture/Program.cs
@@ -1,0 +1,25 @@
+using McpServer.BinaryFixture.Fixtures;
+using McpServer.BinaryFixture.Tools;
+
+// Fixture MCP server for exercising the bridge's binary-content paths against a live agent.
+// Not part of any normal deployment — see deploy/k8s/mcp-binary-fixture.yaml and the README.
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddHealthChecks();
+builder.Services.AddMcpServer()
+    .WithHttpTransport()
+    .WithTools<BinaryFixtureTools>();
+
+var app = builder.Build();
+
+app.MapHealthChecks("/health");
+app.MapMcp();
+
+// The fixtures over plain HTTP as well as MCP. When a live test disagrees with what a model
+// says it saw, the question is always "what was actually in the file" — these answer it without
+// having to reproduce the MCP call.
+app.MapGet("/fixtures/chart.png", () => Results.File(TestMedia.BarChartPng, "image/png"));
+app.MapGet("/fixtures/tone.wav", () => Results.File(TestMedia.ToneWav, "audio/wav"));
+app.MapGet("/fixtures/expected", () => Results.Text(TestMedia.BarChartDescription));
+
+await app.RunAsync();

--- a/src/McpServer.BinaryFixture/README.md
+++ b/src/McpServer.BinaryFixture/README.md
@@ -1,0 +1,99 @@
+# McpServer.BinaryFixture
+
+An MCP server that returns binary content in every shape RockBot's bridge has to cope with, so
+those paths can be exercised against a live agent instead of only in unit tests.
+
+## Why it exists
+
+The MCP bridge captures binary content out of tool responses, and `analyze_file` hands image
+bytes to a vision model. Both are unit-tested — but no server in a normal deployment returns the
+shapes they exist for. The ones RockBot talks to either write files to disk or corrupt their
+bytes on the way out. That left the interesting paths verifiable only in isolation, which is how
+the mangled-binary case in issue #513 stayed hidden until someone smoke-tested capture against a
+real server.
+
+This server closes that gap, and doubles as a fixture for future bridge work.
+
+## Tools
+
+| Tool | Shape returned | What it proves |
+|---|---|---|
+| `get_image` | Typed `image` content block (PNG) | Capture's no-configuration path |
+| `get_audio` | Typed `audio` content block (WAV) | Same path, non-image media |
+| `get_image_with_text` | Text block + image block | Only the image is rewritten |
+| `get_file_base64` | `{name, path, sha, size, encoding, content}` — a repository server's shape. `kind=image` or `kind=text` | The declarative capture rule fires for the image and declines for the text |
+| `get_file_mangled` | Same shape, but content is the PNG's bytes decoded as UTF-8 | The mangled-binary guard: field dropped and explained, not flooded into context |
+| `get_text` | Plain text | Control — never captured |
+| `describe_fixtures` | The fixture image's known description | Checking a vision model's answer against a known one |
+
+## The fixture image
+
+A 240×120 PNG generated in code: three vertical bars, left to right red (medium), green
+(tallest), blue (shortest), on a dark baseline. Generated rather than committed so the repository
+carries no binary blobs — but the real reason is that the content is *known*, so a claim about
+what a vision model saw can be checked against `TestMedia.BarChartDescription` instead of against
+someone's impression of a photo.
+
+The fixtures are also served over plain HTTP for inspection, which answers "what was actually in
+the file" without reproducing the MCP call:
+
+```
+GET /fixtures/chart.png     the image itself
+GET /fixtures/tone.wav      the audio
+GET /fixtures/expected      the image's documented description
+GET /health                 readiness
+```
+
+## Running it
+
+Locally:
+
+```bash
+ASPNETCORE_URLS=http://127.0.0.1:5199 dotnet run --project src/McpServer.BinaryFixture
+curl http://127.0.0.1:5199/fixtures/expected
+```
+
+In-cluster, for a live test against the agent:
+
+```bash
+VERSION=$(grep -oP '<Version>\K[^<]+' Directory.Build.props)
+docker build -f src/McpServer.BinaryFixture/Dockerfile \
+  -t rockylhotka/rockbot-binary-fixture-mcp:$VERSION .
+docker push rockylhotka/rockbot-binary-fixture-mcp:$VERSION
+
+kubectl apply -f deploy/k8s/mcp-binary-fixture.yaml
+```
+
+Then register it in the agent's `mcp.json` on the PVC, with a capture rule so the base64 tools
+are covered as well as the typed blocks:
+
+```json
+"binary-fixture": {
+  "type": "sse",
+  "url": "http://mcp-binary-fixture.rockbot.svc.cluster.local/",
+  "attachments": {
+    "capture": {
+      "rules": [
+        {
+          "tools": ["get_file_base64", "get_file_mangled"],
+          "contentField": "content",
+          "nameField": "name",
+          "encodingField": "encoding"
+        }
+      ]
+    }
+  }
+}
+```
+
+`get_image`, `get_audio`, and `get_image_with_text` need no rule — typed blocks are captured
+without configuration.
+
+## Cleaning up
+
+```bash
+kubectl delete -f deploy/k8s/mcp-binary-fixture.yaml
+```
+
+and remove the `binary-fixture` entry from `mcp.json`. Nothing else is left behind: the server
+holds no state, reads no credentials, and makes no outbound calls.

--- a/src/McpServer.BinaryFixture/Tools/BinaryFixtureTools.cs
+++ b/src/McpServer.BinaryFixture/Tools/BinaryFixtureTools.cs
@@ -1,0 +1,132 @@
+using System.ComponentModel;
+using System.Text;
+using System.Text.Json;
+using McpServer.BinaryFixture.Fixtures;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace McpServer.BinaryFixture.Tools;
+
+/// <summary>
+/// Every shape an MCP server can hand binary content back in, on demand.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The bridge's binary capture and the <c>analyze_file</c> tool are covered by unit tests, but
+/// nothing in a normal deployment returns the shapes they exist for — the servers RockBot talks
+/// to either write files to disk or corrupt their bytes. That leaves the interesting paths
+/// verifiable only in isolation, which is how the mangled-binary case (issue #513) went
+/// unnoticed until it was smoke-tested against a live server.
+/// </para>
+/// <para>
+/// This server closes that gap. Each tool returns one deliberate shape, so a live run can prove
+/// what capture does with it end to end. The payloads are generated in code and their content is
+/// documented in <see cref="TestMedia"/>, so a description produced by a vision model can be
+/// checked against a known answer rather than against an impression of a photo.
+/// </para>
+/// </remarks>
+[McpServerToolType]
+public sealed class BinaryFixtureTools
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true
+    };
+
+    /// <summary>
+    /// Wire-format shim for the MCP SDK's content-block payloads.
+    /// </summary>
+    /// <remarks>
+    /// <c>ImageContentBlock.Data</c> is a <c>ReadOnlyMemory&lt;byte&gt;</c>, which reads like "put
+    /// the file's bytes here" — but in SDK 1.4.0 the serializer writes those bytes out as a UTF-8
+    /// string rather than base64-encoding them. Handing it raw PNG bytes therefore puts mojibake
+    /// on the wire and the receiving client rejects the block outright. What the property wants is
+    /// the base64 text, as bytes. Verified against the wire JSON, not inferred.
+    /// </remarks>
+    private static byte[] Base64Bytes(byte[] payload) =>
+        Encoding.UTF8.GetBytes(Convert.ToBase64String(payload));
+
+    [McpServerTool(Name = "get_image")]
+    [Description(
+        "Returns a small PNG bar chart as a typed MCP image content block. Exercises capture's " +
+        "no-configuration path: the block should be written to the shared volume and replaced " +
+        "with a {path, name, size, mime} descriptor.")]
+    public static ContentBlock GetImage() =>
+        new ImageContentBlock { Data = Base64Bytes(TestMedia.BarChartPng), MimeType = "image/png" };
+
+    [McpServerTool(Name = "get_audio")]
+    [Description(
+        "Returns a short WAV tone as a typed MCP audio content block. Same capture path as " +
+        "get_image, for a non-image media type.")]
+    public static ContentBlock GetAudio() =>
+        new AudioContentBlock { Data = Base64Bytes(TestMedia.ToneWav), MimeType = "audio/wav" };
+
+    [McpServerTool(Name = "get_image_with_text")]
+    [Description(
+        "Returns a text block followed by an image block. Capture should rewrite only the image " +
+        "and leave the surrounding text untouched.")]
+    public static IEnumerable<ContentBlock> GetImageWithText() =>
+    [
+        new TextContentBlock { Text = "Here is the chart you asked for:" },
+        new ImageContentBlock { Data = Base64Bytes(TestMedia.BarChartPng), MimeType = "image/png" }
+    ];
+
+    [McpServerTool(Name = "get_file_base64")]
+    [Description(
+        "Returns a file the way a repository server does: metadata plus base64 content in an " +
+        "ordinary JSON response. Pass kind='image' for a PNG or kind='text' for markdown. " +
+        "Exercises the declarative capture rule — the image should be captured to the shared " +
+        "volume, and the text should be left in the response as content.")]
+    public static string GetFileBase64(
+        [Description("Which fixture to return: 'image' (PNG) or 'text' (markdown).")]
+        string kind = "image")
+    {
+        var isImage = !string.Equals(kind, "text", StringComparison.OrdinalIgnoreCase);
+        var bytes = isImage ? TestMedia.BarChartPng : TestMedia.ReadmeText;
+        var name = isImage ? "chart.png" : "README.md";
+
+        return JsonSerializer.Serialize(new
+        {
+            name,
+            path = $"fixtures/{name}",
+            sha = "0000000000000000000000000000000000000000",
+            size = bytes.Length,
+            encoding = "base64",
+            content = Convert.ToBase64String(bytes)
+        }, JsonOptions);
+    }
+
+    [McpServerTool(Name = "get_file_mangled")]
+    [Description(
+        "Returns a PNG's bytes decoded as UTF-8 text, reproducing the failure mode of servers " +
+        "that stringify binary instead of encoding it. The bytes are unrecoverable by design; " +
+        "capture should drop the field and explain why rather than let it into context.")]
+    public static string GetFileMangled()
+    {
+        // Encoding.UTF8.GetString substitutes U+FFFD for every byte sequence it cannot decode,
+        // which is exactly what the real server does and exactly why the result is unusable.
+        var mangled = Encoding.UTF8.GetString(TestMedia.NoisePng);
+
+        return JsonSerializer.Serialize(new
+        {
+            name = "chart.png",
+            path = "fixtures/chart.png",
+            sha = "0000000000000000000000000000000000000000",
+            size = TestMedia.NoisePng.Length,
+            content = mangled
+        }, JsonOptions);
+    }
+
+    [McpServerTool(Name = "get_text")]
+    [Description(
+        "Returns plain text. The control case: nothing here should ever be captured, whatever " +
+        "rules are configured.")]
+    public static string GetText() => Encoding.UTF8.GetString(TestMedia.ReadmeText);
+
+    [McpServerTool(Name = "describe_fixtures")]
+    [Description(
+        "Returns what the fixture image actually depicts, so a vision model's description can be " +
+        "checked against a known answer. Call this AFTER analysing the image, not before.")]
+    public static string DescribeFixtures() => TestMedia.BarChartDescription;
+}

--- a/src/RockBot.Agent/McpBridge/Attachments/AttachmentGateway.cs
+++ b/src/RockBot.Agent/McpBridge/Attachments/AttachmentGateway.cs
@@ -490,25 +490,9 @@ public sealed class AttachmentGateway
         }
     }
 
-    private static string GuessMime(string fileName)
-    {
-        var ext = Path.GetExtension(fileName).ToLowerInvariant();
-        return ext switch
-        {
-            ".pdf" => "application/pdf",
-            ".png" => "image/png",
-            ".jpg" or ".jpeg" => "image/jpeg",
-            ".gif" => "image/gif",
-            ".txt" or ".log" => "text/plain",
-            ".json" => "application/json",
-            ".csv" => "text/csv",
-            ".html" or ".htm" => "text/html",
-            ".xml" => "application/xml",
-            ".zip" => "application/zip",
-            ".docx" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-            ".xlsx" => "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-            ".pptx" => "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-            _ => "application/octet-stream"
-        };
-    }
+    /// <summary>
+    /// Content type for an uploaded file. Shared with binary capture so the two halves of
+    /// the gateway cannot disagree about what a <c>.png</c> is.
+    /// </summary>
+    private static string GuessMime(string fileName) => AttachmentMime.FromFileName(fileName);
 }

--- a/src/RockBot.Agent/McpBridge/Attachments/AttachmentManifest.cs
+++ b/src/RockBot.Agent/McpBridge/Attachments/AttachmentManifest.cs
@@ -39,6 +39,15 @@ public sealed class AttachmentManifest
     /// argument that triggers response-side rewriting into <c>{path, name, size, mime}</c>.
     /// </summary>
     public AttachmentInboundConfig? Inbound { get; set; }
+
+    /// <summary>
+    /// Binary capture configuration — how the bridge handles binary content a server returns
+    /// without being asked to stash it. Unlike the rest of this manifest, capture of typed
+    /// (image/audio) content blocks is on by default and needs no manifest at all; this block
+    /// exists to turn it off, or to declare the response fields of servers that hand back
+    /// base64 inside ordinary JSON.
+    /// </summary>
+    public AttachmentCaptureConfig? Capture { get; set; }
 }
 
 /// <summary>
@@ -65,4 +74,62 @@ public sealed class AttachmentInboundConfig
     /// underlying call, then transforms the result into <c>{path, name, size, mime}</c>.
     /// </summary>
     public List<string> Tools { get; set; } = [];
+}
+
+/// <summary>
+/// Binary capture configuration. Capture is the fallback for servers that never heard of
+/// RockBot's attachment protocol: rather than letting binary content reach the model as text,
+/// the bridge writes it to the shared attachments directory and hands back a path.
+/// </summary>
+public sealed class AttachmentCaptureConfig
+{
+    /// <summary>
+    /// Whether to capture binary content from this server's responses. Defaults to <c>true</c>,
+    /// and applies even to servers with no <c>attachments</c> block at all — a base64 image in
+    /// the model's context is never the outcome anyone wanted, so this needs no opt-in. Set
+    /// <c>false</c> to send binary content through untouched.
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Declarative response-field rules for servers that return file bytes as base64 inside an
+    /// ordinary JSON response rather than as a typed content block — Gitea's
+    /// <c>get_file_contents</c> shape. Typed image and audio blocks need no rule; MCP already
+    /// labels them.
+    /// </summary>
+    public List<AttachmentCaptureRule> Rules { get; set; } = [];
+}
+
+/// <summary>
+/// One declarative capture rule: which tools it applies to, and which response fields carry the
+/// content, its name, and its type.
+/// </summary>
+/// <remarks>
+/// Fields are read from the top level of the response's JSON object, matching the deliberately
+/// simple <c>arrayKey[*]</c> shape supported by <see cref="AttachmentOutboundConfig.ParamPaths"/>.
+/// Nested pointers can follow when a real server needs them.
+/// </remarks>
+public sealed class AttachmentCaptureRule
+{
+    /// <summary>Tool names this rule applies to. A rule with no tools never matches.</summary>
+    public List<string> Tools { get; set; } = [];
+
+    /// <summary>Response field holding the base64 payload. Defaults to <c>content</c>.</summary>
+    public string ContentField { get; set; } = "content";
+
+    /// <summary>
+    /// Response field holding the file name, used for the saved file and to infer its type.
+    /// When unset the gateway looks at <c>name</c> and <c>path</c> before falling back to a
+    /// generated name.
+    /// </summary>
+    public string? NameField { get; set; }
+
+    /// <summary>Response field holding the MIME type, when the server sends one.</summary>
+    public string? MimeField { get; set; }
+
+    /// <summary>
+    /// Response field naming the payload's encoding (e.g. Gitea's <c>encoding</c>). When set and
+    /// its value is not <c>base64</c>, the rule declines rather than decoding garbage.
+    /// </summary>
+    public string? EncodingField { get; set; }
 }

--- a/src/RockBot.Agent/McpBridge/Attachments/AttachmentMime.cs
+++ b/src/RockBot.Agent/McpBridge/Attachments/AttachmentMime.cs
@@ -1,0 +1,128 @@
+using System.Text;
+
+namespace RockBot.Agent.McpBridge.Attachments;
+
+/// <summary>
+/// Filename ↔ MIME mapping shared by the attachment gateway and binary capture, plus the
+/// "is this actually binary?" test capture uses to decide whether a payload belongs on disk.
+/// </summary>
+internal static class AttachmentMime
+{
+    private static readonly Dictionary<string, string> ByExtension = new(StringComparer.OrdinalIgnoreCase)
+    {
+        [".pdf"] = "application/pdf",
+        [".png"] = "image/png",
+        [".jpg"] = "image/jpeg",
+        [".jpeg"] = "image/jpeg",
+        [".gif"] = "image/gif",
+        [".webp"] = "image/webp",
+        [".bmp"] = "image/bmp",
+        [".svg"] = "image/svg+xml",
+        [".ico"] = "image/vnd.microsoft.icon",
+        [".mp3"] = "audio/mpeg",
+        [".wav"] = "audio/wav",
+        [".ogg"] = "audio/ogg",
+        [".mp4"] = "video/mp4",
+        [".webm"] = "video/webm",
+        [".txt"] = "text/plain",
+        [".log"] = "text/plain",
+        [".md"] = "text/markdown",
+        [".json"] = "application/json",
+        [".csv"] = "text/csv",
+        [".html"] = "text/html",
+        [".htm"] = "text/html",
+        [".xml"] = "application/xml",
+        [".yaml"] = "application/yaml",
+        [".yml"] = "application/yaml",
+        [".zip"] = "application/zip",
+        [".gz"] = "application/gzip",
+        [".docx"] = "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        [".xlsx"] = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        [".pptx"] = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+    };
+
+    private static readonly Dictionary<string, string> ExtensionByMime =
+        BuildReverse();
+
+    private static Dictionary<string, string> BuildReverse()
+    {
+        var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        // First extension wins so image/jpeg resolves to .jpg rather than .jpeg.
+        foreach (var (ext, mime) in ByExtension)
+            map.TryAdd(mime, ext);
+        return map;
+    }
+
+    /// <summary>MIME type for a file name, or <c>application/octet-stream</c> when unknown.</summary>
+    public static string FromFileName(string fileName) =>
+        ByExtension.TryGetValue(Path.GetExtension(fileName), out var mime)
+            ? mime
+            : "application/octet-stream";
+
+    /// <summary>
+    /// File extension (including the dot) for a MIME type, or <c>.bin</c> when unknown.
+    /// Used to name files captured from typed content blocks, which carry no name of their own.
+    /// </summary>
+    public static string ToExtension(string? mime) =>
+        mime is not null && ExtensionByMime.TryGetValue(mime, out var ext) ? ext : ".bin";
+
+    /// <summary>
+    /// Whether a MIME type names content that has no business being rendered as text.
+    /// </summary>
+    public static bool IsBinaryMime(string? mime) =>
+        mime is not null
+        && (mime.StartsWith("image/", StringComparison.OrdinalIgnoreCase)
+            || mime.StartsWith("audio/", StringComparison.OrdinalIgnoreCase)
+            || mime.StartsWith("video/", StringComparison.OrdinalIgnoreCase)
+            || mime.Equals("application/pdf", StringComparison.OrdinalIgnoreCase)
+            || mime.Equals("application/zip", StringComparison.OrdinalIgnoreCase)
+            || mime.Equals("application/gzip", StringComparison.OrdinalIgnoreCase)
+            || mime.Equals("application/octet-stream", StringComparison.OrdinalIgnoreCase)
+            || mime.StartsWith("application/vnd.openxmlformats", StringComparison.OrdinalIgnoreCase))
+        // SVG is an image by MIME but text by nature: the model can read and edit it, and
+        // capturing it to disk would take away something it could otherwise work with.
+        && !mime.Equals("image/svg+xml", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Whether a byte sequence looks like binary data rather than text. Used as the fallback
+    /// when a payload arrives with no usable name or MIME — a repository server returning a
+    /// README and one returning a PNG look identical until you inspect the bytes.
+    /// </summary>
+    /// <remarks>
+    /// A NUL byte is the classic discriminator — it cannot appear in text any tool would hand
+    /// back — and strict UTF-8 decoding catches the rest. Only the head is examined: the answer
+    /// does not improve by reading a 40 MB file to its end.
+    /// </remarks>
+    public static bool LooksBinary(ReadOnlySpan<byte> bytes)
+    {
+        const int HeadLength = 8000;
+        var truncated = bytes.Length > HeadLength;
+        var head = truncated ? bytes[..HeadLength] : bytes;
+
+        if (head.IndexOf((byte)0) >= 0) return true;
+
+        // A head sliced mid-character ends in a partial UTF-8 sequence that strict decoding
+        // would reject, reporting ordinary text as binary. Trim back to a character boundary:
+        // drop trailing continuation bytes (10xxxxxx) and then the lead byte above them.
+        var end = head.Length;
+        if (truncated)
+        {
+            var floor = Math.Max(0, end - 4);
+            while (end > floor && (head[end - 1] & 0xC0) == 0x80) end--;
+            if (end > 0 && (head[end - 1] & 0x80) != 0) end--;
+        }
+
+        try
+        {
+            StrictUtf8.GetString(head[..end]);
+            return false;
+        }
+        catch (DecoderFallbackException)
+        {
+            return true;
+        }
+    }
+
+    private static readonly Encoding StrictUtf8 =
+        Encoding.GetEncoding("utf-8", EncoderFallback.ExceptionFallback, DecoderFallback.ExceptionFallback);
+}

--- a/src/RockBot.Agent/McpBridge/Attachments/BinaryResponseCapture.cs
+++ b/src/RockBot.Agent/McpBridge/Attachments/BinaryResponseCapture.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Protocol;
+using RockBot.Tools.Mcp;
 
 namespace RockBot.Agent.McpBridge.Attachments;
 
@@ -100,10 +101,13 @@ public sealed class BinaryResponseCapture(IAttachmentStorage storage, ILogger? l
 
         foreach (var block in result.Content)
         {
+            // Data is base64 text on the wire despite its byte-typed property — see
+            // McpBinaryPayload. Writing it raw puts "iVBORw0KGgo…" on disk under a .png name,
+            // which every downstream reader then rejects as a corrupt image.
             var payload = block switch
             {
-                ImageContentBlock img => (Bytes: img.Data.ToArray(), Mime: img.MimeType),
-                AudioContentBlock audio => (Bytes: audio.Data.ToArray(), Mime: audio.MimeType),
+                ImageContentBlock img => (Bytes: McpBinaryPayload.Decode(img.Data), Mime: img.MimeType),
+                AudioContentBlock audio => (Bytes: McpBinaryPayload.Decode(audio.Data), Mime: audio.MimeType),
                 _ => default
             };
 

--- a/src/RockBot.Agent/McpBridge/Attachments/BinaryResponseCapture.cs
+++ b/src/RockBot.Agent/McpBridge/Attachments/BinaryResponseCapture.cs
@@ -198,6 +198,13 @@ public sealed class BinaryResponseCapture(IAttachmentStorage storage, ILogger? l
         }
         catch (FormatException)
         {
+            // Not base64. Before declining, check for the worse case: a server that decoded
+            // binary as text and destroyed it on the way out. Nothing can recover those bytes,
+            // but the response should not be allowed to flood context on its way to being
+            // useless. See ReplaceMangledBinary.
+            if (LooksMangled(base64))
+                return ReplaceMangledBinary(serverName, toolName, payload, rule, base64.Length);
+
             logger?.LogDebug(
                 "Binary capture: {Server}/{Tool} field '{Field}' is not valid base64; leaving the response alone",
                 serverName, toolName, rule.ContentField);
@@ -235,6 +242,68 @@ public sealed class BinaryResponseCapture(IAttachmentStorage storage, ILogger? l
         rewritten["size"] = bytes.LongLength;
         rewritten["mime"] = mime;
         rewritten["note"] = CapturedNote;
+        return rewritten;
+    }
+
+    /// <summary>
+    /// Whether a string is binary that some server decoded as text and wrecked in the process.
+    /// </summary>
+    /// <remarks>
+    /// U+FFFD is the giveaway: it is what a UTF-8 decoder substitutes for a byte sequence it
+    /// cannot represent, so a PNG run through <c>Encoding.UTF8.GetString</c> comes out studded
+    /// with them. The thresholds keep an ordinary document that happens to carry a couple of
+    /// encoding glitches out of scope — at eight or more in a kilobyte the file is not text
+    /// anyone can use.
+    /// </remarks>
+    private static bool LooksMangled(string value)
+    {
+        const int MinLength = 1024;
+        const int MinReplacementChars = 8;
+
+        if (value.Length < MinLength) return false;
+
+        var count = 0;
+        foreach (var c in value)
+        {
+            if (c != '�') continue;
+            if (++count >= MinReplacementChars) return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Replaces irrecoverable binary with an explanation of why it is irrecoverable.
+    /// </summary>
+    /// <remarks>
+    /// Measured on a live deployment: one repository MCP server returns a 345 KB PNG through its
+    /// file tool as UTF-8-decoded text, arriving as 1.37 million characters that chunk into 22
+    /// working-memory entries and 22 embedding calls — for bytes that were already destroyed at
+    /// the source, since the decode is lossy and no consumer can undo it. The response is worth
+    /// nothing and costs a great deal, and an agent that reads the mojibake tends to retry the
+    /// same call. So the field is dropped and the reason is stated, which is the only honest
+    /// thing left to say about it. The rest of the response — name, sha, url, size — survives,
+    /// and is usually enough to fetch the file another way.
+    /// </remarks>
+    private JsonObject ReplaceMangledBinary(
+        string serverName,
+        string toolName,
+        JsonObject payload,
+        AttachmentCaptureRule rule,
+        int mangledLength)
+    {
+        logger?.LogWarning(
+            "Binary capture: {Server}/{Tool} returned binary as text in '{Field}' ({Chars} chars, " +
+            "unrecoverable); dropping the field rather than letting it into context",
+            serverName, toolName, rule.ContentField, mangledLength);
+
+        var rewritten = payload.DeepClone().AsObject();
+        RemoveProperty(rewritten, rule.ContentField);
+        rewritten["note"] =
+            $"This server returned the file's bytes as text, which corrupted them beyond recovery " +
+            $"({mangledLength:N0} characters of unusable content, dropped here rather than loaded " +
+            "into context). Calling the same tool again returns the same corrupted text. To work " +
+            "with this file, fetch it by a route that preserves bytes — a raw download URL, or a " +
+            "copy on the shared volume.";
         return rewritten;
     }
 

--- a/src/RockBot.Agent/McpBridge/Attachments/BinaryResponseCapture.cs
+++ b/src/RockBot.Agent/McpBridge/Attachments/BinaryResponseCapture.cs
@@ -1,0 +1,289 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Protocol;
+
+namespace RockBot.Agent.McpBridge.Attachments;
+
+/// <summary>
+/// Catches binary content on its way back from an MCP server and puts it on the shared volume
+/// instead of in the model's context.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The attachment gateway solves file transport for servers that implement RockBot's
+/// convention. Capture is the fallback for the ones that don't — the official Gitea server, for
+/// instance, whose <c>get_file_contents</c> hands back a repository PNG as base64 in an ordinary
+/// JSON response. Left alone that lands in context as ~167K characters of unusable text, gets
+/// chunked into working memory, and still never reaches the model as an image (issue #513).
+/// </para>
+/// <para>
+/// Two rules, deliberately different in what they demand of an operator:
+/// </para>
+/// <list type="number">
+///   <item>
+///     Typed <c>image</c> and <c>audio</c> content blocks are captured with no configuration at
+///     all — MCP has already labelled them, so no guessing is involved.
+///   </item>
+///   <item>
+///     Base64 inside a JSON response is captured only where a manifest rule names the fields.
+///     This follows the same reasoning as the manifest itself: sniffing for "a field that looks
+///     like base64" is exactly the fragile heuristic the attachment design rejected.
+///   </item>
+/// </list>
+/// <para>
+/// Capture never fails a tool call. Anything unexpected — a bad rule, an unwritable volume, a
+/// payload that isn't what the rule claimed — logs and returns the server's original response.
+/// A tool that worked before this class existed still works.
+/// </para>
+/// </remarks>
+public sealed class BinaryResponseCapture(IAttachmentStorage storage, ILogger? logger = null)
+{
+    /// <summary>
+    /// Tells the model what to do with a path, without naming a tool: which file-reading tools
+    /// exist depends on the deployment, and <c>analyze_file</c> in particular is not registered
+    /// unless a model tier can see.
+    /// </summary>
+    private const string CapturedNote =
+        "Binary content was saved to the shared volume instead of being returned inline. " +
+        "Use a tool that takes a file path to work with it.";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false
+    };
+
+    /// <summary>
+    /// Applies both capture rules to a tool result, returning either a rewritten result or the
+    /// original when there was nothing to capture.
+    /// </summary>
+    public async Task<CallToolResult> CaptureAsync(
+        string serverName,
+        string toolName,
+        CallToolResult result,
+        AttachmentCaptureConfig? config,
+        CancellationToken ct)
+    {
+        // A null config means "no attachments block in mcp.json", which is the common case and
+        // the one this class exists for — capture is on unless an operator turns it off.
+        if (config is { Enabled: false }) return result;
+        if (result.Content is not { Count: > 0 }) return result;
+        if (result.IsError == true) return result;
+
+        try
+        {
+            var captured = await CaptureTypedBlocksAsync(serverName, toolName, result, ct);
+            return await CaptureDeclaredFieldsAsync(serverName, toolName, captured, config, ct);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            logger?.LogWarning(ex,
+                "Binary capture failed for {Server}/{Tool}; passing the response through unchanged",
+                serverName, toolName);
+            return result;
+        }
+    }
+
+    // ── Rule 1: typed image/audio content blocks ──────────────────────────────
+
+    private async Task<CallToolResult> CaptureTypedBlocksAsync(
+        string serverName,
+        string toolName,
+        CallToolResult result,
+        CancellationToken ct)
+    {
+        if (!result.Content!.Any(IsTypedBinary)) return result;
+
+        var rewritten = new List<ContentBlock>(result.Content.Count);
+        var capturedCount = 0;
+
+        foreach (var block in result.Content)
+        {
+            var payload = block switch
+            {
+                ImageContentBlock img => (Bytes: img.Data.ToArray(), Mime: img.MimeType),
+                AudioContentBlock audio => (Bytes: audio.Data.ToArray(), Mime: audio.MimeType),
+                _ => default
+            };
+
+            if (payload.Bytes is null)
+            {
+                rewritten.Add(block);
+                continue;
+            }
+
+            var name = GenerateFileName(toolName, payload.Mime);
+            var fullPath = await storage.WriteAsync(name, payload.Bytes, ct);
+            rewritten.Add(DescriptorBlock(fullPath, payload.Bytes.LongLength, payload.Mime));
+            capturedCount++;
+
+            logger?.LogInformation(
+                "Binary capture: {Server}/{Tool} {Mime} block ({Bytes} bytes) → {Path}",
+                serverName, toolName, payload.Mime, payload.Bytes.LongLength, fullPath);
+        }
+
+        return capturedCount == 0
+            ? result
+            : new CallToolResult { Content = rewritten, StructuredContent = result.StructuredContent };
+    }
+
+    private static bool IsTypedBinary(ContentBlock block) =>
+        block is ImageContentBlock or AudioContentBlock;
+
+    // ── Rule 2: declared base64 fields in a JSON response ─────────────────────
+
+    private async Task<CallToolResult> CaptureDeclaredFieldsAsync(
+        string serverName,
+        string toolName,
+        CallToolResult result,
+        AttachmentCaptureConfig? config,
+        CancellationToken ct)
+    {
+        if (config?.Rules is not { Count: > 0 }) return result;
+
+        var rule = config.Rules.FirstOrDefault(r =>
+            r.Tools.Any(t => string.Equals(t, toolName, StringComparison.OrdinalIgnoreCase)));
+        if (rule is null) return result;
+
+        for (var i = 0; i < result.Content!.Count; i++)
+        {
+            if (result.Content[i] is not TextContentBlock text || string.IsNullOrWhiteSpace(text.Text))
+                continue;
+
+            if (JsonNode.Parse(text.Text) is not JsonObject payload)
+                continue;
+
+            var captured = await TryCaptureFieldAsync(serverName, toolName, payload, rule, ct);
+            if (captured is null) continue;
+
+            var rewritten = new List<ContentBlock>(result.Content);
+            rewritten[i] = new TextContentBlock { Text = captured.ToJsonString(JsonOptions) };
+            return new CallToolResult { Content = rewritten, StructuredContent = result.StructuredContent };
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Decodes and saves the payload a rule points at, returning the response object with the
+    /// content field replaced by the file's location — or null when the rule declines.
+    /// </summary>
+    /// <remarks>
+    /// The rest of the response is preserved because it usually carries things worth keeping: a
+    /// commit sha, a URL, the server's own size. Only the field that held the bytes is removed.
+    /// </remarks>
+    private async Task<JsonObject?> TryCaptureFieldAsync(
+        string serverName,
+        string toolName,
+        JsonObject payload,
+        AttachmentCaptureRule rule,
+        CancellationToken ct)
+    {
+        if (ReadString(payload, rule.ContentField) is not { Length: > 0 } base64)
+            return null;
+
+        if (rule.EncodingField is { Length: > 0 } encodingField
+            && ReadString(payload, encodingField) is { Length: > 0 } encoding
+            && !encoding.Equals("base64", StringComparison.OrdinalIgnoreCase))
+        {
+            // The server told us this isn't base64. Believe it rather than decoding noise.
+            return null;
+        }
+
+        byte[] bytes;
+        try
+        {
+            bytes = Convert.FromBase64String(base64);
+        }
+        catch (FormatException)
+        {
+            logger?.LogDebug(
+                "Binary capture: {Server}/{Tool} field '{Field}' is not valid base64; leaving the response alone",
+                serverName, toolName, rule.ContentField);
+            return null;
+        }
+
+        var name = ReadString(payload, rule.NameField)
+            ?? ReadString(payload, "name")
+            ?? PathLeaf(ReadString(payload, "path"));
+
+        var mime = ReadString(payload, rule.MimeField)
+            ?? (name is not null ? AttachmentMime.FromFileName(name) : null);
+
+        // The decisive question: is this actually binary? A repository server returns text and
+        // images through the same tool and the same base64 field, and capturing a README to
+        // disk would take away content the model could have simply read.
+        var isBinary = mime is not null
+            ? AttachmentMime.IsBinaryMime(mime)
+            : AttachmentMime.LooksBinary(bytes);
+
+        if (!isBinary)
+            return null;
+
+        name ??= GenerateFileName(toolName, mime);
+        var fullPath = await storage.WriteAsync(name, bytes, ct);
+
+        logger?.LogInformation(
+            "Binary capture: {Server}/{Tool} field '{Field}' ({Bytes} bytes, {Mime}) → {Path}",
+            serverName, toolName, rule.ContentField, bytes.LongLength, mime ?? "unknown", fullPath);
+
+        var rewritten = payload.DeepClone().AsObject();
+        RemoveProperty(rewritten, rule.ContentField);
+        rewritten["path"] = fullPath;
+        rewritten["name"] = Path.GetFileName(fullPath);
+        rewritten["size"] = bytes.LongLength;
+        rewritten["mime"] = mime;
+        rewritten["note"] = CapturedNote;
+        return rewritten;
+    }
+
+    // ── Shared helpers ────────────────────────────────────────────────────────
+
+    private static ContentBlock DescriptorBlock(string fullPath, long size, string? mime) =>
+        new TextContentBlock
+        {
+            Text = JsonSerializer.Serialize(new
+            {
+                path = fullPath,
+                name = Path.GetFileName(fullPath),
+                size,
+                mime,
+                note = CapturedNote
+            }, JsonOptions)
+        };
+
+    /// <summary>
+    /// Names a file that arrived without one. The tool name makes the origin recoverable from a
+    /// directory listing, and the random suffix keeps concurrent calls from queueing behind
+    /// each other on the storage layer's collision suffixes.
+    /// </summary>
+    private static string GenerateFileName(string toolName, string? mime)
+    {
+        var stem = new string(toolName.Select(c => char.IsLetterOrDigit(c) ? c : '-').ToArray())
+            .Trim('-');
+        if (stem.Length == 0) stem = "capture";
+        return $"{stem}-{Guid.NewGuid().ToString("N")[..8]}{AttachmentMime.ToExtension(mime)}";
+    }
+
+    private static string? ReadString(JsonObject payload, string? field)
+    {
+        if (string.IsNullOrEmpty(field)) return null;
+        foreach (var (key, value) in payload)
+        {
+            if (!string.Equals(key, field, StringComparison.OrdinalIgnoreCase)) continue;
+            return value?.GetValueKind() == JsonValueKind.String ? value.GetValue<string>() : null;
+        }
+        return null;
+    }
+
+    private static void RemoveProperty(JsonObject payload, string field)
+    {
+        var match = payload.FirstOrDefault(p =>
+            string.Equals(p.Key, field, StringComparison.OrdinalIgnoreCase)).Key;
+        if (match is not null) payload.Remove(match);
+    }
+
+    private static string? PathLeaf(string? path) =>
+        string.IsNullOrEmpty(path) ? null : Path.GetFileName(path.Replace('\\', '/'));
+}

--- a/src/RockBot.Agent/McpBridge/McpBridgeService.cs
+++ b/src/RockBot.Agent/McpBridge/McpBridgeService.cs
@@ -41,6 +41,13 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
     private readonly Dictionary<string, McpServerSummary> _serverSummaries = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, AttachmentGatewayEntry> _attachmentGateways = new(StringComparer.OrdinalIgnoreCase);
     private readonly Lazy<IAttachmentStorage> _attachmentStorage = new(() => new AttachmentStorage());
+
+    /// <summary>
+    /// Response-side binary capture. Unlike <see cref="AttachmentGateway"/> this needs no
+    /// manifest and no HTTP client, so a single instance serves every server — including the
+    /// ones with no <c>attachments</c> block, which are exactly the ones it exists for.
+    /// </summary>
+    private readonly Lazy<BinaryResponseCapture> _binaryCapture;
     private readonly SemaphoreSlim _configPersistLock = new(1, 1);
     private ISubscription? _invokeSubscription;
     private ISubscription? _refreshSubscription;
@@ -91,6 +98,8 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
         _tokenProviders = tokenProviders;
         _healthTracker = healthTracker;
         _argGuards = argGuards;
+        _binaryCapture = new Lazy<BinaryResponseCapture>(
+            () => new BinaryResponseCapture(_attachmentStorage.Value, _logger));
     }
 
     public async Task StartAsync(CancellationToken cancellationToken)
@@ -629,6 +638,22 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
         return httpClient;
     }
 
+    /// <summary>
+    /// Runs response-side binary capture for any server. Capture applies whether or not the
+    /// server has an attachment manifest — a manifest only supplies the declarative field rules
+    /// and the switch to turn capture off.
+    /// </summary>
+    private Task<CallToolResult> CaptureBinaryContentAsync(
+        string serverName,
+        string toolName,
+        CallToolResult result,
+        CancellationToken ct)
+    {
+        _serverConfigs.TryGetValue(serverName, out var config);
+        return _binaryCapture.Value.CaptureAsync(
+            serverName, toolName, result, config?.Attachments?.Capture, ct);
+    }
+
     private void InvalidateAttachmentGateway(string serverName)
     {
         if (_attachmentGateways.Remove(serverName, out var entry))
@@ -1029,6 +1054,8 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
                     request.ToolName, arguments, result, ct);
             }
 
+            result = await CaptureBinaryContentAsync(serverName, request.ToolName, result, ct);
+
             sw.Stop();
             var blocks = McpToolExecutor.MapContentBlocks(result);
             var content = blocks is not null ? McpToolExecutor.TextFromBlocks(blocks) : null;
@@ -1171,6 +1198,9 @@ public sealed class McpBridgeService : IHostedService, IAsyncDisposable
                                     request.ToolName, arguments, retryResult, ct);
                             }
                         }
+
+                        retryResult = await CaptureBinaryContentAsync(
+                            serverName, request.ToolName, retryResult, ct);
 
                         sw.Stop();
                         var retryBlocks = McpToolExecutor.MapContentBlocks(retryResult);

--- a/src/RockBot.Agent/Program.cs
+++ b/src/RockBot.Agent/Program.cs
@@ -90,6 +90,11 @@ if (!tierOptions.Balanced.IsConfigured)
 if (!tierOptions.Balanced.IsConfigured && tierOptions.BalancedModels.Count > 0)
     tierOptions.Balanced = tierOptions.BalancedModels[0];
 
+// Published to DI after all the compat fixups above, so anything reading it sees the same
+// resolved tiers the chat clients were built from. Tools that hand bytes to a model consult
+// SupportsImageInput here to find a tier that can actually see — see design/multimodal-input.md.
+builder.Services.AddSingleton(tierOptions);
+
 // ── Per-tier client builder — each tier can use a different provider ─────────
 // Global provider default: LLM__Provider (Copilot | empty = OpenAI-compatible)
 // Per-tier override: LLM__Low__Provider, LLM__Balanced__Provider, LLM__High__Provider

--- a/src/RockBot.Host.Abstractions/LlmTierOptions.cs
+++ b/src/RockBot.Host.Abstractions/LlmTierOptions.cs
@@ -31,6 +31,19 @@ public sealed class LlmTierConfig
     public string? ReasoningEffort { get; set; }
 
     /// <summary>
+    /// Whether this tier's model accepts images as input alongside text. Defaults to
+    /// <c>false</c>: a model that cannot see rejects a request carrying image content with an
+    /// opaque provider error deep in the stack, so the capability is opt-in per tier rather
+    /// than guessed from the model id (which changes far more often than the capability does).
+    /// </summary>
+    /// <remarks>
+    /// Read by tools that hand bytes to a model — <c>analyze_file</c> today. When no tier sets
+    /// it, those tools are not registered at all rather than registered and failing on use.
+    /// See <c>design/multimodal-input.md</c>.
+    /// </remarks>
+    public bool SupportsImageInput { get; set; }
+
+    /// <summary>
     /// Returns true when Endpoint, ApiKey, and ModelId are all non-empty
     /// (OpenAI-compatible provider fully configured).
     /// </summary>

--- a/src/RockBot.Tools.FileSystem/AnalyzeFileToolExecutor.cs
+++ b/src/RockBot.Tools.FileSystem/AnalyzeFileToolExecutor.cs
@@ -1,0 +1,184 @@
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using RockBot.Host;
+
+namespace RockBot.Tools.FileSystem;
+
+/// <summary>
+/// Hands a file on the shared volume to a vision-capable model as real multimodal content and
+/// returns only the model's textual answer.
+/// </summary>
+/// <remarks>
+/// This is a side call, not a richer tool result, and that is deliberate: on OpenAI-compatible
+/// APIs — which is every provider RockBot talks to — tool-role messages accept text only, so
+/// bytes can enter a conversation only as content parts on a user message. Running the analysis
+/// as its own request sidesteps that entirely and keeps the agent's own context free of bytes:
+/// the tool takes a path and returns prose. See <c>design/multimodal-input.md</c>.
+/// </remarks>
+internal sealed class AnalyzeFileToolExecutor(
+    FileSystemOptions options,
+    ILlmClient llmClient,
+    IReadOnlyCollection<ModelTier> visionTiers,
+    ILogger logger) : IToolExecutor
+{
+    /// <summary>
+    /// Steers the analysis model towards describing what is actually in the file. The caller is
+    /// another model that cannot see the bytes, so an invented detail here is indistinguishable
+    /// from an observed one downstream.
+    /// </summary>
+    private const string SystemPrompt =
+        "You are analysing a file on behalf of another agent that cannot see it. Answer only " +
+        "from what is actually present in the file. State plainly when something asked for is " +
+        "not visible or not legible rather than inferring it.";
+
+    /// <summary>
+    /// Order tried when the requested tier cannot see: strongest first, because an analysis
+    /// that has to be re-run is more expensive than the tier difference.
+    /// </summary>
+    private static readonly ModelTier[] FallbackOrder =
+        [ModelTier.High, ModelTier.Balanced, ModelTier.Low];
+
+    private static readonly Dictionary<string, string> MimeByExtension = new(StringComparer.OrdinalIgnoreCase)
+    {
+        [".png"] = "image/png",
+        [".jpg"] = "image/jpeg",
+        [".jpeg"] = "image/jpeg",
+        [".gif"] = "image/gif",
+        [".webp"] = "image/webp",
+        [".bmp"] = "image/bmp",
+        [".pdf"] = "application/pdf",
+        [".mp3"] = "audio/mpeg",
+        [".wav"] = "audio/wav",
+        [".ogg"] = "audio/ogg"
+    };
+
+    public async Task<ToolInvokeResponse> ExecuteAsync(ToolInvokeRequest request, CancellationToken ct)
+    {
+        try
+        {
+            var args = ParseArguments(request.Arguments);
+
+            if (!args.TryGetValue("path", out var pathElement)
+                || pathElement.GetString() is not { Length: > 0 } relativePath)
+                return Error(request, "Missing required argument: path");
+
+            if (!args.TryGetValue("prompt", out var promptElement)
+                || promptElement.GetString() is not { Length: > 0 } prompt)
+                return Error(request, "Missing required argument: prompt");
+
+            var fullPath = FileWriteToolExecutor.SafeResolvePath(options.BasePath, relativePath);
+            if (fullPath is null)
+                return Error(request, "Invalid path: must be within the shared volume.");
+
+            if (!File.Exists(fullPath))
+                return Error(request, $"File not found: {relativePath}");
+
+            var extension = Path.GetExtension(fullPath);
+            if (!MimeByExtension.TryGetValue(extension, out var mime))
+            {
+                return Error(request,
+                    $"Cannot analyse '{relativePath}': unrecognised file type '{extension}'. " +
+                    $"Types this agent can analyse: {string.Join(", ", options.AnalyzeFileMimeTypes)}.");
+            }
+
+            if (!options.AnalyzeFileMimeTypes.Contains(mime, StringComparer.OrdinalIgnoreCase))
+            {
+                return Error(request,
+                    $"Cannot analyse '{relativePath}': {mime} files are not enabled for this agent. " +
+                    $"Types this agent can analyse: {string.Join(", ", options.AnalyzeFileMimeTypes)}.");
+            }
+
+            var length = new FileInfo(fullPath).Length;
+            if (length > options.AnalyzeFileMaxBytes)
+            {
+                return Error(request,
+                    $"Cannot analyse '{relativePath}': {length / 1024} KB exceeds the " +
+                    $"{options.AnalyzeFileMaxBytes / 1024} KB limit for file analysis.");
+            }
+
+            var tier = ResolveTier(args);
+            var bytes = await File.ReadAllBytesAsync(fullPath, ct);
+
+            var messages = new List<ChatMessage>
+            {
+                new(ChatRole.System, SystemPrompt),
+                new(ChatRole.User,
+                [
+                    new TextContent(prompt),
+                    new DataContent(bytes, mime)
+                ])
+            };
+
+            logger.LogInformation(
+                "analyze_file: {Path} ({Mime}, {Bytes} bytes) on {Tier} tier",
+                relativePath, mime, length, tier);
+
+            var response = await llmClient.GetResponseAsync(messages, tier, options: null, ct);
+
+            var text = response.Text;
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return Error(request,
+                    $"The model returned no text for '{relativePath}'. The file may be unreadable " +
+                    "to it, or the request may have been filtered.");
+            }
+
+            return new ToolInvokeResponse
+            {
+                ToolCallId = request.ToolCallId,
+                ToolName = request.ToolName,
+                Content = text,
+                IsError = false
+            };
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            logger.LogWarning(ex, "analyze_file failed");
+            return Error(request, $"Analysis failed: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Honours the requested tier when it can see, and otherwise substitutes the nearest tier
+    /// that can. Sending the request to a blind tier anyway would not merely fail — <see
+    /// cref="ILlmClient"/> retries a failed Low/High call on Balanced, so a blind Balanced tier
+    /// would swallow the second attempt too and report a provider error instead of the real
+    /// cause.
+    /// </summary>
+    private ModelTier ResolveTier(Dictionary<string, JsonElement> args)
+    {
+        var requested = ModelTier.Balanced;
+        if (args.TryGetValue("tier", out var tierElement)
+            && tierElement.ValueKind == JsonValueKind.String
+            && Enum.TryParse<ModelTier>(tierElement.GetString(), ignoreCase: true, out var parsed))
+        {
+            requested = parsed;
+        }
+
+        if (visionTiers.Contains(requested))
+            return requested;
+
+        var substitute = FallbackOrder.First(visionTiers.Contains);
+        logger.LogInformation(
+            "analyze_file: {Requested} tier does not accept image input — using {Substitute}",
+            requested, substitute);
+        return substitute;
+    }
+
+    private static ToolInvokeResponse Error(ToolInvokeRequest request, string message) =>
+        new()
+        {
+            ToolCallId = request.ToolCallId,
+            ToolName = request.ToolName,
+            Content = message,
+            IsError = true
+        };
+
+    private static Dictionary<string, JsonElement> ParseArguments(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+            return [];
+        return JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json) ?? [];
+    }
+}

--- a/src/RockBot.Tools.FileSystem/FileSystemOptions.cs
+++ b/src/RockBot.Tools.FileSystem/FileSystemOptions.cs
@@ -10,4 +10,20 @@ public sealed class FileSystemOptions
     /// Defaults to <c>/rockbot/shared</c>.
     /// </summary>
     public string BasePath { get; set; } = "/rockbot/shared";
+
+    /// <summary>
+    /// Largest file <c>analyze_file</c> will hand to a model, in bytes. Defaults to 8 MiB.
+    /// Providers cap the encoded request well above this; the limit is here so that pointing
+    /// the tool at the wrong file stays cheap.
+    /// </summary>
+    public long AnalyzeFileMaxBytes { get; set; } = 8L * 1024 * 1024;
+
+    /// <summary>
+    /// MIME types <c>analyze_file</c> is permitted to send. Defaults to the four image
+    /// formats every vision-capable provider accepts. Adding <c>application/pdf</c> or an
+    /// audio type is a deployment decision, because whether it works depends on the provider
+    /// behind the configured tier.
+    /// </summary>
+    public IList<string> AnalyzeFileMimeTypes { get; set; } =
+        ["image/png", "image/jpeg", "image/gif", "image/webp"];
 }

--- a/src/RockBot.Tools.FileSystem/FileSystemToolRegistrar.cs
+++ b/src/RockBot.Tools.FileSystem/FileSystemToolRegistrar.cs
@@ -1,11 +1,23 @@
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using RockBot.Host;
 
 namespace RockBot.Tools.FileSystem;
 
+/// <summary>
+/// Registers the shared-volume file tools. <c>analyze_file</c> is conditional — see
+/// <see cref="TryRegisterAnalyzeFile"/>; the rest are always registered.
+/// </summary>
+/// <param name="services">
+/// Used to resolve <see cref="ILlmClient"/> and <see cref="LlmTierOptions"/>, which this
+/// package treats as optional: it is consumed by hosts that configure no LLM client at all,
+/// and their absence simply means <c>analyze_file</c> is not offered.
+/// </param>
 internal sealed class FileSystemToolRegistrar(
     IToolRegistry registry,
     FileSystemOptions options,
+    IServiceProvider services,
     ILogger<FileSystemToolRegistrar> logger) : IHostedService
 {
     private const string WriteSchema = """
@@ -101,6 +113,28 @@ internal sealed class FileSystemToolRegistrar(
         }
         """;
 
+    private const string AnalyzeSchema = """
+        {
+          "type": "object",
+          "properties": {
+            "path": {
+              "type": "string",
+              "description": "Relative path of the image within the shared volume (e.g. 'attachments/diagram.png')"
+            },
+            "prompt": {
+              "type": "string",
+              "description": "What you need to know about the file. Be specific — you get back only the answer to this question, and asking again costs another look."
+            },
+            "tier": {
+              "type": "string",
+              "enum": ["low", "balanced", "high"],
+              "description": "Which model tier examines the file. Defaults to balanced; use high for dense diagrams or fine detail."
+            }
+          },
+          "required": ["path", "prompt"]
+        }
+        """;
+
     public Task StartAsync(CancellationToken cancellationToken)
     {
         registry.Register(new ToolRegistration
@@ -167,8 +201,56 @@ internal sealed class FileSystemToolRegistrar(
         }, new FileGetPathToolExecutor(options));
         logger.LogInformation("Registered file tool: file_get_path");
 
+        TryRegisterAnalyzeFile();
+
         return Task.CompletedTask;
     }
 
     public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    /// <summary>
+    /// Registers <c>analyze_file</c> only when some tier declares it accepts image input.
+    /// Offering the tool otherwise teaches the model a capability the deployment does not have,
+    /// which it then spends turns trying to use.
+    /// </summary>
+    private void TryRegisterAnalyzeFile()
+    {
+        var tierOptions = services.GetService<LlmTierOptions>();
+        var llmClient = services.GetService<ILlmClient>();
+
+        if (tierOptions is null || llmClient is null)
+        {
+            logger.LogInformation(
+                "File tool analyze_file not registered: no {Missing} configured",
+                tierOptions is null ? nameof(LlmTierOptions) : nameof(ILlmClient));
+            return;
+        }
+
+        var visionTiers = VisionTiers.From(tierOptions);
+
+        if (visionTiers.Length == 0)
+        {
+            logger.LogInformation(
+                "File tool analyze_file not registered: no LLM tier sets SupportsImageInput");
+            return;
+        }
+
+        registry.Register(new ToolRegistration
+        {
+            Name = "analyze_file",
+            Description = """
+                Look at an image on the shared volume and answer a question about it. Use this
+                for anything you cannot read as text — diagrams, screenshots, charts, scans,
+                photos. The file is shown to a vision-capable model as an actual image; you get
+                back that model's answer to your prompt, not the file's bytes. Never try to read
+                an image with file_read: it returns unusable text and floods your context.
+                """,
+            ParametersSchema = AnalyzeSchema,
+            Source = "filesystem"
+        }, new AnalyzeFileToolExecutor(options, llmClient, visionTiers, logger));
+
+        logger.LogInformation(
+            "Registered file tool: analyze_file (vision tiers: {Tiers})",
+            string.Join(", ", visionTiers));
+    }
 }

--- a/src/RockBot.Tools.FileSystem/FileSystemToolSkillProvider.cs
+++ b/src/RockBot.Tools.FileSystem/FileSystemToolSkillProvider.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.DependencyInjection;
+using RockBot.Host;
 using RockBot.Tools;
 
 namespace RockBot.Tools.FileSystem;
@@ -5,16 +7,31 @@ namespace RockBot.Tools.FileSystem;
 /// <summary>
 /// Provides the agent with a usage guide for the shared-volume file tools.
 /// </summary>
-internal sealed class FileSystemToolSkillProvider : IToolSkillProvider
+/// <remarks>
+/// The <c>analyze_file</c> section is conditional on the same predicate the registrar uses, so
+/// the guide never documents a tool this deployment does not offer — and never omits one it does,
+/// whichever of the two hosted services starts first.
+/// </remarks>
+internal sealed class FileSystemToolSkillProvider(IServiceProvider services) : IToolSkillProvider
 {
-    public string Name => "files";
-    public string Summary => "Shared-volume file tools (file_write, file_edit, file_read, file_list, file_delete, file_get_path).";
+    private bool HasVision => VisionTiers.From(services.GetService<LlmTierOptions>()).Length > 0
+                              && services.GetService<ILlmClient>() is not null;
 
-    public string GetDocument() =>
+    public string Name => "files";
+
+    public string Summary => HasVision
+        ? "Shared-volume file tools (file_write, file_edit, file_read, file_list, file_delete, file_get_path, analyze_file)."
+        : "Shared-volume file tools (file_write, file_edit, file_read, file_list, file_delete, file_get_path).";
+
+    public string GetDocument() => HasVision
+        ? BaseDocument + AnalyzeFileSection
+        : BaseDocument;
+
+    private const string BaseDocument =
         """
         # Shared Volume File Tools Guide
 
-        Six tools provide direct access to files on the shared volume — a persistent
+        These tools provide direct access to files on the shared volume — a persistent
         filesystem shared across the agent, script pods, and other RockBot services.
 
 
@@ -159,7 +176,51 @@ internal sealed class FileSystemToolSkillProvider : IToolSkillProvider
         - Path traversal outside the shared volume is blocked for security
         - Files in `tmp/` are automatically cleaned up daily — use `drafts/` or
           `exports/` for files that need to persist longer
-        - These tools handle UTF-8 text; for binary files, use scripts to create them
-          and `file_get_path` to pass them to other tools
+        - `file_read` and `file_write` handle UTF-8 text only. To create a binary file, use
+          a script; to pass one to another tool, use `file_get_path`
+        """;
+
+    /// <summary>
+    /// Appended only when a configured tier accepts image input. Leads with the failure it
+    /// replaces: reading an image with <c>file_read</c> is the mistake this tool exists to
+    /// prevent, and it is expensive — a single image can fill working memory with chunked
+    /// mojibake before the agent notices anything is wrong.
+    /// </summary>
+    private const string AnalyzeFileSection =
+        """
+
+
+        ## Looking at Images: analyze_file
+
+        `file_read` cannot read an image. It will return thousands of characters of unusable
+        text, chunk them into working memory, and leave you no closer to knowing what the image
+        shows. Use `analyze_file` instead — for diagrams, screenshots, charts, scans, photos,
+        and anything else you cannot read as text.
+
+        ```
+        analyze_file(
+          path: "attachments/architecture.png",
+          prompt: "Describe the components and how they connect.",
+          tier: "high"
+        )
+        // → "Three services arranged left to right. The gateway on the left ..."
+        ```
+
+        The file is shown to a vision-capable model as an actual image. What comes back is that
+        model's answer to your prompt — not the file's bytes, which never enter your context.
+
+        Because of that, **the answer is all you get**. The model that looked at the image is
+        not in this conversation and cannot be asked a follow-up; a second question means a
+        second call and a second look. So ask for everything you need in one prompt: "list every
+        label and the arrows between them" rather than "what is this diagram of". Specific
+        prompts also produce specific answers — an open-ended prompt gets an open-ended summary
+        that often omits the one detail you needed.
+
+        The `tier` parameter is optional and defaults to balanced. Use `high` for dense diagrams,
+        small text, or fine visual detail.
+
+        Not every deployment can do this. When this section is absent from the guide, no
+        configured model accepts images and there is no way to look at one — say so plainly
+        rather than reading the file as text and guessing at what it contains.
         """;
 }

--- a/src/RockBot.Tools.FileSystem/VisionTiers.cs
+++ b/src/RockBot.Tools.FileSystem/VisionTiers.cs
@@ -1,0 +1,24 @@
+using RockBot.Host;
+
+namespace RockBot.Tools.FileSystem;
+
+/// <summary>
+/// Which configured model tiers accept image input. Shared by the tool registrar (which decides
+/// whether to offer <c>analyze_file</c> at all) and the skill guide (which decides whether to
+/// document it), so the two cannot disagree regardless of the order their hosted services run.
+/// </summary>
+internal static class VisionTiers
+{
+    /// <summary>
+    /// Returns the tiers whose resolved config sets <see cref="LlmTierConfig.SupportsImageInput"/>,
+    /// or an empty array when no LLM tiers are configured at all.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="LlmTierOptions.Resolve"/> falls back to Balanced for an unconfigured tier, so a
+    /// tier listed here genuinely reaches a seeing model when asked for.
+    /// </remarks>
+    public static ModelTier[] From(LlmTierOptions? options) =>
+        options is null
+            ? []
+            : [.. Enum.GetValues<ModelTier>().Where(t => options.Resolve(t).SupportsImageInput)];
+}

--- a/src/RockBot.Tools.Mcp/McpBinaryPayload.cs
+++ b/src/RockBot.Tools.Mcp/McpBinaryPayload.cs
@@ -1,0 +1,90 @@
+using System.Text;
+
+namespace RockBot.Tools.Mcp;
+
+/// <summary>
+/// Reads the byte payload of an MCP image or audio content block.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>ImageContentBlock.Data</c> is typed <c>ReadOnlyMemory&lt;byte&gt;</c>, which reads like "the
+/// file's bytes". In SDK 1.4.0 it is not: the property carries the wire field verbatim, and the
+/// wire field is base64 <em>text</em>. Taking <c>Data.ToArray()</c> therefore yields the ASCII of
+/// "iVBORw0KGgo…" rather than a PNG — verified by capturing a 783-byte fixture image and finding
+/// exactly 1044 bytes of base64 on disk.
+/// </para>
+/// <para>
+/// Because the type says one thing and the contents say another, both readings are handled here
+/// rather than assumed at each call site: the payload is decoded when it really is base64 text and
+/// passed through when it is not. That also means a future SDK version that starts storing decoded
+/// bytes needs no change here.
+/// </para>
+/// </remarks>
+internal static class McpBinaryPayload
+{
+    /// <summary>Returns the payload's real bytes, decoding base64 text when that is what it holds.</summary>
+    public static byte[] Decode(ReadOnlyMemory<byte> data)
+    {
+        if (data.IsEmpty) return [];
+
+        if (TryReadBase64Text(data.Span, out var text)
+            && TryFromBase64(text, out var decoded))
+        {
+            return decoded;
+        }
+
+        return data.ToArray();
+    }
+
+    /// <summary>
+    /// Returns the payload as a base64 string, without re-encoding one it already holds. The
+    /// naive <c>Convert.ToBase64String(block.Data.Span)</c> double-encodes.
+    /// </summary>
+    public static string ToBase64(ReadOnlyMemory<byte> data)
+    {
+        if (data.IsEmpty) return string.Empty;
+
+        if (TryReadBase64Text(data.Span, out var text) && TryFromBase64(text, out _))
+            return text;
+
+        return Convert.ToBase64String(data.Span);
+    }
+
+    /// <summary>
+    /// Whether the bytes are printable ASCII in the base64 alphabet — a cheap gate that keeps real
+    /// binary (which is full of bytes outside it) away from the decode attempt.
+    /// </summary>
+    private static bool TryReadBase64Text(ReadOnlySpan<byte> data, out string text)
+    {
+        text = string.Empty;
+
+        // Base64 encodes 3 bytes into 4, so real base64 text is always a multiple of four; PNG and
+        // WAV headers are not ASCII at all and fail on the first byte.
+        if (data.Length % 4 != 0) return false;
+
+        foreach (var b in data)
+        {
+            var isBase64Char = b is >= (byte)'A' and <= (byte)'Z'
+                or >= (byte)'a' and <= (byte)'z'
+                or >= (byte)'0' and <= (byte)'9'
+                or (byte)'+' or (byte)'/' or (byte)'=';
+            if (!isBase64Char) return false;
+        }
+
+        text = Encoding.ASCII.GetString(data);
+        return true;
+    }
+
+    private static bool TryFromBase64(string text, out byte[] decoded)
+    {
+        var buffer = new byte[text.Length / 4 * 3];
+        if (Convert.TryFromBase64String(text, buffer, out var written))
+        {
+            decoded = written == buffer.Length ? buffer : buffer[..written];
+            return true;
+        }
+
+        decoded = [];
+        return false;
+    }
+}

--- a/src/RockBot.Tools.Mcp/McpToolExecutor.cs
+++ b/src/RockBot.Tools.Mcp/McpToolExecutor.cs
@@ -78,8 +78,8 @@ internal sealed class McpToolExecutor(CallToolDelegate callTool) : IToolExecutor
             blocks.Add(block switch
             {
                 TextContentBlock text => new ToolContentBlock { Type = "text", Text = text.Text },
-                ImageContentBlock img => new ToolContentBlock { Type = "image", Data = Convert.ToBase64String(img.Data.Span), MimeType = img.MimeType },
-                AudioContentBlock audio => new ToolContentBlock { Type = "audio", Data = Convert.ToBase64String(audio.Data.Span), MimeType = audio.MimeType },
+                ImageContentBlock img => new ToolContentBlock { Type = "image", Data = McpBinaryPayload.ToBase64(img.Data), MimeType = img.MimeType },
+                AudioContentBlock audio => new ToolContentBlock { Type = "audio", Data = McpBinaryPayload.ToBase64(audio.Data), MimeType = audio.MimeType },
                 _ => new ToolContentBlock { Type = block.Type ?? "unknown", Text = $"[{block.Type ?? "unknown"} content block]" }
             });
         }

--- a/tests/RockBot.Agent.Tests/Attachments/AttachmentStorageTests.cs
+++ b/tests/RockBot.Agent.Tests/Attachments/AttachmentStorageTests.cs
@@ -1,0 +1,86 @@
+using RockBot.Agent.McpBridge.Attachments;
+
+namespace RockBot.Agent.Tests.Attachments;
+
+/// <summary>
+/// Containment tests for the write path.
+/// </summary>
+/// <remarks>
+/// Binary capture names saved files from the <c>name</c> field of an MCP server's response,
+/// which is to say from a remote party. That makes the leaf-only sanitising in
+/// <see cref="AttachmentStorage"/> a security property rather than a tidiness one, and worth
+/// pinning: a refactor that "simplified" it into a <c>Path.Combine</c> would let a hostile
+/// server write anywhere the agent can reach.
+/// </remarks>
+[TestClass]
+public class AttachmentStorageTests
+{
+    private string _root = null!;
+    private AttachmentStorage _storage = null!;
+
+    [TestInitialize]
+    public void Init()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "rockbot-attachment-storage-tests", Guid.NewGuid().ToString("N"));
+        _storage = new AttachmentStorage(_root);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_root))
+            Directory.Delete(_root, recursive: true);
+    }
+
+    [DataTestMethod]
+    [DataRow("../escaped.png")]
+    [DataRow("../../../../etc/passwd")]
+    [DataRow("subdir/nested.png")]
+    [DataRow("/etc/shadow")]
+    public async Task WriteAsync_TraversalInName_StaysInsideTheBaseDirectory(string hostileName)
+    {
+        var written = await _storage.WriteAsync(hostileName, [1, 2, 3], CancellationToken.None);
+
+        var basePath = Path.GetFullPath(_root);
+        var parent = Path.GetDirectoryName(Path.GetFullPath(written));
+        Assert.AreEqual(basePath, parent, $"'{hostileName}' escaped the attachments directory");
+        Assert.IsTrue(File.Exists(written));
+    }
+
+    [TestMethod]
+    public async Task WriteAsync_EmptyName_FallsBackToADefault()
+    {
+        var written = await _storage.WriteAsync("   ", [1], CancellationToken.None);
+
+        Assert.AreEqual(Path.GetFullPath(_root), Path.GetDirectoryName(Path.GetFullPath(written)));
+        Assert.IsTrue(File.Exists(written));
+    }
+
+    [TestMethod]
+    public async Task WriteAsync_SameNameTwice_DoesNotOverwrite()
+    {
+        var first = await _storage.WriteAsync("chart.png", [1], CancellationToken.None);
+        var second = await _storage.WriteAsync("chart.png", [2], CancellationToken.None);
+
+        Assert.AreNotEqual(first, second);
+        CollectionAssert.AreEqual(new byte[] { 1 }, await File.ReadAllBytesAsync(first));
+        CollectionAssert.AreEqual(new byte[] { 2 }, await File.ReadAllBytesAsync(second));
+    }
+
+    [TestMethod]
+    public async Task ReadAsync_PathOutsideTheBase_IsRejected()
+    {
+        var outside = Path.Combine(Path.GetTempPath(), $"outside-{Guid.NewGuid():N}.txt");
+        await File.WriteAllTextAsync(outside, "secret");
+
+        try
+        {
+            await Assert.ThrowsExactlyAsync<UnauthorizedAccessException>(
+                () => _storage.ReadAsync(outside, CancellationToken.None));
+        }
+        finally
+        {
+            File.Delete(outside);
+        }
+    }
+}

--- a/tests/RockBot.Agent.Tests/Attachments/BinaryResponseCaptureTests.cs
+++ b/tests/RockBot.Agent.Tests/Attachments/BinaryResponseCaptureTests.cs
@@ -18,6 +18,13 @@ public class BinaryResponseCaptureTests
     private static readonly byte[] PngBytes = Convert.FromBase64String(
         "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==");
 
+    /// <summary>
+    /// A content block's payload as it actually arrives: base64 text, despite the property being
+    /// typed as bytes. Capture has to decode it, or a .png on disk contains "iVBORw0KGgo…".
+    /// </summary>
+    private static byte[] WireShape(byte[] payload) =>
+        System.Text.Encoding.ASCII.GetBytes(Convert.ToBase64String(payload));
+
     [TestInitialize]
     public void Init()
     {
@@ -62,7 +69,7 @@ public class BinaryResponseCaptureTests
     {
         var result = new CallToolResult
         {
-            Content = [new ImageContentBlock { Data = PngBytes, MimeType = "image/png" }]
+            Content = [new ImageContentBlock { Data = WireShape(PngBytes), MimeType = "image/png" }]
         };
 
         var captured = await _capture.CaptureAsync(Server, "read_image", result, null, default);
@@ -81,7 +88,7 @@ public class BinaryResponseCaptureTests
         var bytes = new byte[] { 0x49, 0x44, 0x33, 0x00, 0x01 };
         var result = new CallToolResult
         {
-            Content = [new AudioContentBlock { Data = bytes, MimeType = "audio/mpeg" }]
+            Content = [new AudioContentBlock { Data = WireShape(bytes), MimeType = "audio/mpeg" }]
         };
 
         var captured = await _capture.CaptureAsync(Server, "read_audio", result, null, default);
@@ -97,7 +104,7 @@ public class BinaryResponseCaptureTests
             Content =
             [
                 new TextContentBlock { Text = "Here is the diagram:" },
-                new ImageContentBlock { Data = PngBytes, MimeType = "image/png" }
+                new ImageContentBlock { Data = WireShape(PngBytes), MimeType = "image/png" }
             ]
         };
 
@@ -124,7 +131,7 @@ public class BinaryResponseCaptureTests
     {
         var result = new CallToolResult
         {
-            Content = [new ImageContentBlock { Data = PngBytes, MimeType = "image/png" }]
+            Content = [new ImageContentBlock { Data = WireShape(PngBytes), MimeType = "image/png" }]
         };
 
         var captured = await _capture.CaptureAsync(
@@ -140,7 +147,7 @@ public class BinaryResponseCaptureTests
         var result = new CallToolResult
         {
             IsError = true,
-            Content = [new ImageContentBlock { Data = PngBytes, MimeType = "image/png" }]
+            Content = [new ImageContentBlock { Data = WireShape(PngBytes), MimeType = "image/png" }]
         };
 
         Assert.AreSame(result, await _capture.CaptureAsync(Server, "read_image", result, null, default));
@@ -329,7 +336,7 @@ public class BinaryResponseCaptureTests
         var capture = new BinaryResponseCapture(new ThrowingStorage());
         var result = new CallToolResult
         {
-            Content = [new ImageContentBlock { Data = PngBytes, MimeType = "image/png" }]
+            Content = [new ImageContentBlock { Data = WireShape(PngBytes), MimeType = "image/png" }]
         };
 
         Assert.AreSame(result, await capture.CaptureAsync(Server, "read_image", result, null, default));

--- a/tests/RockBot.Agent.Tests/Attachments/BinaryResponseCaptureTests.cs
+++ b/tests/RockBot.Agent.Tests/Attachments/BinaryResponseCaptureTests.cs
@@ -1,0 +1,321 @@
+using System.Text;
+using System.Text.Json;
+using ModelContextProtocol.Protocol;
+using RockBot.Agent.McpBridge.Attachments;
+
+namespace RockBot.Agent.Tests.Attachments;
+
+[TestClass]
+public class BinaryResponseCaptureTests
+{
+    private const string Server = "gitea";
+    private const string Tool = "get_file_contents";
+
+    private FakeStorage _storage = null!;
+    private BinaryResponseCapture _capture = null!;
+
+    /// <summary>Smallest valid PNG — enough to carry a recognisable extension and real bytes.</summary>
+    private static readonly byte[] PngBytes = Convert.FromBase64String(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==");
+
+    [TestInitialize]
+    public void Init()
+    {
+        _storage = new FakeStorage("/rockbot/shared/attachments");
+        _capture = new BinaryResponseCapture(_storage);
+    }
+
+    private static AttachmentCaptureConfig RuleConfig(
+        string contentField = "content",
+        string? nameField = "name",
+        string? mimeField = null,
+        string? encodingField = "encoding",
+        params string[] tools) =>
+        new()
+        {
+            Rules =
+            [
+                new AttachmentCaptureRule
+                {
+                    Tools = [.. tools.Length > 0 ? tools : [Tool]],
+                    ContentField = contentField,
+                    NameField = nameField,
+                    MimeField = mimeField,
+                    EncodingField = encodingField
+                }
+            ]
+        };
+
+    private static CallToolResult TextResult(object payload) =>
+        new() { Content = [new TextContentBlock { Text = JsonSerializer.Serialize(payload) }] };
+
+    private static JsonElement ParseSingleText(CallToolResult result)
+    {
+        var text = ((TextContentBlock)result.Content!.Single()).Text;
+        return JsonDocument.Parse(text).RootElement.Clone();
+    }
+
+    // ── Rule 1: typed content blocks, no configuration required ───────────────
+
+    [TestMethod]
+    public async Task Capture_ImageBlock_WritesFileAndReturnsPath()
+    {
+        var result = new CallToolResult
+        {
+            Content = [new ImageContentBlock { Data = PngBytes, MimeType = "image/png" }]
+        };
+
+        var captured = await _capture.CaptureAsync(Server, "read_image", result, null, default);
+
+        var payload = ParseSingleText(captured);
+        var path = payload.GetProperty("path").GetString()!;
+        Assert.AreEqual(PngBytes.Length, payload.GetProperty("size").GetInt32());
+        Assert.AreEqual("image/png", payload.GetProperty("mime").GetString());
+        StringAssert.EndsWith(path, ".png");
+        CollectionAssert.AreEqual(PngBytes, _storage.Files[path]);
+    }
+
+    [TestMethod]
+    public async Task Capture_AudioBlock_IsCapturedToo()
+    {
+        var bytes = new byte[] { 0x49, 0x44, 0x33, 0x00, 0x01 };
+        var result = new CallToolResult
+        {
+            Content = [new AudioContentBlock { Data = bytes, MimeType = "audio/mpeg" }]
+        };
+
+        var captured = await _capture.CaptureAsync(Server, "read_audio", result, null, default);
+
+        StringAssert.EndsWith(ParseSingleText(captured).GetProperty("path").GetString(), ".mp3");
+    }
+
+    [TestMethod]
+    public async Task Capture_MixedBlocks_LeavesTextAlone()
+    {
+        var result = new CallToolResult
+        {
+            Content =
+            [
+                new TextContentBlock { Text = "Here is the diagram:" },
+                new ImageContentBlock { Data = PngBytes, MimeType = "image/png" }
+            ]
+        };
+
+        var captured = await _capture.CaptureAsync(Server, "read_image", result, null, default);
+
+        Assert.AreEqual(2, captured.Content!.Count);
+        Assert.AreEqual("Here is the diagram:", ((TextContentBlock)captured.Content[0]).Text);
+        StringAssert.Contains(((TextContentBlock)captured.Content[1]).Text, "\"path\"");
+    }
+
+    [TestMethod]
+    public async Task Capture_TextOnlyResult_IsUntouched()
+    {
+        var result = new CallToolResult { Content = [new TextContentBlock { Text = "plain answer" }] };
+
+        var captured = await _capture.CaptureAsync(Server, "some_tool", result, null, default);
+
+        Assert.AreSame(result, captured);
+        Assert.AreEqual(0, _storage.Written.Count);
+    }
+
+    [TestMethod]
+    public async Task Capture_Disabled_LeavesImageBlockAlone()
+    {
+        var result = new CallToolResult
+        {
+            Content = [new ImageContentBlock { Data = PngBytes, MimeType = "image/png" }]
+        };
+
+        var captured = await _capture.CaptureAsync(
+            Server, "read_image", result, new AttachmentCaptureConfig { Enabled = false }, default);
+
+        Assert.AreSame(result, captured);
+        Assert.AreEqual(0, _storage.Written.Count);
+    }
+
+    [TestMethod]
+    public async Task Capture_ErrorResult_IsUntouched()
+    {
+        var result = new CallToolResult
+        {
+            IsError = true,
+            Content = [new ImageContentBlock { Data = PngBytes, MimeType = "image/png" }]
+        };
+
+        Assert.AreSame(result, await _capture.CaptureAsync(Server, "read_image", result, null, default));
+    }
+
+    // ── Rule 2: declared base64 fields (the Gitea shape) ──────────────────────
+
+    [TestMethod]
+    public async Task Capture_DeclaredBase64Image_WritesFileAndStripsContent()
+    {
+        var result = TextResult(new
+        {
+            name = "architecture.png",
+            path = "docs/architecture.png",
+            sha = "abc123",
+            encoding = "base64",
+            content = Convert.ToBase64String(PngBytes)
+        });
+
+        var captured = await _capture.CaptureAsync(Server, Tool, result, RuleConfig(), default);
+
+        var payload = ParseSingleText(captured);
+        Assert.IsFalse(payload.TryGetProperty("content", out _), "the base64 payload must not survive");
+        Assert.AreEqual("abc123", payload.GetProperty("sha").GetString(), "unrelated fields are preserved");
+        Assert.AreEqual("image/png", payload.GetProperty("mime").GetString());
+        Assert.AreEqual(PngBytes.Length, payload.GetProperty("size").GetInt32());
+        CollectionAssert.AreEqual(PngBytes, _storage.Files[payload.GetProperty("path").GetString()!]);
+    }
+
+    [TestMethod]
+    public async Task Capture_DeclaredBase64Markdown_IsLeftInTheResponse()
+    {
+        // The whole point of the binary test: a repository server returns text and images
+        // through the same tool and the same field, and capturing a README to disk would take
+        // away content the model could simply have read.
+        var markdown = Encoding.UTF8.GetBytes("# README\n\nHello, world.\n");
+        var result = TextResult(new
+        {
+            name = "README.md",
+            encoding = "base64",
+            content = Convert.ToBase64String(markdown)
+        });
+
+        var captured = await _capture.CaptureAsync(Server, Tool, result, RuleConfig(), default);
+
+        Assert.AreSame(result, captured);
+        Assert.AreEqual(0, _storage.Written.Count);
+    }
+
+    [TestMethod]
+    public async Task Capture_UnnamedBinaryPayload_FallsBackToSniffing()
+    {
+        var result = TextResult(new { content = Convert.ToBase64String(PngBytes) });
+
+        var captured = await _capture.CaptureAsync(
+            Server, Tool, result, RuleConfig(nameField: null), default);
+
+        Assert.AreEqual(1, _storage.Written.Count);
+        CollectionAssert.AreEqual(PngBytes, _storage.Files[ParseSingleText(captured).GetProperty("path").GetString()!]);
+    }
+
+    [TestMethod]
+    public async Task Capture_UnnamedTextPayload_FallsBackToSniffingAndDeclines()
+    {
+        var result = TextResult(new { content = Convert.ToBase64String("just some prose"u8.ToArray()) });
+
+        var captured = await _capture.CaptureAsync(
+            Server, Tool, result, RuleConfig(nameField: null), default);
+
+        Assert.AreSame(result, captured);
+    }
+
+    [TestMethod]
+    public async Task Capture_NonBase64Encoding_Declines()
+    {
+        var result = TextResult(new { name = "diagram.png", encoding = "utf-8", content = "not base64 at all" });
+
+        Assert.AreSame(result, await _capture.CaptureAsync(Server, Tool, result, RuleConfig(), default));
+    }
+
+    [TestMethod]
+    public async Task Capture_MalformedBase64_DeclinesWithoutFailing()
+    {
+        var result = TextResult(new { name = "diagram.png", encoding = "base64", content = "!!!not-base64!!!" });
+
+        Assert.AreSame(result, await _capture.CaptureAsync(Server, Tool, result, RuleConfig(), default));
+    }
+
+    [TestMethod]
+    public async Task Capture_RuleForAnotherTool_DoesNotMatch()
+    {
+        var result = TextResult(new
+        {
+            name = "architecture.png",
+            encoding = "base64",
+            content = Convert.ToBase64String(PngBytes)
+        });
+
+        var captured = await _capture.CaptureAsync(
+            Server, "some_other_tool", result, RuleConfig(), default);
+
+        Assert.AreSame(result, captured);
+    }
+
+    [TestMethod]
+    public async Task Capture_NoRules_LeavesJsonBase64Alone()
+    {
+        // Without a declared rule the gateway does not go looking for base64 — sniffing every
+        // JSON field is the fragile heuristic the manifest design exists to avoid.
+        var result = TextResult(new
+        {
+            name = "architecture.png",
+            encoding = "base64",
+            content = Convert.ToBase64String(PngBytes)
+        });
+
+        Assert.AreSame(result, await _capture.CaptureAsync(Server, Tool, result, null, default));
+    }
+
+    [TestMethod]
+    public async Task Capture_MimeFieldOverridesExtension()
+    {
+        var result = TextResult(new
+        {
+            name = "download",
+            mimeType = "application/pdf",
+            encoding = "base64",
+            content = Convert.ToBase64String(PngBytes)
+        });
+
+        var captured = await _capture.CaptureAsync(
+            Server, Tool, result, RuleConfig(mimeField: "mimeType"), default);
+
+        Assert.AreEqual("application/pdf", ParseSingleText(captured).GetProperty("mime").GetString());
+    }
+
+    [TestMethod]
+    public async Task Capture_StorageFailure_ReturnsOriginalResult()
+    {
+        // Capture is an optimisation. A tool call that worked before must not start failing
+        // because the shared volume is unwritable.
+        var capture = new BinaryResponseCapture(new ThrowingStorage());
+        var result = new CallToolResult
+        {
+            Content = [new ImageContentBlock { Data = PngBytes, MimeType = "image/png" }]
+        };
+
+        Assert.AreSame(result, await capture.CaptureAsync(Server, "read_image", result, null, default));
+    }
+
+    // ── Fakes ────────────────────────────────────────────────────────────────
+
+    private sealed class FakeStorage(string basePath) : IAttachmentStorage
+    {
+        public Dictionary<string, byte[]> Files { get; } = new(StringComparer.OrdinalIgnoreCase);
+        public List<string> Written { get; } = [];
+        public string BasePath { get; } = basePath;
+
+        public Task<byte[]> ReadAsync(string path, CancellationToken ct) =>
+            Task.FromResult(Files[path]);
+
+        public Task<string> WriteAsync(string preferredFileName, byte[] data, CancellationToken ct)
+        {
+            var fullPath = Path.Combine(BasePath, Path.GetFileName(preferredFileName));
+            Files[fullPath] = data;
+            Written.Add(fullPath);
+            return Task.FromResult(fullPath);
+        }
+    }
+
+    private sealed class ThrowingStorage : IAttachmentStorage
+    {
+        public string BasePath => "/rockbot/shared/attachments";
+        public Task<byte[]> ReadAsync(string path, CancellationToken ct) => throw new IOException("nope");
+        public Task<string> WriteAsync(string preferredFileName, byte[] data, CancellationToken ct) =>
+            throw new IOException("read-only file system");
+    }
+}

--- a/tests/RockBot.Agent.Tests/Attachments/BinaryResponseCaptureTests.cs
+++ b/tests/RockBot.Agent.Tests/Attachments/BinaryResponseCaptureTests.cs
@@ -230,6 +230,50 @@ public class BinaryResponseCaptureTests
     }
 
     [TestMethod]
+    public async Task Capture_BinaryMangledIntoText_DropsTheFieldAndExplains()
+    {
+        // Measured on a live deployment: a repository server returns a PNG through its file tool
+        // as UTF-8-decoded text. The bytes are already destroyed; the only question is whether
+        // 1.37M characters of mojibake also get to flood context.
+        var mangled = new string('�', 40) + new string('x', 2000);
+        var result = TextResult(new
+        {
+            name = "rockbot.png",
+            sha = "511bdfe",
+            size = 345864,
+            content = mangled
+        });
+
+        var captured = await _capture.CaptureAsync(Server, Tool, result, RuleConfig(encodingField: null), default);
+
+        var payload = ParseSingleText(captured);
+        Assert.IsFalse(payload.TryGetProperty("content", out _));
+        Assert.AreEqual("511bdfe", payload.GetProperty("sha").GetString(), "metadata is what's left worth having");
+        StringAssert.Contains(payload.GetProperty("note").GetString()!, "corrupted");
+        Assert.AreEqual(0, _storage.Written.Count, "there are no bytes to save");
+    }
+
+    [TestMethod]
+    public async Task Capture_TextWithAFewEncodingGlitches_IsNotTreatedAsMangled()
+    {
+        // A document with a couple of bad characters is still a document.
+        var text = "# Report\n\nThe caf� served cr�me br�l�e.\n" + new string('x', 2000);
+        var result = TextResult(new { name = "notes.md", content = text });
+
+        var captured = await _capture.CaptureAsync(Server, Tool, result, RuleConfig(encodingField: null), default);
+
+        Assert.AreSame(result, captured);
+    }
+
+    [TestMethod]
+    public async Task Capture_ShortNonBase64Content_IsLeftAlone()
+    {
+        var result = TextResult(new { name = "notes.md", content = "not base64 ���������" });
+
+        Assert.AreSame(result, await _capture.CaptureAsync(Server, Tool, result, RuleConfig(encodingField: null), default));
+    }
+
+    [TestMethod]
     public async Task Capture_RuleForAnotherTool_DoesNotMatch()
     {
         var result = TextResult(new

--- a/tests/RockBot.Tools.FileSystem.Tests/AnalyzeFileToolExecutorTests.cs
+++ b/tests/RockBot.Tools.FileSystem.Tests/AnalyzeFileToolExecutorTests.cs
@@ -1,0 +1,276 @@
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+using RockBot.Host;
+
+namespace RockBot.Tools.FileSystem.Tests;
+
+[TestClass]
+public class AnalyzeFileToolExecutorTests
+{
+    private string _root = null!;
+    private FileSystemOptions _options = null!;
+    private RecordingLlmClient _llm = null!;
+
+    /// <summary>
+    /// A one-pixel PNG is enough: nothing under test decodes the image, and the bytes are only
+    /// checked for being passed through intact.
+    /// </summary>
+    private static readonly byte[] PngBytes = Convert.FromBase64String(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==");
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "rockbot-analyze-file-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+        _options = new FileSystemOptions { BasePath = _root };
+        _llm = new RecordingLlmClient();
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_root))
+            Directory.Delete(_root, recursive: true);
+    }
+
+    private AnalyzeFileToolExecutor Executor(params ModelTier[] visionTiers) =>
+        new(_options, _llm,
+            visionTiers.Length > 0 ? visionTiers : [ModelTier.Balanced],
+            NullLogger.Instance);
+
+    private string WriteBinary(string relativePath, byte[] content)
+    {
+        var full = Path.Combine(_root, relativePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+        File.WriteAllBytes(full, content);
+        return full;
+    }
+
+    private static ToolInvokeRequest Request(object args) => new()
+    {
+        ToolCallId = "call_1",
+        ToolName = "analyze_file",
+        Arguments = JsonSerializer.Serialize(args)
+    };
+
+    [TestMethod]
+    public async Task Execute_MissingPath_ReturnsError()
+    {
+        var result = await Executor().ExecuteAsync(Request(new { prompt = "What is this?" }), default);
+
+        Assert.IsTrue(result.IsError);
+        StringAssert.Contains(result.Content!, "path");
+    }
+
+    [TestMethod]
+    public async Task Execute_MissingPrompt_ReturnsError()
+    {
+        WriteBinary("diagram.png", PngBytes);
+
+        var result = await Executor().ExecuteAsync(Request(new { path = "diagram.png" }), default);
+
+        Assert.IsTrue(result.IsError);
+        StringAssert.Contains(result.Content!, "prompt");
+    }
+
+    [TestMethod]
+    public async Task Execute_PathEscapingBase_ReturnsError()
+    {
+        var result = await Executor().ExecuteAsync(
+            Request(new { path = "../../etc/passwd.png", prompt = "What is this?" }), default);
+
+        Assert.IsTrue(result.IsError);
+        StringAssert.Contains(result.Content!, "within the shared volume");
+        Assert.AreEqual(0, _llm.Calls.Count, "no LLM call should be made for a rejected path");
+    }
+
+    [TestMethod]
+    public async Task Execute_MissingFile_ReturnsError()
+    {
+        var result = await Executor().ExecuteAsync(
+            Request(new { path = "absent.png", prompt = "What is this?" }), default);
+
+        Assert.IsTrue(result.IsError);
+        StringAssert.Contains(result.Content!, "not found");
+    }
+
+    [TestMethod]
+    public async Task Execute_UnrecognisedExtension_ReturnsError()
+    {
+        WriteBinary("notes.txt", "plain text"u8.ToArray());
+
+        var result = await Executor().ExecuteAsync(
+            Request(new { path = "notes.txt", prompt = "What is this?" }), default);
+
+        Assert.IsTrue(result.IsError);
+        StringAssert.Contains(result.Content!, "unrecognised file type");
+        Assert.AreEqual(0, _llm.Calls.Count);
+    }
+
+    [TestMethod]
+    public async Task Execute_KnownTypeNotOnAllowlist_ReturnsError()
+    {
+        WriteBinary("report.pdf", PngBytes);
+
+        var result = await Executor().ExecuteAsync(
+            Request(new { path = "report.pdf", prompt = "Summarise it." }), default);
+
+        Assert.IsTrue(result.IsError);
+        StringAssert.Contains(result.Content!, "application/pdf");
+        Assert.AreEqual(0, _llm.Calls.Count);
+    }
+
+    [TestMethod]
+    public async Task Execute_TypeAddedToAllowlist_IsAccepted()
+    {
+        _options.AnalyzeFileMimeTypes = [.. _options.AnalyzeFileMimeTypes, "application/pdf"];
+        WriteBinary("report.pdf", PngBytes);
+
+        var result = await Executor().ExecuteAsync(
+            Request(new { path = "report.pdf", prompt = "Summarise it." }), default);
+
+        Assert.IsFalse(result.IsError, result.Content);
+        Assert.AreEqual("application/pdf", _llm.Calls[0].Data!.MediaType);
+    }
+
+    [TestMethod]
+    public async Task Execute_FileOverSizeLimit_ReturnsErrorBeforeCallingModel()
+    {
+        _options.AnalyzeFileMaxBytes = 10;
+        WriteBinary("big.png", PngBytes);
+
+        var result = await Executor().ExecuteAsync(
+            Request(new { path = "big.png", prompt = "What is this?" }), default);
+
+        Assert.IsTrue(result.IsError);
+        StringAssert.Contains(result.Content!, "exceeds");
+        Assert.AreEqual(0, _llm.Calls.Count);
+    }
+
+    [TestMethod]
+    public async Task Execute_ValidImage_SendsPromptAndBytesAsMultimodalContent()
+    {
+        WriteBinary("diagrams/arch.png", PngBytes);
+        _llm.ResponseText = "Three services arranged left to right.";
+
+        var result = await Executor().ExecuteAsync(
+            Request(new { path = "diagrams/arch.png", prompt = "Describe the components." }), default);
+
+        Assert.IsFalse(result.IsError, result.Content);
+        Assert.AreEqual("Three services arranged left to right.", result.Content);
+
+        var call = _llm.Calls.Single();
+        Assert.AreEqual("Describe the components.", call.Text);
+        Assert.AreEqual("image/png", call.Data!.MediaType);
+        CollectionAssert.AreEqual(PngBytes, call.Data.Data.ToArray());
+    }
+
+    [TestMethod]
+    public async Task Execute_JpegExtensions_MapToJpegMime()
+    {
+        WriteBinary("photo.jpeg", PngBytes);
+
+        var result = await Executor().ExecuteAsync(
+            Request(new { path = "photo.jpeg", prompt = "What is this?" }), default);
+
+        Assert.IsFalse(result.IsError, result.Content);
+        Assert.AreEqual("image/jpeg", _llm.Calls[0].Data!.MediaType);
+    }
+
+    [TestMethod]
+    public async Task Execute_RequestedTierSupportsImages_UsesIt()
+    {
+        WriteBinary("diagram.png", PngBytes);
+
+        var result = await Executor(ModelTier.Balanced, ModelTier.High).ExecuteAsync(
+            Request(new { path = "diagram.png", prompt = "What is this?", tier = "high" }), default);
+
+        Assert.IsFalse(result.IsError, result.Content);
+        Assert.AreEqual(ModelTier.High, _llm.Calls[0].Tier);
+    }
+
+    [TestMethod]
+    public async Task Execute_RequestedTierCannotSee_SubstitutesACapableTier()
+    {
+        WriteBinary("diagram.png", PngBytes);
+
+        var result = await Executor(ModelTier.High).ExecuteAsync(
+            Request(new { path = "diagram.png", prompt = "What is this?", tier = "low" }), default);
+
+        Assert.IsFalse(result.IsError, result.Content);
+        Assert.AreEqual(ModelTier.High, _llm.Calls[0].Tier);
+    }
+
+    [TestMethod]
+    public async Task Execute_NoTierRequested_DefaultsToBalancedWhenItCanSee()
+    {
+        WriteBinary("diagram.png", PngBytes);
+
+        var result = await Executor(ModelTier.Low, ModelTier.Balanced, ModelTier.High).ExecuteAsync(
+            Request(new { path = "diagram.png", prompt = "What is this?" }), default);
+
+        Assert.IsFalse(result.IsError, result.Content);
+        Assert.AreEqual(ModelTier.Balanced, _llm.Calls[0].Tier);
+    }
+
+    [TestMethod]
+    public async Task Execute_ModelReturnsNoText_ReturnsError()
+    {
+        WriteBinary("diagram.png", PngBytes);
+        _llm.ResponseText = "";
+
+        var result = await Executor().ExecuteAsync(
+            Request(new { path = "diagram.png", prompt = "What is this?" }), default);
+
+        Assert.IsTrue(result.IsError);
+        StringAssert.Contains(result.Content!, "no text");
+    }
+
+    [TestMethod]
+    public async Task Execute_ModelThrows_ReturnsErrorRatherThanPropagating()
+    {
+        WriteBinary("diagram.png", PngBytes);
+        _llm.Throw = new InvalidOperationException("provider said no");
+
+        var result = await Executor().ExecuteAsync(
+            Request(new { path = "diagram.png", prompt = "What is this?" }), default);
+
+        Assert.IsTrue(result.IsError);
+        StringAssert.Contains(result.Content!, "provider said no");
+    }
+
+    private sealed record RecordedCall(ModelTier Tier, string? Text, DataContent? Data);
+
+    private sealed class RecordingLlmClient : ILlmClient
+    {
+        public List<RecordedCall> Calls { get; } = [];
+        public string ResponseText { get; set; } = "ok";
+        public Exception? Throw { get; set; }
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options,
+            CancellationToken cancellationToken)
+            => GetResponseAsync(messages, ModelTier.Balanced, options, cancellationToken);
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ModelTier tier,
+            ChatOptions? options,
+            CancellationToken cancellationToken)
+        {
+            if (Throw is not null)
+                throw Throw;
+
+            var userMessage = messages.Last(m => m.Role == ChatRole.User);
+            Calls.Add(new RecordedCall(
+                tier,
+                userMessage.Contents.OfType<TextContent>().FirstOrDefault()?.Text,
+                userMessage.Contents.OfType<DataContent>().FirstOrDefault()));
+
+            return Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, ResponseText)));
+        }
+    }
+}

--- a/tests/RockBot.Tools.Tests/McpBinaryPayloadTests.cs
+++ b/tests/RockBot.Tools.Tests/McpBinaryPayloadTests.cs
@@ -1,0 +1,69 @@
+using System.Text;
+using RockBot.Tools.Mcp;
+
+namespace RockBot.Tools.Tests;
+
+[TestClass]
+public class McpBinaryPayloadTests
+{
+    /// <summary>Smallest valid PNG — starts with 0x89, which is not ASCII and never base64.</summary>
+    private static readonly byte[] PngBytes = Convert.FromBase64String(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==");
+
+    [TestMethod]
+    public void Decode_Base64TextPayload_ReturnsDecodedBytes()
+    {
+        // What SDK 1.4.0 actually puts in ImageContentBlock.Data: the wire field verbatim,
+        // which is base64 text rather than the file's bytes.
+        var data = Encoding.ASCII.GetBytes(Convert.ToBase64String(PngBytes));
+
+        CollectionAssert.AreEqual(PngBytes, McpBinaryPayload.Decode(data));
+    }
+
+    [TestMethod]
+    public void Decode_RawBinaryPayload_IsPassedThrough()
+    {
+        // What the property's type says it holds. Both readings work, so an SDK that changes
+        // its mind needs no change here.
+        CollectionAssert.AreEqual(PngBytes, McpBinaryPayload.Decode(PngBytes));
+    }
+
+    [TestMethod]
+    public void Decode_EmptyPayload_ReturnsEmpty()
+    {
+        Assert.AreEqual(0, McpBinaryPayload.Decode(ReadOnlyMemory<byte>.Empty).Length);
+    }
+
+    [TestMethod]
+    public void Decode_AsciiTextThatIsNotBase64_IsPassedThrough()
+    {
+        var text = "hello, world!"u8.ToArray();
+
+        CollectionAssert.AreEqual(text, McpBinaryPayload.Decode(text));
+    }
+
+    [TestMethod]
+    public void ToBase64_Base64TextPayload_IsNotDoubleEncoded()
+    {
+        var expected = Convert.ToBase64String(PngBytes);
+        var data = Encoding.ASCII.GetBytes(expected);
+
+        Assert.AreEqual(expected, McpBinaryPayload.ToBase64(data));
+    }
+
+    [TestMethod]
+    public void ToBase64_RawBinaryPayload_IsEncodedOnce()
+    {
+        Assert.AreEqual(Convert.ToBase64String(PngBytes), McpBinaryPayload.ToBase64(PngBytes));
+    }
+
+    [TestMethod]
+    public void ToBase64_RoundTripsThroughDecode()
+    {
+        var wireShape = Encoding.ASCII.GetBytes(Convert.ToBase64String(PngBytes));
+
+        var base64 = McpBinaryPayload.ToBase64(wireShape);
+
+        CollectionAssert.AreEqual(PngBytes, Convert.FromBase64String(base64));
+    }
+}


### PR DESCRIPTION
Steps (A), (B) and (C) of the multimodal plan in #513: binary content now reaches the shared volume instead of the model's context, and a model that can actually see it can be asked about it.

## The problem

RockBot has been text-only end to end. Every model it talks to can see, but nothing in the framework could put a non-text byte in front of one. #513 found this from the outside: an agent asked an MCP server for an image, got 167K characters of textual representation back, chunked it into working memory, and never showed the model an image.

Five separate chokepoints, all verified in the tree and inventoried in the design doc. The one that shapes this PR:

**Images cannot ride in a tool result.** `RegistryToolFunction` already maps MCP image blocks to `DataContent`, which looks like a working path. It isn't. The text-based tool-calling path reduces the result with `result?.ToString()`, so a `List<AIContent>` becomes a bare type name. And on the FICC path, where it survives, every provider is reached through `OpenAIClient(...).AsIChatClient()` — and the OpenAI Chat Completions wire format accepts **only text in tool-role messages**. A `DataContent` there is JSON-serialised into a data-URI string: full base64 token cost, no image.

On OpenAI-compatible APIs, bytes can only enter as content parts on a user message.

## What this adds

`analyze_file(path, prompt, tier)` — a side call rather than a richer tool result, which sidesteps the constraint entirely:

```
analyze_file({ path: "attachments/architecture.png",
               prompt: "Describe the components and how they connect.",
               tier: "high" })
    -> containment check, MIME allowlist, size limit
    -> ILlmClient.GetResponseAsync([User: TextContent(prompt), DataContent(bytes, mime)], tier)
    -> "Three services arranged left to right. ..."
```

A path goes in, prose comes out. Bytes never touch the agent's context, the message bus, or the context budget — which is why the byte-blind `EstimateMessageChars` gap can wait for the inbound-attachment work.

`LlmTierConfig.SupportsImageInput` is the second half. It is opt-in per tier because a blind model rejects image content with an opaque provider error deep in the stack; making the operator say "this model can see" is one config line and removes the whole class of failure.

## Notable decisions

- **Not registered unless a tier declares vision.** Offering the tool otherwise teaches the model a capability the deployment does not have, which it then spends turns trying to use. The file-tools skill guide documents the tool under the same predicate — shared via `VisionTiers.From` so the two cannot disagree whichever hosted service starts first.
- **A requested tier that cannot see is substituted, not attempted.** `ILlmClient` retries a failed Low/High call on Balanced. Sending a vision request to a blind tier would fail twice and surface the less informative second error.
- **`LlmTierOptions` is now registered in DI** by the agent, after the backward-compat fixups, so anything reading it sees the same resolved tiers the chat clients were built from. Consumers that do not register it get an `analyze_file` that never registers — the dependency is optional and its absence reads the same as "no tier declares vision".
- **Lives in `RockBot.Tools.FileSystem`**, which already references `RockBot.Host` (so `ILlmClient` is in scope), already owns `SafeResolvePath`, and already defaults its base path to `/rockbot/shared` — so the MCP attachment gateway's output directory is already inside its reachable scope.

## Enabling it

```json
{ "LLM": { "High": { "ModelId": "openai/gpt-5.5", "SupportsImageInput": true } } }
```

Or `LLM__High__SupportsImageInput=true`. Nothing changes for a deployment that sets neither.

## (C) Binary capture in the MCP bridge

`analyze_file` only helps once bytes are a file on the shared volume, and the attachment gateway only gets them there for servers that implement RockBot's convention. Most don't — including the one in the issue. `BinaryResponseCapture` runs on every MCP response, for every server, manifest or not:

- **Typed `image`/`audio` content blocks are captured with no configuration.** MCP has already labelled them, so nothing is guessed. Bytes go to the attachments directory, the block becomes `{path, name, size, mime, note}`, other blocks are untouched.
- **Base64 inside a JSON response needs a declared rule.** Sniffing for "a field that looks like base64" is the fragile heuristic the attachment design explicitly rejected, so this half stays declarative — and Gitea's shape needs no server change, only a description of the response it already sends:

```json
{ "attachments": { "capture": { "rules": [
  { "tools": ["get_file_contents"], "contentField": "content",
    "nameField": "name", "encodingField": "encoding" }
] } } }
```

The load-bearing detail is deciding what is *actually* binary. A repository server returns a README and a PNG through the same tool and the same field, so capturing on the presence of base64 alone would take away text the model could simply have read. Name or MIME decides when there is one — SVG deliberately excluded, an image by MIME and text by nature — and otherwise the bytes do, via a NUL byte or a strict UTF-8 decode failure.

Capture never fails a tool call: a bad rule, an unwritable volume, or a payload that isn't what the rule claimed logs and passes the server's original response through. That is the opposite of the outbound gateway's stance, deliberately — outbound, a failure means the model's file never got attached and silence would be a lie; inbound, capture is an optimisation on a response that is already complete.

The response object survives the rewrite. Only the content field is removed, so `sha`, `url`, and whatever else the server sent stay alongside the added path descriptor.

## Content-block payloads were being read wrong

Found by pointing a live agent at the fixture server below, and it affects any MCP server that returns typed image or audio blocks — which is to say it was broken before this PR too, just invisibly, because nothing in the reference deployment returns that shape.

`ImageContentBlock.Data` is typed `ReadOnlyMemory<byte>`, which reads like "the file's bytes". In SDK 1.4.0 it is not: it carries the wire field verbatim, and the wire field is base64 *text*. So capture wrote `Data.ToArray()` straight to disk and a 783-byte PNG landed as 1044 bytes of `iVBORw0KGgo…` under a `.png` name, which the vision model then rejected as `invalid_image_format`. The same field was being double-encoded in `McpToolExecutor.MapContentBlocks` (`Convert.ToBase64String` over already-base64 bytes) — pre-existing, fixed alongside.

`McpBinaryPayload` reads either convention, so an SDK version that starts storing decoded bytes needs no change.

## The fixture server

`McpServer.BinaryFixture` returns each binary shape on demand — typed image and audio blocks, a repository server's base64-in-JSON for both an image and a text file, binary mangled into text, and plain text as the control. It exists because none of those shapes occur in a real deployment, which is how both bugs in this PR stayed hidden behind unit tests that had encoded assumptions rather than observations.

Payloads are generated in code: no binary blobs in the repo, and — the actual point — the image's content is documented, so a vision model's description is checked against a known answer instead of an impression of a photo. The fixtures are also served over plain HTTP (`/fixtures/chart.png`) for when a live result and a model's account of it disagree.

It sits outside the Helm chart deliberately (`deploy/k8s/mcp-binary-fixture.yaml`, applied for a test and deleted afterwards) and is `IsPackable=false`. See `src/McpServer.BinaryFixture/README.md`.

## Not in this PR

`design/multimodal-input.md` sequences what remains, now filed:

- **#565** — Blazor and CLI cannot send files to the agent. The other direction from `attach_image`: `UserMessage.Attachments`, an upload control, `--attach`, and the loop injecting image parts onto the user message. Also carries the one-word `ClientCapabilityPresets.Blazor` fix (it omits `ImageAttachment`, so the agent is never told it may attach images to Blazor replies even though the client renders them).
- **#564** — context-size estimation counts a `DataContent` as 50 characters, so images are effectively invisible to the watermark trim. Unreachable today, because nothing puts image parts into the agent's own message list; #565 is what makes it reachable, so it should land first.

Two claims in the design doc were corrected while filing those: `EstimateMessageChars` scores non-text parts at a flat 50 rather than zero, and inbound attachments need **no** schema migration — adding an optional property to `ConversationTurn` is additive, and the conversation store is not enrolled in schema migrations at all. Both had been written from the shape of the code rather than its detail.

## Version: 0.15.0, not a patch

Two things here are behavioural changes for an existing consumer, and a patch release should not carry them:

- **Binary capture is on by default for every MCP server, with no opt-in.** A consumer whose server returns typed image or audio blocks now receives a `{path, name, size, mime}` descriptor where it previously received the block.
- **`McpToolExecutor.MapContentBlocks` stops double-encoding those payloads**, so `ToolContentBlock.Data` changes shape for the same consumers.

Plus new public surface across three packages (`LlmTierConfig.SupportsImageInput`, `FileSystemOptions.AnalyzeFileMaxBytes`/`AnalyzeFileMimeTypes`, `AttachmentManifest.Capture` and its config types, `BinaryResponseCapture`), a new chart value, and a capability the framework did not have at all.

The 0.14.43–0.14.47 trail on the branch was an artefact of needing a fresh image tag per round of live testing; it is collapsed into this one number.

## Testing

48 new tests. `analyze_file` (15): containment rejection, missing file, unrecognised extension, allowlist enforcement in both directions, the size limit, tier honouring and substitution, multimodal content shape (prompt text and bytes both arrive intact), empty response, and provider exceptions. Capture (19): image and audio blocks, mixed blocks, text-only responses left alone, the disable switch, error results, the Gitea shape end to end, a README through the same field left in the response, sniffing fallback in both directions, wrong encoding, malformed base64, unmatched tools, no rules, MIME override, storage failure, and binary a server mangled into text (dropped with an explanation rather than flooding context). Payload decoding (7): base64-text and raw-byte payloads both read correctly, no double-encoding, round trip. Storage containment (7): traversal names, absolute paths, subdirectories, empty-name fallback, collisions, and read-side rejection — pinned because capture now names files from a remote server's response. Full suite green: 3198 passed, 0 failed. Capture was also smoke-tested against a live MCP server, and against `McpServer.BinaryFixture` (added here) which returns every shape on demand — see the comments. Those two runs are what turned up the mangled-binary case and the base64-payload bug respectively.

Closes #513

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uf8a2Z1v9dY3YjjM42zJEj
